### PR TITLE
feat: Update buyer portal URLs to new domain

### DIFF
--- a/twopayment.php
+++ b/twopayment.php
@@ -2572,10 +2572,10 @@ class Twopayment extends PaymentModule
         $environment = Configuration::get('PS_TWO_ENVIRONMENT');
         
         if ($environment === 'production') {
-            return 'https://portal.two.inc';
+            return 'https://buyer.two.inc';
         } else {
             // Development environment (default)
-            return 'https://portal.sandbox.two.inc';
+            return 'https://buyer.sandbox.two.inc';
         }
     }
 
@@ -2586,7 +2586,7 @@ class Twopayment extends PaymentModule
     public function getTwoBuyerPortalUrl()
     {
         $base = $this->getTwoPortalUrl();
-        return rtrim($base, '/') . '/auth/buyer/login';
+        return rtrim($base, '/') . '/login';
     }
 
     /**


### PR DESCRIPTION
## Context

The monolithic portal has been separated into distinct buyer and merchant portals. The buyer portal now lives at `buyer.two.inc` (prod) and `buyer.sandbox.two.inc` (sandbox), and legacy path prefixes have been cleaned up.

Slack: https://two-inc.slack.com/archives/C019RHDC43Y/p1773155145873899?thread_ts=1772702984.297479&cid=C019RHDC43Y

## Changes

- Updated `getTwoPortalUrl()` in `twopayment.php`:
  - `portal.two.inc` → `buyer.two.inc` (production)
  - `portal.sandbox.two.inc` → `buyer.sandbox.two.inc` (sandbox)
- Updated `getTwoBuyerPortalUrl()` in `twopayment.php`:
  - `/auth/buyer/login` → `/login`

## Scope / Non-goals

- All portal URLs are constructed via `getTwoPortalUrl()` and `getTwoBuyerPortalUrl()`, so all template references (using `{$two_portal_url}` and `{$two_buyer_portal_url}`) are automatically updated
- No merchant portal URLs are changed

## Validation

- Verified only `twopayment.php` contains hardcoded portal domain/path references
- All template files consume the URL via PHP variables — no additional changes needed

## Ticket

- No Linear ticket (product-driven domain migration)