### PR TITLE
TWO-25042: Graceful invoice retrieval when order not yet fulfilled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,12 @@ jobs:
         run: |
           php -l twopayment.php
           php -l controllers/front/payment.php
+          php -l controllers/front/invoice.php
+          php -l controllers/admin/AdminTwopaymentInvoiceController.php
+          php -l classes/TwoInvoiceRetrievalService.php
           php -l tests/bootstrap.php
           php -l tests/OrderBuilderTest.php
+          php -l tests/TwoInvoiceRetrievalSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Two Payment module for PrestaShop will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Graceful invoice retrieval when order is not yet fulfilled** (TWO-25042, part of TWO-25040)
+  - Invoice PDF downloads (customer order page and admin order view) are now routed through module controllers instead of linking the browser directly to the payment API
+  - On `400 ORDER_NOT_FULFILLED` the module checks the order state: `FULFILLING` shows an informational "not ready yet" notice, `FULFILLED` retries the fetch once, and any other state is reported with the state named
+  - Customer downloads are protected by the same secure-key ownership guard as the cancel/confirmation callbacks (guest checkout included); admin downloads go through a permission-gated admin controller
+
 ## Latest Release: v2.4.0
 
 **Release Date:** 2026-02-25

--- a/classes/TwoInvoiceRetrievalService.php
+++ b/classes/TwoInvoiceRetrievalService.php
@@ -64,7 +64,10 @@ class TwoInvoiceRetrievalService
             $params['lang'] = $lang;
         }
 
-        $fetch = $this->module->getTwoInvoicePdf($two_order_id, $params);
+        // Tight timeout: this fetch runs synchronously inside a buyer/admin
+        // download request, so it must never pin a PHP worker for the default
+        // 30s API timeout during an API brownout.
+        $fetch = $this->module->getTwoInvoicePdf($two_order_id, $params, Twopayment::API_TIMEOUT_PDF_FETCH);
         if ($this->isPdfSuccess($fetch)) {
             return $this->stream($fetch);
         }
@@ -92,7 +95,7 @@ class TwoInvoiceRetrievalService
 
         if ($state === 'FULFILLED') {
             // The order just became FULFILLED; the PDF may exist now. Retry once.
-            $retry = $this->module->getTwoInvoicePdf($two_order_id, $params);
+            $retry = $this->module->getTwoInvoicePdf($two_order_id, $params, Twopayment::API_TIMEOUT_PDF_FETCH);
             if ($this->isPdfSuccess($retry)) {
                 return $this->stream($retry);
             }
@@ -149,7 +152,11 @@ class TwoInvoiceRetrievalService
     }
 
     /**
-     * Error notice preserving today's error rendering (getTwoErrorMessage).
+     * Error notice. The raw upstream API error text is logged for merchant
+     * diagnostics but never surfaced: the returned message is always the
+     * module's own whitelisted generic error message, so neither the buyer
+     * front controller nor the admin controller can echo arbitrary upstream
+     * text to the browser.
      *
      * @param array $fetch Response from Twopayment::getTwoInvoicePdf
      * @return array
@@ -157,9 +164,12 @@ class TwoInvoiceRetrievalService
     private function errorNotice($fetch)
     {
         $body = (is_array($fetch) && isset($fetch['data']) && is_array($fetch['data'])) ? $fetch['data'] : null;
-        $message = $body !== null ? $this->module->getTwoErrorMessage($body) : null;
-        if (Tools::isEmpty($message)) {
-            $message = $this->module->getTwoInvoiceNoticeMessage(self::NOTICE_ERROR);
+        $upstream = $body !== null ? $this->module->getTwoErrorMessage($body) : null;
+        if (!Tools::isEmpty($upstream)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: invoice retrieval failed - ' . (string)$upstream,
+                2
+            );
         }
 
         return array(
@@ -167,7 +177,7 @@ class TwoInvoiceRetrievalService
             'level' => 'error',
             'code' => self::NOTICE_ERROR,
             'state' => '',
-            'message' => (string)$message,
+            'message' => $this->module->getTwoInvoiceNoticeMessage(self::NOTICE_ERROR),
         );
     }
 

--- a/classes/TwoInvoiceRetrievalService.php
+++ b/classes/TwoInvoiceRetrievalService.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Two Invoice Retrieval Service
+ *
+ * Resolves an invoice PDF download with a graceful order-state check:
+ * when the invoice fetch fails with 400 ORDER_NOT_FULFILLED the service
+ * checks the order state and turns the raw API error into an actionable
+ * user-facing notice (or a single retry when the order is FULFILLED).
+ *
+ * The flow is pure: it returns a discriminated result array and never
+ * echoes, redirects, or exits. Controllers map the result to a PDF stream
+ * or a redirect-with-notice.
+ *
+ * @author Plugin Developer from Two <jgang@two.inc> <support@two.inc>
+ * @copyright Since 2021 Two Team
+ * @license Two Commercial License
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class TwoInvoiceRetrievalService
+{
+    const NOTICE_NOT_READY = 'not_ready';
+    const NOTICE_UNAVAILABLE_STATE = 'unavailable_state';
+    const NOTICE_NO_REFERENCE = 'no_reference';
+    const NOTICE_ERROR = 'error';
+
+    const ERROR_CODE_ORDER_NOT_FULFILLED = 'ORDER_NOT_FULFILLED';
+
+    /** @var Twopayment */
+    private $module;
+
+    /**
+     * @param Twopayment $module Module instance
+     */
+    public function __construct($module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * Resolve the invoice download for a local order.
+     *
+     * Result shapes:
+     * - ['action' => 'stream', 'body' => string, 'content_type' => 'application/pdf']
+     * - ['action' => 'notice', 'level' => 'info'|'error', 'code' => NOTICE_*, 'state' => string, 'message' => string]
+     *
+     * @param int $id_order Local order ID
+     * @param array $twopaymentdata Persisted twopayment row for the order
+     * @param string|null $lang Optional invoice language code
+     * @return array
+     */
+    public function resolveInvoiceDownload($id_order, $twopaymentdata, $lang = null)
+    {
+        $two_order_id = $this->module->resolveTwoOrderIdForInvoice((int)$id_order, $twopaymentdata);
+        if (Tools::isEmpty($two_order_id)) {
+            return $this->notice('error', self::NOTICE_NO_REFERENCE);
+        }
+
+        $params = array();
+        if ($lang) {
+            $params['lang'] = $lang;
+        }
+
+        $fetch = $this->module->getTwoInvoicePdf($two_order_id, $params);
+        if ($this->isPdfSuccess($fetch)) {
+            return $this->stream($fetch);
+        }
+
+        if (!$this->isOrderNotFulfilled($fetch)) {
+            // Any other failure (network error, 5xx, unrelated 400, non-PDF 200
+            // body) keeps today's error behavior - no new flow is invented here.
+            return $this->errorNotice($fetch);
+        }
+
+        $order_state = $this->module->fetchTwoOrderStateFromApi(
+            $two_order_id,
+            Twopayment::API_TIMEOUT_STATE_CHECK
+        );
+        if ((int)$order_state['http_status'] !== Twopayment::HTTP_STATUS_OK || $order_state['state'] === '') {
+            return $this->errorNotice($fetch);
+        }
+
+        $state = $order_state['state'];
+
+        if ($state === 'FULFILLING') {
+            // Informational, not an error: the invoice simply is not ready yet.
+            return $this->notice('info', self::NOTICE_NOT_READY);
+        }
+
+        if ($state === 'FULFILLED') {
+            // The order just became FULFILLED; the PDF may exist now. Retry once.
+            $retry = $this->module->getTwoInvoicePdf($two_order_id, $params);
+            if ($this->isPdfSuccess($retry)) {
+                return $this->stream($retry);
+            }
+
+            return $this->errorNotice($retry);
+        }
+
+        return $this->notice('info', self::NOTICE_UNAVAILABLE_STATE, $state);
+    }
+
+    /**
+     * @param array $fetch Response from Twopayment::getTwoInvoicePdf
+     * @return bool True when the response is a streamable PDF
+     */
+    private function isPdfSuccess($fetch)
+    {
+        if (!is_array($fetch) || (int)($fetch['http_status'] ?? 0) !== Twopayment::HTTP_STATUS_OK) {
+            return false;
+        }
+
+        $body = isset($fetch['body']) ? (string)$fetch['body'] : '';
+        $content_type = isset($fetch['content_type']) ? (string)$fetch['content_type'] : '';
+
+        // Never stream a JSON/HTML error body as a .pdf attachment.
+        return strncmp($body, '%PDF-', 5) === 0 || stripos($content_type, 'application/pdf') !== false;
+    }
+
+    /**
+     * @param array $fetch Response from Twopayment::getTwoInvoicePdf
+     * @return bool
+     */
+    private function isOrderNotFulfilled($fetch)
+    {
+        return is_array($fetch) &&
+            (int)($fetch['http_status'] ?? 0) === Twopayment::HTTP_STATUS_BAD_REQUEST &&
+            (string)($fetch['error_code'] ?? '') === self::ERROR_CODE_ORDER_NOT_FULFILLED;
+    }
+
+    /**
+     * @param string $level 'info' or 'error'
+     * @param string $code NOTICE_* code
+     * @param string $state Two order state (unavailable-state notices only)
+     * @return array
+     */
+    private function notice($level, $code, $state = '')
+    {
+        return array(
+            'action' => 'notice',
+            'level' => $level,
+            'code' => $code,
+            'state' => $state,
+            'message' => $this->module->getTwoInvoiceNoticeMessage($code, $state),
+        );
+    }
+
+    /**
+     * Error notice preserving today's error rendering (getTwoErrorMessage).
+     *
+     * @param array $fetch Response from Twopayment::getTwoInvoicePdf
+     * @return array
+     */
+    private function errorNotice($fetch)
+    {
+        $body = (is_array($fetch) && isset($fetch['data']) && is_array($fetch['data'])) ? $fetch['data'] : null;
+        $message = $body !== null ? $this->module->getTwoErrorMessage($body) : null;
+        if (Tools::isEmpty($message)) {
+            $message = $this->module->getTwoInvoiceNoticeMessage(self::NOTICE_ERROR);
+        }
+
+        return array(
+            'action' => 'notice',
+            'level' => 'error',
+            'code' => self::NOTICE_ERROR,
+            'state' => '',
+            'message' => (string)$message,
+        );
+    }
+
+    /**
+     * @param array $fetch Successful PDF response
+     * @return array
+     */
+    private function stream($fetch)
+    {
+        return array(
+            'action' => 'stream',
+            'body' => (string)$fetch['body'],
+            'content_type' => 'application/pdf',
+        );
+    }
+}

--- a/controllers/admin/AdminTwopaymentInvoiceController.php
+++ b/controllers/admin/AdminTwopaymentInvoiceController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Plugin Developer from Two <jgang@two.inc> <support@two.inc>
+ * @copyright Since 2021 Two Team
+ * @license Two Commercial License
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once dirname(__FILE__) . '/../../classes/TwoInvoiceRetrievalService.php';
+
+/**
+ * Admin invoice PDF download, registered through an invisible tab so
+ * PrestaShop enforces employee authentication, CSRF token, and profile
+ * permissions (same access as the admin order view exposes today).
+ *
+ * Streams the PDF on success; otherwise redirects back to the order view
+ * with a whitelisted notice code rendered by the admin order hooks.
+ */
+class AdminTwopaymentInvoiceController extends ModuleAdminController
+{
+    public function postProcess()
+    {
+        $id_order = (int)Tools::getValue('id_order');
+        $twopaymentdata = $id_order > 0 ? $this->module->getTwoOrderPaymentData($id_order) : false;
+
+        if (!$twopaymentdata) {
+            $this->redirectToOrderView($id_order, TwoInvoiceRetrievalService::NOTICE_NO_REFERENCE, '');
+        }
+
+        $service = new TwoInvoiceRetrievalService($this->module);
+        $result = $service->resolveInvoiceDownload($id_order, $twopaymentdata);
+
+        if (isset($result['action']) && $result['action'] === 'stream') {
+            $order = new Order($id_order);
+            $reference = Validate::isLoadedObject($order) ? (string)$order->reference : (string)$id_order;
+            $this->module->streamTwoInvoicePdf($result, $reference);
+        }
+
+        $this->redirectToOrderView(
+            $id_order,
+            isset($result['code']) ? (string)$result['code'] : TwoInvoiceRetrievalService::NOTICE_ERROR,
+            isset($result['state']) ? (string)$result['state'] : ''
+        );
+    }
+
+    /**
+     * Redirect back to the admin order view carrying only a whitelisted notice
+     * code (never free text) - the admin order hooks map it back to a message.
+     *
+     * @param int $id_order
+     * @param string $code TwoInvoiceRetrievalService::NOTICE_* code
+     * @param string $state Two order state for the unavailable-state notice
+     * @return void
+     */
+    private function redirectToOrderView($id_order, $code, $state)
+    {
+        $url = $this->context->link->getAdminLink(
+            'AdminOrders',
+            true,
+            array('route' => 'admin_orders_view', 'orderId' => (int)$id_order),
+            array('id_order' => (int)$id_order, 'vieworder' => 1)
+        );
+
+        $notice_params = array('two_invoice_notice' => (string)$code);
+        if ($state !== '') {
+            $notice_params['two_invoice_state'] = $state;
+        }
+
+        $url .= (strpos($url, '?') === false ? '?' : '&') . http_build_query($notice_params);
+
+        Tools::redirectAdmin($url);
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Plugin Developer from Two <jgang@two.inc> <support@two.inc>
+ * @copyright Since 2021 Two Team
+ * @license Two Commercial License
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/controllers/front/cancel.php
+++ b/controllers/front/cancel.php
@@ -236,26 +236,13 @@ class TwopaymentCancelModuleFrontController extends ModuleFrontController
      */
     private function isAuthorizedLegacyOrderAccess($order, $customer)
     {
-        if (!Validate::isLoadedObject($order) || !Validate::isLoadedObject($customer)) {
-            return false;
-        }
-
-        $expected_secure_key = trim((string)$customer->secure_key);
-        if (Tools::isEmpty($expected_secure_key)) {
-            return false;
-        }
-
-        $provided_key = trim((string)Tools::getValue('key'));
-        if (!Tools::isEmpty($provided_key)) {
-            return hash_equals($expected_secure_key, $provided_key);
-        }
-
-        $context_customer_id = isset($this->context->customer->id) ? (int)$this->context->customer->id : 0;
-        $context_customer_secure_key = isset($this->context->customer->secure_key) ? trim((string)$this->context->customer->secure_key) : '';
-
-        return $context_customer_id === (int)$order->id_customer &&
-            !Tools::isEmpty($context_customer_secure_key) &&
-            hash_equals($expected_secure_key, $context_customer_secure_key);
+        return $this->module->isTwoOrderCustomerAccessAuthorized(
+            $order,
+            $customer,
+            trim((string)Tools::getValue('key')),
+            isset($this->context->customer->id) ? (int)$this->context->customer->id : 0,
+            isset($this->context->customer->secure_key) ? trim((string)$this->context->customer->secure_key) : ''
+        );
     }
 
 }

--- a/controllers/front/confirmation.php
+++ b/controllers/front/confirmation.php
@@ -553,26 +553,13 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
      */
     private function isAuthorizedLegacyOrderAccess($order, $customer)
     {
-        if (!Validate::isLoadedObject($order) || !Validate::isLoadedObject($customer)) {
-            return false;
-        }
-
-        $expected_secure_key = trim((string)$customer->secure_key);
-        if (Tools::isEmpty($expected_secure_key)) {
-            return false;
-        }
-
-        $provided_key = trim((string)Tools::getValue('key'));
-        if (!Tools::isEmpty($provided_key)) {
-            return hash_equals($expected_secure_key, $provided_key);
-        }
-
-        $context_customer_id = isset($this->context->customer->id) ? (int)$this->context->customer->id : 0;
-        $context_customer_secure_key = isset($this->context->customer->secure_key) ? trim((string)$this->context->customer->secure_key) : '';
-
-        return $context_customer_id === (int)$order->id_customer &&
-            !Tools::isEmpty($context_customer_secure_key) &&
-            hash_equals($expected_secure_key, $context_customer_secure_key);
+        return $this->module->isTwoOrderCustomerAccessAuthorized(
+            $order,
+            $customer,
+            trim((string)Tools::getValue('key')),
+            isset($this->context->customer->id) ? (int)$this->context->customer->id : 0,
+            isset($this->context->customer->secure_key) ? trim((string)$this->context->customer->secure_key) : ''
+        );
     }
 
     private function getInitialAwaitingStatus()

--- a/controllers/front/invoice.php
+++ b/controllers/front/invoice.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @author Plugin Developer from Two <jgang@two.inc> <support@two.inc>
+ * @copyright Since 2021 Two Team
+ * @license Two Commercial License
+ */
+
+require_once dirname(__FILE__) . '/../../classes/TwoInvoiceRetrievalService.php';
+
+/**
+ * Buyer-facing invoice PDF download.
+ *
+ * Fetches the invoice server-side (instead of linking the browser straight to
+ * the API) so a 400 ORDER_NOT_FULFILLED can be turned into a proper notice via
+ * the order-state check in TwoInvoiceRetrievalService.
+ */
+class TwopaymentInvoiceModuleFrontController extends ModuleFrontController
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->context = Context::getContext();
+    }
+
+    public function postProcess()
+    {
+        parent::postProcess();
+
+        $id_order = (int)Tools::getValue('id_order');
+        $order = new Order($id_order);
+        $twopaymentdata = $id_order > 0 ? $this->module->getTwoOrderPaymentData($id_order) : false;
+
+        if (!Validate::isLoadedObject($order) || !$twopaymentdata) {
+            $this->errors[] = $this->module->l('Unable to find the requested order please contact store owner.');
+            $this->redirectWithNotifications('index.php');
+        }
+
+        // Ownership guard shared with the cancel/confirmation callbacks:
+        // secure-key `key` fallback (covers guest checkout) or logged-in
+        // context customer matching the order owner. Timing-safe compares.
+        $customer = new Customer((int)$order->id_customer);
+        $authorized = $this->module->isTwoOrderCustomerAccessAuthorized(
+            $order,
+            $customer,
+            trim((string)Tools::getValue('key')),
+            isset($this->context->customer->id) ? (int)$this->context->customer->id : 0,
+            isset($this->context->customer->secure_key) ? trim((string)$this->context->customer->secure_key) : ''
+        );
+
+        if (!$authorized) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Unauthorized invoice download attempt for order ' . $id_order,
+                3
+            );
+            $this->errors[] = $this->module->l('You are not allowed to access this invoice.');
+            $this->redirectWithNotifications('index.php');
+        }
+
+        $service = new TwoInvoiceRetrievalService($this->module);
+        $result = $service->resolveInvoiceDownload($id_order, $twopaymentdata);
+
+        if (isset($result['action']) && $result['action'] === 'stream') {
+            $this->module->streamTwoInvoicePdf($result, (string)$order->reference);
+        }
+
+        if (isset($result['level']) && $result['level'] === 'error') {
+            $this->errors[] = $result['message'];
+        } else {
+            $this->info[] = $result['message'];
+        }
+
+        $is_logged = isset($this->context->customer) &&
+            is_object($this->context->customer) &&
+            method_exists($this->context->customer, 'isLogged') &&
+            $this->context->customer->isLogged();
+
+        $this->redirectWithNotifications(
+            $is_logged
+                ? 'index.php?controller=order-detail&id_order=' . (int)$id_order
+                : 'index.php?controller=guest-tracking'
+        );
+    }
+}

--- a/tests/OrderBuilderTest.php
+++ b/tests/OrderBuilderTest.php
@@ -866,7 +866,7 @@ final class OrderBuilderTest extends TestCase
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 200,
@@ -897,7 +897,7 @@ final class OrderBuilderTest extends TestCase
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 200,
@@ -926,7 +926,7 @@ final class OrderBuilderTest extends TestCase
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 0,
@@ -977,7 +977,7 @@ final class OrderBuilderTest extends TestCase
                 return $this->forcedLineItems;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->providerCalled = true;
                 return [
@@ -1137,7 +1137,7 @@ final class OrderBuilderTest extends TestCase
     public function testCancelTwoOrderBestEffortReturnsTrueOnSuccessAndFalseOnFailure(): void
     {
         $successModule = new class extends TwopaymentTestHarness {
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return ['http_status' => 200];
             }
@@ -1145,7 +1145,7 @@ final class OrderBuilderTest extends TestCase
         self::assertTrue($successModule->cancelTwoOrderBestEffort('two-success', 'test'));
 
         $failureModule = new class extends TwopaymentTestHarness {
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return ['http_status' => 500];
             }
@@ -1920,7 +1920,7 @@ final class OrderBuilderTest extends TestCase
             public $lastSavedOrderId = null;
             public $lastSavedPaymentData = null;
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-123') {
                     return [
@@ -1982,7 +1982,7 @@ final class OrderBuilderTest extends TestCase
             public $lastSavedOrderId = null;
             public $lastSavedPaymentData = null;
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-456') {
                     return [
@@ -2051,7 +2051,7 @@ final class OrderBuilderTest extends TestCase
                 );
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-789') {
                     return [

--- a/tests/TrackingNumberTest.php
+++ b/tests/TrackingNumberTest.php
@@ -112,7 +112,7 @@ final class TrackingNumberTest extends TestCase
                 return ['marker' => 'update-body'];
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->requests[] = [$endpoint, $payload, $method];
                 return ['http_status' => 200, 'data' => []];
@@ -143,7 +143,7 @@ final class TrackingNumberTest extends TestCase
                 return ['two_order_id' => 'two-order-uuid'];
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->requests[] = $endpoint;
                 return null;
@@ -179,7 +179,7 @@ final class TrackingNumberTest extends TestCase
                 throw new Exception('Cart is empty or invalid');
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->requests[] = $endpoint;
                 return null;
@@ -206,7 +206,7 @@ final class TrackingNumberTest extends TestCase
                 return ['gross_amount' => '105.50'];
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 // The shape a post-fulfilment rejection comes back as.
                 return ['http_status' => 400, 'data' => ['error_message' => 'Order cannot be edited']];
@@ -237,7 +237,7 @@ final class TrackingNumberTest extends TestCase
                 return ['gross_amount' => '105.50'];
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return ['http_status' => 200, 'data' => []];
             }
@@ -349,7 +349,7 @@ final class TrackingNumberTest extends TestCase
                 return ['two_order_id' => ''];
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->requests[] = $endpoint;
                 return null;
@@ -378,7 +378,7 @@ final class TrackingNumberTest extends TestCase
                 return null;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->requests[] = $endpoint;
                 return null;

--- a/tests/TwoInvoiceRetrievalSpec.php
+++ b/tests/TwoInvoiceRetrievalSpec.php
@@ -16,11 +16,13 @@ class TwoInvoiceRetrievalHarness extends TwopaymentTestHarness
     public $orderResponse = ['http_status' => 500];
     public $orderCalls = 0;
     public $lastOrderTimeout = null;
+    public $lastPdfTimeout = null;
     public $attemptRow = false;
 
     public function getTwoInvoicePdf($two_order_id, $params = [], $timeout = null)
     {
         $this->pdfCalls++;
+        $this->lastPdfTimeout = $timeout;
         if (count($this->pdfResponses) > 1) {
             return array_shift($this->pdfResponses);
         }
@@ -42,6 +44,17 @@ class TwoInvoiceRetrievalHarness extends TwopaymentTestHarness
     }
 }
 
+/**
+ * Harness exposing the protected admin-tab self-heal path.
+ */
+class TwoInvoiceTabHarness extends TwopaymentTestHarness
+{
+    public function ensureTab(): void
+    {
+        $this->ensureTwoInvoiceAdminTabRegistered();
+    }
+}
+
 final class TwoInvoiceRetrievalSpec
 {
     public static function runAll(): void
@@ -60,6 +73,9 @@ final class TwoInvoiceRetrievalSpec
         self::testGuestWithWrongKeyDenied();
         self::testLoggedInCustomerMismatchDenied();
         self::testLoggedInOwnerWithMatchingSecureKeyAllowed();
+        self::testErrorNoticeNeverEchoesUpstreamText();
+        self::testAdminTabInstalledWhenMissing();
+        self::testAdminTabNotReinstalledWhenAlreadyRegistered();
     }
 
     private static function pdfOk(): array
@@ -113,6 +129,11 @@ final class TwoInvoiceRetrievalSpec
         TinyAssert::same("%PDF-1.4 test-invoice", $result['body']);
         TinyAssert::same(1, $module->pdfCalls, 'Invoice fetch should be called exactly once');
         TinyAssert::same(0, $module->orderCalls, 'Order GET must not run on a successful fetch');
+        TinyAssert::same(
+            Twopayment::API_TIMEOUT_PDF_FETCH,
+            $module->lastPdfTimeout,
+            'Synchronous PDF fetch must use the tight timeout, not the 30s default'
+        );
     }
 
     private static function testFulfillingReturnsInfoNotice(): void
@@ -141,6 +162,11 @@ final class TwoInvoiceRetrievalSpec
 
         TinyAssert::same('stream', $result['action']);
         TinyAssert::same(2, $module->pdfCalls, 'FULFILLED must retry the invoice fetch exactly once');
+        TinyAssert::same(
+            Twopayment::API_TIMEOUT_PDF_FETCH,
+            $module->lastPdfTimeout,
+            'The FULFILLED retry fetch must also use the tight timeout'
+        );
     }
 
     private static function testFulfilledRetryFailsIsError(): void
@@ -290,5 +316,68 @@ final class TwoInvoiceRetrievalSpec
         $customer = (object) ['secure_key' => 'sk-owner'];
 
         TinyAssert::true($module->isTwoOrderCustomerAccessAuthorized($order, $customer, '', 5, 'sk-owner'));
+    }
+
+    private static function testErrorNoticeNeverEchoesUpstreamText(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [[
+            'http_status' => 400,
+            'body' => '{"error_code":"SOMETHING_ELSE","error_message":"internal upstream detail"}',
+            'content_type' => 'application/json',
+            'error_code' => 'SOMETHING_ELSE',
+            'data' => ['error_code' => 'SOMETHING_ELSE', 'error_message' => 'internal upstream detail'],
+        ]];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(TwoInvoiceRetrievalService::NOTICE_ERROR, $result['code']);
+        TinyAssert::same(
+            $module->getTwoInvoiceNoticeMessage(TwoInvoiceRetrievalService::NOTICE_ERROR),
+            $result['message'],
+            'Error notices must carry only the whitelisted generic message'
+        );
+        TinyAssert::false(
+            strpos($result['message'], 'internal upstream detail') !== false,
+            'Raw upstream API error text must never reach the user-facing message'
+        );
+    }
+
+    private static function testAdminTabInstalledWhenMissing(): void
+    {
+        StubStore::$tabIds = [];
+        StubStore::$tabAddCalls = [];
+
+        $module = new TwoInvoiceTabHarness();
+        $module->ensureTab();
+
+        TinyAssert::same(
+            ['AdminTwopaymentInvoice'],
+            StubStore::$tabAddCalls,
+            'A missing invoice admin tab must be installed by the self-heal path'
+        );
+        TinyAssert::true(
+            Tab::getIdFromClassName('AdminTwopaymentInvoice') > 0,
+            'The tab must be registered after self-heal'
+        );
+
+        StubStore::$tabIds = ['AdminTwopaymentInvoice' => 1];
+        StubStore::$tabAddCalls = [];
+    }
+
+    private static function testAdminTabNotReinstalledWhenAlreadyRegistered(): void
+    {
+        StubStore::$tabIds = ['AdminTwopaymentInvoice' => 42];
+        StubStore::$tabAddCalls = [];
+
+        $module = new TwoInvoiceTabHarness();
+        $module->ensureTab();
+
+        TinyAssert::same([], StubStore::$tabAddCalls, 'An already-registered tab must not be reinstalled');
+        TinyAssert::same(42, Tab::getIdFromClassName('AdminTwopaymentInvoice'), 'Existing tab id must be untouched');
+
+        StubStore::$tabIds = ['AdminTwopaymentInvoice' => 1];
+        StubStore::$tabAddCalls = [];
     }
 }

--- a/tests/TwoInvoiceRetrievalSpec.php
+++ b/tests/TwoInvoiceRetrievalSpec.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/classes/TwoInvoiceRetrievalService.php';
+
+/**
+ * Harness with scriptable API responses for the invoice retrieval flow.
+ * Invoice fetches are consumed from a queue (so retry behavior is observable);
+ * the order GET returns a fixed canned response.
+ */
+class TwoInvoiceRetrievalHarness extends TwopaymentTestHarness
+{
+    public $pdfResponses = [];
+    public $pdfCalls = 0;
+    public $orderResponse = ['http_status' => 500];
+    public $orderCalls = 0;
+    public $lastOrderTimeout = null;
+    public $attemptRow = false;
+
+    public function getTwoInvoicePdf($two_order_id, $params = [], $timeout = null)
+    {
+        $this->pdfCalls++;
+        if (count($this->pdfResponses) > 1) {
+            return array_shift($this->pdfResponses);
+        }
+
+        return $this->pdfResponses[0];
+    }
+
+    public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+    {
+        $this->orderCalls++;
+        $this->lastOrderTimeout = $timeout;
+
+        return $this->orderResponse;
+    }
+
+    protected function getLatestTwoCheckoutAttemptByOrder($id_order)
+    {
+        return $this->attemptRow;
+    }
+}
+
+final class TwoInvoiceRetrievalSpec
+{
+    public static function runAll(): void
+    {
+        self::testStreamsWhenInvoiceReturnsPdf();
+        self::testFulfillingReturnsInfoNotice();
+        self::testFulfilledRetriesOnceThenStreams();
+        self::testFulfilledRetryFailsIsError();
+        self::testOtherStateNamesStateInMessage();
+        self::testMissingOrderIdIsError();
+        self::test200ButNotPdfIsError();
+        self::testNonOrderNotFulfilled400IsErrorAsToday();
+        self::testNetworkErrorIsError();
+        self::testOrderStateFetchFailureIsError();
+        self::testGuestWithValidKeyAllowed();
+        self::testGuestWithWrongKeyDenied();
+        self::testLoggedInCustomerMismatchDenied();
+        self::testLoggedInOwnerWithMatchingSecureKeyAllowed();
+    }
+
+    private static function pdfOk(): array
+    {
+        return [
+            'http_status' => 200,
+            'body' => "%PDF-1.4 test-invoice",
+            'content_type' => 'application/pdf',
+            'error_code' => '',
+            'data' => null,
+        ];
+    }
+
+    private static function notFulfilled(): array
+    {
+        return [
+            'http_status' => 400,
+            'body' => '{"error_code":"ORDER_NOT_FULFILLED"}',
+            'content_type' => 'application/json',
+            'error_code' => 'ORDER_NOT_FULFILLED',
+            'data' => ['error_code' => 'ORDER_NOT_FULFILLED'],
+        ];
+    }
+
+    private static function orderState(string $state): array
+    {
+        return [
+            'http_status' => 200,
+            'data' => ['id' => 'two-1', 'state' => $state],
+        ];
+    }
+
+    private static function service(TwoInvoiceRetrievalHarness $module): TwoInvoiceRetrievalService
+    {
+        return new TwoInvoiceRetrievalService($module);
+    }
+
+    private static function baseRow(): array
+    {
+        return ['two_order_id' => 'two-1'];
+    }
+
+    private static function testStreamsWhenInvoiceReturnsPdf(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::pdfOk()];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('stream', $result['action']);
+        TinyAssert::same("%PDF-1.4 test-invoice", $result['body']);
+        TinyAssert::same(1, $module->pdfCalls, 'Invoice fetch should be called exactly once');
+        TinyAssert::same(0, $module->orderCalls, 'Order GET must not run on a successful fetch');
+    }
+
+    private static function testFulfillingReturnsInfoNotice(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::notFulfilled()];
+        $module->orderResponse = self::orderState('FULFILLING');
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('info', $result['level'], 'FULFILLING must be informational, not an error');
+        TinyAssert::same(TwoInvoiceRetrievalService::NOTICE_NOT_READY, $result['code']);
+        TinyAssert::same(1, $module->pdfCalls, 'No retry while still FULFILLING');
+        TinyAssert::same(1, $module->orderCalls);
+        TinyAssert::same(Twopayment::API_TIMEOUT_STATE_CHECK, $module->lastOrderTimeout, 'State check must use the tight timeout');
+    }
+
+    private static function testFulfilledRetriesOnceThenStreams(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::notFulfilled(), self::pdfOk()];
+        $module->orderResponse = self::orderState('FULFILLED');
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('stream', $result['action']);
+        TinyAssert::same(2, $module->pdfCalls, 'FULFILLED must retry the invoice fetch exactly once');
+    }
+
+    private static function testFulfilledRetryFailsIsError(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::notFulfilled(), self::notFulfilled()];
+        $module->orderResponse = self::orderState('FULFILLED');
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(2, $module->pdfCalls, 'Only one retry is allowed');
+    }
+
+    private static function testOtherStateNamesStateInMessage(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::notFulfilled()];
+        $module->orderResponse = self::orderState('CANCELLED');
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('info', $result['level']);
+        TinyAssert::same(TwoInvoiceRetrievalService::NOTICE_UNAVAILABLE_STATE, $result['code']);
+        TinyAssert::same('CANCELLED', $result['state']);
+        TinyAssert::true(strpos($result['message'], 'CANCELLED') !== false, 'Message must name the order state');
+        TinyAssert::same(1, $module->pdfCalls, 'No retry for non-FULFILLED states');
+    }
+
+    private static function testMissingOrderIdIsError(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::pdfOk()];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, ['two_order_id' => '']);
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(TwoInvoiceRetrievalService::NOTICE_NO_REFERENCE, $result['code']);
+        TinyAssert::same(0, $module->pdfCalls, 'No API call without a Two order reference');
+        TinyAssert::same(0, $module->orderCalls);
+    }
+
+    private static function test200ButNotPdfIsError(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [[
+            'http_status' => 200,
+            'body' => '{"unexpected":"json"}',
+            'content_type' => 'application/json',
+            'error_code' => '',
+            'data' => ['unexpected' => 'json'],
+        ]];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level'], 'A non-PDF 200 body must never be streamed');
+        TinyAssert::same(0, $module->orderCalls);
+    }
+
+    private static function testNonOrderNotFulfilled400IsErrorAsToday(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [[
+            'http_status' => 400,
+            'body' => '{"error_code":"SOMETHING_ELSE","error_message":"other failure"}',
+            'content_type' => 'application/json',
+            'error_code' => 'SOMETHING_ELSE',
+            'data' => ['error_code' => 'SOMETHING_ELSE', 'error_message' => 'other failure'],
+        ]];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(0, $module->orderCalls, 'Unrelated 400s must not trigger the state-check flow');
+        TinyAssert::same(1, $module->pdfCalls, 'Unrelated 400s must not be retried');
+    }
+
+    private static function testNetworkErrorIsError(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [[
+            'http_status' => 0,
+            'body' => '',
+            'content_type' => '',
+            'error_code' => '',
+            'data' => ['error' => 'Connection error', 'error_message' => 'Unable to connect to Two API. Please check your server configuration.'],
+        ]];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(0, $module->orderCalls);
+    }
+
+    private static function testOrderStateFetchFailureIsError(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $module->pdfResponses = [self::notFulfilled()];
+        $module->orderResponse = ['http_status' => 500];
+
+        $result = self::service($module)->resolveInvoiceDownload(7, self::baseRow());
+
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::same(1, $module->pdfCalls, 'No retry when the state cannot be determined');
+    }
+
+    private static function testGuestWithValidKeyAllowed(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $order = (object) ['id_customer' => 5];
+        $customer = (object) ['secure_key' => 'sk-guest-order'];
+
+        // Guest checkout: no logged-in context, only the `key` query parameter.
+        TinyAssert::true($module->isTwoOrderCustomerAccessAuthorized($order, $customer, 'sk-guest-order', 0, ''));
+    }
+
+    private static function testGuestWithWrongKeyDenied(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $order = (object) ['id_customer' => 5];
+        $customer = (object) ['secure_key' => 'sk-guest-order'];
+
+        TinyAssert::false($module->isTwoOrderCustomerAccessAuthorized($order, $customer, 'sk-attacker', 0, ''));
+    }
+
+    private static function testLoggedInCustomerMismatchDenied(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $order = (object) ['id_customer' => 5];
+        $customer = (object) ['secure_key' => 'sk-owner'];
+
+        // Logged-in customer 9 (different secure key) must not access order of customer 5.
+        TinyAssert::false($module->isTwoOrderCustomerAccessAuthorized($order, $customer, '', 9, 'sk-other'));
+    }
+
+    private static function testLoggedInOwnerWithMatchingSecureKeyAllowed(): void
+    {
+        $module = new TwoInvoiceRetrievalHarness();
+        $order = (object) ['id_customer' => 5];
+        $customer = (object) ['secure_key' => 'sk-owner'];
+
+        TinyAssert::true($module->isTwoOrderCustomerAccessAuthorized($order, $customer, '', 5, 'sk-owner'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,10 @@ namespace {
         public static array $dbLastExecuteS = [];
         public static array $orderCarriers = [];
         public static array $carts = [];
+        /** @var array<string,int> Registered admin tab ids by class name */
+        public static array $tabIds = ['AdminTwopaymentInvoice' => 1];
+        /** @var string[] Class names passed to Tab::add() */
+        public static array $tabAddCalls = [];
 
         public static function reset(): void
         {
@@ -67,6 +71,8 @@ namespace {
             self::$cartRules = [];
             self::$orderCarriers = [];
             self::$carts = [];
+            self::$tabIds = ['AdminTwopaymentInvoice' => 1];
+            self::$tabAddCalls = [];
             self::$moduleCurrencies = [
                 'twopayment' => [
                     ['id_currency' => 578], // NOK
@@ -793,11 +799,47 @@ namespace {
         }
     }
 
+    #[\AllowDynamicProperties]
     class Tab
     {
+        public $id = 0;
+        public $class_name = '';
+        public $module = '';
+        public $id_parent = 0;
+        public $active = 0;
+        public $name = [];
+
+        public function __construct($id = null)
+        {
+            $id = (int) $id;
+            if ($id > 0) {
+                $this->id = $id;
+                $className = array_search($id, StubStore::$tabIds, true);
+                if ($className !== false) {
+                    $this->class_name = (string) $className;
+                }
+            }
+        }
+
         public static function getIdFromClassName($className): int
         {
-            return 1;
+            return (int) (StubStore::$tabIds[(string) $className] ?? 0);
+        }
+
+        public function add(): bool
+        {
+            StubStore::$tabAddCalls[] = (string) $this->class_name;
+            $this->id = count(StubStore::$tabIds) + 1;
+            StubStore::$tabIds[(string) $this->class_name] = $this->id;
+            return true;
+        }
+
+        public function delete(): bool
+        {
+            if ($this->class_name !== '') {
+                unset(StubStore::$tabIds[$this->class_name]);
+            }
+            return true;
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -241,6 +241,12 @@ namespace {
             $query = http_build_query((array) $params);
             return 'https://shop.local/module/' . $module . '/' . $controller . ($query !== '' ? '?' . $query : '');
         }
+
+        public function getAdminLink($controller, $withToken = true, $sfRouteParams = [], $params = []): string
+        {
+            $query = http_build_query((array) $params);
+            return 'https://shop.local/admin/' . $controller . ($query !== '' ? '?' . $query : '');
+        }
     }
 
     class Validate

--- a/tests/run.php
+++ b/tests/run.php
@@ -2983,7 +2983,7 @@ final class OrderBuilderSpec
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 200,
@@ -3016,7 +3016,7 @@ final class OrderBuilderSpec
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 200,
@@ -3047,7 +3047,7 @@ final class OrderBuilderSpec
                 return false;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return [
                     'http_status' => 0,
@@ -3100,7 +3100,7 @@ final class OrderBuilderSpec
                 return $this->forcedLineItems;
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 $this->providerCalled = true;
                 return [
@@ -3266,7 +3266,7 @@ final class OrderBuilderSpec
         self::reset();
 
         $successModule = new class extends TwopaymentTestHarness {
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return ['http_status' => 200];
             }
@@ -3274,7 +3274,7 @@ final class OrderBuilderSpec
         TinyAssert::true($successModule->cancelTwoOrderBestEffort('two-success', 'test'));
 
         $failureModule = new class extends TwopaymentTestHarness {
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 return ['http_status' => 500];
             }
@@ -4150,7 +4150,7 @@ final class OrderBuilderSpec
             public $lastSavedOrderId = null;
             public $lastSavedPaymentData = null;
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-123') {
                     return [
@@ -4213,7 +4213,7 @@ final class OrderBuilderSpec
             public $lastSavedOrderId = null;
             public $lastSavedPaymentData = null;
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-456') {
                     return [
@@ -4283,7 +4283,7 @@ final class OrderBuilderSpec
                 );
             }
 
-            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 if ($method === 'GET' && $endpoint === '/v1/order/two-789') {
                     return [
@@ -4543,10 +4543,12 @@ final class OrderBuilderSpec
 }
 
 require __DIR__ . '/CustomerAddressFormatterOverrideSpec.php';
+require __DIR__ . '/TwoInvoiceRetrievalSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
     'CustomerAddressFormatterOverrideSpec::runAll' => [CustomerAddressFormatterOverrideSpec::class, 'runAll'],
+    'TwoInvoiceRetrievalSpec::runAll' => [TwoInvoiceRetrievalSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/translations/es.php
+++ b/translations/es.php
@@ -388,3 +388,9 @@ $_MODULE['<{twopayment}prestashop>displayadminorderleft_a89e7ebb73476ac3150d2697
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_e468fef315b479c151460e6174ce9782'] = 'Descargar factura';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_7cf626ac15afd59a810ec768f6d1b767'] = 'URL de la factura';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_11335f7aaa473442d803c43c8b8d804d'] = 'Los enlaces de factura estarán disponibles cuando el pedido de Two se haya completado.';
+$_MODULE['<{twopayment}prestashop>twopayment_8c597b2f3bc899e1e04f301844c44482'] = 'La factura aún no está lista porque el pedido todavía se está procesando. Por favor, inténtalo de nuevo más tarde.';
+$_MODULE['<{twopayment}prestashop>twopayment_29f0af925c4f989abdeabb32936251f8'] = 'No hay ninguna factura disponible porque el pedido está en estado: %s.';
+$_MODULE['<{twopayment}prestashop>twopayment_696b031073e74bf2cb98e5ef201d4aa3'] = 'DESCONOCIDO';
+$_MODULE['<{twopayment}prestashop>twopayment_6825c19161f9f1b9a4047b08720ac98c'] = 'Este pedido no tiene asignada una referencia de pedido del proveedor de pagos.';
+$_MODULE['<{twopayment}prestashop>twopayment_c86427e7020aa074399a2ecdb9c42a1d'] = 'No se pudo recuperar la factura. Por favor, inténtalo de nuevo más tarde o contacta con el propietario de la tienda.';
+$_MODULE['<{twopayment}prestashop>twopayment_7de934009c752b9208f359e4db589fa0'] = 'No tienes permiso para acceder a esta factura.';

--- a/twopayment.php
+++ b/twopayment.php
@@ -24,6 +24,7 @@ class Twopayment extends PaymentModule
     // Constants for API timeouts (seconds)
     const API_TIMEOUT_SHORT = 30; // Standard API timeout
     const API_TIMEOUT_LONG = 60; // Extended timeout for file uploads
+    const API_TIMEOUT_STATE_CHECK = 10; // Tight timeout for the invoice-download order state check
     
     // Constants for validation tolerances
     const TAX_FORMULA_TOLERANCE = 0.02; // Tolerance for tax formula validation
@@ -87,6 +88,7 @@ class Twopayment extends PaymentModule
         // Ensure custom Two states exist (for existing installations)
         $this->ensureCustomStatesExist();
         $this->ensureRequiredHooksRegistered();
+        $this->ensureTwoInvoiceAdminTabRegistered();
     }
     
     /**
@@ -131,7 +133,66 @@ class Twopayment extends PaymentModule
             }
         }
     }
-    
+
+    /**
+     * Register the invisible admin tab backing the invoice download controller
+     * on existing installations (mirrors ensureRequiredHooksRegistered).
+     */
+    private function ensureTwoInvoiceAdminTabRegistered()
+    {
+        if ((int)$this->id <= 0 || !Module::isInstalled($this->name)) {
+            return;
+        }
+
+        if ((int)Tab::getIdFromClassName('AdminTwopaymentInvoice') > 0) {
+            return;
+        }
+
+        $this->installTwoInvoiceAdminTab();
+    }
+
+    /**
+     * Install the invisible admin tab that exposes AdminTwopaymentInvoiceController.
+     * PrestaShop enforces employee authentication + token + profile permissions
+     * for controllers registered through a tab.
+     *
+     * @return bool
+     */
+    protected function installTwoInvoiceAdminTab()
+    {
+        if ((int)Tab::getIdFromClassName('AdminTwopaymentInvoice') > 0) {
+            return true;
+        }
+
+        $tab = new Tab();
+        $tab->class_name = 'AdminTwopaymentInvoice';
+        $tab->module = $this->name;
+        $tab->id_parent = -1; // Invisible: no menu entry, still permission-gated
+        $tab->active = 1;
+        $tab->name = array();
+        foreach (Language::getLanguages(true) as $language) {
+            $tab->name[(int)$language['id_lang']] = 'Invoice Download';
+        }
+
+        return (bool)$tab->add();
+    }
+
+    /**
+     * Remove the invoice download admin tab.
+     *
+     * @return bool
+     */
+    protected function uninstallTwoInvoiceAdminTab()
+    {
+        $id_tab = (int)Tab::getIdFromClassName('AdminTwopaymentInvoice');
+        if ($id_tab <= 0) {
+            return true;
+        }
+
+        $tab = new Tab($id_tab);
+        return (bool)$tab->delete();
+    }
+
 
     public function install()
     {
@@ -153,6 +214,7 @@ class Twopayment extends PaymentModule
             $this->registerHook('actionOrderEdited') &&
             $this->registerHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->registerHook('actionCustomerAddressSave') &&
+            $this->installTwoInvoiceAdminTab() &&
             $this->installTwoSettings() &&
             $this->createTwoOrderState() &&
             $this->createTwoTables();
@@ -373,6 +435,7 @@ class Twopayment extends PaymentModule
             $this->unregisterHook('actionOrderEdited') &&
             $this->unregisterHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->unregisterHook('actionCustomerAddressSave') &&
+            $this->uninstallTwoInvoiceAdminTab() &&
             $this->uninstallTwoSettings() &&
             $this->deleteTwoTables();
     }
@@ -5396,8 +5459,121 @@ class Twopayment extends PaymentModule
         if (!empty($params)) {
             $pdf_url .= '?' . http_build_query($params);
         }
-        
+
         return $pdf_url;
+    }
+
+    /**
+     * Fetch the invoice PDF bytes for a Two order.
+     *
+     * Unlike setTwoPaymentRequest this returns the raw response body (a PDF must
+     * not be run through json_decode) together with the response content type and,
+     * when the API returned a JSON error body, the decoded error code/payload.
+     *
+     * @param string $two_order_id The Two order ID
+     * @param array $params Optional query parameters (e.g. lang)
+     * @param int|null $timeout Optional per-call timeout override (seconds)
+     * @return array{http_status:int, body:string, content_type:string, error_code:string, data:array|null}
+     */
+    public function getTwoInvoicePdf($two_order_id, $params = [], $timeout = null)
+    {
+        $url = $this->getTwoCheckoutHostUrl() . '/v1/invoice/' . urlencode($two_order_id) . '/pdf';
+        $query = array_merge(
+            array('client' => 'PS', 'client_v' => $this->version),
+            is_array($params) ? $params : array()
+        );
+        $url .= '?' . http_build_query($query);
+
+        $headers = $this->getTwoRequestHeaders('/v1/invoice/' . $two_order_id . '/pdf');
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout !== null ? max(1, (int)$timeout) : self::API_TIMEOUT_SHORT);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+
+        // SSL VERIFICATION - Secure by default
+        $this->configureSslVerification($ch);
+
+        $response_body = curl_exec($ch);
+        $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $content_type = (string)curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+        $curl_error = curl_error($ch);
+        curl_close($ch);
+
+        if ($response_body === false || !empty($curl_error)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: cURL error on invoice PDF fetch - ' . $curl_error . ' (Two order: ' . $two_order_id . ')',
+                3
+            );
+
+            return array(
+                'http_status' => 0,
+                'body' => '',
+                'content_type' => '',
+                'error_code' => '',
+                'data' => array(
+                    'error' => 'Connection error',
+                    'error_message' => 'Unable to connect to Two API. Please check your server configuration.',
+                ),
+            );
+        }
+
+        $decoded = null;
+        $error_code = '';
+        $looks_like_pdf = strncmp((string)$response_body, '%PDF-', 5) === 0;
+        if (!$looks_like_pdf) {
+            $decoded = json_decode((string)$response_body, true);
+            if (is_array($decoded)) {
+                if (isset($decoded['error_code']) && is_scalar($decoded['error_code'])) {
+                    $error_code = strtoupper(trim((string)$decoded['error_code']));
+                } elseif (isset($decoded['data']['error_code']) && is_scalar($decoded['data']['error_code'])) {
+                    $error_code = strtoupper(trim((string)$decoded['data']['error_code']));
+                }
+            }
+        }
+
+        return array(
+            'http_status' => (int)$http_status,
+            'body' => (string)$response_body,
+            'content_type' => $content_type,
+            'error_code' => $error_code,
+            'data' => is_array($decoded) ? $decoded : null,
+        );
+    }
+
+    /**
+     * Resolve the Two order ID for invoice retrieval from the persisted order row,
+     * falling back to attempt telemetry (public wrapper around the admin resolver).
+     *
+     * @param int $id_order
+     * @param array $twopaymentdata
+     * @return string Empty string when no Two order reference exists
+     */
+    public function resolveTwoOrderIdForInvoice($id_order, $twopaymentdata)
+    {
+        return $this->resolveTwoOrderIdForAdmin((int)$id_order, is_array($twopaymentdata) ? $twopaymentdata : array());
+    }
+
+    /**
+     * Fetch the current Two order state via GET /v1/order/{id}.
+     *
+     * @param string $two_order_id
+     * @param int|null $timeout Optional per-call timeout override (seconds)
+     * @return array{http_status:int, state:string} Normalized (uppercase, trimmed) state; empty when unavailable
+     */
+    public function fetchTwoOrderStateFromApi($two_order_id, $timeout = null)
+    {
+        $response = $this->setTwoPaymentRequest('/v1/order/' . $two_order_id, array(), 'GET', array(), $timeout);
+        $http_status = isset($response['http_status']) ? (int)$response['http_status'] : 0;
+        $payload = $this->extractTwoOrderPayloadFromApiResponse($response);
+        $state = isset($payload['state']) ? strtoupper(trim((string)$payload['state'])) : '';
+
+        return array(
+            'http_status' => $http_status,
+            'state' => $state,
+        );
     }
 
     /**
@@ -5766,8 +5942,9 @@ class Twopayment extends PaymentModule
         );
     }
 
-    public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [])
+    public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
     {
+        $request_timeout = $timeout !== null ? max(1, (int)$timeout) : self::API_TIMEOUT_LONG;
         if ($method == "POST" || $method == "PUT") {
             $url = sprintf('%s%s', $this->getTwoCheckoutHostUrl(), $endpoint);
             $url = $url . '?client=PS&client_v=' . $this->version;
@@ -5778,7 +5955,7 @@ class Twopayment extends PaymentModule
             curl_setopt($ch, CURLOPT_URL, $url);
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_TIMEOUT, self::API_TIMEOUT_LONG);
+            curl_setopt($ch, CURLOPT_TIMEOUT, $request_timeout);
             
             // SSL VERIFICATION - Secure by default
             $this->configureSslVerification($ch);
@@ -5828,7 +6005,7 @@ class Twopayment extends PaymentModule
             curl_setopt($ch, CURLOPT_URL, $url);
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_TIMEOUT, self::API_TIMEOUT_LONG);
+            curl_setopt($ch, CURLOPT_TIMEOUT, $request_timeout);
             
             // SSL VERIFICATION - Secure by default
             $this->configureSslVerification($ch);
@@ -6278,6 +6455,126 @@ class Twopayment extends PaymentModule
         }
 
         return false;
+    }
+
+    /**
+     * Shared customer-ownership guard for order-scoped front controller access
+     * (invoice download, legacy cancel/confirmation callbacks).
+     *
+     * Grants access when either:
+     * - a `key` query parameter matching the order customer's secure key is provided
+     *   (timing-safe compare; this path also covers guest checkout), or
+     * - the logged-in context customer owns the order and their secure key matches.
+     *
+     * @param Order $order
+     * @param Customer $customer Customer that owns the order
+     * @param string $provided_key Optional key from the query string
+     * @param int $context_customer_id Current context customer ID
+     * @param string $context_customer_secure_key Current context customer secure key
+     * @return bool
+     */
+    public function isTwoOrderCustomerAccessAuthorized($order, $customer, $provided_key = '', $context_customer_id = 0, $context_customer_secure_key = '')
+    {
+        if (!Validate::isLoadedObject($order) || !Validate::isLoadedObject($customer)) {
+            return false;
+        }
+
+        $expected_secure_key = trim((string)$customer->secure_key);
+        if (Tools::isEmpty($expected_secure_key)) {
+            return false;
+        }
+
+        $provided_key = trim((string)$provided_key);
+        if (!Tools::isEmpty($provided_key)) {
+            return hash_equals($expected_secure_key, $provided_key);
+        }
+
+        $context_customer_id = (int)$context_customer_id;
+        $context_customer_secure_key = trim((string)$context_customer_secure_key);
+
+        return $context_customer_id === (int)$order->id_customer &&
+            !Tools::isEmpty($context_customer_secure_key) &&
+            hash_equals($expected_secure_key, $context_customer_secure_key);
+    }
+
+    /**
+     * Translated, brand-safe user-facing message for an invoice download notice code.
+     *
+     * @param string $code One of TwoInvoiceRetrievalService::NOTICE_* codes
+     * @param string $state Two order state (only used by the unavailable-state message)
+     * @return string
+     */
+    public function getTwoInvoiceNoticeMessage($code, $state = '')
+    {
+        switch ($code) {
+            case 'not_ready':
+                return $this->l('The invoice is not ready yet because the order is still being fulfilled. Please try again later.');
+            case 'unavailable_state':
+                return sprintf(
+                    $this->l('No invoice is available because the order is in state: %s.'),
+                    $state !== '' ? $state : $this->l('UNKNOWN')
+                );
+            case 'no_reference':
+                return $this->l('No payment provider order reference is set for this order.');
+            case 'error':
+            default:
+                return $this->l('The invoice could not be retrieved. Please try again later or contact the store owner.');
+        }
+    }
+
+    /**
+     * Read an invoice download notice from the current request query string
+     * (set by the admin invoice controller redirect). Only whitelisted notice
+     * codes are honored and the state token is sanitized, so a crafted URL can
+     * only ever surface one of the module's own messages.
+     *
+     * @return array{level:string, code:string, message:string}|null
+     */
+    public function getTwoInvoiceNoticeFromRequest()
+    {
+        $allowed = array(
+            'not_ready' => 'info',
+            'unavailable_state' => 'info',
+            'no_reference' => 'error',
+            'error' => 'error',
+        );
+
+        $code = trim((string)Tools::getValue('two_invoice_notice'));
+        if (!isset($allowed[$code])) {
+            return null;
+        }
+
+        $state = strtoupper((string)preg_replace('/[^A-Za-z0-9_]/', '', (string)Tools::getValue('two_invoice_state')));
+        $state = Tools::substr($state, 0, 32);
+
+        return array(
+            'level' => $allowed[$code],
+            'code' => $code,
+            'message' => $this->getTwoInvoiceNoticeMessage($code, $state),
+        );
+    }
+
+    /**
+     * Stream a resolved invoice PDF to the browser and terminate the request.
+     *
+     * @param array $result Stream result from TwoInvoiceRetrievalService (action=stream)
+     * @param string $order_reference Local order reference used to build the filename
+     * @return void
+     */
+    public function streamTwoInvoicePdf($result, $order_reference)
+    {
+        $reference = preg_replace('/[^A-Za-z0-9_-]/', '', (string)$order_reference);
+        $filename = 'invoice-' . ($reference !== '' ? $reference : 'order') . '.pdf';
+        $body = isset($result['body']) ? (string)$result['body'] : '';
+
+        header('Content-Type: application/pdf');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('Content-Length: ' . strlen($body));
+        header('Cache-Control: no-store, no-cache, must-revalidate');
+        header('Pragma: no-cache');
+
+        echo $body;
+        exit;
     }
 
     /**
@@ -7384,12 +7681,21 @@ class Twopayment extends PaymentModule
         $id_order = $params['order']->id;
         $twopaymentdata = $this->getTwoOrderPaymentData($id_order);
         if ($twopaymentdata) {
-            // Generate PDF URL if Two order ID is available
+            // Route the invoice download through the module front controller so the
+            // plugin can check the Two order state instead of exposing a raw API URL
+            // (which returns a bare 400 ORDER_NOT_FULFILLED before fulfillment).
             $pdf_url = null;
             if (!empty($twopaymentdata['two_order_id'])) {
-                $pdf_url = $this->getTwoPdfUrl($twopaymentdata['two_order_id']);
+                $link_params = array('id_order' => (int)$id_order);
+                $order_customer = new Customer((int)$params['order']->id_customer);
+                if (Validate::isLoadedObject($order_customer) && !Tools::isEmpty((string)$order_customer->secure_key)) {
+                    // Same secure-key fallback the cancel/confirmation callbacks use;
+                    // this keeps guest-checkout invoice access working.
+                    $link_params['key'] = (string)$order_customer->secure_key;
+                }
+                $pdf_url = $this->context->link->getModuleLink($this->name, 'invoice', $link_params, true);
             }
-            
+
             $this->context->smarty->assign(array(
                 'twopaymentdata' => $twopaymentdata,
                 'two_portal_url' => $this->getTwoPortalUrl(),
@@ -7408,10 +7714,17 @@ class Twopayment extends PaymentModule
             $twopaymentdata = $this->enrichTwoAdminOrderPaymentData((int)$id_order, $twopaymentdata);
             $invoice_actions_available = $this->shouldExposeTwoInvoiceActions($twopaymentdata);
 
-            // Generate PDF URL if Two order ID is available
+            // Route the invoice download through the module admin controller so the
+            // plugin can check the Two order state (covers the race where the order
+            // just flipped to FULFILLED but the PDF is not generated yet).
             $pdf_url = null;
             if ($invoice_actions_available && !empty($twopaymentdata['two_order_id'])) {
-                $pdf_url = $this->getTwoPdfUrl($twopaymentdata['two_order_id']);
+                $pdf_url = $this->context->link->getAdminLink(
+                    'AdminTwopaymentInvoice',
+                    true,
+                    array(),
+                    array('id_order' => (int)$id_order)
+                );
             }
             
             $this->context->smarty->assign(array(
@@ -7419,6 +7732,7 @@ class Twopayment extends PaymentModule
                 'two_portal_url' => $this->getTwoPortalUrl(), // Dynamic portal URL based on environment
                 'two_pdf_url' => $pdf_url, // PDF invoice URL if available
                 'two_invoice_actions_available' => $invoice_actions_available,
+                'two_invoice_notice' => $this->getTwoInvoiceNoticeFromRequest(),
             ));
             return $this->context->smarty->fetch('module:twopayment/views/templates/hook/displayAdminOrderLeft.tpl');
         }
@@ -7443,10 +7757,17 @@ class Twopayment extends PaymentModule
             $twopaymentdata = $this->enrichTwoAdminOrderPaymentData((int)$id_order, $twopaymentdata);
             $invoice_actions_available = $this->shouldExposeTwoInvoiceActions($twopaymentdata);
 
-            // Generate PDF URL if Two order ID is available
+            // Route the invoice download through the module admin controller so the
+            // plugin can check the Two order state (covers the race where the order
+            // just flipped to FULFILLED but the PDF is not generated yet).
             $pdf_url = null;
             if ($invoice_actions_available && !empty($twopaymentdata['two_order_id'])) {
-                $pdf_url = $this->getTwoPdfUrl($twopaymentdata['two_order_id']);
+                $pdf_url = $this->context->link->getAdminLink(
+                    'AdminTwopaymentInvoice',
+                    true,
+                    array(),
+                    array('id_order' => (int)$id_order)
+                );
             }
             
             $this->context->smarty->assign(array(
@@ -7455,6 +7776,7 @@ class Twopayment extends PaymentModule
                 'two_pdf_url' => $pdf_url, // PDF invoice URL if available
                 'use_own_invoices' => (bool)Configuration::get('PS_TWO_USE_OWN_INVOICES'),
                 'two_invoice_actions_available' => $invoice_actions_available,
+                'two_invoice_notice' => $this->getTwoInvoiceNoticeFromRequest(),
             ));
             return $this->context->smarty->fetch('module:twopayment/views/templates/hook/displayAdminOrderTabContent.tpl');
         }

--- a/twopayment.php
+++ b/twopayment.php
@@ -25,6 +25,8 @@ class Twopayment extends PaymentModule
     const API_TIMEOUT_SHORT = 30; // Standard API timeout
     const API_TIMEOUT_LONG = 60; // Extended timeout for file uploads
     const API_TIMEOUT_STATE_CHECK = 10; // Tight timeout for the invoice-download order state check
+    const API_TIMEOUT_PDF_FETCH = 10; // Tight timeout for synchronous invoice PDF fetches (buyer + admin download clicks)
+    const API_CONNECT_TIMEOUT = 5; // Connection-establishment timeout for all Two API calls
     
     // Constants for validation tolerances
     const TAX_FORMULA_TOLERANCE = 0.02; // Tolerance for tax formula validation
@@ -137,8 +139,9 @@ class Twopayment extends PaymentModule
     /**
      * Register the invisible admin tab backing the invoice download controller
      * on existing installations (mirrors ensureRequiredHooksRegistered).
+     * Protected (not private) so the test suite can exercise the self-heal path.
      */
-    private function ensureTwoInvoiceAdminTabRegistered()
+    protected function ensureTwoInvoiceAdminTabRegistered()
     {
         if ((int)$this->id <= 0 || !Module::isInstalled($this->name)) {
             return;
@@ -5491,6 +5494,7 @@ class Twopayment extends PaymentModule
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout !== null ? max(1, (int)$timeout) : self::API_TIMEOUT_SHORT);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::API_CONNECT_TIMEOUT);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 
         // SSL VERIFICATION - Secure by default
@@ -5956,6 +5960,7 @@ class Twopayment extends PaymentModule
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_TIMEOUT, $request_timeout);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::API_CONNECT_TIMEOUT);
             
             // SSL VERIFICATION - Secure by default
             $this->configureSslVerification($ch);
@@ -6006,6 +6011,7 @@ class Twopayment extends PaymentModule
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_TIMEOUT, $request_timeout);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::API_CONNECT_TIMEOUT);
             
             // SSL VERIFICATION - Secure by default
             $this->configureSslVerification($ch);
@@ -6566,6 +6572,17 @@ class Twopayment extends PaymentModule
         $reference = preg_replace('/[^A-Za-z0-9_-]/', '', (string)$order_reference);
         $filename = 'invoice-' . ($reference !== '' ? $reference : 'order') . '.pdf';
         $body = isset($result['body']) ? (string)$result['body'] : '';
+
+        // Discard any open output buffers (stray notices, BOMs, template output)
+        // and disable on-the-fly compression: gzip re-encoding would make the
+        // response body diverge from the exact Content-Length declared below.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        @ini_set('zlib.output_compression', '0');
+        if (function_exists('apache_setenv')) {
+            @apache_setenv('no-gzip', '1');
+        }
 
         header('Content-Type: application/pdf');
         header('Content-Disposition: attachment; filename="' . $filename . '"');

--- a/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/views/templates/hook/displayAdminOrderLeft.tpl
@@ -11,6 +11,11 @@
         </div>
     </div>
     <div class="panel-body two-admin-content">
+        {if isset($two_invoice_notice) && $two_invoice_notice}
+        <div class="alert {if $two_invoice_notice.level == 'error'}alert-danger{else}alert-info{/if}">
+            {$two_invoice_notice.message|escape:'html':'UTF-8'}
+        </div>
+        {/if}
         {* Order Details Section *}
         <div class="two-details-section">
             {if $twopaymentdata.two_order_id}

--- a/views/templates/hook/displayAdminOrderTabContent.tpl
+++ b/views/templates/hook/displayAdminOrderTabContent.tpl
@@ -12,6 +12,11 @@
     </div>
     
     <div class="two-tab-content">
+        {if isset($two_invoice_notice) && $two_invoice_notice}
+        <div class="alert {if $two_invoice_notice.level == 'error'}alert-danger{else}alert-info{/if}">
+            {$two_invoice_notice.message|escape:'html':'UTF-8'}
+        </div>
+        {/if}
         {* Order Information Section *}
         <div class="two-section">
             <h4 class="two-section-title">{l s='Order Information' mod='twopayment'}</h4>


### PR DESCRIPTION
Implements [TWO-25042](https://linear.app/two-inc/issue/TWO-25042) (PrestaShop child of [TWO-25040](https://linear.app/two-inc/issue/TWO-25040)) per the design + review on the ticket.

## Problem

The customer order-detail page linked "Download invoice PDF" straight to the payment API's `/v1/invoice/{id}/pdf` endpoint, **ungated by fulfillment state** — a buyer clicking it before fulfillment got raw `400 {"error_code":"ORDER_NOT_FULFILLED"}` JSON in their browser. Admin links were FULFILLED-gated but still raced the PDF generation.

## What changed

Invoice downloads now go through module controllers that fetch server-side and implement the parent spec's state-check flow on `400 ORDER_NOT_FULFILLED`:

1. `GET /v1/order/{id}` and check `state` (tight 10s timeout via a new per-call override on `setTwoPaymentRequest` — the previous hardcoded 60s stays the default for all other call sites)
2. `FULFILLING` → informational "invoice not ready yet, try again later" notice
3. `FULFILLED` → retry the invoice fetch once; second failure → error as today
4. Any other state → "no invoice available because the order is in state: X"
5. Any **other** error from the invoice fetch → today's error path (`getTwoErrorMessage`), no new behavior

### Pieces

- **`classes/TwoInvoiceRetrievalService.php`** — pure state-check flow returning a discriminated `stream` / `notice` result (no echo/redirect/exit → unit-testable in the offline runner)
- **`controllers/front/invoice.php`** — buyer download. Ownership guard **reuses the existing cancel/confirmation secure-key pattern** (per review): the duplicated `isAuthorizedLegacyOrderAccess` blocks in `cancel.php`/`confirmation.php` are extracted to `Twopayment::isTwoOrderCustomerAccessAuthorized` (timing-safe `hash_equals`, `key` query fallback covering **guest checkout**), and all three front controllers now gate identically. Notices flash via the module's existing `errors[]/info[] + redirectWithNotifications` pattern.
- **`controllers/admin/AdminTwopaymentInvoiceController.php`** — admin download via an invisible Tab (employee auth + CSRF token + profile permissions, same access as the order view today). Notices round-trip as **whitelisted codes** in the redirect query (never free text) and are rendered by the admin order hooks.
- **`Twopayment::getTwoInvoicePdf`** — raw-bytes PDF fetch reusing `getTwoRequestHeaders`/`getTwoCheckoutHostUrl`/`configureSslVerification` (`setTwoPaymentRequest` json-decodes bodies so it can't stream a PDF). Sniffs `%PDF-`/content-type so a non-PDF 200 body is never streamed as a `.pdf`.
- Tab registered on install, removed on uninstall, self-healed for existing installs in the constructor (mirrors `ensureRequiredHooksRegistered`; robust under git-sync deploys where upgrade scripts don't run).
- New strings translated (`translations/es.php`), brand-safe (no brand name interpolated at all).

### Explicitly untouched (per design/review scope)

- `two_invoice_url` (API-provided `invoice_url`) links — pending the checkout-api owner's answer on what it points at
- `TwoInvoiceUploadService` / self-invoice-upload flow
- Dead `displayPaymentReturn.tpl` (flagged in design as optional cleanup; left alone)

## Testing

`tests/TwoInvoiceRetrievalSpec.php` (offline runner, registered in `tests/run.php` — the suite CI actually gates): stream-on-first-fetch, FULFILLING-info (no retry, 10s state-check timeout asserted), FULFILLED-retry-success, FULFILLED-retry-fail-error, other-state-names-state, missing-reference (zero API calls), non-PDF-200-is-error, unrelated-400-passthrough (no state flow), network-error, order-GET-failure, plus four ownership-guard cases (guest valid key allowed, guest wrong key denied, logged-in mismatch denied, owner allowed).

```
PASS OrderBuilderSpec::runAll
PASS CustomerAddressFormatterOverrideSpec::runAll
PASS TwoInvoiceRetrievalSpec::runAll
All tests passed.
```

`php -l` clean on every touched file; new files added to the workflow's syntax-check step.

Note: `setTwoPaymentRequest` gained an optional 5th `$timeout` param, so all existing test-harness overrides of it were mechanically updated to the new signature (PHP fatals on child overrides with fewer params).

---
*Implemented by Claude (Fable), on Doug's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn