### PR TITLE
TWO-24752/feat: Brand-bounded payment terms and available_terms payload

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -30,4 +30,13 @@ return [
     'payment_subtitle' => 'Buy now, pay later - instant credit',
     'support_email' => 'support@two.inc',
     'documentation_url' => 'https://docs.two.inc',
+    // Payment terms the brand allows in the checkout selector; the
+    // merchant's admin checkboxes narrow within this set. null = no
+    // brand constraint (the Two default - PS merchants already hold
+    // term selections in PS_TWO_PAYMENT_TERMS_* that must keep
+    // working; this differs from WooCommerce, where the brand list IS
+    // the offerable set because WC had no terms before). A partner
+    // edition sets e.g. [30, 60, 90]. Read only by
+    // getAvailablePaymentTerms() - the term-availability seam.
+    'available_terms' => null,
 ];

--- a/tests/run.php
+++ b/tests/run.php
@@ -167,6 +167,8 @@ final class OrderBuilderSpec
         self::testMinimumOrderDeclineHint();
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
+        self::testAvailableTermsRespectBrandConstraint();
+        self::testDefaultTermFallsToShortestBrandTermWhenConstrainedOut();
     }
 
     private static function reset(): void
@@ -4882,6 +4884,38 @@ final class OrderBuilderSpec
 
         TinyAssert::count(1, $items);
         TinyAssert::same([], $items[0]['details']['barcodes']);
+    }
+
+    private static function testAvailableTermsRespectBrandConstraint(): void
+    {
+        self::reset();
+        StubStore::$configuration['PS_TWO_PAYMENT_TERM_TYPE'] = 'STANDARD';
+        StubStore::$configuration['PS_TWO_PAYMENT_TERMS_30'] = 1;
+        StubStore::$configuration['PS_TWO_PAYMENT_TERMS_45'] = 1;
+        StubStore::$configuration['PS_TWO_PAYMENT_TERMS_60'] = 1;
+
+        // No brand constraint (Two default): admin checkboxes stand
+        $module = new TwopaymentTestHarness();
+        TinyAssert::same([30, 45, 60], $module->getAvailablePaymentTerms());
+
+        // Partner constraint narrows the admin selection
+        $module = new TwopaymentTestHarness();
+        $module->setTwoBrand(['available_terms' => [30, 60, 90]]);
+        TinyAssert::same([30, 60], $module->getAvailablePaymentTerms());
+    }
+
+    private static function testDefaultTermFallsToShortestBrandTermWhenConstrainedOut(): void
+    {
+        self::reset();
+        StubStore::$configuration['PS_TWO_PAYMENT_TERM_TYPE'] = 'STANDARD';
+        // Only a term outside the brand set is enabled: the resolved set
+        // would be empty, and the 30-day fallback is also outside the
+        // brand set, so the shortest brand term wins
+        StubStore::$configuration['PS_TWO_PAYMENT_TERMS_15'] = 1;
+
+        $module = new TwopaymentTestHarness();
+        $module->setTwoBrand(['available_terms' => [60, 90]]);
+        TinyAssert::same([60], $module->getAvailablePaymentTerms());
     }
 
     private static function testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -3394,6 +3394,9 @@ class Twopayment extends PaymentModule
             'order_note' => '',
             'line_items' => $line_items,
             'terms' => $this->buildTermsPayload(),
+            // The set offered alongside the selection, for parity with the
+            // Magento/WooCommerce create payloads (TWO-24752)
+            'available_terms' => $this->getAvailablePaymentTerms(),
         ];
 
         if ($this->shouldIncludeTaxSubtotals()) {
@@ -5862,18 +5865,35 @@ class Twopayment extends PaymentModule
         }
         
         $available_terms = array();
-        
+
         foreach ($terms_to_check as $term) {
             if (Configuration::get('PS_TWO_PAYMENT_TERMS_' . $term)) {
                 $available_terms[] = (int)$term;
             }
         }
-        
+
+        // Brand constraint (TWO-24752): a partner edition may bound which
+        // terms can be offered at all; the admin checkboxes narrow within
+        // that set. This method is the term-availability seam - when the
+        // backend grows a term-availability surface it replaces only this
+        // resolution. Do not read term lists anywhere else.
+        $brand = $this->getTwoBrand();
+        $brand_terms = null;
+        if (isset($brand['available_terms']) && is_array($brand['available_terms'])) {
+            $brand_terms = array_map('intval', $brand['available_terms']);
+            $available_terms = array_values(array_intersect($available_terms, $brand_terms));
+        }
+
         // If no terms are configured, default to DEFAULT_PAYMENT_TERM_DAYS
+        // (the shortest brand term when a brand constraint excludes it)
         if (empty($available_terms)) {
             $available_terms = array(self::DEFAULT_PAYMENT_TERM_DAYS);
+            if (is_array($brand_terms) && !empty($brand_terms) && !in_array(self::DEFAULT_PAYMENT_TERM_DAYS, $brand_terms, true)) {
+                sort($brand_terms);
+                $available_terms = array($brand_terms[0]);
+            }
         }
-        
+
         sort($available_terms); // Ensure they're in ascending order
         return $available_terms;
     }


### PR DESCRIPTION
## Change pack

Payment terms are bounded by the brand's allowed set and surfaced in the order payload.

- The brand config declares its allowed payment terms; the admin term selection is intersected with that set, so a partner edition can only offer terms its brand permits.
- The order payload sends `available_terms` (the brand-bounded set) alongside the buyer's chosen term.

Staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_(Description by Claude on Doug's behalf.)_