### PR TITLE
TWO-24813: source payment terms from GET /v1/merchant available_terms

### DIFF
--- a/tests/run.php
+++ b/tests/run.php
@@ -154,6 +154,16 @@ final class OrderBuilderSpec
         self::testExtractOrgNumberFromAddressKeepsNonCountryPrefixVatNumber();
         self::testExtractOrgNumberFromAddressStripsMatchingCountryPrefixVatNumber();
         self::testGetTwoRequestHeadersSkipAuthForOrderIntent();
+        self::testGetAvailablePaymentTermsIntersectsBackendWithAdminSubset();
+        self::testGetAvailablePaymentTermsWithdrawnBackendTermDrops();
+        self::testGetAvailablePaymentTermsFallsBackToHardcodedWhenBackendUnresolved();
+        self::testGetAvailablePaymentTermsEomConstrainsToEomSubset();
+        self::testGetAvailablePaymentTermsEmptyOfferFallsBackToDefault();
+        self::testGetMerchantAvailableTermsCacheOnlyNeverFetches();
+        self::testGetMerchantAvailableTermsRefreshNormalisesCachesAndServesStale();
+        self::testGetMerchantAvailableTermsRespectsExplicitEmptyList();
+        self::testGetMerchantAvailableTermsSkipsFetchWithoutIdentity();
+        self::testInvalidateMerchantAvailableTermsClearsCache();
     }
 
     private static function reset(): void
@@ -4142,6 +4152,184 @@ final class OrderBuilderSpec
 
         TinyAssert::same('45', (string)$resolved['two_day_on_invoice']);
         TinyAssert::same('STANDARD', (string)$resolved['two_payment_term_type']);
+    }
+
+    /**
+     * Gateway harness whose backend available_terms set is injectable, so the
+     * runtime intersection seam can be tested without HTTP (TWO-24813).
+     */
+    private static function termsHarness(array $backend): TwopaymentTestHarness
+    {
+        return new class ($backend) extends TwopaymentTestHarness {
+            public $backend;
+            public function __construct($backend = [])
+            {
+                parent::__construct();
+                $this->backend = $backend;
+            }
+            public function getMerchantAvailableTerms($refresh = false)
+            {
+                return $this->backend;
+            }
+        };
+    }
+
+    private static function testGetAvailablePaymentTermsIntersectsBackendWithAdminSubset(): void
+    {
+        self::reset();
+        // Backend owns the offerable set; the admin narrows FROM it. A tick for
+        // a term the backend does not carry (7) is irrelevant.
+        $module = self::termsHarness([14, 30, 60, 90]);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_7', 1);
+        TinyAssert::same([30, 60], $module->getAvailablePaymentTerms());
+    }
+
+    private static function testGetAvailablePaymentTermsWithdrawnBackendTermDrops(): void
+    {
+        self::reset();
+        // The admin still ticks 60, but the backend has withdrawn it -> it drops.
+        $module = self::termsHarness([30]);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        TinyAssert::same([30], $module->getAvailablePaymentTerms());
+    }
+
+    private static function testGetAvailablePaymentTermsFallsBackToHardcodedWhenBackendUnresolved(): void
+    {
+        self::reset();
+        // Cold cache (unresolved backend): degrade to the historical hardcoded
+        // option list rather than blanking the term set.
+        $module = self::termsHarness([]);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_7', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_90', 1);
+        TinyAssert::same([7, 90], $module->getAvailablePaymentTerms());
+    }
+
+    private static function testGetAvailablePaymentTermsEomConstrainsToEomSubset(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'EOM');
+        // 90 is offered by the backend and ticked, but EOM only allows 30/45/60.
+        $module = self::termsHarness([30, 45, 60, 90]);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_90', 1);
+        TinyAssert::same([30], $module->getAvailablePaymentTerms());
+    }
+
+    private static function testGetAvailablePaymentTermsEmptyOfferFallsBackToDefault(): void
+    {
+        self::reset();
+        // Backend resolves a set but the admin ticks nothing offerable -> the
+        // account default term (pre-feature degrade posture).
+        $module = self::termsHarness([60]);
+        TinyAssert::same([Twopayment::DEFAULT_PAYMENT_TERM_DAYS], $module->getAvailablePaymentTerms());
+    }
+
+    /**
+     * Fetch/cache harness: canned setTwoPaymentRequest responses, call counter.
+     */
+    private static function fetchHarness(): TwopaymentTestHarness
+    {
+        return new class extends TwopaymentTestHarness {
+            public $responses = [];
+            public $calls = 0;
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->calls++;
+                $r = array_shift($this->responses);
+                return $r === null ? ['http_status' => 0] : $r;
+            }
+        };
+    }
+
+    private static function testGetMerchantAvailableTermsCacheOnlyNeverFetches(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'mid');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'key');
+        $module = self::fetchHarness();
+        // Cache-only read never fetches, even with a cold cache: the seam is
+        // reached from render paths that must not block on HTTP.
+        TinyAssert::same([], $module->getMerchantAvailableTerms());
+        TinyAssert::same(0, $module->calls);
+    }
+
+    private static function testGetMerchantAvailableTermsRefreshNormalisesCachesAndServesStale(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'mid');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'key');
+        $module = self::fetchHarness();
+        $expire = static function () {
+            Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, time() - 901);
+        };
+
+        // First refresh: normalised (ints, dedup, non-positive dropped, non-numeric
+        // dropped rather than intval'd to a phantom 1, sorted).
+        $module->responses[] = ['http_status' => 200, 'available_terms' => [60, 30, 30, 0, -5, 90, [7], true, null]];
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms(true));
+        TinyAssert::same(1, $module->calls);
+
+        // Within the TTL: served from cache, no request; cache-only reads agree.
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms(true));
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms());
+        TinyAssert::same(1, $module->calls);
+
+        // Fetch failure after expiry: last-known list served, not blanked.
+        $expire();
+        $module->responses[] = ['http_status' => 0];
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms(true));
+        TinyAssert::same(2, $module->calls);
+
+        // ...and the failure still bumped the clock: an immediate re-refresh does
+        // NOT hammer the API (one stall per TTL, not per view).
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms(true));
+        TinyAssert::same(2, $module->calls);
+
+        // Successful response WITHOUT the field (older backend): stale kept.
+        $expire();
+        $module->responses[] = ['http_status' => 200, 'due_in_days' => 14];
+        TinyAssert::same([30, 60, 90], $module->getMerchantAvailableTerms(true));
+    }
+
+    private static function testGetMerchantAvailableTermsRespectsExplicitEmptyList(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'mid');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'key');
+        $module = self::fetchHarness();
+        // Seed a stale list, then an explicit [] must overwrite it (the backend
+        // says nothing is offerable) - distinct from a failure serving stale.
+        $module->responses[] = ['http_status' => 200, 'available_terms' => [30, 60]];
+        TinyAssert::same([30, 60], $module->getMerchantAvailableTerms(true));
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, time() - 901);
+        $module->responses[] = ['http_status' => 200, 'available_terms' => []];
+        TinyAssert::same([], $module->getMerchantAvailableTerms(true));
+    }
+
+    private static function testGetMerchantAvailableTermsSkipsFetchWithoutIdentity(): void
+    {
+        self::reset();
+        // No merchant id / API key: no fetch even on refresh with an expired TTL
+        // and a queued response.
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, time() - 901);
+        $module = self::fetchHarness();
+        $module->responses[] = ['http_status' => 200, 'available_terms' => [7]];
+        $module->getMerchantAvailableTerms(true);
+        TinyAssert::same(0, $module->calls);
+    }
+
+    private static function testInvalidateMerchantAvailableTermsClearsCache(): void
+    {
+        self::reset();
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30,60]');
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, 999);
+        $module = new TwopaymentTestHarness();
+        TinyAssert::same([30, 60], $module->getMerchantAvailableTerms());
+        $module->invalidateMerchantAvailableTerms();
+        TinyAssert::same([], $module->getMerchantAvailableTerms());
     }
 
     private static function testSyncTwoAdminOrderPaymentDataFromProviderPullsLatestTermsFromTwo(): void

--- a/tests/run.php
+++ b/tests/run.php
@@ -164,6 +164,7 @@ final class OrderBuilderSpec
         self::testGetMerchantAvailableTermsRespectsExplicitEmptyList();
         self::testGetMerchantAvailableTermsSkipsFetchWithoutIdentity();
         self::testInvalidateMerchantAvailableTermsClearsCache();
+        self::testSaveGeneralFormPreservesHiddenBackendWithdrawnTermPreference();
     }
 
     private static function reset(): void
@@ -4330,6 +4331,49 @@ final class OrderBuilderSpec
         TinyAssert::same([30, 60], $module->getMerchantAvailableTerms());
         $module->invalidateMerchantAvailableTerms();
         TinyAssert::same([], $module->getMerchantAvailableTerms());
+    }
+
+    /**
+     * Regression (TWO-24813): the admin checkbox form only renders terms in the
+     * backend-restricted offerable source, so a term the backend has withdrawn
+     * is hidden and never POSTed. Saving the general form (e.g. after changing an
+     * unrelated field) must NOT read that absent POST value as "unchecked" and
+     * zero the merchant's stored preference - the save loop iterates the same
+     * rendered source, leaving hidden keys untouched.
+     */
+    private static function testSaveGeneralFormPreservesHiddenBackendWithdrawnTermPreference(): void
+    {
+        self::reset();
+        Tools::resetTestValues();
+        // Merchant previously ticked both 30 and 60.
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+
+        // Backend has since narrowed the offerable set to [30]; 60 is hidden.
+        $module = new class extends TwopaymentTestHarness {
+            public function getMerchantAvailableTerms($refresh = false)
+            {
+                return [30];
+            }
+            public function saveGeneralForTest(): void
+            {
+                $this->saveTwoGeneralFormValues();
+            }
+        };
+
+        // The form rendered only the 30 checkbox, so only 30 is POSTed.
+        Tools::setTestValue('PS_TWO_ENVIRONMENT', 'development');
+        Tools::setTestValue('PS_TWO_TITLE_1', 'Two title');
+        Tools::setTestValue('PS_TWO_SUB_TITLE_1', 'Two subtitle');
+        Tools::setTestValue('PS_TWO_MERCHANT_SHORT_NAME', 'merchant');
+        Tools::setTestValue('PS_TWO_MERCHANT_API_KEY', 'api-key');
+        Tools::setTestValue('PS_TWO_PAYMENT_TERMS_30', 1);
+
+        $module->saveGeneralForTest();
+
+        // 30 stays on; 60's preference is PRESERVED, not silently zeroed.
+        TinyAssert::same(1, (int) Configuration::get('PS_TWO_PAYMENT_TERMS_30'));
+        TinyAssert::same(1, (int) Configuration::get('PS_TWO_PAYMENT_TERMS_60'));
     }
 
     private static function testSyncTwoAdminOrderPaymentDataFromProviderPullsLatestTermsFromTwo(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -20,6 +20,15 @@ class Twopayment extends PaymentModule
     // Constants for payment terms
     const DEFAULT_PAYMENT_TERM_DAYS = 30; // Default payment term in days
     const PAYMENT_TERMS_OPTIONS = [7, 15, 20, 30, 45, 60, 90]; // Available payment term options
+    // EOM (End-of-Month) terms are only offerable for these durations.
+    const EOM_PAYMENT_TERMS_OPTIONS = [30, 45, 60];
+    // TTL (seconds) for the cached GET /v1/merchant available_terms list (TWO-24813).
+    const MERCHANT_AVAILABLE_TERMS_TTL = 900; // 15 minutes
+    // Dedicated Configuration keys for the cached merchant term list (kept OUT
+    // of the general-settings save path so a checkout-render refresh can never
+    // race a concurrent admin save into reverting other settings - TWO-24813).
+    const CONFIG_MERCHANT_AVAILABLE_TERMS = 'PS_TWO_MERCHANT_AVAILABLE_TERMS';
+    const CONFIG_MERCHANT_AVAILABLE_TERMS_TS = 'PS_TWO_MERCHANT_AVAILABLE_TERMS_TS';
     
     // Constants for API timeouts (seconds)
     const API_TIMEOUT_SHORT = 30; // Standard API timeout
@@ -618,50 +627,10 @@ class Twopayment extends PaymentModule
                         'name' => 'PS_TWO_PAYMENT_TERMS',
                         'desc' => '<span id="two-payment-terms-desc-standard" style="display: none;">' . $this->l('Select which payment terms you want to offer. Standard terms are calculated from the fulfillment date.') . '</span><span id="two-payment-terms-desc-eom" style="display: none;">' . $this->l('Select which payment terms you want to offer. EOM (End-of-Month) terms are calculated from the end of the month at fulfillment, plus the selected days. Only 30, 45, and 60 day terms are available for EOM.') . '</span>',
                         'values' => array(
-                            'query' => array(
-                                array(
-                                    'id' => '7',
-                                    'name' => $this->l('7 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-7 two-term-standard'
-                                ),
-                                array(
-                                    'id' => '15',
-                                    'name' => $this->l('15 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-15 two-term-standard'
-                                ),
-                                array(
-                                    'id' => '20',
-                                    'name' => $this->l('20 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-20 two-term-standard'
-                                ),
-                                array(
-                                    'id' => '30',
-                                    'name' => $this->l('30 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-30 two-term-both'
-                                ),
-                                array(
-                                    'id' => '45',
-                                    'name' => $this->l('45 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-45 two-term-both'
-                                ),
-                                array(
-                                    'id' => '60',
-                                    'name' => $this->l('60 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-60 two-term-both'
-                                ),
-                                array(
-                                    'id' => '90',
-                                    'name' => $this->l('90 days'),
-                                    'val' => '1',
-                                    'class' => 'two-term-option two-term-90 two-term-standard'
-                                ),
-                            ),
+                            // Restrict the tickable set to the merchant's backend
+                            // available_terms (TWO-24813); admin render is one of
+                            // the two sanctioned refresh points.
+                            'query' => $this->buildPaymentTermCheckboxQuery(),
                             'id' => 'id',
                             'name' => 'name'
                         )
@@ -673,6 +642,36 @@ class Twopayment extends PaymentModule
             ),
         );
         return $fields_form;
+    }
+
+    /**
+     * Build the "Available Payment Terms" checkbox rows, restricted to the
+     * merchant's backend available_terms (TWO-24813) and falling back to the
+     * hardcoded option list on a cold cache. The class drives the client-side
+     * STANDARD/EOM show-hide toggle: 30/45/60 are valid under both, the rest are
+     * STANDARD-only. Refreshes the cache (admin config render is a sanctioned
+     * refresh point).
+     *
+     * @return array<int, array{id:string,name:string,val:string,class:string}>
+     */
+    protected function buildPaymentTermCheckboxQuery()
+    {
+        $source = $this->getOfferableTermSource(true);
+        sort($source);
+        $query = array();
+        foreach ($source as $term) {
+            $term = (int) $term;
+            $type_class = in_array($term, self::EOM_PAYMENT_TERMS_OPTIONS, true)
+                ? 'two-term-both'
+                : 'two-term-standard';
+            $query[] = array(
+                'id' => (string) $term,
+                'name' => sprintf($this->l('%d days'), $term),
+                'val' => '1',
+                'class' => 'two-term-option two-term-' . $term . ' ' . $type_class,
+            );
+        }
+        return $query;
     }
 
     protected function getTwoGeneralFormValues()
@@ -763,6 +762,11 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', trim(Tools::getValue('PS_TWO_MERCHANT_API_KEY')));
         Configuration::updateValue('PS_TWO_ENVIRONMENT', Tools::getValue('PS_TWO_ENVIRONMENT'));
         if ($this->verifiedMerchantId) {
+            if ((string) Configuration::get('PS_TWO_MERCHANT_ID') !== (string) $this->verifiedMerchantId) {
+                // Merchant identity changed: drop the cached term list so
+                // serve-stale never bridges the old merchant's terms (TWO-24813).
+                $this->invalidateMerchantAvailableTerms();
+            }
             Configuration::updateValue('PS_TWO_MERCHANT_ID', $this->verifiedMerchantId);
             Configuration::updateValue('PS_TWO_API_KEY_VERIFIED', 1);
         } else {
@@ -2177,6 +2181,11 @@ class Twopayment extends PaymentModule
             'from_end_of_month' => $this->l('from end of month'),
             'end_of_month_plus_days' => $this->l('End of Month + %s days'),
         );
+
+        // Checkout media render is a sanctioned refresh point for the backend
+        // term list (TWO-24813); prime the cache before the cache-only reads
+        // in getAvailablePaymentTerms / getDefaultPaymentTerm below.
+        $this->getMerchantAvailableTerms(true);
 
         Media::addJsDef(array('twopayment' => array(
                 'search_empty_text' => $this->l('No result found'),
@@ -5613,39 +5622,162 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Get available payment terms configured by the merchant
-     * @return array Array of available payment terms in days
+     * The merchant's offerable payment terms (net days, ascending) sourced from
+     * `available_terms` on GET /v1/merchant/{id} - the backend resolves them from
+     * the merchant's pricing packages, so this is the authoritative set the admin
+     * narrows from (TWO-24813). An empty result means the set is not currently
+     * resolved (no verified API key / merchant id yet, or no successful fetch yet)
+     * OR the backend explicitly returned an empty list.
+     *
+     * Cache-only by default: this is read from checkout / cart / admin-render
+     * paths that must not stall on HTTP. A TTL-gated fetch (15 min, 10s request
+     * cap) runs only when $refresh === true, from the two sanctioned refresh
+     * points (the checkout media hook and the admin config render). The cached
+     * list is overwritten only by a successful response carrying an
+     * `available_terms` array; a fetch failure (or an older backend omitting the
+     * field) serves the last-known list for another TTL rather than blanking the
+     * term set on an API blip.
+     *
+     * The cache lives in two dedicated Configuration keys, NOT the general
+     * settings blob, so a checkout-render refresh can never race a concurrent
+     * admin settings save.
+     *
+     * @param bool $refresh Allow a TTL-gated backend fetch on this call.
+     * @return int[] Ascending, unique day counts; empty when unresolved.
      */
+    public function getMerchantAvailableTerms($refresh = false)
+    {
+        if ($refresh) {
+            $checked_on = (int) Configuration::get(self::CONFIG_MERCHANT_AVAILABLE_TERMS_TS);
+            if ($checked_on <= 0 || ($checked_on + self::MERCHANT_AVAILABLE_TERMS_TTL) <= time()) {
+                $merchant_id = Configuration::get('PS_TWO_MERCHANT_ID');
+                $api_key = Configuration::get('PS_TWO_MERCHANT_API_KEY');
+                if (!Tools::isEmpty($merchant_id) && !Tools::isEmpty($api_key)) {
+                    // On a render path even when refreshing, so cap tight.
+                    $response = $this->setTwoPaymentRequest(
+                        '/v1/merchant/' . rawurlencode((string) $merchant_id),
+                        array(),
+                        'GET',
+                        array(),
+                        self::API_TIMEOUT_STATE_CHECK
+                    );
+                    $http_status = isset($response['http_status']) ? (int) $response['http_status'] : 0;
+                    if (
+                        $http_status === self::HTTP_STATUS_OK
+                        && isset($response['available_terms'])
+                        && is_array($response['available_terms'])
+                    ) {
+                        $normalised = $this->normaliseMerchantTerms($response['available_terms']);
+                        Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS, json_encode($normalised));
+                    }
+                    // Bump the clock even on failure so a cold cache does not
+                    // hammer the API on every checkout / admin render (one stall
+                    // per TTL, not per view).
+                    Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, time());
+                }
+            }
+        }
+
+        $cached = Configuration::get(self::CONFIG_MERCHANT_AVAILABLE_TERMS);
+        if (Tools::isEmpty($cached)) {
+            return array();
+        }
+        $decoded = json_decode($cached, true);
+        if (!is_array($decoded)) {
+            return array();
+        }
+        return $this->normaliseMerchantTerms($decoded);
+    }
+
     /**
-     * Get available payment terms filtered by term type (STANDARD or EOM)
-     * @return array Array of available payment term durations (e.g., [30, 45, 60])
+     * Normalise a raw term list into ascending, unique, positive int day counts.
+     * The is_numeric guard drops malformed elements (nested arrays, bools, null)
+     * rather than intval'ing them into a phantom "1 day" term.
+     *
+     * @param mixed $terms
+     * @return int[]
+     */
+    private function normaliseMerchantTerms($terms)
+    {
+        $days = array();
+        foreach ((array) $terms as $t) {
+            if (!is_numeric($t)) {
+                continue;
+            }
+            $d = (int) $t;
+            if ($d > 0) {
+                $days[$d] = $d;
+            }
+        }
+        $days = array_values($days);
+        sort($days);
+        return $days;
+    }
+
+    /**
+     * Drop the cached merchant term list. Called when the merchant identity
+     * changes (new API key / merchant id) - serve-stale caching must never
+     * serve the old merchant's terms under a new identity (TWO-24813).
+     */
+    public function invalidateMerchantAvailableTerms()
+    {
+        Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS, '');
+        Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, 0);
+    }
+
+    /**
+     * The offerable term source set (before the admin narrows it): the backend's
+     * `available_terms` when resolved, else the historical hardcoded option list.
+     * The fallback preserves pre-feature behaviour on a cold cache (fresh install
+     * / API blip) rather than blanking the term UI and checkout - the serve-stale
+     * degrade posture (TWO-24813).
+     *
+     * @param bool $refresh Allow a TTL-gated backend fetch.
+     * @return int[]
+     */
+    private function getOfferableTermSource($refresh = false)
+    {
+        $backend = $this->getMerchantAvailableTerms($refresh);
+        if (!empty($backend)) {
+            return $backend;
+        }
+        return array_map('intval', self::PAYMENT_TERMS_OPTIONS);
+    }
+
+    /**
+     * Available payment terms offered at checkout (ascending). THE runtime seam:
+     * the backend's offerable set (GET /v1/merchant `available_terms`), narrowed
+     * by the merchant's admin checkbox subset, then constrained by the term type
+     * (EOM only supports 30/45/60). A term the backend has withdrawn drops out
+     * even while the admin box is still ticked (TWO-24813). Cache-only - never
+     * blocks on HTTP; the sanctioned refresh points prime the cache.
+     *
+     * @return int[] Array of available payment term durations (e.g., [30, 45, 60])
      */
     public function getAvailablePaymentTerms()
     {
         $term_type = Configuration::get('PS_TWO_PAYMENT_TERM_TYPE');
-        
-        // Determine which terms to check based on type
+
+        // Source set the admin narrows FROM (backend list, else hardcoded).
+        $source = $this->getOfferableTermSource(false);
+
+        // EOM is only offerable for a fixed subset; intersect the source with it.
         if ($term_type === 'EOM') {
-            // EOM only supports 30, 45, 60 day terms
-            $terms_to_check = array('30', '45', '60');
-        } else {
-            // STANDARD supports all terms
-            $terms_to_check = array_map('strval', self::PAYMENT_TERMS_OPTIONS);
+            $source = array_values(array_intersect($source, self::EOM_PAYMENT_TERMS_OPTIONS));
         }
-        
+
         $available_terms = array();
-        
-        foreach ($terms_to_check as $term) {
-            if (Configuration::get('PS_TWO_PAYMENT_TERMS_' . $term)) {
-                $available_terms[] = (int)$term;
+        foreach ($source as $term) {
+            if (Configuration::get('PS_TWO_PAYMENT_TERMS_' . (int) $term)) {
+                $available_terms[] = (int) $term;
             }
         }
-        
-        // If no terms are configured, default to DEFAULT_PAYMENT_TERM_DAYS
+
+        // If nothing is configured/offerable, default to DEFAULT_PAYMENT_TERM_DAYS
         if (empty($available_terms)) {
             $available_terms = array(self::DEFAULT_PAYMENT_TERM_DAYS);
         }
-        
+
         sort($available_terms); // Ensure they're in ascending order
         return $available_terms;
     }

--- a/twopayment.php
+++ b/twopayment.php
@@ -780,8 +780,16 @@ class Twopayment extends PaymentModule
             Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', $term_type);
         }
         
-        // Save payment terms checkboxes
-        $payment_terms = array_map('strval', self::PAYMENT_TERMS_OPTIONS);
+        // Save payment terms checkboxes. Iterate ONLY the terms the admin form
+        // actually rendered (the backend-restricted offerable source), NOT the
+        // full hardcoded list. buildPaymentTermCheckboxQuery() renders a checkbox
+        // per offerable term, so a term the backend has withdrawn is hidden and
+        // never POSTed; iterating the hardcoded list here would read its absent
+        // POST value as unchecked and silently zero the merchant's stored
+        // preference on any unrelated save. Leaving hidden keys untouched
+        // preserves that preference for when the backend re-offers the term
+        // (TWO-24813).
+        $payment_terms = array_map('strval', $this->getOfferableTermSource(false));
         foreach ($payment_terms as $term) {
             Configuration::updateValue('PS_TWO_PAYMENT_TERMS_' . $term, Tools::getValue('PS_TWO_PAYMENT_TERMS_' . $term) ? 1 : 0);
         }


### PR DESCRIPTION
## What

Swap the PrestaShop payment-terms resolution from **brand-set ∩ admin-subset** to **backend `available_terms` (GET /v1/merchant/{id}) ∩ admin-subset**. The backend now owns which terms are offerable; the merchant admin narrows from that set. Parity with WooCommerce TWO-24812 (PR woocommerce-plugin#342), implemented idiomatically in PS (Configuration store, HelperForm), not WordPress options.

Closes TWO-24813 (consumer of TWO-24808).

## How

- **`getMerchantAvailableTerms($refresh = false)`** — the new fetch/cache seam.
  - Cache-only by default: reached from checkout / cart / admin-render paths that must not stall on HTTP.
  - TTL-gated fetch (15 min, 10s request cap) only when `$refresh === true`, from the two sanctioned refresh points: the checkout media hook (`hookActionFrontControllerSetMedia`) and the admin config render (`buildPaymentTermCheckboxQuery`).
  - Serve-stale: the cached list is overwritten **only** by a successful response carrying an `available_terms` array. A fetch failure, or an older backend omitting the field, serves the last-known list for another TTL rather than blanking the checkout's term set. The TTL clock is bumped even on failure (one stall per TTL, not per view).
  - Normalises: int, dedup, drop non-positive and non-numeric (an `is_numeric` guard so a malformed element can't `intval` to a phantom "1 day"), sorted.
  - Cache lives in two **dedicated `Configuration` keys** (`PS_TWO_MERCHANT_AVAILABLE_TERMS`, `..._TS`), kept out of the general-settings save path so a checkout-render refresh can't race a concurrent admin save.
- **`getAvailablePaymentTerms()`** (the runtime seam, unchanged signature) — now sources from the backend list ∩ admin checkboxes, EOM-constrained (30/45/60). A term the backend has withdrawn drops out even while the admin box is still ticked. Falls back to the historical hardcoded option list when the backend is unresolved (cold cache / fresh install / API blip) rather than blanking the checkout.
- **Admin "Available Payment Terms" checkboxes** restricted to the backend list (`buildPaymentTermCheckboxQuery`), preserving the STANDARD/EOM show-hide classes.
- **Identity-change invalidation** — drop the cached list when the verified merchant id changes on save, so serve-stale never bridges merchant identities.

## Tests

10 new offline tests in `tests/run.php` (OrderBuilderSpec): backend∩admin intersection, withdrawn-term drop, cold-cache hardcoded fallback, EOM constraint, empty-offer→default, cache-only-never-fetches, refresh/normalise/serve-stale, explicit-empty overwrite, no-identity skip, invalidation. Full suite green (`php tests/run.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn