### PR TITLE
TWO-24752/feat: replace payment-terms slider with chip selector

### DIFF
--- a/views/css/two.css
+++ b/views/css/two.css
@@ -625,6 +625,11 @@
     outline: none;
 }
 
+.two-term-chip:focus-visible {
+    outline: 2px solid #374151;
+    outline-offset: 2px;
+}
+
 .two-term-chip--selected,
 .two-term-chip--selected:hover,
 .two-term-chip--selected:focus {
@@ -635,17 +640,7 @@
 }
 
 .two-term-chip--single {
-    border-color: #374151;
-    background: #374151;
-    color: white;
-    font-weight: 500;
     cursor: default;
-}
-
-.two-term-chip--single:hover {
-    border-color: #374151;
-    background: #374151;
-    color: white;
 }
 
 .two-term-chip__days {

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -572,66 +572,91 @@
     line-height: 1.4;
 }
 
-.two-terms-slider-container {
+/*
+ * Payment terms chip selector (TWO-24752). Replaces the previous slider.
+ * Structure/behaviour mirrors the Magento (Hyva) and WooCommerce chip
+ * selectors; the palette keeps PrestaShop's existing slate accent
+ * (#374151) so the chips stay consistent with the rest of this checkout.
+ * The column layout leaves room for a per-chip surcharge sub-label.
+ */
+.two-term-chips {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 10px;
 }
 
-.two-terms-slider {
+.two-term-chips__container {
     display: flex;
     justify-content: center;
-    align-items: center;
-    gap: 6px;
+    align-items: stretch;
+    gap: 8px;
     flex-wrap: wrap;
     width: 100%;
     max-width: 350px;
 }
 
-.two-term-option {
+.two-term-chip {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 40px;
-    height: 32px;
-    padding: 6px 10px;
+    min-width: 44px;
+    padding: 8px 14px;
     border: 1px solid #d1d5db;
-    border-radius: 16px;
+    border-radius: 8px;
     background: white;
     color: #6b7280;
     font-size: 12px;
     font-weight: 400;
+    font-family: inherit;
     cursor: pointer;
     transition: all 0.15s ease;
     user-select: none;
-    position: relative;
 }
 
-.two-term-option:hover {
+.two-term-chip:hover {
     border-color: #9ca3af;
     color: #374151;
     background: #f9fafb;
 }
 
-.two-term-option.active {
+.two-term-chip:focus {
+    outline: none;
+}
+
+.two-term-chip--selected,
+.two-term-chip--selected:hover,
+.two-term-chip--selected:focus {
     border-color: #374151;
     background: #374151;
     color: white;
     font-weight: 500;
 }
 
-.two-term-option.active::after {
-    content: '';
-    position: absolute;
-    bottom: -6px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 0;
-    height: 0;
-    border-left: 4px solid transparent;
-    border-right: 4px solid transparent;
-    border-top: 4px solid #374151;
+.two-term-chip--single {
+    border-color: #374151;
+    background: #374151;
+    color: white;
+    font-weight: 500;
+    cursor: default;
+}
+
+.two-term-chip--single:hover {
+    border-color: #374151;
+    background: #374151;
+    color: white;
+}
+
+.two-term-chip__days {
+    font-weight: inherit;
+    line-height: 1.3;
+}
+
+.two-term-chip__surcharge {
+    font-size: 0.85em;
+    line-height: 1.3;
+    opacity: 0.85;
 }
 
 .two-terms-selected {
@@ -662,13 +687,12 @@
         margin-top: 12px;
     }
     
-    .two-terms-slider {
+    .two-term-chips__container {
         gap: 6px;
     }
     
-    .two-term-option {
+    .two-term-chip {
         min-width: 40px;
-        height: 32px;
         padding: 6px 10px;
         font-size: 12px;
     }

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -1142,9 +1142,9 @@ class TwoCheckoutManager {
                     <h4 class="two-terms-title">${this.t('choose_payment_terms', 'Choose the Buy Now, Pay Later option that works best for you')}</h4>
                     <p class="two-terms-description">${this.t('payment_period_starts', 'Your payment period starts when your order is fulfilled')}</p>
                 </div>
-                <div class="two-terms-slider-container">
-                    <div class="two-terms-slider" id="two-terms-slider">
-                        <!-- Terms will be populated by JavaScript -->
+                <div class="two-term-chips">
+                    <div class="two-term-chips__container" id="two-terms-chips">
+                        <!-- Chips will be populated by JavaScript -->
                     </div>
                     <div class="two-terms-selected">
                         <span class="two-terms-selected-days" id="two-selected-days"></span>
@@ -1164,10 +1164,10 @@ class TwoCheckoutManager {
      * ENHANCED: Initialize payment terms selector with robust error handling
      */
     initializePaymentTerms() {
-        // Try multiple selectors for terms slider
-        let termsSlider = document.querySelector('#two-terms-slider');
-        if (!termsSlider) {
-            termsSlider = document.querySelector('.two-terms-slider');
+        // Try multiple selectors for the chip container
+        let termsContainer = document.querySelector('#two-terms-chips');
+        if (!termsContainer) {
+            termsContainer = document.querySelector('.two-term-chips__container');
         }
         
         let selectedDays = document.querySelector('#two-selected-days');
@@ -1175,19 +1175,19 @@ class TwoCheckoutManager {
             selectedDays = document.querySelector('.two-terms-selected-days');
         }
         
-        if (!termsSlider) {
-            console.error('Two Payment: Terms slider element not found');
+        if (!termsContainer) {
+            console.error('Two Payment: Terms chip container not found');
             return;
         }
         
-        // Check if already initialized with our terms
-        if (termsSlider.hasChildNodes() && termsSlider.querySelector('.two-term-option')) {
+        // Check if already initialized with our chips
+        if (termsContainer.hasChildNodes() && termsContainer.querySelector('.two-term-chip')) {
             return;
         }
         
-        if (termsSlider.hasChildNodes()) {
+        if (termsContainer.hasChildNodes()) {
             // Clear existing content to reinitialize
-            termsSlider.innerHTML = '';
+            termsContainer.innerHTML = '';
         }
         
         // Get payment terms from admin configuration (passed via template)
@@ -1216,38 +1216,52 @@ class TwoCheckoutManager {
             }
         }
         
-        // Create term options
+        // A single offered term is applied silently (no selectable chips).
+        const singleTerm = availableTerms.length === 1;
+
+        // Create term chips (parity with Magento/WooCommerce chip selector)
         availableTerms.forEach((days, index) => {
-            const termOption = document.createElement('div');
-            termOption.className = 'two-term-option';
-            
+            const termChip = document.createElement('button');
+            termChip.type = 'button';
+            termChip.className = 'two-term-chip' + (singleTerm ? ' two-term-chip--single' : '');
+
+            const daysLabel = document.createElement('span');
+            daysLabel.className = 'two-term-chip__days';
+
             // Format display based on term type (EOM+X for End-of-Month, X for Standard)
             if (termType === 'EOM') {
-                termOption.textContent = 'EOM+' + days;
-                termOption.title = this.t('end_of_month_plus_days', 'End of Month + %s days').replace('%s', days);
+                daysLabel.textContent = 'EOM+' + days;
+                termChip.title = this.t('end_of_month_plus_days', 'End of Month + %s days').replace('%s', days);
             } else {
-                termOption.textContent = days;
-                termOption.title = days + ' ' + this.t('days', 'days');
+                daysLabel.textContent = days;
+                termChip.title = days + ' ' + this.t('days', 'days');
             }
-            
-            termOption.dataset.days = days;
-            
-            // Set default term: use configured default, or if only one term, make it active, or first term
-            const isDefaultTerm = defaultTerm ? (days === defaultTerm) : 
-                                 (availableTerms.length === 1 ? true : index === 0);
-            
+            termChip.appendChild(daysLabel);
+
+            termChip.dataset.days = days;
+
+            // Set default term: use configured default, or if only one term, make it selected, or first term
+            const isDefaultTerm = defaultTerm ? (days === defaultTerm) :
+                                 (singleTerm ? true : index === 0);
+
             if (isDefaultTerm) {
-                termOption.classList.add('active');
+                termChip.classList.add('two-term-chip--selected');
             }
-            
-            termOption.addEventListener('click', () => {
-                // Remove active class from all options
-                termsSlider.querySelectorAll('.two-term-option').forEach(opt => {
-                    opt.classList.remove('active');
+
+            // A single term is non-selectable; skip the click handler.
+            if (singleTerm) {
+                termsContainer.appendChild(termChip);
+                return;
+            }
+
+            termChip.addEventListener('click', () => {
+                // Remove selected state from all chips
+                termsContainer.querySelectorAll('.two-term-chip').forEach(chip => {
+                    chip.classList.remove('two-term-chip--selected');
                 });
                 
-                // Add active class to selected option
-                termOption.classList.add('active');
+                // Mark clicked chip as selected
+                termChip.classList.add('two-term-chip--selected');
                 
                 // Update selected term display
                 if (selectedDays) {
@@ -1286,7 +1300,7 @@ class TwoCheckoutManager {
                 }
             });
             
-            termsSlider.appendChild(termOption);
+            termsContainer.appendChild(termChip);
         });
         
         // Set initial selected term display

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -1192,13 +1192,20 @@ class TwoCheckoutManager {
         
         // Get payment terms from admin configuration (passed via template)
         const availableTerms = this.config.available_payment_terms;
-        const defaultTerm = this.config.default_payment_term;
+        const configuredDefaultTerm = this.config.default_payment_term;
         const termType = this.config.payment_term_type || 'STANDARD';
-        
+
         // If no terms configured, don't show payment terms
         if (!availableTerms || !Array.isArray(availableTerms) || availableTerms.length === 0) {
             return;
         }
+
+        // Guard against a configured default that isn't actually offered — falls back
+        // to the first offered term so the chip UI and "Pay in X days" text never
+        // point at a term with no selectable chip.
+        const defaultTerm = availableTerms.includes(configuredDefaultTerm) ? configuredDefaultTerm : null;
+
+        termsContainer.setAttribute('role', 'radiogroup');
         
         // Update description based on term type
         var termsDescription = document.querySelector('#two-terms-description');
@@ -1219,11 +1226,38 @@ class TwoCheckoutManager {
         // A single offered term is applied silently (no selectable chips).
         const singleTerm = availableTerms.length === 1;
 
+        // Tracks the in-flight persist request so a rapid second click aborts the
+        // first — otherwise two POSTs can race and the server can persist whichever
+        // lands last rather than whichever the buyer clicked last.
+        let pendingTermRequest = null;
+
+        const formatChipLabel = (days) => termType === 'EOM'
+            ? this.t('end_of_month_plus_days', 'End of Month + %s days').replace('%s', days)
+            : days + ' ' + this.t('days', 'days');
+
+        const formatPayInLabel = (days) => {
+            const payInText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.pay_in
+                ? window.twopayment.i18n.pay_in
+                : 'Pay in';
+            const daysText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.days
+                ? window.twopayment.i18n.days
+                : 'days';
+            const fromEndOfMonthText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.from_end_of_month
+                ? window.twopayment.i18n.from_end_of_month
+                : 'from end of month';
+
+            return termType === 'EOM'
+                ? payInText + ' ' + days + ' ' + daysText + ' ' + fromEndOfMonthText
+                : payInText + ' ' + days + ' ' + daysText;
+        };
+
         // Create term chips (parity with Magento/WooCommerce chip selector)
         availableTerms.forEach((days, index) => {
             const termChip = document.createElement('button');
             termChip.type = 'button';
             termChip.className = 'two-term-chip' + (singleTerm ? ' two-term-chip--single' : '');
+            termChip.setAttribute('role', 'radio');
+            termChip.setAttribute('aria-label', formatPayInLabel(days));
 
             const daysLabel = document.createElement('span');
             daysLabel.className = 'two-term-chip__days';
@@ -1231,11 +1265,10 @@ class TwoCheckoutManager {
             // Format display based on term type (EOM+X for End-of-Month, X for Standard)
             if (termType === 'EOM') {
                 daysLabel.textContent = 'EOM+' + days;
-                termChip.title = this.t('end_of_month_plus_days', 'End of Month + %s days').replace('%s', days);
             } else {
                 daysLabel.textContent = days;
-                termChip.title = days + ' ' + this.t('days', 'days');
             }
+            termChip.title = formatChipLabel(days);
             termChip.appendChild(daysLabel);
 
             termChip.dataset.days = days;
@@ -1247,9 +1280,13 @@ class TwoCheckoutManager {
             if (isDefaultTerm) {
                 termChip.classList.add('two-term-chip--selected');
             }
+            termChip.setAttribute('aria-checked', isDefaultTerm ? 'true' : 'false');
 
-            // A single term is non-selectable; skip the click handler.
+            // A single term is non-selectable; skip the click handler and remove it
+            // from the tab order so it doesn't present as a dead interactive control.
             if (singleTerm) {
+                termChip.disabled = true;
+                termChip.setAttribute('aria-disabled', 'true');
                 termsContainer.appendChild(termChip);
                 return;
             }
@@ -1258,72 +1295,52 @@ class TwoCheckoutManager {
                 // Remove selected state from all chips
                 termsContainer.querySelectorAll('.two-term-chip').forEach(chip => {
                     chip.classList.remove('two-term-chip--selected');
+                    chip.setAttribute('aria-checked', 'false');
                 });
-                
+
                 // Mark clicked chip as selected
                 termChip.classList.add('two-term-chip--selected');
-                
+                termChip.setAttribute('aria-checked', 'true');
+
                 // Update selected term display
                 if (selectedDays) {
-                    const payInText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.pay_in 
-                        ? window.twopayment.i18n.pay_in 
-                        : 'Pay in';
-                    const daysText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.days 
-                        ? window.twopayment.i18n.days 
-                        : 'days';
-                    const fromEndOfMonthText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.from_end_of_month 
-                        ? window.twopayment.i18n.from_end_of_month 
-                        : 'from end of month';
-
-                    if (termType === 'EOM') {
-                        // For EOM: Show "Pay in X days from end of month" format
-                        selectedDays.textContent = payInText + ' ' + days + ' ' + daysText + ' ' + fromEndOfMonthText;
-                    } else {
-                        // For Standard: Show "Pay in 30 days" format
-                        selectedDays.textContent = payInText + ' ' + days + ' ' + daysText;
-                    }
+                    selectedDays.textContent = formatPayInLabel(days);
                 }
 
-                // Persist selection in cookie via backend (10s timeout)
+                // Persist selection in cookie via backend (10s timeout). Abort any
+                // still-in-flight persist so an out-of-order response can't leave
+                // the cookie holding a term the buyer already clicked away from.
                 try {
                     if (window.twopayment && window.twopayment.order_intent_url && window.twopayment.ajax_token) {
-                        $.ajax({
+                        if (pendingTermRequest && pendingTermRequest.abort) {
+                            pendingTermRequest.abort();
+                        }
+                        pendingTermRequest = $.ajax({
                             url: window.twopayment.order_intent_url,
                             type: 'POST',
                             dataType: 'json',
                             data: { ajax: 1, action: 'savePaymentTerm', token: window.twopayment.ajax_token, days: days },
                             timeout: 10000
+                        }).fail((xhr, statusText) => {
+                            if (statusText !== 'abort') {
+                                console.error('Two Payment: Error saving term:', statusText);
+                            }
                         });
                     }
                 } catch (e) {
                     console.error('Two Payment: Error saving term:', e);
                 }
             });
-            
+
             termsContainer.appendChild(termChip);
         });
         
-        // Set initial selected term display
-        const activeTerm = defaultTerm || (availableTerms.length === 1 ? availableTerms[0] : availableTerms[0]);
-        
-        if (selectedDays && activeTerm) {
-            const payInText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.pay_in 
-                ? window.twopayment.i18n.pay_in 
-                : 'Pay in';
-            const daysText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.days 
-                ? window.twopayment.i18n.days 
-                : 'days';
-            const fromEndOfMonthText = window.twopayment && window.twopayment.i18n && window.twopayment.i18n.from_end_of_month 
-                ? window.twopayment.i18n.from_end_of_month 
-                : 'from end of month';
+        // Set initial selected term display — falls back to the first offered term
+        // when no valid default was configured (defaultTerm is null in that case).
+        const activeTerm = defaultTerm || availableTerms[0];
 
-            if (termType === 'EOM') {
-                // For EOM: Show "Pay in X days from end of month" format
-                selectedDays.textContent = payInText + ' ' + activeTerm + ' ' + daysText + ' ' + fromEndOfMonthText;
-            } else {
-                // For Standard: Show "Pay in 30 days" format
-                selectedDays.textContent = payInText + ' ' + activeTerm + ' ' + daysText;
-            }
+        if (selectedDays && activeTerm) {
+            selectedDays.textContent = formatPayInLabel(activeTerm);
         }
     }
     

--- a/views/templates/hook/paymentinfo.tpl
+++ b/views/templates/hook/paymentinfo.tpl
@@ -64,9 +64,9 @@
                 {l s='Your payment period starts when your order is fulfilled' mod='twopayment'}
             </p>
         </div>
-        <div class="two-terms-slider-container">
-            <div class="two-terms-slider" id="two-terms-slider">
-                {* Terms will be populated by JavaScript *}
+        <div class="two-term-chips">
+            <div class="two-term-chips__container" id="two-terms-chips">
+                {* Chips will be populated by JavaScript *}
             </div>
             <div class="two-terms-selected">
                 <span class="two-terms-selected-days" id="two-selected-days">30</span>


### PR DESCRIPTION
## What

Replaces the buyer-facing payment-terms **slider** with a **chip selector**, matching the pattern the Magento (Hyvä) and WooCommerce plugins already ship (TWO-24752, chip half).

This is a **selector-widget swap only** — no pricing/fee logic changed.

## Changes

- **Template** (`paymentinfo.tpl`) + **JS fallback markup**: `two-terms-slider` / `two-terms-slider-container` → `two-term-chips` / `two-term-chips__container` (`#two-terms-chips`).
- **JS render** (`TwoCheckoutManager.js`): each available term now renders as a `<button class="two-term-chip">` with a `two-term-chip__days` label. Selected state is `two-term-chip--selected`; a single offered term renders as a non-interactive `two-term-chip--single` (parity with the sibling plugins). Term click, cookie persistence via the existing `savePaymentTerm` AJAX handler, and the "Pay in X days" summary line are unchanged.
- **CSS** (`two.css`): slider rules replaced with chip rules. Column layout leaves room for a future per-chip surcharge sub-label (`two-term-chip__surcharge`). Palette keeps PrestaShop's existing slate accent (`#374151`) rather than the siblings' brand blue, so chips stay consistent with the rest of this checkout.

## Scope notes

- Out of scope for this PR (the rest of TWO-24752): async per-chip surcharge fetch via `POST /v1/pricing/order/fee`, PHP AJAX handlers, offset pricing fee. Only the widget swap.
- Admin-config term checkboxes in `twopayment.php` (which use `two-term-standard`/`two-term-both` for their own show/hide JS) are untouched.

## Testing

- Existing offline PHP test suite (`php tests/run.php`) passes — no PHP business logic changed, and there is no JS test framework in the repo (none introduced).
- `node --check` passes on the modified JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn