### PR TITLE
TWO-24748/feat: Brand-code plumbing and test target for the dev harness

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,10 @@
 # Store country (NO|GB|SE|DK|FI|NL|DE)
 # TWO_STORE_COUNTRY=NO
 
+# Brand to run the module as (brands/{code}.php; resolves via the
+# PS_TWO_BRAND_CODE configuration value). Defaults to two.
+# TWO_BRAND_CODE=two
+
 # FRP proxy subdomain user (defaults to $USER)
 # PROXY_USER=
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TWO_ENVIRONMENT      ?= sandbox
 TWO_STORE_COUNTRY    ?= NO
 export TWO_STORE_COUNTRY
 
-.PHONY: help install configure run debug stop clean flush logs proxy archive
+.PHONY: help install configure run debug stop clean flush logs proxy archive test
 
 .DEFAULT_GOAL := help
 
@@ -84,6 +84,7 @@ configure:
 		-e TWO_API_KEY=$(TWO_API_KEY) \
 		-e TWO_ENVIRONMENT=$(TWO_ENVIRONMENT) \
 		-e TWO_API_BASE_URL=$(TWO_API_BASE_URL) \
+		-e TWO_BRAND_CODE=$(TWO_BRAND_CODE) \
 		$(CONTAINER) php /var/www/html/modules/$(MODULE_NAME)/dev/configure.php
 	docker exec $(CONTAINER) bash -c "rm -rf /var/www/html/var/cache/*"
 
@@ -133,6 +134,10 @@ proxy:
 ## Tail PrestaShop + module logs
 logs:
 	docker exec $(CONTAINER) bash -c "tail -f /var/www/html/var/logs/*.log /var/log/apache2/error.log 2>/dev/null"
+
+## Run the unit test harness (same suite CI runs)
+test:
+	docker run --rm -v "$(CURDIR)":/app -w /app php:8.2-cli php tests/run.php
 
 ## Create a versioned zip archive
 archive:

--- a/brands/index.php
+++ b/brands/index.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Plugin Developer from Two <jgang@two.inc> <support@two.inc>
+ * @copyright Since 2021 Two Team
+ * @license Two Commercial License
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/brands/two.php
+++ b/brands/two.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Two brand configuration — the default brand of the base module.
+ *
+ * A partner edition supplies its own file with the same shape and the
+ * module loads it instead (see Twopayment::getTwoBrand()). Every key
+ * here has a runtime consumer — new keys land with the code that reads
+ * them.
+ *
+ * `vendor_name` and `brand_tag` are sent in the create/intent/update
+ * order payloads ONLY when non-empty, so the Two brand (empty values)
+ * produces a byte-identical payload to the pre-brand-config module.
+ */
+
+return [
+    'code' => 'two',
+    'provider' => 'Two',
+    'product_name' => 'Two',
+    'display_name' => 'Two - BNPL for businesses',
+    'description' => 'This module allows any merchant to accept payments with Two payment gateway.',
+    'payment_title' => 'Pay with Two',
+    'payment_subtitle' => 'Buy now, pay later - instant credit',
+    'logo_path' => 'views/img/TwoLogo.svg',
+    'support_email' => 'support@two.inc',
+    'documentation_url' => 'https://docs.two.inc',
+    'vendor_name' => '',
+    'brand_tag' => '',
+];

--- a/brands/two.php
+++ b/brands/two.php
@@ -18,9 +18,6 @@
  * - product_name, code → Smarty var {$two_brand.*} (assigned at
  *   setMedia + payment-option render) and tests
  * - support_email, documentation_url → admin help panel
- * - vendor_name → order payload (create/intent/update) ONLY when
- *   non-empty, so the Two brand (empty) produces a byte-identical
- *   payload to the pre-brand-config module
  */
 
 return [
@@ -33,5 +30,4 @@ return [
     'payment_subtitle' => 'Buy now, pay later - instant credit',
     'support_email' => 'support@two.inc',
     'documentation_url' => 'https://docs.two.inc',
-    'vendor_name' => '',
 ];

--- a/brands/two.php
+++ b/brands/two.php
@@ -5,7 +5,10 @@
  * A partner edition sets the PS_TWO_BRAND_CODE configuration value;
  * Twopayment::getTwoBrand() resolves it to brands/{code}.php and merges
  * that file over these defaults, so a partner file declares only what
- * differs.
+ * differs. PS_TWO_BRAND_CODE is the PRODUCTION selection mechanism —
+ * unlike the WooCommerce plugin's TWO_BRAND_CODE, which is a dev-only
+ * env override (its production selection is the overlay plugin's
+ * twoinc_brand_file filter).
  *
  * Consumer map (every key has a runtime reader — new keys land with the
  * code that reads them):

--- a/brands/two.php
+++ b/brands/two.php
@@ -2,14 +2,22 @@
 /**
  * Two brand configuration — the default brand of the base module.
  *
- * A partner edition supplies its own file with the same shape and the
- * module loads it instead (see Twopayment::getTwoBrand()). Every key
- * here has a runtime consumer — new keys land with the code that reads
- * them.
+ * A partner edition sets the PS_TWO_BRAND_CODE configuration value;
+ * Twopayment::getTwoBrand() resolves it to brands/{code}.php and merges
+ * that file over these defaults, so a partner file declares only what
+ * differs.
  *
- * `vendor_name` and `brand_tag` are sent in the create/intent/update
- * order payloads ONLY when non-empty, so the Two brand (empty values)
- * produces a byte-identical payload to the pre-brand-config module.
+ * Consumer map (every key has a runtime reader — new keys land with the
+ * code that reads them):
+ * - provider, display_name, description → module constructor identity
+ * - payment_title, payment_subtitle → payment-option defaults when the
+ *   merchant has not configured PS_TWO_TITLE / PS_TWO_SUB_TITLE
+ * - product_name, code → Smarty var {$two_brand.*} (assigned at
+ *   setMedia + payment-option render) and tests
+ * - support_email, documentation_url → admin help panel
+ * - vendor_name → order payload (create/intent/update) ONLY when
+ *   non-empty, so the Two brand (empty) produces a byte-identical
+ *   payload to the pre-brand-config module
  */
 
 return [
@@ -20,9 +28,7 @@ return [
     'description' => 'This module allows any merchant to accept payments with Two payment gateway.',
     'payment_title' => 'Pay with Two',
     'payment_subtitle' => 'Buy now, pay later - instant credit',
-    'logo_path' => 'views/img/TwoLogo.svg',
     'support_email' => 'support@two.inc',
     'documentation_url' => 'https://docs.two.inc',
     'vendor_name' => '',
-    'brand_tag' => '',
 ];

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -223,6 +223,15 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                 } else {
                     $message = $this->module->l('Invalid order data. Please check your details and try again.');
                 }
+                // Fast-reject on the merchant/partner minimum order value
+                // carries a machine-readable error_code; surface the
+                // minimum in the buyer's currency
+                if (isset($response['error_code']) && $response['error_code'] === 'ORDER_BELOW_MIN_INVOICE_AMOUNT') {
+                    $minimum_hint = $this->module->getTwoMinimumOrderDeclineHint($response['error_code'], $cart);
+                    if (!Tools::isEmpty($minimum_hint)) {
+                        $message .= ' ' . $minimum_hint;
+                    }
+                }
             } elseif ($http_status >= Twopayment::HTTP_STATUS_SERVER_ERROR) {
                 $message = $this->module->l('Payment provider temporarily unavailable. Please try again later.');
             }
@@ -370,7 +379,27 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                             $cancelled ? 2 : 3
                         );
                     }
-                    $this->errors[] = $this->module->l('Unable to redirect to payment provider. Please try again.');
+                    if (isset($response['status']) && strtoupper((string)$response['status']) === 'REJECTED') {
+                        // Credit-declined orders come back 201 without a
+                        // payment_url; tell the buyer the product was
+                        // declined rather than implying a technical fault,
+                        // and surface the minimum when attributable to it
+                        $brand = $this->module->getTwoBrand();
+                        $message = sprintf(
+                            $this->module->l('Invoice purchase with %s is not available for this order.'),
+                            isset($brand['product_name']) ? $brand['product_name'] : 'Two'
+                        );
+                        $minimum_hint = $this->module->getTwoMinimumOrderDeclineHint(
+                            isset($response['decline_reason']) ? $response['decline_reason'] : null,
+                            $cart
+                        );
+                        if (!Tools::isEmpty($minimum_hint)) {
+                            $message .= ' ' . $minimum_hint;
+                        }
+                        $this->errors[] = $message;
+                    } else {
+                        $this->errors[] = $this->module->l('Unable to redirect to payment provider. Please try again.');
+                    }
                     $this->redirectWithNotifications('index.php?controller=order');
                 }
 

--- a/dev/configure.php
+++ b/dev/configure.php
@@ -31,6 +31,7 @@ $keys = [
     'PS_TWO_MERCHANT_SHORT_NAME',
     'PS_TWO_MERCHANT_ID',
     'PS_TWO_API_KEY_VERIFIED',
+    'PS_TWO_BRAND_CODE',
 ];
 $db = Db::getInstance();
 foreach ($keys as $key) {
@@ -54,6 +55,13 @@ Configuration::resetStaticCache();
 
 Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', $apiKey);
 Configuration::updateValue('PS_TWO_ENVIRONMENT', $pluginEnv);
+
+// Brand selection (TWO-24746): resolves brands/{code}.php in the module.
+$brandCode = getenv('TWO_BRAND_CODE');
+if ($brandCode !== false && $brandCode !== '') {
+    Configuration::updateValue('PS_TWO_BRAND_CODE', $brandCode);
+    echo "Brand code set to {$brandCode}" . PHP_EOL;
+}
 
 // --- Verify the API key against Two so merchant_short_name gets populated. ---
 // TWO_API_BASE_URL is set by the Makefile from gcloud identity:

--- a/dev/lg-audit-2026-06-10.md
+++ b/dev/lg-audit-2026-06-10.md
@@ -1,0 +1,119 @@
+# LG Prestashop Plugin Audit — 2026-06-10
+
+Store: `amigos.tiendadelamigolg.com` (sandbox)
+PS version: 1.7.6.5
+Plugin version: 2.4.0 (current)
+
+---
+
+## Presenting symptom
+
+Buyer places order, Two API call succeeds, checkout never progresses. No visible error.
+
+---
+
+## Installed modules
+
+### Payment / Checkout
+| Module | Tech name | Version | Author | Status |
+|---|---|---|---|---|
+| PrestaShop Checkout | `ps_checkout` | 1.5.2 | PrestaShop | **Enabled** |
+| PayPal | `paypal` | 5.7.7 | 202 ecommerce | **Enabled** |
+| Bank wire | `ps_wirepayment` | 2.1.0 | PrestaShop | **Enabled** |
+| Cheque | `ps_checkpayment` | 2.0.4 | PrestaShop | Disabled |
+| Cetelem financing | `cetelempayment` | 17.6.4 | Dabasystem | Disabled |
+
+### Shipping / Cart
+| Module | Tech name | Version | Author | Status |
+|---|---|---|---|---|
+| Cart block | `ps_shoppingcart` | 2.0.3 | PrestaShop | **Enabled** |
+| Logistics | `logistics_categories` | 1.0.0 | Imagar | **Enabled** |
+| Advanced Pack | `pm_advancedpack` | 5.2.11 | Presta-Module | **Enabled** |
+
+### Other
+| Module | Tech name | Version | Author | Status |
+|---|---|---|---|---|
+| Search bar | `ps_searchbar` | 2.0.1 | PrestaShop | **Enabled** |
+| Language selector | `ps_languageselector` | 2.1.0 | PrestaShop | **Enabled** |
+| Share buttons | `ps_sharebuttons` | 2.1.0 | PrestaShop | **Enabled** |
+| Bulk actions | `massactions` | 2.4.1 | ZLab Solutions | **Enabled** |
+| Hide product/category | `addifyhideprocat` | 1.3.1 | Addify | **Enabled** |
+| Currency selector | `ps_currencyselector` | 2.0.1 | PrestaShop | Disabled |
+| Faceted search | `ps_facetedsearch` | 4.0.4 | PrestaShop | Disabled |
+| Migration tool | `migrationpro` | 6.2.0 | MigrationPro | Disabled |
+
+---
+
+## Two plugin settings
+
+| Setting | Value |
+|---|---|
+| API Key | **Empty** |
+| Environment | **Development** (→ `api.sandbox.two.inc`) |
+| Title | Business invoice 30 days |
+| Payment term type | STANDARD |
+| Active terms | 7, 15, 20, 30 days |
+| Account type selector | No |
+| Company autocomplete | Yes |
+| Auto-fulfil with Two | Yes |
+| Fulfilled status trigger | Shipped (stored correctly; visually blank in multi-select — cosmetic rendering issue) |
+| Debug mode | No |
+| SSL verify disabled | No |
+
+---
+
+## Root cause of checkout hang
+
+### Immediate cause: no API key
+
+Flow:
+1. Order intent AJAX → `api.sandbox.two.inc/v1/order_intent` — **succeeds** (intent endpoint requires no API key by design)
+2. Customer clicks Place Order
+3. `payment.php` calls backend intent check → passes (same reason)
+4. `payment.php` POSTs to `/v1/order` with no `X-API-Key` header → **401**
+5. `failCheckout()` fires → `$this->errors[] = message; redirectWithNotifications('index.php?controller=order')`
+6. `ps_checkout` submitted the form via AJAX — gets back a 302 redirect response
+7. AJAX follows redirect, receives checkout page HTML — `ps_checkout` has no handler for this
+8. UI freezes silently. Customer sees nothing.
+
+**Fix for this customer: add their sandbox API key in the Two plugin config.**
+
+### Structural cause: `ps_checkout` AJAX incompatibility (TWO-24768)
+
+Our `failCheckout()` always redirects. `ps_checkout` submits payment forms via AJAX — a 302 in response to AJAX is silently swallowed. This will cause silent failures for *any* error condition on a `ps_checkout` store, not just missing API key.
+
+We have zero `ps_checkout`-specific code in the plugin.
+
+Tracked in Linear: [TWO-24768](https://linear.app/tillit/issue/TWO-24768)
+
+---
+
+## Secondary findings
+
+### Multi-select rendering cosmetic bug
+The "fulfilled status trigger" multi-select appears empty in the admin UI, but "Currently active: Shipped" is shown below it — the stored value is correct. Likely a type mismatch (int vs string) in our `HelperForm` option rendering causing the pre-selection to fail visually.
+
+### Duplicate PayPal paths
+`ps_checkout` bundles PayPal via its own Braintree/PayPal SDK. The standalone `paypal` module by 202 ecommerce is also enabled. Classic source of duplicate PayPal buttons and order-state collisions — worth flagging to the customer.
+
+### `logistics_categories` v1.0.0 (Imagar)
+Bespoke shipping module at initial version. Custom carrier logic hooks the cart — highest-suspicion item if shipping calculation ever misbehaves.
+
+### `pm_advancedpack` (Advanced Pack)
+Hooks cart and order creation for product bundles. If bundle products are in the cart, this can cause cart-hash drift between our intent snapshot and order creation. Monitor if reconciliation errors appear.
+
+### `migrationpro` left installed
+Heavyweight migration/upgrade tool sitting on a live (sandbox) store — disabled but should be removed.
+
+---
+
+## Actions
+
+| # | Action | Owner |
+|---|---|---|
+| 1 | Add sandbox API key to Two plugin config | Customer |
+| 2 | Confirm environment = Development is intentional for this sandbox store | Customer |
+| 3 | Fix `failCheckout` to return JSON on AJAX requests (TWO-24768) | Two eng |
+| 4 | Investigate multi-select pre-selection rendering bug | Two eng |
+| 5 | Advise customer to disable standalone `paypal` module (conflicts with `ps_checkout`) | Support |
+| 6 | Advise customer to remove `migrationpro` from production | Support |

--- a/dev/probe-hosts.php
+++ b/dev/probe-hosts.php
@@ -1,0 +1,12 @@
+<?php
+define('_PS_ADMIN_DIR_', '/var/www/html/admin-dev');
+require '/var/www/html/config/config.inc.php';
+$mod = Module::getInstanceByName('twopayment');
+echo "_PS_MODE_DEV_: " . (_PS_MODE_DEV_ ? 'true' : 'false') . "\n";
+echo "getenv TWO_API_BASE_URL: '" . getenv('TWO_API_BASE_URL') . "'\n";
+echo "getenv TWO_PORTAL_BASE_URL: '" . getenv('TWO_PORTAL_BASE_URL') . "'\n";
+echo "PS_TWO_ENVIRONMENT (config): '" . Configuration::get('PS_TWO_ENVIRONMENT') . "'\n";
+echo "getTwoCheckoutHostUrl(): " . $mod->getTwoCheckoutHostUrl() . "\n";
+echo "getTwoPortalUrl(): " . $mod->getTwoPortalUrl() . "\n";
+echo "merchant_short_name: '" . $mod->merchant_short_name . "'\n";
+echo "api_key_verified: " . Configuration::get('PS_TWO_API_KEY_VERIFIED') . "\n";

--- a/dev/probe-payment.php
+++ b/dev/probe-payment.php
@@ -1,0 +1,36 @@
+<?php
+define('_PS_ADMIN_DIR_', '/var/www/html/admin-dev');
+require '/var/www/html/config/config.inc.php';
+
+$cartId = (int)($argv[1] ?? 6);
+$ctx = Context::getContext();
+$cart = new Cart($cartId);
+if (!Validate::isLoadedObject($cart)) {
+    echo "cart $cartId not found\n";
+    exit(1);
+}
+$ctx->cart = $cart;
+$ctx->customer = new Customer($cart->id_customer);
+$ctx->currency = new Currency($cart->id_currency ?: 1);
+$ctx->language = new Language($cart->id_lang ?: 1);
+$ctx->shop = new Shop((int)$cart->id_shop ?: 1);
+
+$mod = Module::getInstanceByName('twopayment');
+echo "module loaded: " . ($mod ? 'yes' : 'NO') . "\n";
+echo "active=" . ($mod->active ? '1' : '0') . "\n";
+echo "merchant_short_name='" . $mod->merchant_short_name . "'\n";
+echo "api_key_empty=" . (empty($mod->api_key) ? 'YES' : 'no') . "\n";
+echo "cart id_address_invoice=" . $cart->id_address_invoice . "\n";
+echo "cart id_carrier=" . $cart->id_carrier . "\n";
+echo "PS_TWO_USE_ACCOUNT_TYPE=" . Configuration::get('PS_TWO_USE_ACCOUNT_TYPE') . "\n";
+if ($cart->id_address_invoice) {
+    $addr = new Address($cart->id_address_invoice);
+    echo "billing address loaded: " . (Validate::isLoadedObject($addr) ? 'yes' : 'NO') . "\n";
+    echo "billing address country iso: ";
+    $country = new Country($addr->id_country);
+    echo $country->iso_code . "\n";
+    echo "billing address account_type: '" . ($addr->account_type ?? '(null)') . "'\n";
+}
+
+$result = $mod->hookPaymentOptions(['cart' => $cart]);
+echo "hookPaymentOptions returned: " . var_export($result, true) . "\n";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -814,6 +814,16 @@ namespace {
         {
             return $string;
         }
+
+        public function setTwoBrand(array $brand): void
+        {
+            $this->brand = $brand;
+        }
+
+        public function applyTwoBrandPayloadIdentityForTests(array $request_data): array
+        {
+            return $this->applyTwoBrandPayloadIdentity($request_data);
+        }
     }
 
     StubStore::reset();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -607,6 +607,17 @@ namespace {
         public bool $loaded = false;
         public int $id = 0;
         public string $iso_code = 'EUR';
+        public float $conversion_rate = 1.0;
+
+        public static function getIdByIsoCode($iso_code)
+        {
+            foreach (StubStore::$currencies as $id => $fields) {
+                if (($fields['iso_code'] ?? null) === $iso_code) {
+                    return (int) $id;
+                }
+            }
+            return 0;
+        }
 
         public function __construct($id = null)
         {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -271,9 +271,18 @@ namespace {
 
     class PrestaShopLogger
     {
+        /** @var array<int,array{message:string,severity:int}> */
+        public static array $logs = [];
+
         public static function addLog($message, $severity = 1, $errorCode = null, $objectType = null, $objectId = null, $allowDuplicate = false): bool
         {
+            self::$logs[] = ['message' => (string) $message, 'severity' => (int) $severity];
             return true;
+        }
+
+        public static function reset(): void
+        {
+            self::$logs = [];
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -820,10 +820,6 @@ namespace {
             $this->brand = $brand;
         }
 
-        public function applyTwoBrandPayloadIdentityForTests(array $request_data): array
-        {
-            return $this->applyTwoBrandPayloadIdentity($request_data);
-        }
     }
 
     StubStore::reset();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -835,6 +835,11 @@ namespace {
         {
             return $this->applyTwoBrandPayloadIdentity($request_data);
         }
+
+        public function getTwoPlatformMinimumInDefaultCurrencyForTests(array $gate)
+        {
+            return $this->getTwoPlatformMinimumInDefaultCurrency($gate);
+        }
     }
 
     StubStore::reset();

--- a/tests/run.php
+++ b/tests/run.php
@@ -162,6 +162,7 @@ final class OrderBuilderSpec
         self::testAvailabilityGateChecksBillingCountry();
         self::testAvailabilityGateGrossBasis();
         self::testMerchantMinimumGatesAlone();
+        self::testPlatformMinimumConvertsToDefaultCurrency();
         self::testBrandPayloadIdentityOmittedForTwoBrand();
         self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
@@ -536,6 +537,30 @@ final class OrderBuilderSpec
 
         StubStore::$cartTotals[22][true][Cart::BOTH] = 500.0;
         TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testPlatformMinimumConvertsToDefaultCurrency(): void
+    {
+        self::reset();
+        // Shop default GBP; brand minimum 250 EUR; EUR rate 1.16 per GBP
+        // -> floor 215.52 GBP. Missing rate -> null (validation skips,
+        // checkout gate fails closed instead).
+        StubStore::$currencies[826] = ['iso_code' => 'GBP', 'conversion_rate' => 1.0];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.16];
+        StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 826;
+        $module = new TwopaymentTestHarness();
+
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net', 'billing_countries' => ['NL']];
+        TinyAssert::same(215.52, $module->getTwoPlatformMinimumInDefaultCurrencyForTests($gate));
+
+        // Same currency: no conversion
+        StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 978;
+        TinyAssert::same(250.0, $module->getTwoPlatformMinimumInDefaultCurrencyForTests($gate));
+
+        // No rate for the brand currency
+        unset(StubStore::$currencies[978]);
+        StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 826;
+        TinyAssert::same(null, $module->getTwoPlatformMinimumInDefaultCurrencyForTests($gate));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -163,6 +163,7 @@ final class OrderBuilderSpec
         self::testAvailabilityGateGrossBasis();
         self::testMerchantMinimumGatesAlone();
         self::testPlatformMinimumConvertsToDefaultCurrency();
+        self::testMinimumOrderDeclineHint();
         self::testBrandPayloadIdentityOmittedForTwoBrand();
         self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
@@ -561,6 +562,45 @@ final class OrderBuilderSpec
         unset(StubStore::$currencies[978]);
         StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 826;
         TinyAssert::same(null, $module->getTwoPlatformMinimumInDefaultCurrencyForTests($gate));
+    }
+
+    private static function testMinimumOrderDeclineHint(): void
+    {
+        self::reset();
+        StubStore::$currencies[826] = ['iso_code' => 'GBP', 'conversion_rate' => 1.0];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.16];
+        StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 826;
+        $module = new TwopaymentTestHarness();
+        $module->setTwoBrand([
+            'product_name' => 'Testbrand',
+            'availability_gate' => [
+                'min_order_amount' => 250.0,
+                'currency' => 'EUR',
+                'basis' => 'net',
+                'billing_countries' => ['NL'],
+            ],
+        ]);
+
+        $cart = new Cart(31);
+        $cart->id_currency = 826;
+        StubStore::$cartTotals[31][false][Cart::BOTH] = 100.0;
+
+        // Machine-readable reason: hint in the cart currency (250 EUR -> 215.52 GBP)
+        $hint = $module->getTwoMinimumOrderDeclineHint('ORDER_BELOW_MIN_INVOICE_AMOUNT', $cart);
+        TinyAssert::same('Minimum order value is 215.52 GBP excluding tax.', $hint);
+
+        // Generic reason, basket strictly below the minimum: fallback hint fires
+        $hint = $module->getTwoMinimumOrderDeclineHint(null, $cart);
+        TinyAssert::same('Minimum order value is 215.52 GBP excluding tax.', $hint);
+
+        // Generic reason, basket at/above the minimum: no hint
+        StubStore::$cartTotals[31][false][Cart::BOTH] = 300.0;
+        TinyAssert::same('', $module->getTwoMinimumOrderDeclineHint(null, $cart));
+
+        // No usable rate: fail-soft, no hint even with the explicit reason
+        unset(StubStore::$currencies[978]);
+        StubStore::$cartTotals[31][false][Cart::BOTH] = 100.0;
+        TinyAssert::same('', $module->getTwoMinimumOrderDeclineHint('ORDER_BELOW_MIN_INVOICE_AMOUNT', $cart));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -160,6 +160,8 @@ final class OrderBuilderSpec
         self::testAvailabilityGateConvertsViaPrestashopRates();
         self::testAvailabilityGateFailsClosedWithoutRate();
         self::testAvailabilityGateChecksBillingCountry();
+        self::testAvailabilityGateGrossBasis();
+        self::testMerchantMinimumGatesAlone();
         self::testBrandPayloadIdentityOmittedForTwoBrand();
         self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
@@ -447,7 +449,7 @@ final class OrderBuilderSpec
     {
         self::reset();
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
-        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net', 'billing_countries' => ['NL']];
         // 56 => BE in the stub country table; add NL
         StubStore::$countries[100] = 'NL';
 
@@ -466,7 +468,7 @@ final class OrderBuilderSpec
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
         StubStore::$currencies[826] = ['iso_code' => 'GBP', 'conversion_rate' => 0.85];
         StubStore::$countries[100] = 'NL';
-        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net', 'billing_countries' => ['NL']];
 
         // GBP 230 net -> EUR 270.59: passes only because of conversion
         [$module, $cart, $address] = self::gateFixture($gate, 230.0, 826, 100);
@@ -483,7 +485,7 @@ final class OrderBuilderSpec
         // SEK exists but the gate currency EUR has no stub entry: no rate
         StubStore::$currencies[752] = ['iso_code' => 'SEK', 'conversion_rate' => 11.0];
         StubStore::$countries[100] = 'NL';
-        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net', 'billing_countries' => ['NL']];
 
         [$module, $cart, $address] = self::gateFixture($gate, 10000.0, 752, 100);
         TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
@@ -493,11 +495,47 @@ final class OrderBuilderSpec
     {
         self::reset();
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
-        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net', 'billing_countries' => ['NL']];
 
         // 47 => NO in the stub country table
         [$module, $cart, $address] = self::gateFixture($gate, 300.0, 978, 47);
         TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testAvailabilityGateGrossBasis(): void
+    {
+        self::reset();
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
+        StubStore::$countries[100] = 'NL';
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'basis' => 'gross', 'billing_countries' => ['NL']];
+
+        // Gross basis compares the with-tax total
+        [$module, $cart, $address] = self::gateFixture($gate, 0.0, 978, 100);
+        StubStore::$cartTotals[21][true][Cart::BOTH] = 250.0;
+        TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+        StubStore::$cartTotals[21][true][Cart::BOTH] = 249.99;
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testMerchantMinimumGatesAlone(): void
+    {
+        self::reset();
+        // No brand gate (Two): the merchant's own minimum gates, gross,
+        // in the shop default currency
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
+        StubStore::$configuration['PS_CURRENCY_DEFAULT'] = 978;
+        StubStore::$configuration['PS_TWO_MERCHANT_MIN_ORDER'] = '500';
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(22);
+        $cart->id_currency = 978;
+        $address = new Address();
+
+        StubStore::$cartTotals[22][true][Cart::BOTH] = 499.0;
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+
+        StubStore::$cartTotals[22][true][Cart::BOTH] = 500.0;
+        TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -155,8 +155,6 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsAllowsPositiveDiscount();
         self::testGetTwoProductItemsToleratesUnitPriceRoundingDrift();
         self::testBrandConfigLoadsAndIsAccessibleFromModule();
-        self::testBrandPayloadIdentityOmittedForTwoBrand();
-        self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
     }
@@ -381,35 +379,6 @@ final class OrderBuilderSpec
         TinyAssert::same('two', $brand['code']);
         TinyAssert::same('Two', $brand['product_name']);
         TinyAssert::same('Two - BNPL for businesses', $brand['display_name']);
-        // The Two brand must not declare payload identity (payload parity
-        // with the pre-brand-config module)
-        TinyAssert::same('', $brand['vendor_name']);
-    }
-
-    private static function testBrandPayloadIdentityOmittedForTwoBrand(): void
-    {
-        self::reset();
-        $module = new TwopaymentTestHarness();
-
-        $payload = $module->applyTwoBrandPayloadIdentityForTests(['currency' => 'EUR']);
-
-        TinyAssert::same(['currency' => 'EUR'], $payload);
-    }
-
-    private static function testBrandPayloadIdentityAppliedWhenBrandSetsIt(): void
-    {
-        self::reset();
-        $module = new TwopaymentTestHarness();
-        $module->setTwoBrand([
-            'vendor_name' => 'Partner Vendor',
-        ]);
-
-        $payload = $module->applyTwoBrandPayloadIdentityForTests(['currency' => 'EUR']);
-
-        TinyAssert::same('Partner Vendor', $payload['vendor_name']);
-        // brand_tag is deliberately NOT a payload field: the Magento
-        // reference uses it only as a checkout-URL query param.
-        TinyAssert::false(isset($payload['brand_tag']));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void
@@ -565,8 +534,10 @@ final class OrderBuilderSpec
         TinyAssert::same('105.50', $payload['gross_amount']);
         TinyAssert::same('100.00', $payload['net_amount']);
         TinyAssert::same('5.50', $payload['tax_amount']);
-        // Two-brand payload parity: the brand layer must not add identity
-        // keys to a real built payload (empty vendor_name stays omitted)
+        // Brand-layer payload parity: brand config must never add identity
+        // keys to the order body. vendor_name is a marketplace-seller field
+        // the merchant declares (see the parity plan), brand_tag is a
+        // checkout-URL param — neither belongs to a brand.
         TinyAssert::false(isset($payload['vendor_name']));
         TinyAssert::false(isset($payload['brand_tag']));
         TinyAssert::same('0.055', $payload['line_items'][0]['tax_rate']);

--- a/tests/run.php
+++ b/tests/run.php
@@ -152,6 +152,8 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsSkipsEmptyBarcodeEntries();
         self::testGetTwoProductItemsThrowsOnNegativeDiscount();
         self::testGetTwoProductItemsThrowsOnNegativeReduction();
+        self::testGetTwoProductItemsAllowsPositiveDiscount();
+        self::testGetTwoProductItemsToleratesUnitPriceRoundingDrift();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
     }
@@ -159,6 +161,7 @@ final class OrderBuilderSpec
     private static function reset(): void
     {
         StubStore::reset();
+        PrestaShopLogger::reset();
     }
 
     private static function testValidateTwoLineItemsRejectsBrokenTaxFormula(): void
@@ -316,6 +319,13 @@ final class OrderBuilderSpec
             },
             'Negative discount calculated for product 888'
         );
+
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(3, PrestaShopLogger::$logs[0]['severity']);
+        TinyAssert::true(
+            strpos(PrestaShopLogger::$logs[0]['message'], '100 = 100 < net total 105') !== false,
+            'Log line must include the computed amounts: ' . PrestaShopLogger::$logs[0]['message']
+        );
     }
 
     private static function testGetTwoProductItemsThrowsOnNegativeReduction(): void
@@ -351,8 +361,89 @@ final class OrderBuilderSpec
             static function () use ($module, $cart): void {
                 $module->getTwoProductItems($cart);
             },
-            'Negative discount calculated for product 889'
+            'Negative reduction for product 889'
         );
+
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(3, PrestaShopLogger::$logs[0]['severity']);
+    }
+
+    private static function testGetTwoProductItemsAllowsPositiveDiscount(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(14);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // quantity * unit_price (100.00) > net total (95.00) -> 5.00 discount,
+        // the healthy discounted-cart path must keep working
+        StubStore::$cartProducts[14] = [[
+            'id_product' => 890,
+            'link_rewrite' => 'discounted-product',
+            'name' => 'Discounted Product',
+            'description_short' => 'Cart-rule discounted',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 95.00,
+            'total_wt' => 114.95,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[890] = [['name' => 'Misc']];
+        StubStore::$images[890] = ['id_image' => 9014];
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('5.00', (string)$items[0]['discount_amount']);
+        TinyAssert::same('95.00', (string)$items[0]['net_amount']);
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+
+    private static function testGetTwoProductItemsToleratesUnitPriceRoundingDrift(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(15);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // PrestaShop stores unit prices at 6dp: 3 x 8.344 = 25.032, line total
+        // rounded to 25.03. Deriving the discount from the ROUNDED unit price
+        // (3 x 8.34 = 25.02) would manufacture a phantom -0.01 discount and
+        // fail the cart; deriving at full precision yields 0.00.
+        StubStore::$cartProducts[15] = [[
+            'id_product' => 891,
+            'link_rewrite' => 'six-decimal-product',
+            'name' => 'Six Decimal Product',
+            'description_short' => 'Unit price with 3rd-decimal precision',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 25.03,
+            'total_wt' => 30.29,
+            'cart_quantity' => 3,
+            'rate' => 21.0,
+            'price' => 8.344,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[891] = [['name' => 'Misc']];
+        StubStore::$images[891] = ['id_image' => 9015];
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('0.00', (string)$items[0]['discount_amount']);
+        TinyAssert::same('25.03', (string)$items[0]['net_amount']);
+        TinyAssert::count(0, PrestaShopLogger::$logs);
     }
 
     private static function testGetTwoNewOrderDataSupportsFivePointFivePercentVat(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -155,6 +155,11 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsAllowsPositiveDiscount();
         self::testGetTwoProductItemsToleratesUnitPriceRoundingDrift();
         self::testBrandConfigLoadsAndIsAccessibleFromModule();
+        self::testAvailabilityGateAbsentForTwoBrand();
+        self::testAvailabilityGateComparesNetAndHidesBelowMinimum();
+        self::testAvailabilityGateConvertsViaPrestashopRates();
+        self::testAvailabilityGateFailsClosedWithoutRate();
+        self::testAvailabilityGateChecksBillingCountry();
         self::testBrandPayloadIdentityOmittedForTwoBrand();
         self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
@@ -410,6 +415,89 @@ final class OrderBuilderSpec
         // brand_tag is deliberately NOT a payload field: the Magento
         // reference uses it only as a checkout-URL query param.
         TinyAssert::false(isset($payload['brand_tag']));
+    }
+
+    private static function gateFixture(array $gate, float $netTotal, int $idCurrency, int $idCountry): array
+    {
+        $module = new TwopaymentTestHarness();
+        $module->setTwoBrand(['availability_gate' => $gate]);
+
+        $cart = new Cart(21);
+        $cart->id_currency = $idCurrency;
+        StubStore::$cartTotals[21][false][Cart::BOTH] = $netTotal;
+
+        $address = new Address();
+        $address->id_country = $idCountry;
+
+        return [$module, $cart, $address];
+    }
+
+    private static function testAvailabilityGateAbsentForTwoBrand(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(20);
+        $address = new Address();
+
+        TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testAvailabilityGateComparesNetAndHidesBelowMinimum(): void
+    {
+        self::reset();
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+        // 56 => BE in the stub country table; add NL
+        StubStore::$countries[100] = 'NL';
+
+        [$module, $cart, $address] = self::gateFixture($gate, 249.99, 978, 100);
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+
+        // The minimum is inclusive and compares NET
+        [$module, $cart, $address] = self::gateFixture($gate, 250.0, 978, 100);
+        TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testAvailabilityGateConvertsViaPrestashopRates(): void
+    {
+        self::reset();
+        // Shop default currency EUR (rate 1.0); cart in GBP at 0.85 per EUR
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
+        StubStore::$currencies[826] = ['iso_code' => 'GBP', 'conversion_rate' => 0.85];
+        StubStore::$countries[100] = 'NL';
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+
+        // GBP 230 net -> EUR 270.59: passes only because of conversion
+        [$module, $cart, $address] = self::gateFixture($gate, 230.0, 826, 100);
+        TinyAssert::true($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+
+        // GBP 200 net -> EUR 235.29: hidden
+        [$module, $cart, $address] = self::gateFixture($gate, 200.0, 826, 100);
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testAvailabilityGateFailsClosedWithoutRate(): void
+    {
+        self::reset();
+        // SEK exists but the gate currency EUR has no stub entry: no rate
+        StubStore::$currencies[752] = ['iso_code' => 'SEK', 'conversion_rate' => 11.0];
+        StubStore::$countries[100] = 'NL';
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+
+        [$module, $cart, $address] = self::gateFixture($gate, 10000.0, 752, 100);
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
+    }
+
+    private static function testAvailabilityGateChecksBillingCountry(): void
+    {
+        self::reset();
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'conversion_rate' => 1.0];
+        $gate = ['min_order_amount' => 250.0, 'currency' => 'EUR', 'billing_countries' => ['NL']];
+
+        // 47 => NO in the stub country table
+        [$module, $cart, $address] = self::gateFixture($gate, 300.0, 978, 47);
+        TinyAssert::false($module->isTwoBrandAvailabilityGateSatisfied($cart, $address));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -154,6 +154,9 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsThrowsOnNegativeReduction();
         self::testGetTwoProductItemsAllowsPositiveDiscount();
         self::testGetTwoProductItemsToleratesUnitPriceRoundingDrift();
+        self::testBrandConfigLoadsAndIsAccessibleFromModule();
+        self::testBrandPayloadIdentityOmittedForTwoBrand();
+        self::testBrandPayloadIdentityAppliedWhenBrandSetsIt();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
     }
@@ -366,6 +369,47 @@ final class OrderBuilderSpec
 
         TinyAssert::count(1, PrestaShopLogger::$logs);
         TinyAssert::same(3, PrestaShopLogger::$logs[0]['severity']);
+    }
+
+    private static function testBrandConfigLoadsAndIsAccessibleFromModule(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $brand = $module->getTwoBrand();
+
+        TinyAssert::same('two', $brand['code']);
+        TinyAssert::same('Two', $brand['product_name']);
+        TinyAssert::same('Two - BNPL for businesses', $brand['display_name']);
+        // The Two brand must not declare payload identity (payload parity
+        // with the pre-brand-config module)
+        TinyAssert::same('', $brand['vendor_name']);
+        TinyAssert::same('', $brand['brand_tag']);
+    }
+
+    private static function testBrandPayloadIdentityOmittedForTwoBrand(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $payload = $module->applyTwoBrandPayloadIdentityForTests(['currency' => 'EUR']);
+
+        TinyAssert::same(['currency' => 'EUR'], $payload);
+    }
+
+    private static function testBrandPayloadIdentityAppliedWhenBrandSetsIt(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $module->setTwoBrand([
+            'vendor_name' => 'Partner Vendor',
+            'brand_tag' => 'partnertag',
+        ]);
+
+        $payload = $module->applyTwoBrandPayloadIdentityForTests(['currency' => 'EUR']);
+
+        TinyAssert::same('Partner Vendor', $payload['vendor_name']);
+        TinyAssert::same('partnertag', $payload['brand_tag']);
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -150,6 +150,8 @@ final class OrderBuilderSpec
         self::testGetTwoErrorMessageReadsNestedDataMessage();
         self::testGetTwoErrorMessageIgnoresSuccessMessagePayload();
         self::testGetTwoProductItemsSkipsEmptyBarcodeEntries();
+        self::testGetTwoProductItemsThrowsOnNegativeDiscount();
+        self::testGetTwoProductItemsThrowsOnNegativeReduction();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
     }
@@ -276,6 +278,81 @@ final class OrderBuilderSpec
         TinyAssert::same('10.55', (string)$items[1]['gross_amount']);
         TinyAssert::same('0.55', (string)$items[1]['tax_amount']);
         TinyAssert::same('0.055', (string)$items[1]['tax_rate']);
+    }
+
+    private static function testGetTwoProductItemsThrowsOnNegativeDiscount(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(12);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // quantity * unit_price (100.00) < net total (105.00) -> negative discount,
+        // previously clamped to 0, now surfaced as an error
+        StubStore::$cartProducts[12] = [[
+            'id_product' => 888,
+            'link_rewrite' => 'mispriced-product',
+            'name' => 'Mispriced Product',
+            'description_short' => 'Inconsistent pricing data',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 105.00,
+            'total_wt' => 127.05,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+
+        StubStore::$productCategories[888] = [['name' => 'Misc']];
+        StubStore::$images[888] = ['id_image' => 9012];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Negative discount calculated for product 888'
+        );
+    }
+
+    private static function testGetTwoProductItemsThrowsOnNegativeReduction(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(13);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 999;
+
+        // No unit price -> reduction branch; a negative reduction is a data
+        // inconsistency, previously zeroed silently, now surfaced as an error
+        StubStore::$cartProducts[13] = [[
+            'id_product' => 889,
+            'link_rewrite' => 'negative-reduction-product',
+            'name' => 'Negative Reduction Product',
+            'description_short' => 'Inconsistent reduction data',
+            'manufacturer_name' => 'Acme',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 121.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'reduction' => -2.00,
+        ]];
+
+        StubStore::$productCategories[889] = [['name' => 'Misc']];
+        StubStore::$images[889] = ['id_image' => 9013];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Negative discount calculated for product 889'
+        );
     }
 
     private static function testGetTwoNewOrderDataSupportsFivePointFivePercentVat(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -384,7 +384,6 @@ final class OrderBuilderSpec
         // The Two brand must not declare payload identity (payload parity
         // with the pre-brand-config module)
         TinyAssert::same('', $brand['vendor_name']);
-        TinyAssert::same('', $brand['brand_tag']);
     }
 
     private static function testBrandPayloadIdentityOmittedForTwoBrand(): void
@@ -403,13 +402,14 @@ final class OrderBuilderSpec
         $module = new TwopaymentTestHarness();
         $module->setTwoBrand([
             'vendor_name' => 'Partner Vendor',
-            'brand_tag' => 'partnertag',
         ]);
 
         $payload = $module->applyTwoBrandPayloadIdentityForTests(['currency' => 'EUR']);
 
         TinyAssert::same('Partner Vendor', $payload['vendor_name']);
-        TinyAssert::same('partnertag', $payload['brand_tag']);
+        // brand_tag is deliberately NOT a payload field: the Magento
+        // reference uses it only as a checkout-URL query param.
+        TinyAssert::false(isset($payload['brand_tag']));
     }
 
     private static function testGetTwoProductItemsAllowsPositiveDiscount(): void
@@ -565,6 +565,10 @@ final class OrderBuilderSpec
         TinyAssert::same('105.50', $payload['gross_amount']);
         TinyAssert::same('100.00', $payload['net_amount']);
         TinyAssert::same('5.50', $payload['tax_amount']);
+        // Two-brand payload parity: the brand layer must not add identity
+        // keys to a real built payload (empty vendor_name stays omitted)
+        TinyAssert::false(isset($payload['vendor_name']));
+        TinyAssert::false(isset($payload['brand_tag']));
         TinyAssert::same('0.055', $payload['line_items'][0]['tax_rate']);
     }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -2189,6 +2189,75 @@ class Twopayment extends PaymentModule
         }
     }
 
+    /**
+     * Brand product constraints (e.g. a partner edition's minimum NET
+     * order value in a specific currency/market) hide the payment option
+     * when unmet. NET because the funding partner's server-side risk
+     * rule compares the order's net value — a gross-compared gate would
+     * show the option on baskets the credit check then declines. Baskets
+     * in other currencies convert via PrestaShop's currency rates,
+     * failing closed without a usable rate. The Two brand sets no gate.
+     *
+     * @param Cart $cart
+     * @param Address $billing_address
+     *
+     * @return bool
+     */
+    public function isTwoBrandAvailabilityGateSatisfied($cart, $billing_address)
+    {
+        $brand = $this->getTwoBrand();
+        $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
+        if (!$gate) {
+            return true;
+        }
+        if (!isset($gate['min_order_amount'], $gate['currency'], $gate['billing_countries'])) {
+            // Malformed gate config must not judge with missing criteria
+            return true;
+        }
+
+        $billing_country = Country::getIsoById((int) $billing_address->id_country);
+        if (!in_array($billing_country, $gate['billing_countries'], true)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Payment option hidden - billing country ' . ($billing_country ?: 'unknown')
+                . ' outside the brand gate (' . implode(',', $gate['billing_countries']) . ')',
+                1
+            );
+            return false;
+        }
+
+        $net_total = (float) $cart->getOrderTotal(false, Cart::BOTH);
+        $cart_currency = new Currency((int) $cart->id_currency);
+        if ($cart_currency->iso_code !== $gate['currency']) {
+            // PrestaShop stores each currency's rate against the shop
+            // default currency; the cross rate is target/source
+            $from_rate = (float) $cart_currency->conversion_rate;
+            $to_id = Currency::getIdByIsoCode($gate['currency']);
+            $to_rate = $to_id ? (float) (new Currency((int) $to_id))->conversion_rate : 0.0;
+            if ($from_rate <= 0 || $to_rate <= 0) {
+                // Fail closed: without a rate we cannot prove the brand's
+                // minimum is met
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Payment option hidden - no conversion rate from '
+                    . $cart_currency->iso_code . ' to ' . $gate['currency'] . ' for the brand gate',
+                    2
+                );
+                return false;
+            }
+            $net_total = round($net_total / $from_rate * $to_rate, 2);
+        }
+
+        if ($net_total < (float) $gate['min_order_amount']) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Payment option hidden - net total ' . $net_total . ' ' . $gate['currency']
+                . ' below the brand minimum ' . $gate['min_order_amount'],
+                1
+            );
+            return false;
+        }
+
+        return true;
+    }
+
     public function hookPaymentOptions($params)
     {
         if (!$this->active) {
@@ -2217,6 +2286,10 @@ class Twopayment extends PaymentModule
                 'TwoPayment: Payment option hidden - unsupported cart currency for cart ' . (int)$cart->id,
                 2
             );
+            return [];
+        }
+
+        if (!$this->isTwoBrandAvailabilityGateSatisfied($cart, $billing_address)) {
             return [];
         }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -14,7 +14,6 @@ if (!defined('_PS_VERSION_')) {
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic
-    const GROSS_AMOUNT_TOLERANCE = 0.02; // 2 cents tolerance for rounding differences
     const ORDER_INTENT_EXPIRY_SECONDS = 1800; // 30 minutes
     
     // Constants for payment terms
@@ -3174,22 +3173,25 @@ class Twopayment extends PaymentModule
                 // Calculate discount from PrestaShop's values
                 $expected_total = $quantity * $unit_price_net;
                 $discount_amount = round($expected_total - $net_amount_prestashop, 2);
-                
-                // Ensure discount is not negative (protect against edge cases)
+
+                // A negative discount means quantity * unit_price < net total - a data
+                // inconsistency we must surface, not silently correct. The checkout-api
+                // validates order amounts and rejects bad payloads with a clear error.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ', clamping to 0', 2);
-                    $discount_amount = 0;
+                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity x unit_price < net total)', 3);
+                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
-                
+
                 $net_amount = $net_amount_prestashop;
             } else {
                 $discount_amount = isset($line_item['reduction']) ? (float)$line_item['reduction'] : 0;
-                
-                // Ensure discount is not negative
+
+                // Surface negative reductions instead of silently zeroing them (see above).
                 if ($discount_amount < 0) {
-                    $discount_amount = 0;
+                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'], 3);
+                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
-                
+
                 $unit_price_net = ($net_amount_prestashop + $discount_amount) / $quantity;
                 $unit_price_net = round($unit_price_net, 2);
                 

--- a/twopayment.php
+++ b/twopayment.php
@@ -92,7 +92,6 @@ class Twopayment extends PaymentModule
             'payment_subtitle' => 'Buy now, pay later - instant credit',
             'support_email' => 'support@two.inc',
             'documentation_url' => 'https://docs.two.inc',
-            'vendor_name' => '',
         );
 
         $config = $defaults;
@@ -108,33 +107,6 @@ class Twopayment extends PaymentModule
         return $this->brand;
     }
 
-    /**
-     * Add the brand's payload identity (vendor_name) to an order request
-     * body. Applied to create, intent AND update bodies so the brand
-     * identity cannot diverge between order lifecycle calls. The key is
-     * only sent when the brand sets it, so the Two brand's payloads are
-     * unchanged.
-     *
-     * vendor_name as a body FIELD has cross-plugin precedent (the
-     * WooCommerce plugin sends it, though from a merchant gateway
-     * option rather than brand config — the source is not yet
-     * converged across plugins). brand_tag does NOT — the Magento
-     * plugin uses it solely as a checkout-URL query param — so it
-     * stays out of the body and lands with the checkout-URL code that
-     * consumes it.
-     *
-     * @param array $request_data
-     *
-     * @return array
-     */
-    protected function applyTwoBrandPayloadIdentity($request_data)
-    {
-        $brand = $this->getTwoBrand();
-        if (!empty($brand['vendor_name'])) {
-            $request_data['vendor_name'] = $brand['vendor_name'];
-        }
-        return $request_data;
-    }
 
     public function __construct()
     {
@@ -2640,7 +2612,7 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
-        return $this->applyTwoBrandPayloadIdentity($request_data);
+        return $request_data;
     }
 
     /**
@@ -2996,8 +2968,6 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
-        $request_data = $this->applyTwoBrandPayloadIdentity($request_data);
-
         PrestaShopLogger::addLog('TwoPayment: Order creation with terms - ' . json_encode($request_data['terms']), 1);
         
         return $request_data;
@@ -3089,7 +3059,7 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
-        return $this->applyTwoBrandPayloadIdentity($request_data);
+        return $request_data;
     }
 
     public function getTwoNewRefundData($order, $two_order_snapshot = null)

--- a/twopayment.php
+++ b/twopayment.php
@@ -3168,28 +3168,34 @@ class Twopayment extends PaymentModule
             $unit_price_net_prestashop = isset($line_item['price']) ? (float)$line_item['price'] : null;
             
             if ($unit_price_net_prestashop !== null) {
-                $unit_price_net = round($unit_price_net_prestashop, 2);
-                
-                // Calculate discount from PrestaShop's values
-                $expected_total = $quantity * $unit_price_net;
+                // Derive the discount at PrestaShop's native precision (6dp) and
+                // round once at the payload boundary. Rounding the unit price to
+                // 2dp before multiplying manufactures phantom +/-0.01 discounts
+                // whenever the third decimal of the unit price rounds opposite to
+                // the line total (e.g. 3 x 8.344: 3x8.34=25.02 vs total 25.03).
+                $expected_total = $quantity * $unit_price_net_prestashop;
                 $discount_amount = round($expected_total - $net_amount_prestashop, 2);
 
                 // A negative discount means quantity * unit_price < net total - a data
                 // inconsistency we must surface, not silently correct. The checkout-api
                 // validates order amounts and rejects bad payloads with a clear error.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity x unit_price < net total)', 3);
+                    PrestaShopLogger::addLog('TwoPayment: Negative discount calculated for product ' . $line_item['id_product'] . ' (quantity ' . $quantity . ' x unit price ' . $unit_price_net_prestashop . ' = ' . $expected_total . ' < net total ' . $net_amount_prestashop . ')', 3);
                     throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
                 }
 
+                $unit_price_net = round($unit_price_net_prestashop, 2);
                 $net_amount = $net_amount_prestashop;
             } else {
-                $discount_amount = isset($line_item['reduction']) ? (float)$line_item['reduction'] : 0;
+                // Round to currency precision before the sign check; sub-cent float
+                // residue in PrestaShop's computed reduction is not a data error.
+                $discount_amount = isset($line_item['reduction']) ? round((float)$line_item['reduction'], 2) : 0;
 
-                // Surface negative reductions instead of silently zeroing them (see above).
+                // A negative reduction is a data inconsistency; surface it rather
+                // than silently zeroing it.
                 if ($discount_amount < 0) {
-                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'], 3);
-                    throw new Exception('Negative discount calculated for product ' . $line_item['id_product']);
+                    PrestaShopLogger::addLog('TwoPayment: Negative reduction for product ' . $line_item['id_product'] . ' (reduction ' . $discount_amount . ')', 3);
+                    throw new Exception('Negative reduction for product ' . $line_item['id_product']);
                 }
 
                 $unit_price_net = ($net_amount_prestashop + $discount_amount) / $quantity;

--- a/twopayment.php
+++ b/twopayment.php
@@ -57,21 +57,64 @@ class Twopayment extends PaymentModule
     protected $errors = array();
     protected $verifiedMerchantId = null;
     protected $verifiedMerchantShortName = null;
+    /** @var array|null Brand config, lazily loaded from brands/two.php */
+    protected $brand = null;
+
+    /**
+     * Brand configuration for this module edition.
+     *
+     * Lazy so every entry point gets the config regardless of how the
+     * module was constructed (PrestaShop instantiation, AJAX
+     * controllers, the test harness which skips the module constructor).
+     *
+     * @return array
+     */
+    public function getTwoBrand()
+    {
+        if ($this->brand === null) {
+            $this->brand = require dirname(__FILE__) . '/brands/two.php';
+        }
+        return $this->brand;
+    }
+
+    /**
+     * Add the brand's payload identity (vendor_name, brand_tag) to an
+     * order request body. Applied to create, intent AND update bodies so
+     * the brand identity cannot diverge between order lifecycle calls.
+     * Keys are only sent when the brand sets them, so the Two brand's
+     * payloads are unchanged.
+     *
+     * @param array $request_data
+     *
+     * @return array
+     */
+    protected function applyTwoBrandPayloadIdentity($request_data)
+    {
+        $brand = $this->getTwoBrand();
+        if (!empty($brand['vendor_name'])) {
+            $request_data['vendor_name'] = $brand['vendor_name'];
+        }
+        if (!empty($brand['brand_tag'])) {
+            $request_data['brand_tag'] = $brand['brand_tag'];
+        }
+        return $request_data;
+    }
 
     public function __construct()
     {
+        $brand = $this->getTwoBrand();
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
         $this->version = '2.4.0';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
-        $this->author = 'Two';
+        $this->author = $brand['provider'];
         $this->bootstrap = true;
         $this->module_key = '0dff0a98ae080e510d4e23d22abcfe9c';
         $this->author_address = '';
         parent::__construct();
         $this->languages = Language::getLanguages(false);
-        $this->displayName = $this->l('Two - BNPL for businesses');
-        $this->description = $this->l('This module allows any merchant to accept payments with Two payment gateway.');
+        $this->displayName = $this->l($brand['display_name']);
+        $this->description = $this->l($brand['description']);
         $this->merchant_short_name = Configuration::get('PS_TWO_MERCHANT_SHORT_NAME');
         $this->api_key = Configuration::get('PS_TWO_MERCHANT_API_KEY');
         $this->enable_company_name = Configuration::get('PS_TWO_ENABLE_COMPANY_NAME');
@@ -1109,8 +1152,8 @@ class Twopayment extends PaymentModule
             <div class="panel-body">
                 <p>' . $this->l('For technical support or questions about this plugin:') . '</p>
                 <ul>
-                    <li><strong>' . $this->l('Email:') . '</strong> <a href="mailto:support@two.inc">support@two.inc</a></li>
-                    <li><strong>' . $this->l('Documentation:') . '</strong> <a href="https://docs.two.inc" target="_blank">docs.two.inc</a></li>
+                    <li><strong>' . $this->l('Email:') . '</strong> <a href="mailto:' . $this->getTwoBrand()['support_email'] . '">' . $this->getTwoBrand()['support_email'] . '</a></li>
+                    <li><strong>' . $this->l('Documentation:') . '</strong> <a href="' . $this->getTwoBrand()['documentation_url'] . '" target="_blank">' . preg_replace('#^https?://#', '', $this->getTwoBrand()['documentation_url']) . '</a></li>
                     <li><strong>' . $this->l('Merchant Portal:') . '</strong> <a href="' . $this->getTwoPortalUrl() . '" target="_blank">' . $this->l('Open Two Portal') . '</a></li>
                 </ul>
                 <p style="margin-top:15px;"><small class="text-muted">' . $this->l('Plugin Version:') . ' ' . $this->version . ' | ' . $this->l('PrestaShop:') . ' ' . _PS_VERSION_ . '</small></p>
@@ -1938,6 +1981,11 @@ class Twopayment extends PaymentModule
             return;
         }
 
+        // Brand identity for templates ({$two_brand.product_name} etc.).
+        // Template {l s='...'} literals stay as-is until the translations
+        // pass (TWO-24760) so existing dictionaries keep matching.
+        $this->context->smarty->assign('two_brand', $this->getTwoBrand());
+
         // CRITICAL FIX FOR PRESTASHOP 1.7.6.5: Multi-layer jQuery loading strategy
         // Issue: addJquery() may exist but not output jQuery to HTML on some installations
         // Solution: Triple-layer approach ensures jQuery is ALWAYS available
@@ -2160,15 +2208,17 @@ class Twopayment extends PaymentModule
         $title = Configuration::get('PS_TWO_TITLE', $this->context->language->id);
         $subtitle = Configuration::get('PS_TWO_SUB_TITLE', $this->context->language->id);
 
+        $brand = $this->getTwoBrand();
         if (Tools::isEmpty($title)) {
-            $title = $this->l('Pay with Two');
+            $title = $this->l($brand['payment_title']);
         }
         if (Tools::isEmpty($subtitle)) {
-            $subtitle = $this->l('Buy now, pay later - instant credit');
+            $subtitle = $this->l($brand['payment_subtitle']);
         }
 
         // Order intent is now handled on frontend via AJAX
         $this->context->smarty->assign(array(
+            'two_brand' => $brand,
             'subtitle' => $subtitle,
             'enable_order_intent' => $this->enable_order_intent,
             'payment_enable' => true, // Always enable, frontend will handle approval
@@ -2551,7 +2601,7 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
-        return $request_data;
+        return $this->applyTwoBrandPayloadIdentity($request_data);
     }
 
     /**
@@ -2907,6 +2957,8 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
+        $request_data = $this->applyTwoBrandPayloadIdentity($request_data);
+
         PrestaShopLogger::addLog('TwoPayment: Order creation with terms - ' . json_encode($request_data['terms']), 1);
         
         return $request_data;
@@ -2998,7 +3050,7 @@ class Twopayment extends PaymentModule
             $request_data['tax_subtotals'] = $tax_subtotals;
         }
 
-        return $request_data;
+        return $this->applyTwoBrandPayloadIdentity($request_data);
     }
 
     public function getTwoNewRefundData($order, $two_order_snapshot = null)

--- a/twopayment.php
+++ b/twopayment.php
@@ -471,6 +471,7 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
+        Configuration::deleteByName('PS_TWO_MERCHANT_MIN_ORDER');
         return true;
     }
 
@@ -1024,6 +1025,13 @@ class Twopayment extends PaymentModule
                         ),
                     ),
                     array(
+                        'type' => 'text',
+                        'label' => $this->l('Minimum Order Value'),
+                        'name' => 'PS_TWO_MERCHANT_MIN_ORDER',
+                        'desc' => $this->getTwoMerchantMinimumOrderDescription(),
+                        'required' => false,
+                    ),
+                    array(
                         'type' => 'switch',
                         'label' => $this->l('Enable Debug Mode'),
                         'name' => 'PS_TWO_DEBUG_MODE',
@@ -1066,12 +1074,32 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         $fields_values['PS_TWO_DEBUG_MODE'] = Tools::getValue('PS_TWO_DEBUG_MODE', Configuration::get('PS_TWO_DEBUG_MODE'));
+        $fields_values['PS_TWO_MERCHANT_MIN_ORDER'] = Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER', Configuration::get('PS_TWO_MERCHANT_MIN_ORDER'));
         return $fields_values;
     }
 
     protected function validTwoOtherFormValues()
     {
-        // No validation needed for current Other Settings
+        $value = trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER'));
+        if ($value === '') {
+            return;
+        }
+        $value = str_replace(',', '.', $value);
+        if (!is_numeric($value) || (float) $value < 0) {
+            $this->errors[] = $this->l('Minimum Order Value must be a non-negative number.');
+            return;
+        }
+        $brand = $this->getTwoBrand();
+        $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
+        if ($gate && isset($gate['min_order_amount']) && (float) $value <= (float) $gate['min_order_amount']) {
+            // The brand minimum is the platform/partner floor; merchants
+            // may only raise the bar
+            $this->errors[] = sprintf(
+                $this->l('Minimum Order Value must exceed the platform minimum of %1$s %2$s.'),
+                $gate['min_order_amount'],
+                $gate['currency']
+            );
+        }
     }
 
     protected function saveTwoOtherFormValues()
@@ -1087,6 +1115,10 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
         Configuration::updateValue('PS_TWO_DEBUG_MODE', Tools::getValue('PS_TWO_DEBUG_MODE'));
+        Configuration::updateValue(
+            'PS_TWO_MERCHANT_MIN_ORDER',
+            str_replace(',', '.', trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER')))
+        );
 
         $this->output .= $this->displayConfirmation($this->l('Other settings are updated.'));
     }
@@ -2207,55 +2239,136 @@ class Twopayment extends PaymentModule
     {
         $brand = $this->getTwoBrand();
         $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
-        if (!$gate) {
-            return true;
-        }
-        if (!isset($gate['min_order_amount'], $gate['currency'], $gate['billing_countries'])) {
+        if ($gate && !isset($gate['min_order_amount'], $gate['currency'], $gate['basis'], $gate['billing_countries'])) {
             // Malformed gate config must not judge with missing criteria
+            $gate = null;
+        }
+        $merchant_minimum = $this->getTwoMerchantMinimumOrder();
+        if (!$gate && !$merchant_minimum) {
             return true;
         }
 
-        $billing_country = Country::getIsoById((int) $billing_address->id_country);
-        if (!in_array($billing_country, $gate['billing_countries'], true)) {
-            PrestaShopLogger::addLog(
-                'TwoPayment: Payment option hidden - billing country ' . ($billing_country ?: 'unknown')
-                . ' outside the brand gate (' . implode(',', $gate['billing_countries']) . ')',
-                1
-            );
+        if ($gate) {
+            $billing_country = Country::getIsoById((int) $billing_address->id_country);
+            if (!in_array($billing_country, $gate['billing_countries'], true)) {
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Payment option hidden - billing country ' . ($billing_country ?: 'unknown')
+                    . ' outside the brand gate (' . implode(',', $gate['billing_countries']) . ')',
+                    1
+                );
+                return false;
+            }
+            if (!$this->cartSatisfiesTwoMinimum($cart, $gate['min_order_amount'], $gate['currency'], $gate['basis'], 'brand minimum')) {
+                return false;
+            }
+        }
+
+        if ($merchant_minimum
+            && !$this->cartSatisfiesTwoMinimum(
+                $cart,
+                $merchant_minimum['amount'],
+                $merchant_minimum['currency'],
+                $merchant_minimum['basis'],
+                'merchant minimum'
+            )
+        ) {
             return false;
         }
 
-        $net_total = (float) $cart->getOrderTotal(false, Cart::BOTH);
+        return true;
+    }
+
+    /**
+     * Whether the cart meets one minimum-order constraint, comparing on
+     * the declared basis (net = excl. tax, gross = incl.) and converting
+     * via PrestaShop's currency rates when the cart currency differs —
+     * failing closed without a usable rate.
+     *
+     * @param Cart $cart
+     * @param float $amount
+     * @param string $currency
+     * @param string $basis
+     * @param string $label For the log line
+     *
+     * @return bool
+     */
+    protected function cartSatisfiesTwoMinimum($cart, $amount, $currency, $basis, $label)
+    {
+        $basket_value = (float) $cart->getOrderTotal($basis === 'gross', Cart::BOTH);
         $cart_currency = new Currency((int) $cart->id_currency);
-        if ($cart_currency->iso_code !== $gate['currency']) {
+        if ($cart_currency->iso_code !== $currency) {
             // PrestaShop stores each currency's rate against the shop
             // default currency; the cross rate is target/source
             $from_rate = (float) $cart_currency->conversion_rate;
-            $to_id = Currency::getIdByIsoCode($gate['currency']);
+            $to_id = Currency::getIdByIsoCode($currency);
             $to_rate = $to_id ? (float) (new Currency((int) $to_id))->conversion_rate : 0.0;
             if ($from_rate <= 0 || $to_rate <= 0) {
-                // Fail closed: without a rate we cannot prove the brand's
-                // minimum is met
                 PrestaShopLogger::addLog(
                     'TwoPayment: Payment option hidden - no conversion rate from '
-                    . $cart_currency->iso_code . ' to ' . $gate['currency'] . ' for the brand gate',
+                    . $cart_currency->iso_code . ' to ' . $currency . ' for the ' . $label,
                     2
                 );
                 return false;
             }
-            $net_total = round($net_total / $from_rate * $to_rate, 2);
+            $basket_value = round($basket_value / $from_rate * $to_rate, 2);
         }
 
-        if ($net_total < (float) $gate['min_order_amount']) {
+        if ($basket_value < (float) $amount) {
             PrestaShopLogger::addLog(
-                'TwoPayment: Payment option hidden - net total ' . $net_total . ' ' . $gate['currency']
-                . ' below the brand minimum ' . $gate['min_order_amount'],
+                'TwoPayment: Payment option hidden - basket ' . $basket_value . ' ' . $currency
+                . ' (' . $basis . ') below the ' . $label . ' ' . $amount,
                 1
             );
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * The merchant's own optional minimum order value, as
+     * ['amount', 'currency', 'basis'] or null. Interpreted in the brand
+     * minimum's currency/basis when the brand declares a gate, otherwise
+     * the shop default currency, gross. Validated on save to exceed the
+     * brand minimum — merchants may only raise the bar.
+     *
+     * @return array|null
+     */
+    /**
+     * Dynamic description for the Minimum Order Value setting: shows the
+     * brand minimum the merchant's value must exceed.
+     *
+     * @return string
+     */
+    protected function getTwoMerchantMinimumOrderDescription()
+    {
+        $brand = $this->getTwoBrand();
+        $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
+        if ($gate && isset($gate['min_order_amount'], $gate['currency'])) {
+            return sprintf(
+                $this->l('Platform minimum: %1$s %2$s (%3$s tax). A value here must exceed it and is interpreted in the same currency and tax basis.'),
+                $gate['min_order_amount'],
+                $gate['currency'],
+                (isset($gate['basis']) ? $gate['basis'] : 'net') === 'gross' ? $this->l('including') : $this->l('excluding')
+            );
+        }
+        return $this->l('Hide the payment option below this order value (shop default currency, including tax). Leave empty for no minimum.');
+    }
+
+    public function getTwoMerchantMinimumOrder()
+    {
+        $value = (float) Configuration::get('PS_TWO_MERCHANT_MIN_ORDER');
+        if ($value <= 0) {
+            return null;
+        }
+        $brand = $this->getTwoBrand();
+        $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
+        $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        return [
+            'amount' => $value,
+            'currency' => isset($gate['currency']) ? $gate['currency'] : $default_currency->iso_code,
+            'basis' => isset($gate['basis']) ? $gate['basis'] : 'gross',
+        ];
     }
 
     public function hookPaymentOptions($params)

--- a/twopayment.php
+++ b/twopayment.php
@@ -67,22 +67,59 @@ class Twopayment extends PaymentModule
      * module was constructed (PrestaShop instantiation, AJAX
      * controllers, the test harness which skips the module constructor).
      *
+     * Partner editions set the PS_TWO_BRAND_CODE configuration value;
+     * it resolves to brands/{code}.php (basename-confined to brands/)
+     * and merges over the Two defaults, so a partner file declares only
+     * what differs. Missing or unresolvable files degrade to the Two
+     * defaults — a half-synced deploy must not fatal the checkout.
+     *
      * @return array
      */
     public function getTwoBrand()
     {
-        if ($this->brand === null) {
-            $this->brand = require dirname(__FILE__) . '/brands/two.php';
+        if ($this->brand !== null) {
+            return $this->brand;
         }
+
+        $defaults_file = dirname(__FILE__) . '/brands/two.php';
+        $defaults = is_file($defaults_file) ? require $defaults_file : array(
+            'code' => 'two',
+            'provider' => 'Two',
+            'product_name' => 'Two',
+            'display_name' => 'Two - BNPL for businesses',
+            'description' => 'This module allows any merchant to accept payments with Two payment gateway.',
+            'payment_title' => 'Pay with Two',
+            'payment_subtitle' => 'Buy now, pay later - instant credit',
+            'support_email' => 'support@two.inc',
+            'documentation_url' => 'https://docs.two.inc',
+            'vendor_name' => '',
+        );
+
+        $config = $defaults;
+        $brand_code = Configuration::get('PS_TWO_BRAND_CODE');
+        if ($brand_code && $brand_code !== 'two') {
+            $brand_file = dirname(__FILE__) . '/brands/' . basename((string)$brand_code) . '.php';
+            if (is_file($brand_file)) {
+                $config = array_merge($defaults, (array) require $brand_file);
+            }
+        }
+
+        $this->brand = $config;
         return $this->brand;
     }
 
     /**
-     * Add the brand's payload identity (vendor_name, brand_tag) to an
-     * order request body. Applied to create, intent AND update bodies so
-     * the brand identity cannot diverge between order lifecycle calls.
-     * Keys are only sent when the brand sets them, so the Two brand's
-     * payloads are unchanged.
+     * Add the brand's payload identity (vendor_name) to an order request
+     * body. Applied to create, intent AND update bodies so the brand
+     * identity cannot diverge between order lifecycle calls. The key is
+     * only sent when the brand sets it, so the Two brand's payloads are
+     * unchanged.
+     *
+     * vendor_name as a body field has cross-plugin precedent (the
+     * WooCommerce plugin sends it conditionally). brand_tag does NOT —
+     * the Magento plugin uses it solely as a checkout-URL query param —
+     * so it stays out of the body and lands with the checkout-URL code
+     * that consumes it.
      *
      * @param array $request_data
      *
@@ -93,9 +130,6 @@ class Twopayment extends PaymentModule
         $brand = $this->getTwoBrand();
         if (!empty($brand['vendor_name'])) {
             $request_data['vendor_name'] = $brand['vendor_name'];
-        }
-        if (!empty($brand['brand_tag'])) {
-            $request_data['brand_tag'] = $brand['brand_tag'];
         }
         return $request_data;
     }
@@ -1086,6 +1120,9 @@ class Twopayment extends PaymentModule
      */
     protected function renderTwoPluginInfo()
     {
+        $brand = $this->getTwoBrand();
+        $support_email = $brand['support_email'];
+        $documentation_url = $brand['documentation_url'];
         $html = '
         <div class="panel">
             <div class="panel-heading">
@@ -1152,8 +1189,8 @@ class Twopayment extends PaymentModule
             <div class="panel-body">
                 <p>' . $this->l('For technical support or questions about this plugin:') . '</p>
                 <ul>
-                    <li><strong>' . $this->l('Email:') . '</strong> <a href="mailto:' . $this->getTwoBrand()['support_email'] . '">' . $this->getTwoBrand()['support_email'] . '</a></li>
-                    <li><strong>' . $this->l('Documentation:') . '</strong> <a href="' . $this->getTwoBrand()['documentation_url'] . '" target="_blank">' . preg_replace('#^https?://#', '', $this->getTwoBrand()['documentation_url']) . '</a></li>
+                    <li><strong>' . $this->l('Email:') . '</strong> <a href="mailto:' . Tools::safeOutput($support_email) . '">' . Tools::safeOutput($support_email) . '</a></li>
+                    <li><strong>' . $this->l('Documentation:') . '</strong> <a href="' . Tools::safeOutput($documentation_url) . '" target="_blank">' . Tools::safeOutput(preg_replace('#^https?://#', '', $documentation_url)) . '</a></li>
                     <li><strong>' . $this->l('Merchant Portal:') . '</strong> <a href="' . $this->getTwoPortalUrl() . '" target="_blank">' . $this->l('Open Two Portal') . '</a></li>
                 </ul>
                 <p style="margin-top:15px;"><small class="text-muted">' . $this->l('Plugin Version:') . ' ' . $this->version . ' | ' . $this->l('PrestaShop:') . ' ' . _PS_VERSION_ . '</small></p>

--- a/twopayment.php
+++ b/twopayment.php
@@ -1091,15 +1091,73 @@ class Twopayment extends PaymentModule
         }
         $brand = $this->getTwoBrand();
         $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
-        if ($gate && isset($gate['min_order_amount']) && (float) $value <= (float) $gate['min_order_amount']) {
-            // The brand minimum is the platform/partner floor; merchants
-            // may only raise the bar
-            $this->errors[] = sprintf(
-                $this->l('Minimum Order Value must exceed the platform minimum of %1$s %2$s.'),
-                $gate['min_order_amount'],
-                $gate['currency']
-            );
+        if (!$gate || !isset($gate['min_order_amount'], $gate['currency'])) {
+            return;
         }
+        // The brand minimum is the platform/partner floor; merchants may
+        // only raise the bar. The field is interpreted in the shop default
+        // currency, so the floor is converted before comparing. Without a
+        // usable rate the comparison is skipped here — the checkout gate
+        // enforces both minima independently and fails closed.
+        $floor = $this->getTwoPlatformMinimumInDefaultCurrency($gate);
+        if ($floor === null || (float) $value > $floor) {
+            return;
+        }
+        $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $floor_display = $this->formatTwoMinimumForDisplay($floor, $default_currency->iso_code);
+        $native_display = $this->formatTwoMinimumForDisplay((float) $gate['min_order_amount'], $gate['currency']);
+        $this->errors[] = sprintf(
+            $this->l('Minimum Order Value must exceed the platform minimum of %1$s, %2$s tax.'),
+            $floor_display === $native_display ? $floor_display : $floor_display . ' (' . $native_display . ')',
+            (isset($gate['basis']) ? $gate['basis'] : 'net') === 'gross' ? $this->l('including') : $this->l('excluding')
+        );
+    }
+
+    /**
+     * The brand's platform minimum expressed in the shop default currency
+     * (the currency the merchant minimum field is interpreted in), or
+     * null when no usable conversion rate exists. PrestaShop stores each
+     * currency's rate against the shop default currency.
+     *
+     * @param array $gate
+     *
+     * @return float|null
+     */
+    protected function getTwoPlatformMinimumInDefaultCurrency($gate)
+    {
+        $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        if ($gate['currency'] === $default_currency->iso_code) {
+            return (float) $gate['min_order_amount'];
+        }
+        $brand_currency_id = Currency::getIdByIsoCode($gate['currency']);
+        $rate = $brand_currency_id ? (float) (new Currency((int) $brand_currency_id))->conversion_rate : 0.0;
+        if ($rate <= 0) {
+            return null;
+        }
+        return round((float) $gate['min_order_amount'] / $rate, 2);
+    }
+
+    /**
+     * A minimum-order amount formatted with its currency for admin
+     * display, via the locale price formatter when available (symbol,
+     * e.g. "£215.73"), falling back to "amount ISO".
+     *
+     * @param float $amount
+     * @param string $iso_code
+     *
+     * @return string
+     */
+    protected function formatTwoMinimumForDisplay($amount, $iso_code)
+    {
+        $context = Context::getContext();
+        if (method_exists($context, 'getCurrentLocale') && $context->getCurrentLocale()) {
+            try {
+                return $context->getCurrentLocale()->formatPrice($amount, $iso_code);
+            } catch (Exception $e) {
+                // Fall through to the plain format
+            }
+        }
+        return $amount . ' ' . $iso_code;
     }
 
     protected function saveTwoOtherFormValues()
@@ -2326,17 +2384,11 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * The merchant's own optional minimum order value, as
-     * ['amount', 'currency', 'basis'] or null. Interpreted in the brand
-     * minimum's currency/basis when the brand declares a gate, otherwise
-     * the shop default currency, gross. Validated on save to exceed the
-     * brand minimum — merchants may only raise the bar.
-     *
-     * @return array|null
-     */
-    /**
      * Dynamic description for the Minimum Order Value setting: shows the
-     * brand minimum the merchant's value must exceed.
+     * brand minimum the merchant's value must exceed, converted into the
+     * shop default currency the field is interpreted in, with the native
+     * value in brackets — e.g. "Platform minimum £215.73 (€250.00)".
+     * Without a usable conversion rate the native value alone is shown.
      *
      * @return string
      */
@@ -2345,16 +2397,33 @@ class Twopayment extends PaymentModule
         $brand = $this->getTwoBrand();
         $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
         if ($gate && isset($gate['min_order_amount'], $gate['currency'])) {
+            $native_display = $this->formatTwoMinimumForDisplay((float) $gate['min_order_amount'], $gate['currency']);
+            $minimum_display = $native_display;
+            $floor = $this->getTwoPlatformMinimumInDefaultCurrency($gate);
+            $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+            if ($floor !== null && $gate['currency'] !== $default_currency->iso_code) {
+                $minimum_display = $this->formatTwoMinimumForDisplay($floor, $default_currency->iso_code)
+                    . ' (' . $native_display . ')';
+            }
             return sprintf(
-                $this->l('Platform minimum: %1$s %2$s (%3$s tax). A value here must exceed it and is interpreted in the same currency and tax basis.'),
-                $gate['min_order_amount'],
-                $gate['currency'],
+                $this->l('Platform minimum %1$s, %2$s tax. A value here is interpreted in the shop default currency on the same tax basis and must exceed it.'),
+                $minimum_display,
                 (isset($gate['basis']) ? $gate['basis'] : 'net') === 'gross' ? $this->l('including') : $this->l('excluding')
             );
         }
         return $this->l('Hide the payment option below this order value (shop default currency, including tax). Leave empty for no minimum.');
     }
 
+    /**
+     * The merchant's own optional minimum order value, as
+     * ['amount', 'currency', 'basis'] or null. Interpreted in the SHOP
+     * DEFAULT currency on the brand minimum's tax basis when the brand
+     * declares a gate, else gross. Validated on save to exceed the brand
+     * minimum converted to that currency — merchants may only raise the
+     * bar.
+     *
+     * @return array|null
+     */
     public function getTwoMerchantMinimumOrder()
     {
         $value = (float) Configuration::get('PS_TWO_MERCHANT_MIN_ORDER');
@@ -2366,7 +2435,7 @@ class Twopayment extends PaymentModule
         $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
         return [
             'amount' => $value,
-            'currency' => isset($gate['currency']) ? $gate['currency'] : $default_currency->iso_code,
+            'currency' => $default_currency->iso_code,
             'basis' => isset($gate['basis']) ? $gate['basis'] : 'gross',
         ];
     }

--- a/twopayment.php
+++ b/twopayment.php
@@ -1116,8 +1116,7 @@ class Twopayment extends PaymentModule
     /**
      * The brand's platform minimum expressed in the shop default currency
      * (the currency the merchant minimum field is interpreted in), or
-     * null when no usable conversion rate exists. PrestaShop stores each
-     * currency's rate against the shop default currency.
+     * null when no usable conversion rate exists.
      *
      * @param array $gate
      *
@@ -1126,15 +1125,85 @@ class Twopayment extends PaymentModule
     protected function getTwoPlatformMinimumInDefaultCurrency($gate)
     {
         $default_currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
-        if ($gate['currency'] === $default_currency->iso_code) {
-            return (float) $gate['min_order_amount'];
+        return $this->convertTwoAmount((float) $gate['min_order_amount'], $gate['currency'], $default_currency->iso_code);
+    }
+
+    /**
+     * Convert an amount between two currencies via PrestaShop's rates
+     * (each currency's rate is stored against the shop default currency;
+     * the cross rate is target/source), or null when either rate is
+     * unusable.
+     *
+     * @param float $amount
+     * @param string $from_iso
+     * @param string $to_iso
+     *
+     * @return float|null
+     */
+    protected function convertTwoAmount($amount, $from_iso, $to_iso)
+    {
+        if ($from_iso === $to_iso) {
+            return (float) $amount;
         }
-        $brand_currency_id = Currency::getIdByIsoCode($gate['currency']);
-        $rate = $brand_currency_id ? (float) (new Currency((int) $brand_currency_id))->conversion_rate : 0.0;
-        if ($rate <= 0) {
+        $from_id = Currency::getIdByIsoCode($from_iso);
+        $to_id = Currency::getIdByIsoCode($to_iso);
+        $from_rate = $from_id ? (float) (new Currency((int) $from_id))->conversion_rate : 0.0;
+        $to_rate = $to_id ? (float) (new Currency((int) $to_id))->conversion_rate : 0.0;
+        if ($from_rate <= 0 || $to_rate <= 0) {
             return null;
         }
-        return round((float) $gate['min_order_amount'] / $rate, 2);
+        return round((float) $amount / $from_rate * $to_rate, 2);
+    }
+
+    /**
+     * Buyer-facing hint when a Two decline is attributable to the brand
+     * minimum order value: keyed primarily on the API's machine-readable
+     * reason (decline_reason on intents and rejected orders, error_code
+     * on order-create 400s), with a strictly-below-minimum check as
+     * fallback while older backends carry only a generic reason. The
+     * minimum is shown in the CART currency via PrestaShop's rates.
+     * Fail-soft: an unresolvable conversion means no hint, never a
+     * blocked message.
+     *
+     * @param string|null $reason
+     * @param Cart $cart
+     *
+     * @return string Empty when the decline is not attributable to the minimum
+     */
+    public function getTwoMinimumOrderDeclineHint($reason, $cart)
+    {
+        $brand = $this->getTwoBrand();
+        $gate = isset($brand['availability_gate']) ? $brand['availability_gate'] : null;
+        if (!$gate || !isset($gate['min_order_amount'], $gate['currency'], $gate['basis'])) {
+            return '';
+        }
+
+        $cart_currency = new Currency((int) $cart->id_currency);
+        $declined_on_minimum = $reason === 'ORDER_BELOW_MIN_INVOICE_AMOUNT';
+        if (!$declined_on_minimum) {
+            $basket_value = (float) $cart->getOrderTotal($gate['basis'] === 'gross', Cart::BOTH);
+            $basket_in_gate_currency = $this->convertTwoAmount($basket_value, $cart_currency->iso_code, $gate['currency']);
+            $declined_on_minimum = $basket_in_gate_currency !== null
+                && $basket_in_gate_currency < (float) $gate['min_order_amount'];
+        }
+        if (!$declined_on_minimum) {
+            return '';
+        }
+
+        $minimum_in_cart_currency = $this->convertTwoAmount(
+            (float) $gate['min_order_amount'],
+            $gate['currency'],
+            $cart_currency->iso_code
+        );
+        if ($minimum_in_cart_currency === null) {
+            return '';
+        }
+
+        return sprintf(
+            $this->l('Minimum order value is %1$s %2$s tax.'),
+            $this->formatTwoMinimumForDisplay($minimum_in_cart_currency, $cart_currency->iso_code),
+            $gate['basis'] === 'gross' ? $this->l('including') : $this->l('excluding')
+        );
     }
 
     /**
@@ -2973,6 +3042,14 @@ class Twopayment extends PaymentModule
 
                     if (!Tools::isEmpty($provider_message)) {
                         $result['message'] = $provider_message;
+                    }
+
+                    $minimum_hint = $this->getTwoMinimumOrderDeclineHint(
+                        isset($response['decline_reason']) ? $response['decline_reason'] : null,
+                        $cart
+                    );
+                    if (!Tools::isEmpty($minimum_hint)) {
+                        $result['message'] .= ' ' . $minimum_hint;
                     }
                 }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -115,11 +115,13 @@ class Twopayment extends PaymentModule
      * only sent when the brand sets it, so the Two brand's payloads are
      * unchanged.
      *
-     * vendor_name as a body field has cross-plugin precedent (the
-     * WooCommerce plugin sends it conditionally). brand_tag does NOT —
-     * the Magento plugin uses it solely as a checkout-URL query param —
-     * so it stays out of the body and lands with the checkout-URL code
-     * that consumes it.
+     * vendor_name as a body FIELD has cross-plugin precedent (the
+     * WooCommerce plugin sends it, though from a merchant gateway
+     * option rather than brand config — the source is not yet
+     * converged across plugins). brand_tag does NOT — the Magento
+     * plugin uses it solely as a checkout-URL query param — so it
+     * stays out of the body and lands with the checkout-URL code that
+     * consumes it.
      *
      * @param array $request_data
      *


### PR DESCRIPTION
## What

D2 of the plugin parity plan (TWO-24739 → TWO-24748). **Ticket premise correction**: the dev harness (Makefile with install/configure/proxy targets, compose stack, `dev/configure.php`, `.env.local.example`) already exists from earlier work — the ticket predates it. The actual gaps:

**Stacked on #32** (needs the `PS_TWO_BRAND_CODE` brand seam).

- `TWO_BRAND_CODE` plumbed end-to-end: `.env.local.example` → `make configure` → `dev/configure.php` → `PS_TWO_BRAND_CODE` configuration value (which the TWO-24746 loader resolves to `brands/{code}.php`). Included in configure.php's duplicate-row pruning.
- `make test`: runs `tests/run.php` in a `php:8.2` container — same suite as CI.

**Test-coverage audit** (ticket scope): `tests/run.php` (TinyAssert harness, dependency-free) covers order composition, tax/discount edge cases, brand config, and address formatting; CI (`tests.yml`) lints + runs it on every PR. "Establish PHPUnit baseline" is superseded — `phpunit.xml.dist` remains a stub for future adoption.

## Test plan

- [x] `php -l dev/configure.php`
- [x] `make test` green
- [ ] `make install && make configure TWO_BRAND_CODE=two` on a dev box; confirm `PS_TWO_BRAND_CODE` row written once

🤖 Generated with [Claude Code](https://claude.com/claude-code)