### PR TITLE
INF-1458/feat: derive frp tunnel domain per-env via FRP_ENV selector

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,5 +12,9 @@
 # FRP proxy subdomain user (defaults to $USER)
 # PROXY_USER=
 
+# FRP env the tunnel targets: staging | release (defaults to staging). The tunnel
+# comes up at <subdomain>.frp.<FRP_ENV>.two.inc; only staging/release are provisioned.
+# FRP_ENV=staging
+
 # FRP auth token (defaults to GCP Secret Manager fetch)
 # FRP_AUTH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ Thumbs.db
 *.zip
 
 
+
+.worktrees/

--- a/frpc.toml
+++ b/frpc.toml
@@ -10,4 +10,4 @@ localPort = {{ .Envs.PORT }}
 name = "{{ .Envs.SUBDOMAIN }}"
 type = "http"
 localIP = "{{ .Envs.HOST }}"
-subdomain = "{{ .Envs.SUBDOMAIN }}"
+customDomains = ["{{ .Envs.FRP_DOMAIN }}"]

--- a/start-proxy.sh
+++ b/start-proxy.sh
@@ -5,11 +5,16 @@
 # If no token is provided, attempts to fetch it from GCP Secret Manager
 # (requires an active @two.inc gcloud login).
 
+# Preserve an inline override (e.g. `FRP_ENV=release ./start-proxy.sh`) so
+# sourcing .env.local below doesn't clobber it.
+_FRP_ENV_OVERRIDE="${FRP_ENV}"
+
 if [ -f .env.local ]; then
   set -a
   source .env.local
   set +a
 fi
+FRP_ENV="${_FRP_ENV_OVERRIDE:-${FRP_ENV:-staging}}"
 
 PROXY_USER="${PROXY_USER:-$USER}"
 export HOST="${HOST:-127.0.0.1}"
@@ -20,7 +25,11 @@ USER_LOWER=$(echo "${PROXY_USER}" | tr '[:upper:]' '[:lower:]')
 SANITIZED_USER=$(echo "${USER_LOWER}" | sed -E 's/[^a-z0-9-]+/-/g' | sed -E 's/^-+|-+$//g' | sed -E 's/--+/-/g')
 export SUBDOMAIN="prestashop-${SANITIZED_USER}"
 
-PROXY_URL="https://${SUBDOMAIN}.frp.beta.two.inc"
+# FRP env the tunnel targets (only staging/release are provisioned). The
+# staging/release guard is enforced in start mode below so stop/url still work.
+export FRP_DOMAIN="${SUBDOMAIN}.frp.${FRP_ENV}.two.inc"
+
+PROXY_URL="https://${FRP_DOMAIN}"
 
 # ── stop mode ────────────────────────────────────────────────────────────────
 if [ "$1" = "stop" ]; then
@@ -72,6 +81,15 @@ else
   fi
   export FRP_AUTH_TOKEN
 fi
+
+# Per-env FRP is only provisioned for staging and release (routes/certs/DNS/authz).
+case "${FRP_ENV}" in
+  staging | release) ;;
+  *)
+    echo "FRP tunnels are only supported for staging or release (got FRP_ENV='${FRP_ENV}')"
+    exit 1
+    ;;
+esac
 
 frpc -c frpc.toml &
 FRP_PID=$!


### PR DESCRIPTION
## Context

The local frp dev tunnel used the `subdomain` shorthand (resolves only under `subDomainHost = frp.beta.two.inc`). Per-env frp routing/certs/DNS for staging + release is now live. The plugin has no Two-API base URL to derive the env from, so the tunnel env is an explicit `FRP_ENV` selector (defaults to staging).

## Changes (single commit)

- `frpc.toml`: `subdomain` → `customDomains = ["{{ .Envs.FRP_DOMAIN }}"]`
- `start-proxy.sh`: preserve an inline `FRP_ENV` override across the `.env.local` source; default to staging; derive `FRP_DOMAIN` (`<subdomain>.frp.<FRP_ENV>.two.inc`); enforce staging/release only in **start mode** (so `stop`/`url` still work for any value)
- `.env.local.example`: document `FRP_ENV`

## How to connect to a different env

`FRP_ENV=release` (in `.env.local` or inline).

## Validation

- `bash -n start-proxy.sh` clean; staging/release guard rejects others in start mode; `stop`/`url` unaffected
- `check-toml` skipped on the commit: `frpc.toml` uses frpc Go-template placeholders (not literal TOML)

## Ticket

- https://linear.app/tillit/issue/INF-1458