### PR TITLE
TWO-24755/refactor: Sole trader via payment-step toggle (align with Magento/WooCommerce)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ Thumbs.db
 
 
 .worktrees/
+
+.review/

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Sole trader checkout support — business logic (TWO-24755).
+ *
+ * All decisioning lives here; the address-form override and the JS layer
+ * only render what these methods return (the ps_checkout adaptation,
+ * TWO-24770, must be able to wrap this with a new presentation layer).
+ *
+ * Two gates decide whether the Sole Trader account type is offered for a
+ * billing country, and both must pass:
+ *  - country-level legal truth from the registry endpoint
+ *    GET /registry/v1/supported-company-types/<ISO> (TWO-24753), and
+ *  - the merchant's PS_TWO_ENABLE_SOLE_TRADER admin toggle (which itself
+ *    requires account-type mode, since the option rides that selector).
+ *
+ * The flow mirrors the Magento reference: the buyer picks Sole Trader,
+ * the module server-side mints two delegated-authority tokens with the
+ * merchant API key, the buyer registers or logs in through Two's hosted
+ * signup popup, and the checkout autofills the company data from
+ * GET /autofill/v1/buyer/current. No sole-trader-specific fields are
+ * collected and the order payload is unchanged — an enrolled sole
+ * trader's organization number (TWO:ST…) carries the semantics and the
+ * backend derives the company type from it (TWO-24749 spike).
+ */
+class TwoSoleTrader
+{
+    const REGISTERED_BUSINESS = 'REGISTERED_BUSINESS';
+    const SOLE_TRADER = 'SOLE_TRADER';
+
+    /** Cookie key prefix; full key is prefix + ISO country code. */
+    const COOKIE_KEY_PREFIX = 'two_company_types_';
+
+    /** Matches the registry endpoint's Cache-Control max-age. */
+    const CACHE_TTL_SECONDS = 3600;
+
+    /** @var array<string, string[]> request-scoped cache, keyed by country */
+    private static $types_cache = array();
+
+    /**
+     * Whether the merchant has opted into sole trader checkout. Requires
+     * account-type mode: the Sole Trader option is a third value on the
+     * existing Personal/Business selector.
+     */
+    public static function isEnabled()
+    {
+        return (int) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') === 1
+            && (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE') === 1;
+    }
+
+    /**
+     * Whether the Sole Trader option should be offered for a billing
+     * country: merchant toggle on AND the country legally supports it.
+     *
+     * @param TwoPayment $module
+     * @param string $countryIso
+     *
+     * @return bool
+     */
+    public static function isAvailable($module, $countryIso)
+    {
+        return self::isEnabled()
+            && in_array(self::SOLE_TRADER, self::getSupportedCompanyTypes($module, $countryIso), true);
+    }
+
+    /**
+     * Whether an account type is allowed to pay with Two. Business always
+     * is; sole trader only when the feature is available for the country.
+     *
+     * @param TwoPayment $module
+     * @param string $accountType
+     * @param string $countryIso
+     *
+     * @return bool
+     */
+    public static function isAccountTypeAllowed($module, $accountType, $countryIso)
+    {
+        if ($accountType === 'business') {
+            return true;
+        }
+        if ($accountType === 'sole_trader') {
+            return self::isAvailable($module, $countryIso);
+        }
+        return false;
+    }
+
+    /**
+     * The buyer company types Two supports for a country, from
+     * GET /registry/v1/supported-company-types/<ISO>. Cached in the
+     * context cookie for the endpoint's own max-age. Fail-soft: any error
+     * (network, non-200, malformed body) resolves to registered-business
+     * only — checkout never blocks, the option just doesn't show.
+     *
+     * @param TwoPayment $module
+     * @param string $countryIso
+     *
+     * @return string[]
+     */
+    public static function getSupportedCompanyTypes($module, $countryIso)
+    {
+        $countryIso = strtoupper(trim((string) $countryIso));
+        if (!preg_match('/^[A-Z]{2}$/', $countryIso)) {
+            return array(self::REGISTERED_BUSINESS);
+        }
+
+        if (array_key_exists($countryIso, self::$types_cache)) {
+            return self::$types_cache[$countryIso];
+        }
+
+        $cookie = Context::getContext()->cookie;
+        $cookieKey = self::COOKIE_KEY_PREFIX . $countryIso;
+        if ($cookie && !empty($cookie->{$cookieKey})) {
+            $cached = json_decode($cookie->{$cookieKey}, true);
+            if (
+                is_array($cached)
+                && isset($cached['types'], $cached['fetched_at'])
+                && is_array($cached['types'])
+                && time() - (int) $cached['fetched_at'] < self::CACHE_TTL_SECONDS
+            ) {
+                return self::$types_cache[$countryIso] = $cached['types'];
+            }
+        }
+
+        $types = self::fetchSupportedCompanyTypes($module, $countryIso);
+
+        if ($cookie) {
+            $cookie->{$cookieKey} = json_encode(array(
+                'types' => $types,
+                'fetched_at' => time(),
+            ));
+        }
+        return self::$types_cache[$countryIso] = $types;
+    }
+
+    /**
+     * Uncached registry call. @see getSupportedCompanyTypes()
+     *
+     * @return string[]
+     */
+    private static function fetchSupportedCompanyTypes($module, $countryIso)
+    {
+        $response = $module->setTwoPaymentRequest(
+            '/registry/v1/supported-company-types/' . $countryIso,
+            null,
+            'GET'
+        );
+        if (
+            !is_array($response)
+            || (int) ($response['http_status'] ?? 0) !== 200
+            || !isset($response['supported_company_types'])
+            || !is_array($response['supported_company_types'])
+        ) {
+            return array(self::REGISTERED_BUSINESS);
+        }
+        $types = array_values(array_filter($response['supported_company_types'], 'is_string'));
+        return count($types) > 0 ? $types : array(self::REGISTERED_BUSINESS);
+    }
+
+    /**
+     * Mint the two delegated-authority tokens the sole-trader flow needs,
+     * server-side with the merchant API key (the key never reaches the
+     * browser). The Two API returns each token in the
+     * `two-delegated-authority-token` response HEADER, not the body —
+     * hence a dedicated request here rather than setTwoPaymentRequest,
+     * which discards response headers.
+     *
+     * @param TwoPayment $module
+     *
+     * @return array{delegation_token: string, autofill_token: string}|null
+     */
+    public static function mintTokens($module)
+    {
+        $delegationToken = self::mintToken($module, '/registry/v1/delegation', array(
+            'create_proposal' => true,
+            'read_current_business' => true,
+        ));
+        $autofillToken = self::mintToken($module, '/autofill/v1/delegation', array(
+            'read_current_buyer' => true,
+            'write_current_buyer' => true,
+        ));
+        if ($delegationToken === null || $autofillToken === null) {
+            return null;
+        }
+        return array(
+            'delegation_token' => $delegationToken,
+            'autofill_token' => $autofillToken,
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    private static function mintToken($module, $endpoint, array $payload)
+    {
+        $result = self::postCapturingHeaders($module, $endpoint, $payload);
+        if ($result === null || $result['status'] >= 300) {
+            return null;
+        }
+        $token = isset($result['headers']['two-delegated-authority-token'])
+            ? trim($result['headers']['two-delegated-authority-token'])
+            : '';
+        return $token !== '' ? $token : null;
+    }
+
+    /**
+     * POST to the Two API capturing response headers (lower-cased keys).
+     * Seam for tests: overridable transport via the static $transport hook.
+     *
+     * @return array{status: int, headers: array<string, string>}|null
+     */
+    private static function postCapturingHeaders($module, $endpoint, array $payload)
+    {
+        if (self::$transport !== null) {
+            return call_user_func(self::$transport, $endpoint, $payload);
+        }
+
+        $url = $module->getTwoCheckoutHostUrl() . $endpoint;
+        $responseHeaders = array();
+
+        $ch = curl_init();
+        curl_setopt_array($ch, array(
+            CURLOPT_URL => $url,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($payload),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTPHEADER => array(
+                'Content-Type: application/json',
+                'X-API-Key: ' . Configuration::get('PS_TWO_MERCHANT_API_KEY'),
+            ),
+            CURLOPT_HEADERFUNCTION => function ($ch, $header) use (&$responseHeaders) {
+                $parts = explode(':', $header, 2);
+                if (count($parts) === 2) {
+                    $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+                }
+                return strlen($header);
+            },
+        ));
+        $body = curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($body === false || $error) {
+            PrestaShopLogger::addLog('TwoPayment: sole trader token mint failed - ' . $error, 2);
+            return null;
+        }
+        return array('status' => $status, 'headers' => $responseHeaders);
+    }
+
+    /**
+     * Base URL of Two's hosted sole-trader signup page (the checkout-page
+     * app, not the API). Derived from the configured environment.
+     *
+     * @return string
+     */
+    public static function getSignupPageUrl()
+    {
+        $env = (string) Configuration::get('PS_TWO_ENVIRONMENT');
+        if (strtoupper($env) === 'SANDBOX') {
+            return 'https://checkout.sandbox.two.inc/soletrader/signup';
+        }
+        return 'https://checkout.two.inc/soletrader/signup';
+    }
+
+    /** @var callable|null test seam for postCapturingHeaders */
+    public static $transport = null;
+
+    /**
+     * Test seam: clear the request-scoped types cache.
+     */
+    public static function resetCache()
+    {
+        self::$types_cache = array();
+        self::$transport = null;
+    }
+}

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -24,7 +24,6 @@
  */
 class TwoSoleTrader
 {
-    const REGISTERED_BUSINESS = 'REGISTERED_BUSINESS';
     const SOLE_TRADER = 'SOLE_TRADER';
 
     /** Cookie key prefix; full key is prefix + ISO country code. */
@@ -84,11 +83,15 @@ class TwoSoleTrader
     }
 
     /**
-     * The buyer company types Two supports for a country, from
-     * GET /registry/v1/supported-company-types/<ISO>. Cached in the
-     * context cookie for the endpoint's own max-age. Fail-soft: any error
-     * (network, non-200, malformed body) resolves to registered-business
-     * only — checkout never blocks, the option just doesn't show.
+     * The buyer company types the Two registry supports for a country,
+     * from GET /registry/v1/supported-company-types/<ISO> — only the
+     * types that need registry enrollment before they can buy (sole
+     * traders). Registered businesses need no enrollment and are always
+     * supported, so the endpoint deliberately omits them: an empty list
+     * means business-only checkout. Cached in the context cookie for the
+     * endpoint's own max-age. Fail-soft: any error (network, non-200,
+     * malformed body) also resolves to an empty list — checkout never
+     * blocks, the option just doesn't show.
      *
      * @param TwoPayment $module
      * @param string $countryIso
@@ -99,7 +102,7 @@ class TwoSoleTrader
     {
         $countryIso = strtoupper(trim((string) $countryIso));
         if (!preg_match('/^[A-Z]{2}$/', $countryIso)) {
-            return array(self::REGISTERED_BUSINESS);
+            return array();
         }
 
         if (array_key_exists($countryIso, self::$types_cache)) {
@@ -149,10 +152,9 @@ class TwoSoleTrader
             || !isset($response['supported_company_types'])
             || !is_array($response['supported_company_types'])
         ) {
-            return array(self::REGISTERED_BUSINESS);
+            return array();
         }
-        $types = array_values(array_filter($response['supported_company_types'], 'is_string'));
-        return count($types) > 0 ? $types : array(self::REGISTERED_BUSINESS);
+        return array_values(array_filter($response['supported_company_types'], 'is_string'));
     }
 
     /**

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -216,6 +216,10 @@ class TwoSoleTrader
                 return strlen($header);
             },
         ));
+        // Honour the merchant's SSL-verify setting (and its production
+        // hardening) the same way every other Two API call does, rather
+        // than leaving this curl on libcurl defaults.
+        $module->configureSslVerification($ch);
         $body = curl_exec($ch);
         $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -36,14 +36,14 @@ class TwoSoleTrader
     private static $types_cache = array();
 
     /**
-     * Whether the merchant has opted into sole trader checkout. Requires
-     * account-type mode: the Sole Trader option is a third value on the
-     * existing Personal/Business selector.
+     * Whether the merchant has opted into sole trader checkout. Surfaced as
+     * a Business / Sole-trader toggle on the payment step (TWO-24755), the
+     * same model the Magento and WooCommerce plugins use — there is no
+     * account-type selector on the address form.
      */
     public static function isEnabled()
     {
-        return (int) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') === 1
-            && (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE') === 1;
+        return (int) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') === 1;
     }
 
     /**
@@ -59,27 +59,6 @@ class TwoSoleTrader
     {
         return self::isEnabled()
             && in_array(self::SOLE_TRADER, self::getSupportedCompanyTypes($module, $countryIso), true);
-    }
-
-    /**
-     * Whether an account type is allowed to pay with Two. Business always
-     * is; sole trader only when the feature is available for the country.
-     *
-     * @param TwoPayment $module
-     * @param string $accountType
-     * @param string $countryIso
-     *
-     * @return bool
-     */
-    public static function isAccountTypeAllowed($module, $accountType, $countryIso)
-    {
-        if ($accountType === 'business') {
-            return true;
-        }
-        if ($accountType === 'sole_trader') {
-            return self::isAvailable($module, $countryIso);
-        }
-        return false;
     }
 
     /**

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -67,6 +67,12 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             case 'clearOrderIntentResult':
                 $this->ajaxProcessClearOrderIntentResult();
                 break;
+            case 'soleTraderAvailability':
+                $this->ajaxProcessSoleTraderAvailability();
+                break;
+            case 'soleTraderTokens':
+                $this->ajaxProcessSoleTraderTokens();
+                break;
             default:
                 $this->sendJsonResponse(json_encode([
                     'success' => false,
@@ -97,6 +103,57 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         $this->context->cookie->setExpire(time() + Twopayment::COOKIE_EXPIRY_ONE_HOUR);
         PrestaShopLogger::addLog('TwoPayment: Saved selected payment term ' . $days . ' days in cookie', 1);
         $this->sendJsonResponse(json_encode(['success' => true]));
+    }
+
+    /**
+     * Whether the sole trader account type applies for a billing country
+     * (TWO-24755). Combines the registry endpoint's country answer with the
+     * merchant toggle, both server-side; JS only renders the result.
+     */
+    public function ajaxProcessSoleTraderAvailability()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        $country = (string) Tools::getValue('country');
+        $this->sendJsonResponse(json_encode([
+            'success' => true,
+            'available' => TwoSoleTrader::isAvailable($this->module, $country),
+        ]));
+    }
+
+    /**
+     * Mint the delegation + autofill tokens for the sole-trader flow
+     * (TWO-24755) and hand the browser what it needs to open the hosted
+     * signup popup and autofill the buyer. The merchant API key stays
+     * server-side; tokens are scoped and short-lived by the Two API.
+     */
+    public function ajaxProcessSoleTraderTokens()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        if (!$this->isPost()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Only POST requests allowed')]));
+            return;
+        }
+        if (!TwoSoleTrader::isEnabled()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Sole trader checkout is not enabled')]));
+            return;
+        }
+        $tokens = TwoSoleTrader::mintTokens($this->module);
+        if ($tokens === null) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Could not initialise the sole trader flow')]));
+            return;
+        }
+        $this->sendJsonResponse(json_encode([
+            'success' => true,
+            'delegation_token' => $tokens['delegation_token'],
+            'autofill_token' => $tokens['autofill_token'],
+            'signup_url' => TwoSoleTrader::getSignupPageUrl(),
+        ]));
     }
 
     /**
@@ -279,9 +336,12 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         }
         
 
-        // SECURITY LAYER: Verify account type (kept for defense-in-depth)
-        if (empty($accountType) || $accountType !== 'business') {
-            PrestaShopLogger::addLog('TwoPayment: Order intent blocked - non-business account type: ' . $accountType, 2);
+        // SECURITY LAYER: Verify account type (kept for defense-in-depth).
+        // Business always passes; sole trader only where the feature is
+        // available for the billing country (TWO-24755).
+        $countryIso = (string) Country::getIsoById((int) $address->id_country);
+        if (empty($accountType) || !TwoSoleTrader::isAccountTypeAllowed($this->module, $accountType, $countryIso)) {
+            PrestaShopLogger::addLog('TwoPayment: Order intent blocked - ineligible account type: ' . $accountType, 2);
             $this->sendJsonResponse(json_encode([
                 'success' => false,
                 'error' => $this->module->l('Two payment is only available for business accounts')

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -299,14 +299,7 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         $companyData = $this->getCompanyDataWithFallbacks();
         $companyName = $companyData['company'];
         $companyId = $companyData['companyid'];
-        // Determine account type only when merchant explicitly enabled account-type mode.
-        // In strict account-type mode, missing/invalid account_type must be blocked.
-        $useAccountType = (int)Configuration::get('PS_TWO_USE_ACCOUNT_TYPE');
-        $accountType = 'business';
-        if ($useAccountType) {
-            $accountType = property_exists($address, 'account_type') ? trim((string) $address->account_type) : '';
-        }
-        
+
         // Store company data in PrestaShop session for future use
         $this->storeCompanyDataInSession($companyData);
         
@@ -334,20 +327,11 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             ]));
             return;
         }
-        
 
-        // SECURITY LAYER: Verify account type (kept for defense-in-depth).
-        // Business always passes; sole trader only where the feature is
-        // available for the billing country (TWO-24755).
-        $countryIso = (string) Country::getIsoById((int) $address->id_country);
-        if (empty($accountType) || !TwoSoleTrader::isAccountTypeAllowed($this->module, $accountType, $countryIso)) {
-            PrestaShopLogger::addLog('TwoPayment: Order intent blocked - ineligible account type: ' . $accountType, 2);
-            $this->sendJsonResponse(json_encode([
-                'success' => false,
-                'error' => $this->module->l('Two payment is only available for business accounts')
-            ]));
-            return;
-        }
+        // A company name plus a verified org number is the business guard:
+        // registered businesses search/select their company, and enrolled
+        // sole traders carry the synthetic org number their Two registration
+        // minted (TWO-24755), so both arrive here as a valid business.
 
         try {
             // Set address with validated form data for API call (form-first approach)

--- a/override/classes/form/CustomerAddressFormatter.php
+++ b/override/classes/form/CustomerAddressFormatter.php
@@ -38,33 +38,13 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
 
         $format = $this->moveFieldBefore($format, 'id_country', 'company');
 
-        $useAccountType = (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE') === 1;
-
-        if ($useAccountType && !isset($format['account_type'])) {
-            $accountTypeField = (new FormField())
-                ->setName('account_type')
-                ->setType('select')
-                ->setRequired(true)
-                ->addAvailableValue('personal', $this->getFieldLabel('personal_type'))
-                ->addAvailableValue('business', $this->getFieldLabel('business_type'))
-                ->setLabel($this->getFieldLabel('account_type'));
-            // Sole trader (TWO-24755): third option, only where the country
-            // legally supports it AND the merchant opted in. The address form
-            // re-renders per country, so the decision stays server-side.
-            if ($this->isSoleTraderAvailable()) {
-                $accountTypeField->addAvailableValue('sole_trader', $this->getFieldLabel('sole_trader_type'));
-            }
-            $this->applyFieldDefinitionMetadata($accountTypeField, 'account_type');
-            $format = $this->insertFieldAfter($format, 'token', 'account_type', $accountTypeField);
-        }
-
+        // B2B checkout: the company field is always present (the buyer types
+        // or searches their company). Sole traders enrol through the
+        // payment-step Sole-trader toggle (TWO-24755), which autofills this
+        // field from their Two registration — there is no account-type
+        // selector here, matching the Magento and WooCommerce plugins.
         if (isset($format['company']) && $format['company'] instanceof FormField) {
             $format['company']->addAvailableValue('placeholder', $this->translator->trans('Search your company name', [], 'Shop.Forms.Labels'));
-            if ($useAccountType) {
-                $format['company']->addAvailableValue('data-conditional-field', 'business');
-                $format['company']->addAvailableValue('data-conditional-required', 'business');
-                $format['company']->addAvailableValue('data-initial-state', 'hidden');
-            }
         }
 
         if (isset($format['phone']) && $format['phone'] instanceof FormField) {
@@ -91,28 +71,6 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
         }
 
         return $format;
-    }
-
-    /**
-     * Whether the Sole Trader account type applies for this form's country.
-     * Delegates to the module's business-logic class (TWO-24755); rendering
-     * stays here, decisioning there.
-     */
-    private function isSoleTraderAvailable()
-    {
-        if (!class_exists('TwoSoleTrader')) {
-            $classFile = _PS_MODULE_DIR_ . 'twopayment/classes/TwoSoleTrader.php';
-            if (!file_exists($classFile)) {
-                return false;
-            }
-            require_once $classFile;
-        }
-        $module = Module::getInstanceByName('twopayment');
-        $country = $this->getCountry();
-        if (!$module || !$country || empty($country->iso_code)) {
-            return false;
-        }
-        return TwoSoleTrader::isAvailable($module, $country->iso_code);
     }
 
     private function insertFieldAfter(array $format, $afterKey, $newKey, FormField $field)
@@ -236,14 +194,6 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
                 return $this->translator->trans('Identification number', [], 'Shop.Forms.Labels');
             case 'other':
                 return $this->translator->trans('Other', [], 'Shop.Forms.Labels');
-            case 'account_type':
-                return $this->translator->trans('Account Type', [], 'Shop.Forms.Labels');
-            case 'personal_type':
-                return $this->translator->trans('Personal', [], 'Shop.Forms.Labels');
-            case 'business_type':
-                return $this->translator->trans('Business', [], 'Shop.Forms.Labels');
-            case 'sole_trader_type':
-                return $this->translator->trans('Sole trader', [], 'Shop.Forms.Labels');
             case 'companyid':
                 return $this->translator->trans('Company ID', [], 'Shop.Forms.Labels');
             case 'department':

--- a/override/classes/form/CustomerAddressFormatter.php
+++ b/override/classes/form/CustomerAddressFormatter.php
@@ -48,6 +48,12 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
                 ->addAvailableValue('personal', $this->getFieldLabel('personal_type'))
                 ->addAvailableValue('business', $this->getFieldLabel('business_type'))
                 ->setLabel($this->getFieldLabel('account_type'));
+            // Sole trader (TWO-24755): third option, only where the country
+            // legally supports it AND the merchant opted in. The address form
+            // re-renders per country, so the decision stays server-side.
+            if ($this->isSoleTraderAvailable()) {
+                $accountTypeField->addAvailableValue('sole_trader', $this->getFieldLabel('sole_trader_type'));
+            }
             $this->applyFieldDefinitionMetadata($accountTypeField, 'account_type');
             $format = $this->insertFieldAfter($format, 'token', 'account_type', $accountTypeField);
         }
@@ -85,6 +91,28 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
         }
 
         return $format;
+    }
+
+    /**
+     * Whether the Sole Trader account type applies for this form's country.
+     * Delegates to the module's business-logic class (TWO-24755); rendering
+     * stays here, decisioning there.
+     */
+    private function isSoleTraderAvailable()
+    {
+        if (!class_exists('TwoSoleTrader')) {
+            $classFile = _PS_MODULE_DIR_ . 'twopayment/classes/TwoSoleTrader.php';
+            if (!file_exists($classFile)) {
+                return false;
+            }
+            require_once $classFile;
+        }
+        $module = Module::getInstanceByName('twopayment');
+        $country = $this->getCountry();
+        if (!$module || !$country || empty($country->iso_code)) {
+            return false;
+        }
+        return TwoSoleTrader::isAvailable($module, $country->iso_code);
     }
 
     private function insertFieldAfter(array $format, $afterKey, $newKey, FormField $field)
@@ -214,6 +242,8 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
                 return $this->translator->trans('Personal', [], 'Shop.Forms.Labels');
             case 'business_type':
                 return $this->translator->trans('Business', [], 'Shop.Forms.Labels');
+            case 'sole_trader_type':
+                return $this->translator->trans('Sole trader', [], 'Shop.Forms.Labels');
             case 'companyid':
                 return $this->translator->trans('Company ID', [], 'Shop.Forms.Labels');
             case 'department':

--- a/tests/OrderBuilderTest.php
+++ b/tests/OrderBuilderTest.php
@@ -1698,67 +1698,6 @@ final class OrderBuilderTest extends TestCase
         self::assertCount(0, $controller->styles);
     }
 
-    public function testHookPaymentOptionsBlocksWhenAccountTypeMissingInStrictMode(): void
-    {
-        $module = new class extends TwopaymentTestHarness {
-            protected function getTwoPaymentOption()
-            {
-                return (object) ['method' => 'two'];
-            }
-        };
-
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 1);
-        StubStore::$countries[826] = 'GB';
-        StubStore::$addresses[901] = [
-            'id_country' => 826,
-            'company' => 'Acme UK Ltd',
-            'vat_number' => 'GB123456789',
-            'loaded' => true,
-        ];
-
-        $cart = new Cart(501);
-        $cart->id_address_invoice = 901;
-        $cart->id_currency = 978;
-        $module->context->cart = $cart;
-        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
-        StubStore::$moduleCurrencies['twopayment'] = [['id_currency' => 978]];
-
-        $options = $module->hookPaymentOptions([]);
-
-        self::assertCount(0, $options);
-    }
-
-    public function testHookPaymentOptionsBlocksNonBusinessWhenAccountTypePresent(): void
-    {
-        $module = new class extends TwopaymentTestHarness {
-            protected function getTwoPaymentOption()
-            {
-                return (object) ['method' => 'two'];
-            }
-        };
-
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 1);
-        StubStore::$countries[34] = 'ES';
-        StubStore::$addresses[902] = [
-            'id_country' => 34,
-            'company' => 'Acme ES S.L.',
-            'dni' => 'B12345678',
-            'account_type' => 'private',
-            'loaded' => true,
-        ];
-
-        $cart = new Cart(502);
-        $cart->id_address_invoice = 902;
-        $cart->id_currency = 978;
-        $module->context->cart = $cart;
-        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
-        StubStore::$moduleCurrencies['twopayment'] = [['id_currency' => 978]];
-
-        $options = $module->hookPaymentOptions([]);
-
-        self::assertCount(0, $options);
-    }
-
     public function testHookPaymentOptionsAllowsTwoCoveredCurrencies(): void
     {
         $module = new class extends TwopaymentTestHarness {
@@ -1768,7 +1707,6 @@ final class OrderBuilderTest extends TestCase
             }
         };
 
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
         StubStore::$countries[826] = 'GB';
         StubStore::$addresses[904] = [
             'id_country' => 826,
@@ -1809,7 +1747,6 @@ final class OrderBuilderTest extends TestCase
             }
         };
 
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
         StubStore::$countries[826] = 'GB';
         StubStore::$addresses[903] = [
             'id_country' => 826,

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 /**
- * Unit spec for the sole-trader business logic (TWO-24755): both gates
+ * Unit spec for the sole-trader business logic (TWO-24755): the two gates
  * (registry endpoint + merchant toggle), fail-soft registry handling,
- * fail-closed token minting, and the account_type form option.
+ * fail-closed token minting, and that the address form carries no
+ * account-type selector (sole traders enrol via the payment-step toggle).
  */
 
 /**
@@ -37,16 +38,15 @@ final class TwoSoleTraderSpec
     {
         $tests = [
             'testAvailableWhenRegistryAndToggleAgree',
+            'testEnabledFollowsToggleOnly',
             'testHiddenWhenToggleOff',
-            'testHiddenWhenAccountTypeModeOff',
             'testHiddenWhenRegistryOmitsIt',
             'testRegistryErrorFallsBackToNoSoleTrader',
             'testRegistryRejectsMalformedCountry',
             'testRegistryResponseCachedPerRequest',
-            'testAccountTypeAllowedMatrix',
             'testTokenMintReadsHeaderAndFailsClosed',
             'testSignupUrlFollowsEnvironment',
-            'testFormatterAddsThirdOptionOnlyWhenAvailable',
+            'testFormatterHasNoAccountTypeField',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -84,7 +84,7 @@ final class TwoSoleTraderSpec
     private static function testAvailableWhenRegistryAndToggleAgree(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
@@ -96,27 +96,27 @@ final class TwoSoleTraderSpec
     private static function testHiddenWhenToggleOff(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 0, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 0],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
     }
 
-    private static function testHiddenWhenAccountTypeModeOff(): void
+    private static function testEnabledFollowsToggleOnly(): void
     {
-        // The option rides the account_type selector; without that mode the
-        // feature cannot surface no matter what the toggle says.
-        $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 0],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
-        );
-        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
+        // The feature is gated solely by the merchant toggle now — there is
+        // no account-type mode to also satisfy (TWO-24755 alignment).
+        self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
+        TinyAssert::true(TwoSoleTrader::isEnabled());
+
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TinyAssert::false(TwoSoleTrader::isEnabled());
     }
 
     private static function testHiddenWhenRegistryOmitsIt(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
             ['/registry/v1/supported-company-types/' => self::registryOk([])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'NO'));
@@ -125,7 +125,7 @@ final class TwoSoleTraderSpec
     private static function testRegistryErrorFallsBackToNoSoleTrader(): void
     {
         // Network error (transport returns false)
-        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
         TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
 
         // Non-200
@@ -146,7 +146,7 @@ final class TwoSoleTraderSpec
     private static function testRegistryRejectsMalformedCountry(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         // Never hits the API for junk country input
@@ -159,7 +159,7 @@ final class TwoSoleTraderSpec
     private static function testRegistryResponseCachedPerRequest(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
@@ -171,27 +171,9 @@ final class TwoSoleTraderSpec
         TinyAssert::count(2, $module->requests);
     }
 
-    private static function testAccountTypeAllowedMatrix(): void
-    {
-        $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
-        );
-        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'NO'));
-        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
-        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'personal', 'GB'));
-        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, '', 'GB'));
-
-        // Toggle off: sole_trader rejected even for GB, business still fine
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
-        TwoSoleTrader::resetCache();
-        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
-        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'GB'));
-    }
-
     private static function testTokenMintReadsHeaderAndFailsClosed(): void
     {
-        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
 
         // Happy path: both mints return the token header (case handled by
         // the transport, which lower-cases header names)
@@ -231,7 +213,7 @@ final class TwoSoleTraderSpec
         TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
     }
 
-    private static function testFormatterAddsThirdOptionOnlyWhenAvailable(): void
+    private static function testFormatterHasNoAccountTypeField(): void
     {
         $overridePath = dirname(__DIR__) . '/override/classes/form/CustomerAddressFormatter.php';
         if (!class_exists('CustomerAddressFormatter', false)) {
@@ -245,32 +227,19 @@ final class TwoSoleTraderSpec
             }
         };
 
-        $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+        // Even with sole trader enabled and the registry returning it, the
+        // address form carries no account-type selector — buyers always
+        // enter company details (B2B) and sole traders enrol via the
+        // payment-step toggle (TWO-24755).
+        self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
 
         $country = new Country();
         $country->iso_code = 'GB';
-        $formatter = new CustomerAddressFormatter($country, $translator, []);
-        $format = $formatter->getFormat();
-        TinyAssert::true(isset($format['account_type']), 'Expected account_type field');
-        TinyAssert::same('Sole trader', $format['account_type']->getAvailableValue('sole_trader'), 'Expected sole_trader option for GB with toggle on');
-
-        // Unsupported country: no third option
-        TwoSoleTrader::resetCache();
-        $module->cannedResponses = ['/registry/v1/supported-company-types/' => self::registryOk([])];
-        $country = new Country();
-        $country->iso_code = 'NO';
         $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
-        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option for NO');
-
-        // Toggle off: no third option even for GB
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
-        TwoSoleTrader::resetCache();
-        $country = new Country();
-        $country->iso_code = 'GB';
-        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
-        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option when toggle off');
+        TinyAssert::false(isset($format['account_type']), 'Address form must not add an account_type field');
+        TinyAssert::true(isset($format['company']), 'Company field is still present for B2B checkout');
     }
 }

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit spec for the sole-trader business logic (TWO-24755): both gates
+ * (registry endpoint + merchant toggle), fail-soft registry handling,
+ * fail-closed token minting, and the account_type form option.
+ */
+
+/**
+ * Harness whose Two API surface returns canned responses keyed by
+ * endpoint prefix, recording every request.
+ */
+final class TwoSoleTraderTestHarness extends TwopaymentTestHarness
+{
+    /** @var array<string, mixed> */
+    public $cannedResponses = [];
+    /** @var string[] */
+    public $requests = [];
+
+    public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+    {
+        $this->requests[] = $endpoint;
+        foreach ($this->cannedResponses as $prefix => $response) {
+            if (strpos($endpoint, $prefix) === 0) {
+                return $response;
+            }
+        }
+        return false;
+    }
+}
+
+final class TwoSoleTraderSpec
+{
+    public static function runAll(): void
+    {
+        $tests = [
+            'testAvailableWhenRegistryAndToggleAgree',
+            'testHiddenWhenToggleOff',
+            'testHiddenWhenAccountTypeModeOff',
+            'testHiddenWhenRegistryOmitsIt',
+            'testRegistryErrorFallsBackToRegisteredBusiness',
+            'testRegistryRejectsMalformedCountry',
+            'testRegistryResponseCachedPerRequest',
+            'testAccountTypeAllowedMatrix',
+            'testTokenMintReadsHeaderAndFailsClosed',
+            'testSignupUrlFollowsEnvironment',
+            'testFormatterAddsThirdOptionOnlyWhenAvailable',
+        ];
+        foreach ($tests as $test) {
+            self::reset();
+            self::$test();
+            print("PASS TwoSoleTraderSpec::$test\n");
+        }
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        TwoSoleTrader::resetCache();
+        PrestaShopLogger::reset();
+    }
+
+    private static function harness(array $config, array $responses): TwoSoleTraderTestHarness
+    {
+        foreach ($config as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        $module = new TwoSoleTraderTestHarness();
+        $module->cannedResponses = $responses;
+        StubStore::$moduleInstance = $module;
+        return $module;
+    }
+
+    private static function registryOk(array $types): array
+    {
+        return [
+            'http_status' => 200,
+            'supported_company_types' => $types,
+        ];
+    }
+
+    private static function testAvailableWhenRegistryAndToggleAgree(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
+        // Lowercase input normalises to the same country
+        TwoSoleTrader::resetCache();
+        TinyAssert::true(TwoSoleTrader::isAvailable($module, 'gb'));
+    }
+
+    private static function testHiddenWhenToggleOff(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 0, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
+    }
+
+    private static function testHiddenWhenAccountTypeModeOff(): void
+    {
+        // The option rides the account_type selector; without that mode the
+        // feature cannot surface no matter what the toggle says.
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 0],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
+    }
+
+    private static function testHiddenWhenRegistryOmitsIt(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS'])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'NO'));
+    }
+
+    private static function testRegistryErrorFallsBackToRegisteredBusiness(): void
+    {
+        // Network error (transport returns false)
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+
+        // Non-200
+        TwoSoleTrader::resetCache();
+        $module->cannedResponses = [
+            '/registry/v1/supported-company-types/' => ['http_status' => 404],
+        ];
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+
+        // 200 with malformed body
+        TwoSoleTrader::resetCache();
+        $module->cannedResponses = [
+            '/registry/v1/supported-company-types/' => ['http_status' => 200, 'data' => 'junk'],
+        ];
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+    }
+
+    private static function testRegistryRejectsMalformedCountry(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        // Never hits the API for junk country input
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, ''));
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'G'));
+        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GBR'));
+        TinyAssert::count(0, $module->requests);
+    }
+
+    private static function testRegistryResponseCachedPerRequest(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'gb');
+        TinyAssert::count(1, $module->requests);
+        // A different country is its own cache entry
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'US');
+        TinyAssert::count(2, $module->requests);
+    }
+
+    private static function testAccountTypeAllowedMatrix(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'NO'));
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'personal', 'GB'));
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, '', 'GB'));
+
+        // Toggle off: sole_trader rejected even for GB, business still fine
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TwoSoleTrader::resetCache();
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'GB'));
+    }
+
+    private static function testTokenMintReadsHeaderAndFailsClosed(): void
+    {
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+
+        // Happy path: both mints return the token header (case handled by
+        // the transport, which lower-cases header names)
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            return [
+                'status' => 200,
+                'headers' => ['two-delegated-authority-token' => $endpoint === '/registry/v1/delegation' ? 'reg-token' : 'autofill-token'],
+            ];
+        };
+        TinyAssert::same(
+            ['delegation_token' => 'reg-token', 'autofill_token' => 'autofill-token'],
+            TwoSoleTrader::mintTokens($module)
+        );
+
+        // Second mint failing voids the pair — never hand the browser half a flow
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            if ($endpoint === '/autofill/v1/delegation') {
+                return ['status' => 500, 'headers' => []];
+            }
+            return ['status' => 200, 'headers' => ['two-delegated-authority-token' => 'reg-token']];
+        };
+        TinyAssert::same(null, TwoSoleTrader::mintTokens($module));
+
+        // Missing header on a 200 also fails closed
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            return ['status' => 200, 'headers' => []];
+        };
+        TinyAssert::same(null, TwoSoleTrader::mintTokens($module));
+    }
+
+    private static function testSignupUrlFollowsEnvironment(): void
+    {
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', 'PRODUCTION');
+        TinyAssert::same('https://checkout.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', 'SANDBOX');
+        TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+    }
+
+    private static function testFormatterAddsThirdOptionOnlyWhenAvailable(): void
+    {
+        $overridePath = dirname(__DIR__) . '/override/classes/form/CustomerAddressFormatter.php';
+        if (!class_exists('CustomerAddressFormatter', false)) {
+            require_once $overridePath;
+        }
+
+        $translator = new class {
+            public function trans($message, array $params = [], $domain = null): string
+            {
+                return (string) $message;
+            }
+        };
+
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+        );
+
+        $country = new Country();
+        $country->iso_code = 'GB';
+        $formatter = new CustomerAddressFormatter($country, $translator, []);
+        $format = $formatter->getFormat();
+        TinyAssert::true(isset($format['account_type']), 'Expected account_type field');
+        TinyAssert::same('Sole trader', $format['account_type']->getAvailableValue('sole_trader'), 'Expected sole_trader option for GB with toggle on');
+
+        // Unsupported country: no third option
+        TwoSoleTrader::resetCache();
+        $module->cannedResponses = ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS'])];
+        $country = new Country();
+        $country->iso_code = 'NO';
+        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
+        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option for NO');
+
+        // Toggle off: no third option even for GB
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TwoSoleTrader::resetCache();
+        $country = new Country();
+        $country->iso_code = 'GB';
+        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
+        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option when toggle off');
+    }
+}

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -40,7 +40,7 @@ final class TwoSoleTraderSpec
             'testHiddenWhenToggleOff',
             'testHiddenWhenAccountTypeModeOff',
             'testHiddenWhenRegistryOmitsIt',
-            'testRegistryErrorFallsBackToRegisteredBusiness',
+            'testRegistryErrorFallsBackToNoSoleTrader',
             'testRegistryRejectsMalformedCountry',
             'testRegistryResponseCachedPerRequest',
             'testAccountTypeAllowedMatrix',
@@ -85,7 +85,7 @@ final class TwoSoleTraderSpec
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
         // Lowercase input normalises to the same country
@@ -97,7 +97,7 @@ final class TwoSoleTraderSpec
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 0, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
     }
@@ -108,7 +108,7 @@ final class TwoSoleTraderSpec
         // feature cannot surface no matter what the toggle says.
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 0],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
     }
@@ -117,42 +117,42 @@ final class TwoSoleTraderSpec
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk([])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'NO'));
     }
 
-    private static function testRegistryErrorFallsBackToRegisteredBusiness(): void
+    private static function testRegistryErrorFallsBackToNoSoleTrader(): void
     {
         // Network error (transport returns false)
         $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
 
         // Non-200
         TwoSoleTrader::resetCache();
         $module->cannedResponses = [
             '/registry/v1/supported-company-types/' => ['http_status' => 404],
         ];
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
 
         // 200 with malformed body
         TwoSoleTrader::resetCache();
         $module->cannedResponses = [
             '/registry/v1/supported-company-types/' => ['http_status' => 200, 'data' => 'junk'],
         ];
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
     }
 
     private static function testRegistryRejectsMalformedCountry(): void
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         // Never hits the API for junk country input
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, ''));
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'G'));
-        TinyAssert::same(['REGISTERED_BUSINESS'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GBR'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, ''));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'G'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GBR'));
         TinyAssert::count(0, $module->requests);
     }
 
@@ -160,7 +160,7 @@ final class TwoSoleTraderSpec
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
         TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
@@ -175,7 +175,7 @@ final class TwoSoleTraderSpec
     {
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'NO'));
         TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
@@ -247,7 +247,7 @@ final class TwoSoleTraderSpec
 
         $module = self::harness(
             ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER'])]
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
 
         $country = new Country();
@@ -259,7 +259,7 @@ final class TwoSoleTraderSpec
 
         // Unsupported country: no third option
         TwoSoleTrader::resetCache();
-        $module->cannedResponses = ['/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS'])];
+        $module->cannedResponses = ['/registry/v1/supported-company-types/' => self::registryOk([])];
         $country = new Country();
         $country->iso_code = 'NO';
         $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,8 @@ namespace {
         public static array $taxRuleRates = [];
         public static array $dbExecuteSResponses = [];
         public static array $dbLastExecuteS = [];
+        /** @var object|null returned by Module::getInstanceByName in tests */
+        public static $moduleInstance = null;
 
         public static function reset(): void
         {
@@ -78,6 +80,7 @@ namespace {
             self::$taxRuleRates = [];
             self::$dbExecuteSResponses = [];
             self::$dbLastExecuteS = [];
+            self::$moduleInstance = null;
 
             $context = Context::getContext();
             $context->cookie = new Cookie();
@@ -104,6 +107,11 @@ namespace {
     class Module
     {
         public int $id = 1;
+
+        public static function getInstanceByName($name)
+        {
+            return StubStore::$moduleInstance;
+        }
 
         public static function isInstalled($name): bool
         {
@@ -351,6 +359,8 @@ namespace {
 
     class Country
     {
+        public $iso_code = '';
+
         public static function getIsoById($id)
         {
             return StubStore::$countries[(int) $id] ?? false;
@@ -804,6 +814,10 @@ namespace {
         {
             return 1;
         }
+    }
+
+    if (!defined('_PS_MODULE_DIR_')) {
+        define('_PS_MODULE_DIR_', dirname(__DIR__, 2) . '/');
     }
 
     require_once dirname(__DIR__) . '/twopayment.php';

--- a/tests/run.php
+++ b/tests/run.php
@@ -4958,10 +4958,12 @@ final class OrderBuilderSpec
 }
 
 require __DIR__ . '/CustomerAddressFormatterOverrideSpec.php';
+require __DIR__ . '/TwoSoleTraderSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
     'CustomerAddressFormatterOverrideSpec::runAll' => [CustomerAddressFormatterOverrideSpec::class, 'runAll'],
+    'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -131,8 +131,6 @@ final class OrderBuilderSpec
         self::testOtherSettingsFormDoesNotExposeOrderIntentToggle();
         self::testHookActionAdminControllerSetMediaRegistersCssOnModuleConfigPage();
         self::testHookActionAdminControllerSetMediaSkipsUnrelatedAdminPage();
-        self::testHookPaymentOptionsBlocksWhenAccountTypeMissingInStrictMode();
-        self::testHookPaymentOptionsBlocksNonBusinessWhenAccountTypePresent();
         self::testHookPaymentOptionsAllowsTwoCoveredCurrencies();
         self::testHookPaymentOptionsBlocksUnsupportedCurrency();
         self::testMergeTwoPaymentTermFallbackUsesFallbackWhenMissing();
@@ -4297,71 +4295,6 @@ final class OrderBuilderSpec
         TinyAssert::same(0, count($controller->styles));
     }
 
-    private static function testHookPaymentOptionsBlocksWhenAccountTypeMissingInStrictMode(): void
-    {
-        self::reset();
-        $module = new class extends TwopaymentTestHarness {
-            protected function getTwoPaymentOption()
-            {
-                return (object) ['method' => 'two'];
-            }
-        };
-
-        $module->active = true;
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 1);
-        StubStore::$countries[826] = 'GB';
-        StubStore::$addresses[901] = [
-            'id_country' => 826,
-            'company' => 'Acme UK Ltd',
-            'vat_number' => 'GB123456789',
-            'loaded' => true,
-        ];
-
-        $cart = new Cart(501);
-        $cart->id_address_invoice = 901;
-        $cart->id_currency = 978;
-        $module->context->cart = $cart;
-        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
-        StubStore::$moduleCurrencies['twopayment'] = [['id_currency' => 978]];
-
-        $options = $module->hookPaymentOptions([]);
-
-        TinyAssert::same(0, count($options));
-    }
-
-    private static function testHookPaymentOptionsBlocksNonBusinessWhenAccountTypePresent(): void
-    {
-        self::reset();
-        $module = new class extends TwopaymentTestHarness {
-            protected function getTwoPaymentOption()
-            {
-                return (object) ['method' => 'two'];
-            }
-        };
-
-        $module->active = true;
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 1);
-        StubStore::$countries[34] = 'ES';
-        StubStore::$addresses[902] = [
-            'id_country' => 34,
-            'company' => 'Acme ES S.L.',
-            'dni' => 'B12345678',
-            'account_type' => 'private',
-            'loaded' => true,
-        ];
-
-        $cart = new Cart(502);
-        $cart->id_address_invoice = 902;
-        $cart->id_currency = 978;
-        $module->context->cart = $cart;
-        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
-        StubStore::$moduleCurrencies['twopayment'] = [['id_currency' => 978]];
-
-        $options = $module->hookPaymentOptions([]);
-
-        TinyAssert::same(0, count($options));
-    }
-
     private static function testHookPaymentOptionsAllowsTwoCoveredCurrencies(): void
     {
         self::reset();
@@ -4373,7 +4306,6 @@ final class OrderBuilderSpec
         };
 
         $module->active = true;
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
         StubStore::$countries[826] = 'GB';
         StubStore::$addresses[904] = [
             'id_country' => 826,
@@ -4416,7 +4348,6 @@ final class OrderBuilderSpec
         };
 
         $module->active = true;
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
         StubStore::$countries[826] = 'GB';
         StubStore::$addresses[903] = [
             'id_country' => 826,

--- a/twopayment.php
+++ b/twopayment.php
@@ -6387,7 +6387,7 @@ class Twopayment extends PaymentModule
      * @param resource|CurlHandle $ch cURL handle
      * @return void
      */
-    private function configureSslVerification($ch)
+    public function configureSslVerification($ch)
     {
         // Check if SSL verification is disabled via configuration (for corporate networks)
         $disable_ssl_verify = (bool)Configuration::get('PS_TWO_DISABLE_SSL_VERIFY', false);

--- a/twopayment.php
+++ b/twopayment.php
@@ -11,6 +11,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+require_once __DIR__ . '/classes/TwoSoleTrader.php';
+
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic
@@ -227,6 +229,7 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
         Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 0); // Disabled by default - must be enabled after coordinating with Two
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
@@ -443,6 +446,7 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_ENABLE_TAX_SUBTOTALS');
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
+        Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         Configuration::deleteByName('PS_TWO_MERCHANT_MIN_ORDER');
         Configuration::deleteByName('PS_TWO_MERCHANT_MIN_ORDER_BASIS');
@@ -824,6 +828,26 @@ class Twopayment extends PaymentModule
                     ),
                     array(
                         'type' => 'switch',
+                        'label' => $this->l('Enable sole trader checkout'),
+                        'name' => 'PS_TWO_ENABLE_SOLE_TRADER',
+                        'is_bool' => true,
+                        'desc' => $this->l('Adds a Sole Trader option to the Account Type selector for buyers in countries where Two supports sole traders (currently the UK and US). Requires Account Type selection to be enabled.'),
+                        'required' => true,
+                        'values' => array(
+                            array(
+                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_ON',
+                                'value' => 1,
+                                'label' => $this->l('Yes')
+                            ),
+                            array(
+                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_OFF',
+                                'value' => 0,
+                                'label' => $this->l('No')
+                            ),
+                        ),
+                    ),
+                    array(
+                        'type' => 'switch',
                         'label' => $this->l('Activate company name auto-complete'),
                         'name' => 'PS_TWO_ENABLE_COMPANY_NAME',
                         'is_bool' => true,
@@ -1060,6 +1084,7 @@ class Twopayment extends PaymentModule
     {
         $fields_values = array();
         $fields_values['PS_TWO_USE_ACCOUNT_TYPE'] = Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE', Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'));
+        $fields_values['PS_TWO_ENABLE_SOLE_TRADER'] = Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', Configuration::get('PS_TWO_ENABLE_SOLE_TRADER'));
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_ENABLE_DEPARTMENT'] = Tools::getValue('PS_TWO_ENABLE_DEPARTMENT', Configuration::get('PS_TWO_ENABLE_DEPARTMENT'));
@@ -1230,6 +1255,7 @@ class Twopayment extends PaymentModule
     protected function saveTwoOtherFormValues()
     {
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE'));
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_ENABLE_DEPARTMENT', Tools::getValue('PS_TWO_ENABLE_DEPARTMENT'));
@@ -2279,6 +2305,14 @@ class Twopayment extends PaymentModule
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,
                 'use_account_type' => (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'),
+                'sole_trader' => array(
+                    'enabled' => TwoSoleTrader::isEnabled() ? 1 : 0,
+                    'signup_url' => TwoSoleTrader::getSignupPageUrl(),
+                    'i18n' => array(
+                        'popup_prompt' => $this->l('Click here to log in or sign up as a sole trader with Two.'),
+                        'error' => $this->l('Something went wrong setting up sole trader checkout. Please try again.'),
+                    ),
+                ),
                 'order_intent_url' => $this->context->link->getModuleLink($this->name, 'orderintent'),
                 'ajax_token' => Tools::getToken(false),
                 'module_dir' => $this->_path,
@@ -2305,6 +2339,7 @@ class Twopayment extends PaymentModule
         // Ensures they load AFTER jQuery
         $this->context->controller->registerJavascript('two-company-search', 'modules/twopayment/views/js/modules/TwoCompanySearch.js', array('priority' => 201, 'async' => false));
         $this->context->controller->registerJavascript('two-order-intent', 'modules/twopayment/views/js/modules/TwoOrderIntent.js', array('priority' => 202, 'async' => false));
+        $this->context->controller->registerJavascript('two-sole-trader', 'modules/twopayment/views/js/modules/TwoSoleTrader.js', array('priority' => 204, 'async' => false));
         $this->context->controller->registerJavascript('two-field-validation', 'modules/twopayment/views/js/modules/TwoFieldValidation.js', array('priority' => 203, 'async' => false));
         // Phone validation removed - Two API handles phone number validation
         $this->context->controller->registerJavascript('two-checkout-manager', 'modules/twopayment/views/js/modules/TwoCheckoutManager.js', array('priority' => 205, 'async' => false));
@@ -2618,14 +2653,16 @@ class Twopayment extends PaymentModule
             return [];
         }
 
-        // If merchant uses account type selection, gate payment option to business accounts
+        // If merchant uses account type selection, gate payment option to
+        // business accounts — or sole traders where available (TWO-24755).
         if ((int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE')) {
             $account_type = property_exists($billing_address, 'account_type') ? trim((string) $billing_address->account_type) : '';
-            if ($account_type !== 'business') {
-                PrestaShopLogger::addLog('TwoPayment: Payment option hidden - account type is not business (current: ' . ($account_type ?: 'not set') . ')', 1);
+            $billing_country_iso = (string) Country::getIsoById((int) $billing_address->id_country);
+            if (!TwoSoleTrader::isAccountTypeAllowed($this, $account_type, $billing_country_iso)) {
+                PrestaShopLogger::addLog('TwoPayment: Payment option hidden - account type not eligible (current: ' . ($account_type ?: 'not set') . ')', 1);
                 return [];
             }
-            PrestaShopLogger::addLog('TwoPayment: Payment option shown for business account path', 1);
+            PrestaShopLogger::addLog('TwoPayment: Payment option shown for ' . $account_type . ' account path', 1);
         } else {
             // When account type selection is disabled, allow showing Two option; FE will prompt for company selection as needed
             PrestaShopLogger::addLog('TwoPayment: Payment option shown (account type disabled)', 1);

--- a/twopayment.php
+++ b/twopayment.php
@@ -132,7 +132,6 @@ class Twopayment extends PaymentModule
         $this->enable_project = Configuration::get('PS_TWO_ENABLE_PROJECT');
         // Order intent pre-check is mandatory for all checkouts.
         $this->enable_order_intent = 1;
-        $this->use_account_type = Configuration::get('PS_TWO_USE_ACCOUNT_TYPE');
         $this->finalize_purchase_shipping = Configuration::get('PS_TWO_FINALIZE_PURCHASE');
         
         // Ensure custom Two states exist (for existing installations)
@@ -228,7 +227,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', 1);
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
         Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
         Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 0); // Disabled by default - must be enabled after coordinating with Two
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
@@ -445,7 +443,6 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_ENABLE_PROJECT');
         Configuration::deleteByName('PS_TWO_ENABLE_TAX_SUBTOTALS');
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
-        Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         Configuration::deleteByName('PS_TWO_MERCHANT_MIN_ORDER');
@@ -808,30 +805,10 @@ class Twopayment extends PaymentModule
                 'input' => array(
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Use Account Type selection'),
-                        'name' => 'PS_TWO_USE_ACCOUNT_TYPE',
-                        'is_bool' => true,
-                        'desc' => $this->l('If Yes, the address form will show Account Type and company fields become required for business. If No, the address form will not show Account Type and Two will prompt for company only at payment time.'),
-                        'required' => true,
-                        'values' => array(
-                            array(
-                                'id' => 'PS_TWO_USE_ACCOUNT_TYPE_ON',
-                                'value' => 1,
-                                'label' => $this->l('Yes')
-                            ),
-                            array(
-                                'id' => 'PS_TWO_USE_ACCOUNT_TYPE_OFF',
-                                'value' => 0,
-                                'label' => $this->l('No')
-                            ),
-                        ),
-                    ),
-                    array(
-                        'type' => 'switch',
                         'label' => $this->l('Enable sole trader checkout'),
                         'name' => 'PS_TWO_ENABLE_SOLE_TRADER',
                         'is_bool' => true,
-                        'desc' => $this->l('Adds a Sole Trader option to the Account Type selector for buyers in countries where Two supports sole traders (currently the UK and US). Requires Account Type selection to be enabled.'),
+                        'desc' => $this->l('Shows a Business / Sole trader toggle on the payment step for buyers in countries where Two supports sole traders (currently the UK and US).'),
                         'required' => true,
                         'values' => array(
                             array(
@@ -1083,7 +1060,6 @@ class Twopayment extends PaymentModule
     protected function getTwoOtherFormValues()
     {
         $fields_values = array();
-        $fields_values['PS_TWO_USE_ACCOUNT_TYPE'] = Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE', Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'));
         $fields_values['PS_TWO_ENABLE_SOLE_TRADER'] = Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', Configuration::get('PS_TWO_ENABLE_SOLE_TRADER'));
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
@@ -1254,7 +1230,6 @@ class Twopayment extends PaymentModule
 
     protected function saveTwoOtherFormValues()
     {
-        Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE'));
         Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
@@ -1399,7 +1374,7 @@ class Twopayment extends PaymentModule
         $api_verified = (bool) Configuration::get('PS_TWO_API_KEY_VERIFIED');
         $ssl_disabled = (bool) Configuration::get('PS_TWO_DISABLE_SSL_VERIFY');
         $order_intent_enabled = true;
-        $use_account_type = (bool) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE');
+        $sole_trader_enabled = (bool) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER');
         $term_type = (string) Configuration::get('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD');
         $available_terms = $this->getAvailablePaymentTerms();
 
@@ -1430,8 +1405,8 @@ class Twopayment extends PaymentModule
                 'ok' => true,
             ),
             array(
-                'label' => $this->l('Account type mode'),
-                'value' => $use_account_type ? $this->l('Enabled') : $this->l('Disabled'),
+                'label' => $this->l('Sole trader checkout'),
+                'value' => $sole_trader_enabled ? $this->l('Enabled') : $this->l('Disabled'),
                 'ok' => true,
             ),
             array(
@@ -2304,11 +2279,12 @@ class Twopayment extends PaymentModule
                 'enable_department' => $this->enable_department,
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,
-                'use_account_type' => (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'),
                 'sole_trader' => array(
                     'enabled' => TwoSoleTrader::isEnabled() ? 1 : 0,
                     'signup_url' => TwoSoleTrader::getSignupPageUrl(),
                     'i18n' => array(
+                        'registered_business' => $this->l('Registered business'),
+                        'sole_trader' => $this->l('Sole trader'),
                         'popup_prompt' => $this->l('Click here to log in or sign up as a sole trader with Two.'),
                         'error' => $this->l('Something went wrong setting up sole trader checkout. Please try again.'),
                     ),
@@ -2318,6 +2294,7 @@ class Twopayment extends PaymentModule
                 'module_dir' => $this->_path,
                 'client' => 'PS',
                 'client_version' => $this->version,
+                'shop_country' => (string) Context::getContext()->country->iso_code,
                 'countries' => $param_countries,
                 'available_payment_terms' => $this->getAvailablePaymentTerms(),
                 'default_payment_term' => $this->getDefaultPaymentTerm(),
@@ -2653,21 +2630,12 @@ class Twopayment extends PaymentModule
             return [];
         }
 
-        // If merchant uses account type selection, gate payment option to
-        // business accounts — or sole traders where available (TWO-24755).
-        if ((int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE')) {
-            $account_type = property_exists($billing_address, 'account_type') ? trim((string) $billing_address->account_type) : '';
-            $billing_country_iso = (string) Country::getIsoById((int) $billing_address->id_country);
-            if (!TwoSoleTrader::isAccountTypeAllowed($this, $account_type, $billing_country_iso)) {
-                PrestaShopLogger::addLog('TwoPayment: Payment option hidden - account type not eligible (current: ' . ($account_type ?: 'not set') . ')', 1);
-                return [];
-            }
-            PrestaShopLogger::addLog('TwoPayment: Payment option shown for ' . $account_type . ' account path', 1);
-        } else {
-            // When account type selection is disabled, allow showing Two option; FE will prompt for company selection as needed
-            PrestaShopLogger::addLog('TwoPayment: Payment option shown (account type disabled)', 1);
-        }
-        
+        // B2B checkout: Two shows for any company-bearing buyer. The
+        // front-end prompts for the company at payment time when needed, and
+        // sole traders enrol through the payment-step toggle (TWO-24755);
+        // the order-intent pre-check enforces a verified company + org number.
+        PrestaShopLogger::addLog('TwoPayment: Payment option shown', 1);
+
         $payment_options = [
             $this->getTwoPaymentOption(),
         ];

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1141,3 +1141,53 @@
 .payment-option.two-loading::after {
     display: none !important;
 }
+
+/* Sole trader Business / Sole trader toggle (TWO-24755) */
+.two-sole-trader {
+    margin: 0 0 12px;
+}
+
+.two-sole-trader__toggle {
+    display: inline-flex;
+    border: 1px solid #d0d5dd;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.two-sole-trader__mode {
+    padding: 6px 14px;
+    font-size: 13px;
+    line-height: 1.4;
+    cursor: pointer;
+    background: #fff;
+    color: #344054;
+    user-select: none;
+}
+
+.two-sole-trader__mode + .two-sole-trader__mode {
+    border-left: 1px solid #d0d5dd;
+}
+
+.two-sole-trader__mode--selected {
+    background: #1a1a1a;
+    color: #fff;
+}
+
+.two-sole-trader__prompt {
+    display: inline-block;
+    margin-top: 8px;
+    font-size: 13px;
+    text-decoration: underline;
+}
+
+.two-sole-trader__status {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #027a48;
+}
+
+.two-sole-trader__error {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #b42318;
+}

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2,12 +2,21 @@
  * Two Sole Trader - presentation layer for the sole-trader checkout flow
  * (TWO-24755).
  *
- * All decisioning lives server-side in classes/TwoSoleTrader.php (whether
- * the option shows for a country, token minting); this module only reacts
- * to the buyer's account_type, opens Two's hosted signup popup, autofills
- * the company data from GET /autofill/v1/buyer/current, and persists it
- * through the existing saveCompany action so the regular order-intent and
- * payment paths run unchanged. Mirrors the Magento reference flow.
+ * Renders a Business / Sole trader toggle on the payment step — the same
+ * model as the Magento and WooCommerce plugins — shown only where Two's
+ * registry says the billing country supports sole traders AND the merchant
+ * has enabled the feature. There is no account-type selector on the address
+ * form; the buyer always enters company details (B2B), and sole traders
+ * enrol from this toggle.
+ *
+ * Picking "Sole trader" mints the delegation + autofill tokens server-side,
+ * opens Two's hosted signup popup, and autofills the company fields from
+ * GET /autofill/v1/buyer/current. An enrolled sole trader then checks out as
+ * a regular business — the synthetic organization number their registration
+ * minted carries the semantics, so the order payload is unchanged.
+ *
+ * All decisioning (country eligibility, token minting) lives server-side in
+ * classes/TwoSoleTrader.php; this module only renders the result.
  */
 class TwoSoleTrader {
     constructor(config) {
@@ -17,11 +26,18 @@ class TwoSoleTrader {
             orderIntentUrl: '',
             ajaxToken: '',
             signupUrl: '',
+            shopCountry: '',
+            i18n: {},
             ...config
         };
+        this.mode = 'business';
         this.tokens = null;
         this.flowStarted = false;
         this.messageListenerBound = false;
+        // Server-resolved availability, cached per billing country for the
+        // page's lifetime so the toggle settles without re-fetching.
+        this.availabilityByCountry = {};
+        this.renderedForCountry = null;
 
         if (this.config.enabled) {
             this.init();
@@ -30,55 +46,26 @@ class TwoSoleTrader {
 
     init() {
         const self = this;
-        // The account_type select lives on the address step; the payment
-        // box renders later. Watch both: select changes and DOM arrival of
-        // the payment container (checkout step transitions re-render).
+        // The payment box and the billing country can both re-render across
+        // checkout step transitions; re-evaluate availability on each change.
         document.addEventListener('change', function (event) {
-            if (event.target && event.target.matches("select[name='account_type']")) {
-                self.evaluate();
+            if (event.target && event.target.matches("select[name='id_country'], select[name='country']")) {
+                self.refreshAvailability();
             }
         });
         const observer = new MutationObserver(function () {
-            self.evaluate();
+            self.refreshAvailability();
         });
         observer.observe(document.body, { childList: true, subtree: true });
-        this.evaluate();
-    }
-
-    accountType() {
-        const field = document.querySelector("select[name='account_type']");
-        if (field && field.value) {
-            return field.value;
-        }
-        try {
-            return sessionStorage.getItem('two_account_type') || '';
-        } catch (e) {
-            return '';
-        }
+        this.refreshAvailability();
     }
 
     container() {
         return document.querySelector('.two-sole-trader');
     }
 
-    /**
-     * Show/hide the sole-trader block and kick the flow off exactly once
-     * per page when the buyer is in sole-trader mode at the payment step.
-     */
-    evaluate() {
-        const container = this.container();
-        if (!container) {
-            return;
-        }
-        if (this.accountType() === 'sole_trader') {
-            container.style.display = 'block';
-            if (!this.flowStarted) {
-                this.flowStarted = true;
-                this.fetchTokens();
-            }
-        } else {
-            container.style.display = 'none';
-        }
+    text(key, fallback) {
+        return (this.config.i18n && this.config.i18n[key]) || fallback;
     }
 
     moduleUrl(action) {
@@ -87,6 +74,148 @@ class TwoSoleTrader {
         url.searchParams.set('action', action);
         url.searchParams.set('token', this.config.ajaxToken);
         return url.toString();
+    }
+
+    billingCountry() {
+        const field = document.querySelector("select[name='id_country'], select[name='country']");
+        if (field && field.selectedOptions && field.selectedOptions.length) {
+            const iso = field.selectedOptions[0].getAttribute('data-iso-code');
+            if (iso) {
+                return iso.toUpperCase();
+            }
+        }
+        return (this.config.shopCountry || '').toUpperCase();
+    }
+
+    /**
+     * Decide whether to show the toggle for the current billing country.
+     * Availability (registry endpoint + merchant toggle) is resolved
+     * server-side; fail-soft to "not available" so checkout never blocks.
+     */
+    refreshAvailability() {
+        const container = this.container();
+        if (!container) {
+            return;
+        }
+        const country = this.billingCountry();
+        if (!country) {
+            this.hide();
+            return;
+        }
+        if (country === this.renderedForCountry) {
+            return; // already settled for this country
+        }
+        if (country in this.availabilityByCountry) {
+            this.apply(country, this.availabilityByCountry[country]);
+            return;
+        }
+        const self = this;
+        fetch(this.moduleUrl('soleTraderAvailability') + '&country=' + encodeURIComponent(country), { method: 'GET' })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                const available = !!(json && json.success && json.available);
+                self.availabilityByCountry[country] = available;
+                // The buyer may have changed country mid-request; only apply
+                // if the answer is still for the current one.
+                if (self.billingCountry() === country) {
+                    self.apply(country, available);
+                }
+            })
+            .catch(function () {
+                if (self.billingCountry() === country) {
+                    self.apply(country, false);
+                }
+            });
+    }
+
+    apply(country, available) {
+        this.renderedForCountry = country;
+        if (available) {
+            this.render();
+        } else {
+            this.hide();
+        }
+    }
+
+    hide() {
+        const container = this.container();
+        if (container) {
+            container.style.display = 'none';
+        }
+        if (this.mode === 'sole_trader') {
+            this.setMode('business');
+        }
+    }
+
+    /**
+     * Render the Business / Sole trader toggle into the payment-step
+     * container. Chips are built once; subsequent calls just reveal it.
+     */
+    render() {
+        const container = this.container();
+        if (!container) {
+            return;
+        }
+        container.style.display = 'block';
+        const toggle = container.querySelector('.two-sole-trader__toggle');
+        if (toggle && toggle.dataset.twoBuilt !== '1') {
+            const self = this;
+            [
+                { value: 'business', label: this.text('registered_business', 'Registered business') },
+                { value: 'sole_trader', label: this.text('sole_trader', 'Sole trader') }
+            ].forEach(function (option) {
+                const chip = document.createElement('span');
+                chip.className = 'two-sole-trader__mode';
+                chip.setAttribute('role', 'button');
+                chip.setAttribute('tabindex', '0');
+                chip.dataset.mode = option.value;
+                chip.textContent = option.label;
+                chip.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    self.setMode(option.value);
+                });
+                chip.addEventListener('keypress', function (event) {
+                    if (event.which === 13 || event.which === 32) {
+                        event.preventDefault();
+                        self.setMode(option.value);
+                    }
+                });
+                toggle.appendChild(chip);
+            });
+            toggle.dataset.twoBuilt = '1';
+        }
+        this.updateChips();
+    }
+
+    updateChips() {
+        const container = this.container();
+        if (!container) {
+            return;
+        }
+        const self = this;
+        container.querySelectorAll('.two-sole-trader__mode').forEach(function (chip) {
+            chip.classList.toggle('two-sole-trader__mode--selected', chip.dataset.mode === self.mode);
+        });
+    }
+
+    /**
+     * Switch mode. Sole trader mints tokens then autofills (or prompts the
+     * signup popup) once per page; business just hides the prompt. The popup
+     * opens from the prompt link's own click so the blocker lets it through.
+     */
+    setMode(mode) {
+        this.mode = mode;
+        this.updateChips();
+        if (mode === 'sole_trader') {
+            if (!this.flowStarted) {
+                this.flowStarted = true;
+                this.fetchTokens();
+            } else if (this.tokens) {
+                this.getCurrentBuyer();
+            }
+        } else {
+            this.hidePrompt();
+        }
     }
 
     fetchTokens() {
@@ -174,17 +303,6 @@ class TwoSoleTrader {
             });
     }
 
-    billingCountry() {
-        const field = document.querySelector("select[name='id_country'], select[name='country']");
-        if (field && field.selectedOptions && field.selectedOptions.length) {
-            const iso = field.selectedOptions[0].getAttribute('data-iso-code');
-            if (iso) {
-                return iso;
-            }
-        }
-        return (window.twopayment && window.twopayment.shop_country) || '';
-    }
-
     openPopup() {
         if (!this.tokens) {
             return;
@@ -222,7 +340,7 @@ class TwoSoleTrader {
         this.messageListenerBound = true;
         const self = this;
         window.addEventListener('message', function (event) {
-            if (self.accountType() !== 'sole_trader' || !self.tokens) {
+            if (self.mode !== 'sole_trader' || !self.tokens) {
                 return;
             }
             if (event.origin !== new URL(self.tokens.signup_url).origin) {
@@ -256,6 +374,10 @@ class TwoSoleTrader {
         const prompt = this.container() && this.container().querySelector('.two-sole-trader__prompt');
         if (prompt) {
             prompt.style.display = 'none';
+        }
+        const status = this.container() && this.container().querySelector('.two-sole-trader__status');
+        if (status) {
+            status.style.display = 'none';
         }
     }
 

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -1,0 +1,278 @@
+/**
+ * Two Sole Trader - presentation layer for the sole-trader checkout flow
+ * (TWO-24755).
+ *
+ * All decisioning lives server-side in classes/TwoSoleTrader.php (whether
+ * the option shows for a country, token minting); this module only reacts
+ * to the buyer's account_type, opens Two's hosted signup popup, autofills
+ * the company data from GET /autofill/v1/buyer/current, and persists it
+ * through the existing saveCompany action so the regular order-intent and
+ * payment paths run unchanged. Mirrors the Magento reference flow.
+ */
+class TwoSoleTrader {
+    constructor(config) {
+        this.config = {
+            enabled: false,
+            checkoutHost: '',
+            orderIntentUrl: '',
+            ajaxToken: '',
+            signupUrl: '',
+            ...config
+        };
+        this.tokens = null;
+        this.flowStarted = false;
+        this.messageListenerBound = false;
+
+        if (this.config.enabled) {
+            this.init();
+        }
+    }
+
+    init() {
+        const self = this;
+        // The account_type select lives on the address step; the payment
+        // box renders later. Watch both: select changes and DOM arrival of
+        // the payment container (checkout step transitions re-render).
+        document.addEventListener('change', function (event) {
+            if (event.target && event.target.matches("select[name='account_type']")) {
+                self.evaluate();
+            }
+        });
+        const observer = new MutationObserver(function () {
+            self.evaluate();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        this.evaluate();
+    }
+
+    accountType() {
+        const field = document.querySelector("select[name='account_type']");
+        if (field && field.value) {
+            return field.value;
+        }
+        try {
+            return sessionStorage.getItem('two_account_type') || '';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    container() {
+        return document.querySelector('.two-sole-trader');
+    }
+
+    /**
+     * Show/hide the sole-trader block and kick the flow off exactly once
+     * per page when the buyer is in sole-trader mode at the payment step.
+     */
+    evaluate() {
+        const container = this.container();
+        if (!container) {
+            return;
+        }
+        if (this.accountType() === 'sole_trader') {
+            container.style.display = 'block';
+            if (!this.flowStarted) {
+                this.flowStarted = true;
+                this.fetchTokens();
+            }
+        } else {
+            container.style.display = 'none';
+        }
+    }
+
+    moduleUrl(action) {
+        const url = new URL(this.config.orderIntentUrl, window.location.origin);
+        url.searchParams.set('ajax', '1');
+        url.searchParams.set('action', action);
+        url.searchParams.set('token', this.config.ajaxToken);
+        return url.toString();
+    }
+
+    fetchTokens() {
+        const self = this;
+        fetch(this.moduleUrl('soleTraderTokens'), { method: 'POST' })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                if (json && json.success && json.autofill_token) {
+                    self.tokens = json;
+                    self.bindPopupMessageListener();
+                    self.getCurrentBuyer();
+                } else {
+                    self.showError();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    /**
+     * Autofill from the buyer's current Two sole-trader business. A 404 or
+     * an email mismatch means no usable registration yet - show the signup
+     * prompt instead.
+     */
+    getCurrentBuyer() {
+        const self = this;
+        fetch(this.config.checkoutHost + '/autofill/v1/buyer/current', {
+            credentials: 'include',
+            headers: { 'two-delegated-authority-token': this.tokens.autofill_token }
+        })
+            .then(function (response) {
+                if (response.ok) {
+                    return response.json();
+                }
+                if (response.status === 404) {
+                    return null;
+                }
+                throw new Error('autofill/v1/buyer/current failed');
+            })
+            .then(function (json) {
+                const emailField = document.querySelector("input[name='email'], #email");
+                const checkoutEmail = emailField ? emailField.value : '';
+                if (json && (!checkoutEmail || json.email === checkoutEmail)) {
+                    self.applyBuyer(json);
+                } else {
+                    self.showPrompt();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    /**
+     * Persist the enrolled sole trader's company data through the existing
+     * saveCompany cookie action; the order-intent and payment paths then
+     * pick it up via the regular company-data fallback chain.
+     */
+    applyBuyer(buyer) {
+        const self = this;
+        const country = this.billingCountry();
+        const body = new URLSearchParams({
+            company: buyer.company_name || '',
+            companyid: buyer.organization_number || '',
+            country: country
+        });
+        fetch(this.moduleUrl('saveCompany'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+        })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                if (json && json.success) {
+                    self.showStatus(buyer.company_name || buyer.organization_number);
+                    self.hidePrompt();
+                    document.dispatchEvent(new CustomEvent('two:sole-trader-ready'));
+                } else {
+                    self.showError();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    billingCountry() {
+        const field = document.querySelector("select[name='id_country'], select[name='country']");
+        if (field && field.selectedOptions && field.selectedOptions.length) {
+            const iso = field.selectedOptions[0].getAttribute('data-iso-code');
+            if (iso) {
+                return iso;
+            }
+        }
+        return (window.twopayment && window.twopayment.shop_country) || '';
+    }
+
+    openPopup() {
+        if (!this.tokens) {
+            return;
+        }
+        const firstName = document.querySelector("input[name='firstname']");
+        const lastName = document.querySelector("input[name='lastname']");
+        const email = document.querySelector("input[name='email'], #email");
+        const phone = document.querySelector("input[name='phone']");
+        const prefill = {
+            email: email ? email.value : '',
+            first_name: firstName ? firstName.value : '',
+            last_name: lastName ? lastName.value : '',
+            phone_number: phone ? phone.value : ''
+        };
+        const url =
+            this.tokens.signup_url +
+            '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
+            '&autofillToken=' + encodeURIComponent(this.tokens.autofill_token) +
+            '&autofillData=' + encodeURIComponent(btoa(JSON.stringify(prefill)));
+        window.open(
+            url,
+            '_blank',
+            'location=yes,resizable=yes,scrollbars=yes,status=yes,height=805,width=610'
+        );
+    }
+
+    /**
+     * The hosted signup posts 'ACCEPTED' back to the opener when the buyer
+     * completes registration; re-fetch the buyer to autofill.
+     */
+    bindPopupMessageListener() {
+        if (this.messageListenerBound) {
+            return;
+        }
+        this.messageListenerBound = true;
+        const self = this;
+        window.addEventListener('message', function (event) {
+            if (self.accountType() !== 'sole_trader' || !self.tokens) {
+                return;
+            }
+            if (event.origin !== new URL(self.tokens.signup_url).origin) {
+                return;
+            }
+            if (event.data === 'ACCEPTED') {
+                self.getCurrentBuyer();
+            } else {
+                self.showError();
+            }
+        });
+    }
+
+    showPrompt() {
+        const self = this;
+        const prompt = this.container() && this.container().querySelector('.two-sole-trader__prompt');
+        if (!prompt) {
+            return;
+        }
+        prompt.style.display = 'inline';
+        if (!prompt.dataset.twoBound) {
+            prompt.dataset.twoBound = '1';
+            prompt.addEventListener('click', function (event) {
+                event.preventDefault();
+                self.openPopup();
+            });
+        }
+    }
+
+    hidePrompt() {
+        const prompt = this.container() && this.container().querySelector('.two-sole-trader__prompt');
+        if (prompt) {
+            prompt.style.display = 'none';
+        }
+    }
+
+    showStatus(label) {
+        const status = this.container() && this.container().querySelector('.two-sole-trader__status');
+        if (status) {
+            status.textContent = label;
+            status.style.display = 'inline';
+        }
+    }
+
+    showError() {
+        const error = this.container() && this.container().querySelector('.two-sole-trader__error');
+        if (error) {
+            error.style.display = 'inline';
+        }
+    }
+}
+
+window.TwoSoleTrader = TwoSoleTrader;

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -133,7 +133,9 @@
                     checkoutHost: twopayment.checkout_host,
                     orderIntentUrl: twopayment.order_intent_url,
                     ajaxToken: twopayment.ajax_token,
-                    signupUrl: twopayment.sole_trader.signup_url
+                    signupUrl: twopayment.sole_trader.signup_url,
+                    shopCountry: twopayment.shop_country,
+                    i18n: twopayment.sole_trader.i18n || {}
                 });
             }
 

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -119,7 +119,24 @@
             
             // Store global reference for modules
             window.TwoCheckoutManager_Instance = checkoutManager;
-            
+
+            // Sole trader flow (TWO-24755) - separate presentation module,
+            // active only when the merchant enabled it.
+            if (
+                typeof TwoSoleTrader !== 'undefined' &&
+                twopayment.sole_trader &&
+                String(twopayment.sole_trader.enabled) === '1' &&
+                !window.TwoSoleTrader_Instance
+            ) {
+                window.TwoSoleTrader_Instance = new TwoSoleTrader({
+                    enabled: true,
+                    checkoutHost: twopayment.checkout_host,
+                    orderIntentUrl: twopayment.order_intent_url,
+                    ajaxToken: twopayment.ajax_token,
+                    signupUrl: twopayment.sole_trader.signup_url
+                });
+            }
+
         } catch (error) {
             console.error('Two Payment: Initialization failed:', error);
             

--- a/views/templates/hook/paymentinfo.tpl
+++ b/views/templates/hook/paymentinfo.tpl
@@ -12,9 +12,11 @@
         <span class="two-result-text"></span>
     </div>
 
-    {* Sole trader flow (TWO-24755) - shown by TwoSoleTrader.js when the
-       buyer's account type is sole_trader *}
+    {* Sole trader flow (TWO-24755) - TwoSoleTrader.js renders the
+       Business / Sole trader toggle into .two-sole-trader__toggle when the
+       billing country supports sole traders and the merchant enabled it. *}
     <div class="two-sole-trader" style="display: none;">
+        <div class="two-sole-trader__toggle"></div>
         <a href="#" class="two-sole-trader__prompt" style="display: none;">{l s='Click here to log in or sign up as a sole trader with Two.' mod='twopayment'}</a>
         <span class="two-sole-trader__status" style="display: none;"></span>
         <span class="two-sole-trader__error" style="display: none;">{l s='Something went wrong setting up sole trader checkout. Please try again.' mod='twopayment'}</span>

--- a/views/templates/hook/paymentinfo.tpl
+++ b/views/templates/hook/paymentinfo.tpl
@@ -11,6 +11,14 @@
         <span class="two-result-icon"></span>
         <span class="two-result-text"></span>
     </div>
+
+    {* Sole trader flow (TWO-24755) - shown by TwoSoleTrader.js when the
+       buyer's account type is sole_trader *}
+    <div class="two-sole-trader" style="display: none;">
+        <a href="#" class="two-sole-trader__prompt" style="display: none;">{l s='Click here to log in or sign up as a sole trader with Two.' mod='twopayment'}</a>
+        <span class="two-sole-trader__status" style="display: none;"></span>
+        <span class="two-sole-trader__error" style="display: none;">{l s='Something went wrong setting up sole trader checkout. Please try again.' mod='twopayment'}</span>
+    </div>
     
     {* Header Section *}
     <div class="two-header">


### PR DESCRIPTION
## Change pack

Sole-trader checkout for PrestaShop, matching the Magento and WooCommerce plugins.

- **B2B address form** — the company field is always present; there is no account-type selector.
- **Payment-step Business / Sole trader toggle**, shown only where Two's registry (`/registry/v1/supported-company-types/<ISO>`) reports sole-trader support for the billing country **and** the merchant enabled `PS_TWO_ENABLE_SOLE_TRADER`.
- Choosing **Sole trader** mints delegation + autofill tokens server-side (merchant API key never reaches the browser), opens Two's hosted signup popup, and autofills the company fields from `/autofill/v1/buyer/current`.
- An enrolled sole trader checks out as a regular business — their synthetic organization number carries the semantics, so the order payload is unchanged. The order-intent pre-check enforces a verified company + org number.

Staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_(Description by Claude on Doug's behalf.)_