### PR TITLE
TWO-24759: PrestaShop partial refunds via credit slips

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@ This folder contains deterministic tests for order-building and payload safety l
 - Large rounded discount split handling keeps tax-formula validation stable
 - Cart-rule monetary (`value_real`/`value_tax_exc`) discount line attribution
 - Tracking number sourcing (order_carrier vs legacy shipping_number) and the admin tracking-update hook (TWO-24762)
+- Partial refunds via credit slips: amount+currency payload, slip-ID idempotency key, remaining-balance guard, and duplicate-refund suppression (TWO-24759)
 
 ## Why this matters
 

--- a/tests/RefundSpec.php
+++ b/tests/RefundSpec.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-24759 - partial refunds via PrestaShop credit slips
+ * (hookActionOrderSlipAdd -> POST /v1/order/{id}/refund).
+ */
+final class RefundSpec
+{
+    public static function runAll(): void
+    {
+        self::testPartialRefundPayloadHasCorrectAmount();
+        self::testIdempotencyKeyUsesSlipId();
+        self::testSequentialSlipsSameAmountIssueTwoDistinctCalls();
+        self::testFullAmountSlipAfterStatusRefundIsSuppressed();
+        self::testAmountExceedingRemainingBalanceIsRejected();
+        self::testSlipOnNonTwoOrderMakesNoApiCall();
+        self::testGrossAmountSumsProductsAndShippingTaxIncl();
+        self::testPayloadBuilderFormatsAmountAsTwoDecimalString();
+    }
+
+    /**
+     * Order stub: the hook only touches id, module, id_currency and the
+     * Validate::isLoadedObject 'loaded' flag.
+     */
+    private static function makeOrder(int $id = 5100, string $module = 'twopayment'): object
+    {
+        return new class ($id, $module) {
+            public bool $loaded = true;
+            public int $id;
+            public $module;
+            public int $id_currency = 826;
+
+            public function __construct(int $id, string $module)
+            {
+                $this->id = $id;
+                $this->module = $module;
+            }
+        };
+    }
+
+    /**
+     * Credit-slip stub carrying the tax-inclusive totals the hook reads.
+     */
+    private static function makeSlip(int $id, float $products, float $shipping = 0.0, int $idOrder = 5100): object
+    {
+        return new class ($id, $products, $shipping, $idOrder) {
+            public int $id;
+            public int $id_order;
+            public $total_products_tax_incl;
+            public $total_shipping_tax_incl;
+
+            public function __construct(int $id, float $products, float $shipping, int $idOrder)
+            {
+                $this->id = $id;
+                $this->id_order = $idOrder;
+                $this->total_products_tax_incl = $products;
+                $this->total_shipping_tax_incl = $shipping;
+            }
+        };
+    }
+
+    /**
+     * Harness recording every setTwoPaymentRequest call. GET returns the
+     * supplied Two-order snapshot; POST /refund returns a 201 success.
+     */
+    private static function makeModule(array $twoOrder, ?array $paymentData = ['two_order_id' => 'two-order-uuid']): object
+    {
+        return new class ($twoOrder, $paymentData) extends TwopaymentTestHarness {
+            public array $requests = [];
+            private array $twoOrder;
+            private $paymentData;
+
+            public function __construct(array $twoOrder, $paymentData)
+            {
+                parent::__construct();
+                $this->twoOrder = $twoOrder;
+                $this->paymentData = $paymentData;
+            }
+
+            public function getTwoOrderPaymentData($id_order)
+            {
+                return $this->paymentData;
+            }
+
+            public function setTwoOrderPaymentData($id_order, $payment_data)
+            {
+                return true;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->requests[] = [
+                    'endpoint' => $endpoint,
+                    'payload' => $payload,
+                    'method' => $method,
+                    'headers' => $additional_headers,
+                ];
+
+                if ($method === 'POST' && strpos($endpoint, '/refund') !== false) {
+                    return ['http_status' => 201, 'id' => 'refund-uuid'];
+                }
+
+                // GET order snapshot (initial check + post-refund refresh).
+                return $this->twoOrder;
+            }
+
+            /** @return array<int, array> the POST /refund calls only */
+            public function refundCalls(): array
+            {
+                return array_values(array_filter($this->requests, static function ($r) {
+                    return $r['method'] === 'POST' && strpos($r['endpoint'], '/refund') !== false;
+                }));
+            }
+        };
+    }
+
+    private static function fulfilledOrder(float $gross, array $refunds = [], string $currency = 'GBP'): array
+    {
+        return [
+            'id' => 'two-order-uuid',
+            'state' => 'FULFILLED',
+            'status' => 'APPROVED',
+            'gross_amount' => (string)$gross,
+            'currency' => $currency,
+            'refunds' => $refunds,
+        ];
+    }
+
+    private static function testPartialRefundPayloadHasCorrectAmount(): void
+    {
+        StubStore::reset();
+        $module = self::makeModule(self::fulfilledOrder(100.00));
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(501, 30.00),
+        ]);
+
+        $refunds = $module->refundCalls();
+        TinyAssert::count(1, $refunds);
+        TinyAssert::same('/v1/order/two-order-uuid/refund', $refunds[0]['endpoint']);
+        TinyAssert::same('30.00', $refunds[0]['payload']['amount']);
+        TinyAssert::same('GBP', $refunds[0]['payload']['currency']);
+        // Simple amount+currency payload - no line-item breakdown.
+        TinyAssert::false(isset($refunds[0]['payload']['line_items']));
+    }
+
+    private static function testIdempotencyKeyUsesSlipId(): void
+    {
+        StubStore::reset();
+        $module = self::makeModule(self::fulfilledOrder(100.00));
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(742, 25.00),
+        ]);
+
+        $refunds = $module->refundCalls();
+        TinyAssert::count(1, $refunds);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_742'], $refunds[0]['headers']);
+    }
+
+    private static function testSequentialSlipsSameAmountIssueTwoDistinctCalls(): void
+    {
+        StubStore::reset();
+        // gross 100, no prior refunds: two 30.00 slips are both within balance.
+        // Distinct slip IDs must yield distinct idempotency keys (no collision
+        // by amount).
+        $module = self::makeModule(self::fulfilledOrder(100.00));
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(801, 30.00),
+        ]);
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(802, 30.00),
+        ]);
+
+        $refunds = $module->refundCalls();
+        TinyAssert::count(2, $refunds);
+        TinyAssert::same('30.00', $refunds[0]['payload']['amount']);
+        TinyAssert::same('30.00', $refunds[1]['payload']['amount']);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_801'], $refunds[0]['headers']);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_802'], $refunds[1]['headers']);
+        TinyAssert::notSame($refunds[0]['headers'][0], $refunds[1]['headers'][0]);
+    }
+
+    private static function testFullAmountSlipAfterStatusRefundIsSuppressed(): void
+    {
+        StubStore::reset();
+        // The status-change full-refund path already refunded the whole order
+        // (refund total_amount is negative at Two). A concurrent full-amount
+        // credit slip must NOT double-refund: remaining balance is zero.
+        $module = self::makeModule(self::fulfilledOrder(100.00, [['total_amount' => '-100.00']]));
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(900, 100.00),
+        ]);
+
+        TinyAssert::count(0, $module->refundCalls());
+    }
+
+    private static function testAmountExceedingRemainingBalanceIsRejected(): void
+    {
+        StubStore::reset();
+        // gross 100, already refunded 80 -> remaining 20. A 50.00 slip exceeds
+        // the remaining refundable balance and must be rejected.
+        $module = self::makeModule(self::fulfilledOrder(100.00, [['total_amount' => '-80.00']]));
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(910, 50.00),
+        ]);
+
+        TinyAssert::count(0, $module->refundCalls());
+
+        // But a slip within the remaining balance still goes through.
+        $ok = self::makeModule(self::fulfilledOrder(100.00, [['total_amount' => '-80.00']]));
+        $ok->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(911, 20.00),
+        ]);
+        TinyAssert::count(1, $ok->refundCalls());
+        TinyAssert::same('20.00', $ok->refundCalls()[0]['payload']['amount']);
+    }
+
+    private static function testSlipOnNonTwoOrderMakesNoApiCall(): void
+    {
+        StubStore::reset();
+        // No Two payment row for this order -> nothing to refund at Two, and
+        // no order snapshot should even be fetched.
+        $module = self::makeModule(self::fulfilledOrder(100.00), null);
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(920, 40.00),
+        ]);
+
+        TinyAssert::count(0, $module->requests);
+    }
+
+    private static function testGrossAmountSumsProductsAndShippingTaxIncl(): void
+    {
+        StubStore::reset();
+        $module = self::makeModule(self::fulfilledOrder(500.00));
+
+        TinyAssert::same(125.50, $module->getTwoCreditSlipGrossAmount(self::makeSlip(1, 100.00, 25.50)));
+        TinyAssert::same(100.00, $module->getTwoCreditSlipGrossAmount(self::makeSlip(1, 100.00, 0.0)));
+    }
+
+    private static function testPayloadBuilderFormatsAmountAsTwoDecimalString(): void
+    {
+        StubStore::reset();
+        $module = self::makeModule(self::fulfilledOrder(500.00));
+
+        $payload = $module->buildTwoPartialRefundPayload(7.5, 'NOK');
+        TinyAssert::same('7.50', $payload['amount']);
+        TinyAssert::same('NOK', $payload['currency']);
+    }
+}

--- a/tests/RefundSpec.php
+++ b/tests/RefundSpec.php
@@ -15,6 +15,8 @@ final class RefundSpec
         self::testSequentialSlipsSameAmountIssueTwoDistinctCalls();
         self::testFullAmountSlipAfterStatusRefundIsSuppressed();
         self::testAmountExceedingRemainingBalanceIsRejected();
+        self::testMissingGrossAmountFailsClosed();
+        self::testEmptyCurrencyFailsClosed();
         self::testSlipOnNonTwoOrderMakesNoApiCall();
         self::testGrossAmountSumsProductsAndShippingTaxIncl();
         self::testPayloadBuilderFormatsAmountAsTwoDecimalString();
@@ -159,7 +161,7 @@ final class RefundSpec
 
         $refunds = $module->refundCalls();
         TinyAssert::count(1, $refunds);
-        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_742'], $refunds[0]['headers']);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_two-order-uuid_slip_742'], $refunds[0]['headers']);
     }
 
     private static function testSequentialSlipsSameAmountIssueTwoDistinctCalls(): void
@@ -183,8 +185,8 @@ final class RefundSpec
         TinyAssert::count(2, $refunds);
         TinyAssert::same('30.00', $refunds[0]['payload']['amount']);
         TinyAssert::same('30.00', $refunds[1]['payload']['amount']);
-        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_801'], $refunds[0]['headers']);
-        TinyAssert::same(['X-Idempotency-Key: partial_refund_slip_802'], $refunds[1]['headers']);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_two-order-uuid_slip_801'], $refunds[0]['headers']);
+        TinyAssert::same(['X-Idempotency-Key: partial_refund_two-order-uuid_slip_802'], $refunds[1]['headers']);
         TinyAssert::notSame($refunds[0]['headers'][0], $refunds[1]['headers'][0]);
     }
 
@@ -226,6 +228,48 @@ final class RefundSpec
         ]);
         TinyAssert::count(1, $ok->refundCalls());
         TinyAssert::same('20.00', $ok->refundCalls()[0]['payload']['amount']);
+    }
+
+    private static function testMissingGrossAmountFailsClosed(): void
+    {
+        StubStore::reset();
+        // Two GET returns a valid order (has id + refundable state) but NO
+        // gross_amount. The balance guard cannot be evaluated, so the refund
+        // must be refused (fail closed) - NOT posted with an unbounded amount.
+        $degraded = [
+            'id' => 'two-order-uuid',
+            'state' => 'FULFILLED',
+            'status' => 'APPROVED',
+            'currency' => 'GBP',
+            'refunds' => [],
+            // gross_amount deliberately absent
+        ];
+        $module = self::makeModule($degraded);
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(930, 40.00),
+        ]);
+
+        // GET was made, but no /refund POST.
+        TinyAssert::count(0, $module->refundCalls());
+    }
+
+    private static function testEmptyCurrencyFailsClosed(): void
+    {
+        StubStore::reset();
+        // Two GET carries an empty currency and the order's currency cannot be
+        // resolved (no StubStore currency for id 826 -> Currency not loaded).
+        // Posting {currency: ''} risks a wrong-currency refund, so fail closed.
+        $noCurrency = self::fulfilledOrder(100.00, [], '');
+        $module = self::makeModule($noCurrency);
+
+        $module->hookActionOrderSlipAdd([
+            'order' => self::makeOrder(),
+            'order_slip' => self::makeSlip(940, 30.00),
+        ]);
+
+        TinyAssert::count(0, $module->refundCalls());
     }
 
     private static function testSlipOnNonTwoOrderMakesNoApiCall(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -4573,12 +4573,14 @@ final class OrderBuilderSpec
 require __DIR__ . '/CustomerAddressFormatterOverrideSpec.php';
 require __DIR__ . '/TwoInvoiceRetrievalSpec.php';
 require __DIR__ . '/TrackingNumberSpec.php';
+require __DIR__ . '/RefundSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
     'CustomerAddressFormatterOverrideSpec::runAll' => [CustomerAddressFormatterOverrideSpec::class, 'runAll'],
     'TwoInvoiceRetrievalSpec::runAll' => [TwoInvoiceRetrievalSpec::class, 'runAll'],
     'TrackingNumberSpec::runAll' => [TrackingNumberSpec::class, 'runAll'],
+    'RefundSpec::runAll' => [RefundSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -2016,9 +2016,9 @@ class Twopayment extends PaymentModule
      *
      * Idempotency + duplicate-refund protection:
      *  - The idempotency key is derived from the credit slip ID
-     *    (partial_refund_slip_{id}), NOT order id + amount. Two separate
-     *    partial refunds of the same amount on one order have distinct slip
-     *    IDs and therefore distinct keys - they must NOT collide.
+     *    (partial_refund_{two_order_id}_slip_{id}), NOT order id + amount. Two
+     *    separate partial refunds of the same amount on one order have distinct
+     *    slip IDs and therefore distinct keys - they must NOT collide.
      *  - A remaining-refundable-balance guard (gross_amount minus the sum of
      *    existing Two refunds) is enforced BEFORE calling the API. This
      *    generalises the full-refund path's "already fully refunded" guards:
@@ -2098,10 +2098,21 @@ class Twopayment extends PaymentModule
             $already_refunded = $this->getTwoOrderRefundedTotal($current_two_order);
             $remaining = $gross_amount - $already_refunded;
 
+            // Fail CLOSED when we can't establish the order gross. Unlike the
+            // full-refund path (which posts a body-less refund whose amount Two
+            // computes server-side), this path sends a client-specified amount,
+            // so a missing/zero gross_amount would otherwise disable the
+            // over-refund guard entirely and allow an unbounded, arbitrary-many
+            // refund. If we cannot validate the balance, do not refund.
+            if ($gross_amount <= 0) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund skipped - cannot determine order gross amount to validate refundable balance. Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id, 3);
+                return;
+            }
+
             // Reject if this slip would push total refunds past the order gross.
             // The 0.01 tolerance absorbs 2dp rounding. This blocks over-refunding
             // and the full-amount-slip + status-change double-refund race.
-            if ($gross_amount > 0 && $slip_amount > ($remaining + 0.01)) {
+            if ($slip_amount > ($remaining + 0.01)) {
                 PrestaShopLogger::addLog('TwoPayment: Partial refund rejected - amount ' . $slip_amount . ' exceeds remaining refundable balance ' . $remaining . ' (gross: ' . $gross_amount . ', already refunded: ' . $already_refunded . '). Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id, 2);
                 return;
             }
@@ -2111,11 +2122,23 @@ class Twopayment extends PaymentModule
                 ? $current_two_order['currency']
                 : $this->getTwoOrderCurrencyIso($order);
 
+            // Fail CLOSED on an unresolved currency rather than POSTing a
+            // malformed {amount, currency:''} body: an empty/missing currency
+            // could be silently coerced server-side to a different currency,
+            // turning a correct amount into a wrong-magnitude refund.
+            if ($currency === '' || $currency === null) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund skipped - could not resolve refund currency. Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id, 3);
+                return;
+            }
+
             $payload = $this->buildTwoPartialRefundPayload($slip_amount, $currency);
 
             // Idempotency key derived from the credit slip ID (NOT amount) so
             // two same-amount partial refunds on one order don't collide.
-            $idempotency_key = 'partial_refund_slip_' . $slip_id;
+            // Scoped by the Two order ID as well so the key is unambiguous even
+            // if two PrestaShop installs sharing one Two merchant account
+            // happen to mint the same autoincrement slip ID.
+            $idempotency_key = 'partial_refund_' . $two_order_id . '_slip_' . $slip_id;
 
             $response = $this->setTwoPaymentRequest('/v1/order/' . $two_order_id . '/refund', $payload, 'POST', ['X-Idempotency-Key: ' . $idempotency_key]);
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -207,6 +207,7 @@ class Twopayment extends PaymentModule
             $this->registerHook('actionAdminControllerSetMedia') &&
             $this->registerHook('actionFrontControllerSetMedia') &&
             $this->registerHook('actionOrderStatusUpdate') &&
+            $this->registerHook('actionOrderSlipAdd') &&
             $this->registerHook('actionObjectOrderHistoryAddBefore') &&
             $this->registerHook('paymentOptions') &&
             $this->registerHook('displayPaymentReturn') &&
@@ -428,6 +429,7 @@ class Twopayment extends PaymentModule
             $this->unregisterHook('actionAdminControllerSetMedia') &&
             $this->unregisterHook('actionFrontControllerSetMedia') &&
             $this->unregisterHook('actionOrderStatusUpdate') &&
+            $this->unregisterHook('actionOrderSlipAdd') &&
             $this->unregisterHook('actionObjectOrderHistoryAddBefore') &&
             $this->unregisterHook('paymentOptions') &&
             $this->unregisterHook('displayPaymentReturn') &&
@@ -1994,6 +1996,252 @@ class Twopayment extends PaymentModule
                 }
             }
         }
+    }
+
+    /**
+     * Handle PrestaShop credit slip creation (partial refunds).
+     *
+     * PrestaShop credit slips are the mechanism for partial refunds. The
+     * full-refund path in hookActionOrderStatusUpdate only fires on a status
+     * change to "Refunded" and issues a body-less full refund; it does NOT
+     * cover credit slips, so partial refunds previously reached Two only when
+     * the merchant used the Two merchant portal.
+     *
+     * This hook builds an {amount, currency} partial-refund payload from the
+     * credit slip and calls POST /v1/order/{id}/refund. Two's refund endpoint
+     * accepts a simple {amount, currency} body for partial refunds (line_items
+     * optional) - confirmed against the checkout-api RefundRequestSchema
+     * (PartialRefundRequestSchema) - so we avoid mapping PrestaShop's
+     * credit-slip product list to Two line items.
+     *
+     * Idempotency + duplicate-refund protection:
+     *  - The idempotency key is derived from the credit slip ID
+     *    (partial_refund_slip_{id}), NOT order id + amount. Two separate
+     *    partial refunds of the same amount on one order have distinct slip
+     *    IDs and therefore distinct keys - they must NOT collide.
+     *  - A remaining-refundable-balance guard (gross_amount minus the sum of
+     *    existing Two refunds) is enforced BEFORE calling the API. This
+     *    generalises the full-refund path's "already fully refunded" guards:
+     *    it blocks over-refunding and blocks the double-refund race where a
+     *    full-amount slip fires alongside a status change to Refunded (both
+     *    hooks can fire for a full-amount slip, and the status hook's own
+     *    guards do NOT protect this hook). It deliberately does NOT
+     *    blanket-skip on Two state == REFUNDED, because Two reports REFUNDED
+     *    even after a partial refund; a blanket skip would break legitimate
+     *    sequential partial refunds.
+     *
+     * Best-effort: any failure is logged and swallowed so the admin's
+     * credit-slip action is never broken.
+     *
+     * @param array $params PrestaShop hook params; expects order_slip.
+     * @return void
+     */
+    public function hookActionOrderSlipAdd($params)
+    {
+        try {
+            if (!is_array($params) || !isset($params['order_slip']) || !is_object($params['order_slip'])) {
+                return;
+            }
+
+            $slip = $params['order_slip'];
+            $slip_id = isset($slip->id) ? (int)$slip->id : 0;
+            if ($slip_id <= 0) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund skipped - credit slip has no usable ID.', 2);
+                return;
+            }
+
+            $order = isset($params['order']) && is_object($params['order']) ? $params['order'] : null;
+            if ($order === null) {
+                $id_order = isset($slip->id_order) ? (int)$slip->id_order : 0;
+                if ($id_order > 0) {
+                    $order = new Order($id_order);
+                }
+            }
+            if (!$order || !Validate::isLoadedObject($order) || $order->module != $this->name) {
+                return;
+            }
+            $id_order = (int)$order->id;
+
+            $orderpaymentdata = $this->getTwoOrderPaymentData($id_order);
+            if (!$orderpaymentdata || empty($orderpaymentdata['two_order_id'])) {
+                // Not a Two order (or no Two mapping): nothing to refund at Two.
+                return;
+            }
+            $two_order_id = $orderpaymentdata['two_order_id'];
+
+            $slip_amount = $this->getTwoCreditSlipGrossAmount($slip);
+            if ($slip_amount <= 0) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund skipped - non-positive slip amount for Two order ID: ' . $two_order_id . ', Slip ID: ' . $slip_id, 2);
+                return;
+            }
+
+            PrestaShopLogger::addLog('TwoPayment: Initiating partial refund for Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id . ', Amount: ' . $slip_amount, 1);
+
+            // Fetch the current Two order to validate refundable state and remaining balance.
+            $current_two_order = $this->setTwoPaymentRequest('/v1/order/' . $two_order_id, [], 'GET');
+            if (!$current_two_order || !isset($current_two_order['id'])) {
+                PrestaShopLogger::addLog('TwoPayment: Cannot retrieve Two order for partial refund check. Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order, 3);
+                return;
+            }
+
+            // Two only allows refunds for FULFILLED orders. REFUNDED is allowed
+            // too: the state shows REFUNDED even after a partial refund, and
+            // further partial refunds within the remaining balance are valid.
+            $order_state = isset($current_two_order['state']) ? $current_two_order['state'] : null;
+            if ($order_state !== 'FULFILLED' && $order_state !== 'REFUNDED') {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund skipped - order not in refundable state. Current state: ' . $order_state . '. Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order, 2);
+                return;
+            }
+
+            // Remaining-balance guard: gross minus the sum of existing refunds.
+            $gross_amount = isset($current_two_order['gross_amount']) ? (float)$current_two_order['gross_amount'] : 0.0;
+            $already_refunded = $this->getTwoOrderRefundedTotal($current_two_order);
+            $remaining = $gross_amount - $already_refunded;
+
+            // Reject if this slip would push total refunds past the order gross.
+            // The 0.01 tolerance absorbs 2dp rounding. This blocks over-refunding
+            // and the full-amount-slip + status-change double-refund race.
+            if ($gross_amount > 0 && $slip_amount > ($remaining + 0.01)) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund rejected - amount ' . $slip_amount . ' exceeds remaining refundable balance ' . $remaining . ' (gross: ' . $gross_amount . ', already refunded: ' . $already_refunded . '). Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id, 2);
+                return;
+            }
+
+            // The refund currency must match the Two order currency.
+            $currency = isset($current_two_order['currency']) && $current_two_order['currency']
+                ? $current_two_order['currency']
+                : $this->getTwoOrderCurrencyIso($order);
+
+            $payload = $this->buildTwoPartialRefundPayload($slip_amount, $currency);
+
+            // Idempotency key derived from the credit slip ID (NOT amount) so
+            // two same-amount partial refunds on one order don't collide.
+            $idempotency_key = 'partial_refund_slip_' . $slip_id;
+
+            $response = $this->setTwoPaymentRequest('/v1/order/' . $two_order_id . '/refund', $payload, 'POST', ['X-Idempotency-Key: ' . $idempotency_key]);
+
+            $http_status = isset($response['http_status']) ? (int)$response['http_status'] : 0;
+            if ($http_status === self::HTTP_STATUS_CREATED && isset($response['id']) && $response['id']) {
+                PrestaShopLogger::addLog('TwoPayment: Partial refund successful (HTTP ' . self::HTTP_STATUS_CREATED . ') for Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id . ', Idempotency Key: ' . $idempotency_key, 1);
+
+                // Refresh stored payment data with the latest order snapshot.
+                $order_after = $this->setTwoPaymentRequest('/v1/order/' . $two_order_id, [], 'GET');
+                if (isset($order_after['id']) && $order_after['id']) {
+                    $resolved_terms = $this->resolveTwoPaymentTermsFromOrderResponse(
+                        $order_after,
+                        isset($orderpaymentdata['two_day_on_invoice']) ? (string)$orderpaymentdata['two_day_on_invoice'] : (string)$this->getSelectedPaymentTerm(),
+                        isset($orderpaymentdata['two_payment_term_type']) ? $orderpaymentdata['two_payment_term_type'] : Configuration::get('PS_TWO_PAYMENT_TERM_TYPE')
+                    );
+                    $payment_data = array(
+                        'two_order_id' => $two_order_id,
+                        'two_order_reference' => isset($order_after['merchant_reference']) ? $order_after['merchant_reference'] : (isset($orderpaymentdata['two_order_reference']) ? $orderpaymentdata['two_order_reference'] : ''),
+                        'two_order_state' => isset($order_after['state']) ? $order_after['state'] : (isset($orderpaymentdata['two_order_state']) ? $orderpaymentdata['two_order_state'] : ''),
+                        'two_order_status' => isset($order_after['status']) ? $order_after['status'] : (isset($orderpaymentdata['two_order_status']) ? $orderpaymentdata['two_order_status'] : ''),
+                        'two_day_on_invoice' => $resolved_terms['two_day_on_invoice'],
+                        'two_payment_term_type' => $resolved_terms['two_payment_term_type'],
+                        'two_invoice_url' => isset($order_after['invoice_url']) ? $order_after['invoice_url'] : (isset($orderpaymentdata['two_invoice_url']) ? $orderpaymentdata['two_invoice_url'] : ''),
+                        'two_invoice_id' => isset($order_after['invoice_details']['id']) ? $order_after['invoice_details']['id'] : (isset($orderpaymentdata['two_invoice_id']) ? $orderpaymentdata['two_invoice_id'] : null),
+                    );
+                    $this->setTwoOrderPaymentData($id_order, $payment_data);
+                }
+            } else {
+                $error_message = 'Unknown error';
+                if (isset($response['error'])) {
+                    $error_message = is_array($response['error']) ? json_encode($response['error']) : $response['error'];
+                } elseif (isset($response['message'])) {
+                    $error_message = $response['message'];
+                }
+                $log_message = 'TwoPayment: Partial refund FAILED for Two order ID: ' . $two_order_id . ', Order ID: ' . $id_order . ', Slip ID: ' . $slip_id;
+                $log_message .= ', HTTP Status: ' . ($http_status > 0 ? $http_status : 'Unknown');
+                $log_message .= ', Error: ' . $error_message;
+                $log_message .= ', Idempotency Key: ' . $idempotency_key;
+                $log_message .= ', Response Summary: ' . json_encode($this->buildTwoApiResponseLogSummary($response));
+                PrestaShopLogger::addLog($log_message, 3);
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Exception during partial refund. Exception: ' . $e->getMessage() . ', Trace: ' . $e->getTraceAsString(), 3);
+        }
+    }
+
+    /**
+     * Compute the gross (tax-inclusive) refund amount from a PrestaShop credit
+     * slip: refunded products (tax incl) plus refunded shipping (tax incl).
+     * Falls back to the legacy amount / shipping_cost_amount fields when the
+     * tax-incl totals are absent.
+     *
+     * @param object $slip OrderSlip
+     * @return float
+     */
+    public function getTwoCreditSlipGrossAmount($slip)
+    {
+        $products = 0.0;
+        if (isset($slip->total_products_tax_incl) && $slip->total_products_tax_incl !== null && $slip->total_products_tax_incl !== '') {
+            $products = (float)$slip->total_products_tax_incl;
+        } elseif (isset($slip->amount)) {
+            $products = (float)$slip->amount;
+        }
+
+        $shipping = 0.0;
+        if (isset($slip->total_shipping_tax_incl) && $slip->total_shipping_tax_incl !== null && $slip->total_shipping_tax_incl !== '') {
+            $shipping = (float)$slip->total_shipping_tax_incl;
+        } elseif (isset($slip->shipping_cost_amount)) {
+            $shipping = (float)$slip->shipping_cost_amount;
+        }
+
+        return round($products + $shipping, 2);
+    }
+
+    /**
+     * Sum the absolute value of every existing Two refund total on an order
+     * response. Two records refund total_amount as a negative number.
+     *
+     * @param array $two_order Two order API response
+     * @return float
+     */
+    public function getTwoOrderRefundedTotal($two_order)
+    {
+        $total = 0.0;
+        if (isset($two_order['refunds']) && is_array($two_order['refunds'])) {
+            foreach ($two_order['refunds'] as $refund) {
+                if (isset($refund['total_amount'])) {
+                    $total += abs((float)$refund['total_amount']);
+                }
+            }
+        }
+        return round($total, 2);
+    }
+
+    /**
+     * Build the {amount, currency} partial-refund payload for Two. Amount is a
+     * 2dp decimal string, matching Two's Money format.
+     *
+     * @param float $amount Gross refund amount
+     * @param string $currency ISO currency code
+     * @return array
+     */
+    public function buildTwoPartialRefundPayload($amount, $currency)
+    {
+        return array(
+            'amount' => number_format((float)$amount, 2, '.', ''),
+            'currency' => $currency,
+        );
+    }
+
+    /**
+     * Resolve the ISO currency code for a PrestaShop order (fallback when the
+     * Two order response carries no currency).
+     *
+     * @param object $order Order
+     * @return string
+     */
+    public function getTwoOrderCurrencyIso($order)
+    {
+        if (isset($order->id_currency) && (int)$order->id_currency > 0) {
+            $currency = new Currency((int)$order->id_currency);
+            if (Validate::isLoadedObject($currency)) {
+                return (string)$currency->iso_code;
+            }
+        }
+        return '';
     }
 
     /**


### PR DESCRIPTION
## What

Adds partial-refund support to the PrestaShop plugin. Until now only full refunds reached Two (fired on a status change to "Refunded"). PrestaShop **credit slips** — the partial-refund mechanism — triggered nothing on Two's side, so partial refunds only reached Two via the merchant portal.

Closes TWO-24759.

## How

- Register `actionOrderSlipAdd` in `install()` / `uninstall()`.
- Implement `hookActionOrderSlipAdd($params)`: build an `{amount, currency}` payload from the credit slip and `POST /v1/order/{id}/refund`.
- Full-refund path in `hookActionOrderStatusUpdate` is **unchanged** — extended, not replaced.

### API payload shape (ticket's open question — resolved)
Two's `POST /v1/order/{id}/refund` accepts a simple `amount` + `currency` body for partial refunds; `line_items` is optional. Verified against checkout-api `PartialRefundRequestSchema` (`amount`/`currency` required, `line_items` nullable). So we do **not** map PrestaShop's credit-slip product list to Two line items.

### Idempotency & duplicate-refund protection
- Idempotency key is `partial_refund_slip_{slip_id}` — keyed on the **credit slip ID**, not order + amount, so two same-amount partial refunds on one order don't collide.
- A **remaining-refundable-balance guard** (order gross minus the sum of existing Two refunds) runs before the API call. It blocks over-refunding and the double-refund race where a full-amount slip fires alongside a status change to "Refunded" (both hooks can fire; the status hook's own guards don't protect this one).

### ⚠️ Deliberate deviation from the ticket, flagging for review
The ticket says "include all three duplicate-refund guards from the full-refund path". Guard #1 there is a **blanket skip when Two state == REFUNDED**. But Two reports `REFUNDED` even after a *partial* refund (the full-refund path itself notes this), so a blanket skip would block legitimate **sequential** partial refunds — which the ticket's own test plan ("50% → PARTIALLY_REFUNDED, remaining 50% → REFUNDED") and unit-test list require. I implemented the guards' *protective intent* as the remaining-balance check (a generalisation of guard #3) instead of copying guard #1 verbatim. This satisfies both the double-refund protection and the sequential-partials requirement. Happy to revisit if the intent was different.

## Tests
`tests/RefundSpec.php` (offline harness, matches existing spec precedent; run via `php tests/run.php`):
- Correct amount in payload (within order total)
- Idempotency key uses slip ID
- Two sequential same-amount slips → two distinct API calls (different keys, no collision)
- Full-amount slip after a status refund → suppressed (called at most once)
- Amount exceeding remaining balance → rejected; within-balance → allowed
- Slip on a non-Two order → no API call
- Gross-amount summation (products + shipping tax-incl) and payload-builder formatting units

All 5 spec suites pass. `php -l` clean.

## Not covered / owed (manual, per ticket)
- Live 50% then remaining-50% checkout on staging (Two shows PARTIALLY_REFUNDED → REFUNDED).
- **Verify hook params shape on the target PrestaShop version.** The implementation uses `$params['order_slip']` per the ticket; the code guards defensively if it's absent, but this should be confirmed against a live credit-slip creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn