### PR TITLE
TWO-24741/fix: Surface negative discounts instead of clamping to zero

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -287,9 +287,18 @@ namespace {
 
     class PrestaShopLogger
     {
+        /** @var array<int,array{message:string,severity:int}> */
+        public static array $logs = [];
+
         public static function addLog($message, $severity = 1, $errorCode = null, $objectType = null, $objectId = null, $allowDuplicate = false): bool
         {
+            self::$logs[] = ['message' => (string) $message, 'severity' => (int) $severity];
             return true;
+        }
+
+        public static function reset(): void
+        {
+            self::$logs = [];
         }
     }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -153,6 +153,8 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsSkipsEmptyBarcodeEntries();
         self::testGetTwoProductItemsThrowsOnNegativeDiscount();
         self::testGetTwoProductItemsThrowsOnNegativeReduction();
+        self::testGetTwoProductItemsAllowsPositiveDiscount();
+        self::testGetTwoProductItemsToleratesUnitPriceRoundingDrift();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
         self::testGetTwoRequestHeadersSkipAuthForOrderIntent();
@@ -173,6 +175,7 @@ final class OrderBuilderSpec
     private static function reset(): void
     {
         StubStore::reset();
+        PrestaShopLogger::reset();
     }
 
     private static function testValidateTwoLineItemsRejectsBrokenTaxFormula(): void
@@ -330,6 +333,13 @@ final class OrderBuilderSpec
             },
             'Negative discount calculated for product 888'
         );
+
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(3, PrestaShopLogger::$logs[0]['severity']);
+        TinyAssert::true(
+            strpos(PrestaShopLogger::$logs[0]['message'], '100 = 100 < net total 105') !== false,
+            'Log line must include the computed amounts: ' . PrestaShopLogger::$logs[0]['message']
+        );
     }
 
     private static function testGetTwoProductItemsThrowsOnNegativeReduction(): void
@@ -365,8 +375,89 @@ final class OrderBuilderSpec
             static function () use ($module, $cart): void {
                 $module->getTwoProductItems($cart);
             },
-            'Negative discount calculated for product 889'
+            'Negative reduction for product 889'
         );
+
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(3, PrestaShopLogger::$logs[0]['severity']);
+    }
+
+    private static function testGetTwoProductItemsAllowsPositiveDiscount(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(14);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // quantity * unit_price (100.00) > net total (95.00) -> 5.00 discount,
+        // the healthy discounted-cart path must keep working
+        StubStore::$cartProducts[14] = [[
+            'id_product' => 890,
+            'link_rewrite' => 'discounted-product',
+            'name' => 'Discounted Product',
+            'description_short' => 'Cart-rule discounted',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 95.00,
+            'total_wt' => 114.95,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[890] = [['name' => 'Misc']];
+        StubStore::$images[890] = ['id_image' => 9014];
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('5.00', (string)$items[0]['discount_amount']);
+        TinyAssert::same('95.00', (string)$items[0]['net_amount']);
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+
+    private static function testGetTwoProductItemsToleratesUnitPriceRoundingDrift(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(15);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // PrestaShop stores unit prices at 6dp: 3 x 8.344 = 25.032, line total
+        // rounded to 25.03. Deriving the discount from the ROUNDED unit price
+        // (3 x 8.34 = 25.02) would manufacture a phantom -0.01 discount and
+        // fail the cart; deriving at full precision yields 0.00.
+        StubStore::$cartProducts[15] = [[
+            'id_product' => 891,
+            'link_rewrite' => 'six-decimal-product',
+            'name' => 'Six Decimal Product',
+            'description_short' => 'Unit price with 3rd-decimal precision',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 25.03,
+            'total_wt' => 30.29,
+            'cart_quantity' => 3,
+            'rate' => 21.0,
+            'price' => 8.344,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[891] = [['name' => 'Misc']];
+        StubStore::$images[891] = ['id_image' => 9015];
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('0.00', (string)$items[0]['discount_amount']);
+        TinyAssert::same('25.03', (string)$items[0]['net_amount']);
+        TinyAssert::count(0, PrestaShopLogger::$logs);
     }
 
     private static function testGetTwoNewOrderDataSupportsFivePointFivePercentVat(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -151,6 +151,8 @@ final class OrderBuilderSpec
         self::testGetTwoErrorMessageReadsNestedDataMessage();
         self::testGetTwoErrorMessageIgnoresSuccessMessagePayload();
         self::testGetTwoProductItemsSkipsEmptyBarcodeEntries();
+        self::testGetTwoProductItemsThrowsOnNegativeDiscount();
+        self::testGetTwoProductItemsThrowsOnNegativeReduction();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
         self::testGetTwoRequestHeadersSkipAuthForOrderIntent();
@@ -290,6 +292,81 @@ final class OrderBuilderSpec
         TinyAssert::same('10.55', (string)$items[1]['gross_amount']);
         TinyAssert::same('0.55', (string)$items[1]['tax_amount']);
         TinyAssert::same('0.055', (string)$items[1]['tax_rate']);
+    }
+
+    private static function testGetTwoProductItemsThrowsOnNegativeDiscount(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(12);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // quantity * unit_price (100.00) < net total (105.00) -> negative discount,
+        // previously clamped to 0, now surfaced as an error
+        StubStore::$cartProducts[12] = [[
+            'id_product' => 888,
+            'link_rewrite' => 'mispriced-product',
+            'name' => 'Mispriced Product',
+            'description_short' => 'Inconsistent pricing data',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 105.00,
+            'total_wt' => 127.05,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[888] = [['name' => 'Misc']];
+        StubStore::$images[888] = ['id_image' => 9012];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Negative discount calculated for product 888'
+        );
+    }
+
+    private static function testGetTwoProductItemsThrowsOnNegativeReduction(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(13);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // No unit price -> reduction branch; a negative reduction is a data
+        // inconsistency, previously zeroed silently, now surfaced as an error
+        StubStore::$cartProducts[13] = [[
+            'id_product' => 889,
+            'link_rewrite' => 'negative-reduction-product',
+            'name' => 'Negative Reduction Product',
+            'description_short' => 'Inconsistent reduction data',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 121.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'reduction' => -2.00,
+        ]];
+
+        StubStore::$productCategories[889] = [['name' => 'Misc']];
+        StubStore::$images[889] = ['id_image' => 9013];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Negative discount calculated for product 889'
+        );
     }
 
     private static function testGetTwoNewOrderDataSupportsFivePointFivePercentVat(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -16,7 +16,6 @@ require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic
-    const GROSS_AMOUNT_TOLERANCE = 0.02; // 2 cents tolerance for rounding differences
     const ORDER_INTENT_EXPIRY_SECONDS = 1800; // 30 minutes
     
     // Constants for payment terms
@@ -3866,22 +3865,25 @@ class Twopayment extends PaymentModule
                 // Calculate discount from PrestaShop's values
                 $expected_total = $quantity * $unit_price_net;
                 $discount_amount = round($expected_total - $net_amount_prestashop, 2);
-                
-                // Ensure discount is not negative (protect against edge cases)
+
+                // A negative discount means quantity * unit_price < net total - a data
+                // inconsistency we must surface, not silently correct. The checkout-api
+                // validates order amounts and rejects bad payloads with a clear error.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ', clamping to 0', 2);
-                    $discount_amount = 0;
+                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity x unit_price < net total)', 3);
+                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
-                
+
                 $net_amount = $net_amount_prestashop;
             } else {
                 $discount_amount = isset($line_item['reduction']) ? (float)$line_item['reduction'] : 0;
-                
-                // Ensure discount is not negative
+
+                // Surface negative reductions instead of silently zeroing them (see above).
                 if ($discount_amount < 0) {
-                    $discount_amount = 0;
+                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'], 3);
+                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
-                
+
                 $unit_price_net = ($net_amount_prestashop + $discount_amount) / $quantity;
                 $unit_price_net = round($unit_price_net, 2);
                 

--- a/twopayment.php
+++ b/twopayment.php
@@ -3860,28 +3860,34 @@ class Twopayment extends PaymentModule
             $unit_price_net_prestashop = isset($line_item['price']) ? (float)$line_item['price'] : null;
             
             if ($unit_price_net_prestashop !== null) {
-                $unit_price_net = round($unit_price_net_prestashop, 2);
-                
-                // Calculate discount from PrestaShop's values
-                $expected_total = $quantity * $unit_price_net;
+                // Derive the discount at PrestaShop's native precision (6dp) and
+                // round once at the payload boundary. Rounding the unit price to
+                // 2dp before multiplying manufactures phantom +/-0.01 discounts
+                // whenever the third decimal of the unit price rounds opposite to
+                // the line total (e.g. 3 x 8.344: 3x8.34=25.02 vs total 25.03).
+                $expected_total = $quantity * $unit_price_net_prestashop;
                 $discount_amount = round($expected_total - $net_amount_prestashop, 2);
 
                 // A negative discount means quantity * unit_price < net total - a data
                 // inconsistency we must surface, not silently correct. The checkout-api
                 // validates order amounts and rejects bad payloads with a clear error.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity x unit_price < net total)', 3);
+                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity ' . $quantity . ' x unit price ' . $unit_price_net_prestashop . ' = ' . $expected_total . ' < net total ' . $net_amount_prestashop . ')', 3);
                     throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
 
+                $unit_price_net = round($unit_price_net_prestashop, 2);
                 $net_amount = $net_amount_prestashop;
             } else {
-                $discount_amount = isset($line_item['reduction']) ? (float)$line_item['reduction'] : 0;
+                // Round to currency precision before the sign check; sub-cent float
+                // residue in PrestaShop's computed reduction is not a data error.
+                $discount_amount = isset($line_item['reduction']) ? round((float)$line_item['reduction'], 2) : 0;
 
-                // Surface negative reductions instead of silently zeroing them (see above).
+                // A negative reduction is a data inconsistency; surface it rather
+                // than silently zeroing it.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'], 3);
-                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
+                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'] . ' (reduction ' . $discount_amount . ')', 3);
+                    throw new Exception('Negative reduction for product ' . $line_item['id_product']);
                 }
 
                 $unit_price_net = ($net_amount_prestashop + $discount_amount) / $quantity;


### PR DESCRIPTION
## Change pack

Order line-item discounts are propagated raw instead of being silently corrected.

- **Negative discounts surface as a logged exception** rather than being clamped to zero. A negative discount means `quantity × unit_price < net total` — a data inconsistency. checkout-api validates order amounts and rejects bad payloads with a clear error, so the plugin propagates raw values rather than hiding the problem.
- **Discounts are derived at native precision** (PrestaShop's unrounded 6dp unit price), rounded once at the payload boundary — matching the Magento plugin's precision model. Rounding the unit price to 2dp first manufactured phantom −0.01 discounts on healthy carts.
- The two failure modes (unit-price branch vs reduction branch) get distinct exception messages, with computed amounts in the logs.
- Removes the dead `GROSS_AMOUNT_TOLERANCE` snap constant.

Staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_(Description by Claude on Doug's behalf.)_