### PR TITLE
TWO-24752/feat: PrestaShop buyer surcharge (offset pricing fee) + brand-driven rounding

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Two brand defaults (PrestaShop).
+ *
+ * A minimal brand-config seam mirroring the WooCommerce plugin's
+ * brands/two.php and the Magento plugin's brand descriptors. Values here are
+ * the Two defaults; a white-label overlay can replace this file to narrow or
+ * relabel them. Only the surcharge-relevant keys are defined for now
+ * (TWO-24893); the full brand-config foundation is TWO-24746.
+ *
+ * @return array<string, mixed>
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+return array(
+    // Increments the buyer surcharge line may be rounded to, offered in the
+    // admin Rounding Step select. Mirrors the WooCommerce brand
+    // available_rounding_steps and Magento's RoundingStep source model; an
+    // overlay narrows the set.
+    'rounding_steps' => array(0.10, 0.50, 1.00, 5.00, 10.00),
+    // Buyer-facing label for the offset-pricing fee line; null falls back to
+    // the translated default in Twopayment::getTwoSurchargeLineLabel().
+    'fee_line_label' => null,
+);

--- a/classes/TwoSurchargeCalculator.php
+++ b/classes/TwoSurchargeCalculator.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Buyer surcharge (offset pricing fee) payload builder — pure logic.
+ *
+ * PrestaShop equivalent of Magento's Service/Order/SurchargeCalculator and the
+ * WooCommerce plugin's WC_Twoinc_Payment_Terms::build_buyer_fee_share. All fee
+ * arithmetic is done server-side by POST /v1/pricing/order/fee; this class only
+ * maps merchant config onto the request's `buyer_fee_share` block. Keeping it
+ * dependency-free (no PrestaShop classes) makes it directly unit-testable and
+ * satisfies TWO-24752's requirement that surcharge business logic live in PHP,
+ * callable independently of the checkout rendering path.
+ *
+ * TWO-24752 (offset pricing fee) + TWO-24893 (brand-driven rounding relay).
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class TwoSurchargeCalculator
+{
+    /**
+     * Stored surcharge-rounding basis -> pricing-API basis. "none" (and any
+     * unmapped value) omits the rounding block. Mirrors Magento's
+     * SurchargeCalculator::ROUNDING_BASIS_TO_API and the WooCommerce plugin's
+     * ROUNDING_BASIS_TO_API.
+     */
+    const ROUNDING_BASIS_TO_API = array(
+        'up' => 'UP',
+        'down' => 'DOWN',
+        'standard' => 'STANDARD',
+    );
+
+    /** Surcharge methods that carry a fee (anything else is treated as "none"). */
+    const VALID_TYPES = array('percentage', 'fixed', 'fixed_and_percentage');
+
+    /**
+     * Coerce a stored surcharge type to a known value, defaulting to "none".
+     *
+     * @param mixed $type
+     * @return string
+     */
+    public static function normalizeType($type)
+    {
+        $type = (string) $type;
+
+        return in_array($type, self::VALID_TYPES, true) ? $type : 'none';
+    }
+
+    /**
+     * Build the buyer_fee_share block for one term, or null when no surcharge
+     * is configured. Mirrors Magento/WooCommerce:
+     *  - percentage types supply `percentage` (0.0 for fixed-only so the API
+     *    default of 100% is never silently applied)
+     *  - `surcharge_basis` is sent explicitly
+     *  - fixed types supply `surcharge`
+     *  - a positive limit on a percentage type supplies `cap`
+     *  - rounding (percentage modes only) supplies `rounding`
+     *  - differential mode supplies `reference_terms` (default term) so the
+     *    API computes the delta itself — no delta math in the plugin
+     *
+     * @param array    $settings   {type, differential(bool), grid, rounding_basis, rounding_step}
+     * @param int      $days       selected term in days
+     * @param int|null $defaultTerm default term for differential reference_terms
+     * @param bool     $isEndOfMonth whether the merchant uses end-of-month terms
+     * @return array|null
+     */
+    public static function buildBuyerFeeShare(array $settings, $days, $defaultTerm, $isEndOfMonth)
+    {
+        $type = self::normalizeType(isset($settings['type']) ? $settings['type'] : 'none');
+        if ($type === 'none') {
+            return null;
+        }
+
+        $hasPercentage = in_array($type, array('percentage', 'fixed_and_percentage'), true);
+        $hasFixed = in_array($type, array('fixed', 'fixed_and_percentage'), true);
+
+        $grid = isset($settings['grid']) && is_array($settings['grid']) ? $settings['grid'] : array();
+        $days = (int) $days;
+        $row = isset($grid[$days]) && is_array($grid[$days]) ? $grid[$days] : array();
+
+        $buyer_fee_share = array(
+            'percentage' => $hasPercentage && isset($row['percentage']) ? (float) $row['percentage'] : 0.0,
+            'surcharge_basis' => 'buyer_pays',
+        );
+
+        // Fixed amounts and caps are sent in the store currency as configured.
+        // The plugin does no FX conversion (single-currency stores only for
+        // fixed surcharge); percentage surcharge is currency-agnostic.
+        if ($hasFixed && isset($row['fixed']) && (float) $row['fixed'] > 0) {
+            $buyer_fee_share['surcharge'] = (float) $row['fixed'];
+        }
+
+        // `cap` only applies where the fee has a percentage component — a
+        // fixed-only fee is constant, nothing to clamp — so a stored limit left
+        // over from a previous surcharge type must not leak into a fixed-only
+        // request.
+        if ($hasPercentage && isset($row['limit']) && (float) $row['limit'] > 0) {
+            $buyer_fee_share['cap'] = (float) $row['limit'];
+        }
+
+        // `rounding` snaps the final buyer line to a clean increment,
+        // server-side. Percentage modes only, for the same reason as `cap`.
+        if ($hasPercentage) {
+            $rounding = self::buildRounding(
+                isset($settings['rounding_basis']) ? $settings['rounding_basis'] : 'none',
+                isset($settings['rounding_step']) ? $settings['rounding_step'] : null
+            );
+            if ($rounding !== null) {
+                $buyer_fee_share['rounding'] = $rounding;
+            }
+        }
+
+        if (!empty($settings['differential']) && $defaultTerm !== null) {
+            $buyer_fee_share['reference_terms'] = self::buildTermsBlock((int) $defaultTerm, (bool) $isEndOfMonth);
+        }
+
+        return $buyer_fee_share;
+    }
+
+    /**
+     * The rounding block for buyer_fee_share, or null when rounding is off.
+     * The backend does the arithmetic; the plugin only relays {step, basis}.
+     * A None/unmapped basis or a non-positive step omits the block (the API
+     * requires both keys and rejects step <= 0). Mirrors Magento's
+     * SurchargeCalculator::buildRounding and WooCommerce's build_rounding.
+     *
+     * @param mixed      $basis
+     * @param float|null $step
+     * @return array|null
+     */
+    public static function buildRounding($basis, $step)
+    {
+        $basis = (string) $basis;
+        if (!isset(self::ROUNDING_BASIS_TO_API[$basis])) {
+            return null;
+        }
+        if ($step === null) {
+            return null;
+        }
+        $step = (float) $step;
+        if ($step <= 0) {
+            return null;
+        }
+
+        return array(
+            'step' => $step,
+            'basis' => self::ROUNDING_BASIS_TO_API[$basis],
+        );
+    }
+
+    /**
+     * A NET_TERMS block for a duration, adding
+     * duration_days_calculated_from = END_OF_MONTH when the merchant uses
+     * end-of-month terms (Magento/WooCommerce parity).
+     *
+     * @param int  $days
+     * @param bool $isEndOfMonth
+     * @return array
+     */
+    public static function buildTermsBlock($days, $isEndOfMonth)
+    {
+        $block = array(
+            'type' => 'NET_TERMS',
+            'duration_days' => (int) $days,
+        );
+        if ($isEndOfMonth) {
+            $block['duration_days_calculated_from'] = 'END_OF_MONTH';
+        }
+
+        return $block;
+    }
+}

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -37,6 +37,8 @@ final class SurchargeSpec
         self::testSurchargeLineItemPassesThroughApiTaxRate();
         self::testSurchargeLineItemDisabledReturnsNull();
         self::testSurchargeLineItemRoundsTaxOnBoundary();
+        self::testSurchargeLineItemTaxRateSelfConsistentAtHighPrecision();
+        self::testSurchargeLineItemHonorsExplicitTermOverride();
         self::testOrderPayloadInjectsSurchargeLineAndBumpsTotals();
     }
 
@@ -367,6 +369,63 @@ final class SurchargeSpec
         TinyAssert::same('12.63', $line['gross_amount']);
         // The constructed line must satisfy the Two line-item formulas.
         TinyAssert::true($module->validateTwoLineItems([$line]));
+    }
+
+    private static function testSurchargeLineItemTaxRateSelfConsistentAtHighPrecision(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                // Tax rate needing more than TAX_RATE_PRECISION (3dp) decimals.
+                // Tax must be computed from the SNAPPED rate that is actually
+                // sent, else the line fails validateTwoLineItems and is dropped.
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => '1000.00',
+                    'total_fee_tax_rate' => '0.210098',
+                    'currency' => 'EUR',
+                ];
+            }
+        };
+        $cart = new Cart(1);
+        $cart->id_currency = 978;
+        $line = $module->buildTwoSurchargeLineItemForCart($cart, 5000.0);
+        TinyAssert::same('0.21', $line['tax_rate'], 'rate is snapped to the sent precision');
+        TinyAssert::same('210.00', $line['tax_amount'], 'tax computed from the sent (snapped) rate, not full precision');
+        TinyAssert::same('1210.00', $line['gross_amount']);
+        TinyAssert::true($module->validateTwoLineItems([$line]), 'high-precision fee tax rate must not silently drop the line');
+    }
+
+    private static function testSurchargeLineItemHonorsExplicitTermOverride(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '4');
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        // No buyer cookie set, so getSelectedPaymentTerm() would default to 30 —
+        // the explicit override (the update/admin path's persisted term) must win.
+        $module = new class extends TwopaymentTestHarness {
+            public $capturedDays = null;
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->capturedDays = isset($payload['order_terms']['duration_days'])
+                    ? $payload['order_terms']['duration_days']
+                    : null;
+                return ['http_status' => 200, 'buyer_fee_share' => '5.00', 'total_fee_tax_rate' => '0.25', 'currency' => 'EUR'];
+            }
+        };
+        $cart = new Cart(1);
+        $cart->id_currency = 978;
+        $line = $module->buildTwoSurchargeLineItemForCart($cart, 100.0, 60);
+        TinyAssert::same(60, $module->capturedDays, 'explicit term override must reach the fee quote, not the default term');
+        TinyAssert::same('SERVICE', $line['type']);
     }
 
     private static function testOrderPayloadInjectsSurchargeLineAndBumpsTotals(): void

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -1,0 +1,470 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Offset pricing fee (buyer surcharge) + brand-driven rounding relay.
+ * TWO-24752 (offset fee) and TWO-24893 (rounding basis + brand step).
+ *
+ * Covers: buyer_fee_share payload construction per term, the rounding relay
+ * and its edge cases, the fee-quote fetch (fail-soft), fee-line construction
+ * with API tax-rate passthrough, and end-to-end injection into the order
+ * payload including a rounding-boundary amount.
+ */
+final class SurchargeSpec
+{
+    public static function runAll(): void
+    {
+        self::testBuildBuyerFeeShareReturnsNullWhenDisabled();
+        self::testBuildBuyerFeeSharePercentageOnly();
+        self::testBuildBuyerFeeShareFixedOnlyOmitsPercentageCapAndRounding();
+        self::testBuildBuyerFeeShareFixedAndPercentage();
+        self::testBuildBuyerFeeShareCapOnlyWithPositiveLimit();
+        self::testBuildBuyerFeeShareRoundingOmittedForFixedOnly();
+        self::testBuildBuyerFeeShareDifferentialAddsReferenceTerms();
+        self::testBuildBuyerFeeShareDifferentialReferenceTermsHonorsEndOfMonth();
+        self::testBuildRoundingMapsBasisAndKeepsStep();
+        self::testBuildRoundingOmittedForNoneUnmappedOrNonPositiveStep();
+        self::testBuildTermsBlockEndOfMonth();
+        self::testNormalizeTypeFallsBackToNone();
+        self::testGetSurchargeSettingsReadsConfigGrid();
+        self::testBuildTwoBuyerFeeShareWiresConfigAndDefaultTerm();
+        self::testRoundingStepOptionsAreBrandDrivenSortedAndFormatted();
+        self::testSurchargeLineLabelTemplateBrandAndDefault();
+        self::testFetchTermFeeFailsSoftOnHttpError();
+        self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
+        self::testFetchTermFeeParsesSuccess();
+        self::testSurchargeLineItemPassesThroughApiTaxRate();
+        self::testSurchargeLineItemDisabledReturnsNull();
+        self::testSurchargeLineItemRoundsTaxOnBoundary();
+        self::testOrderPayloadInjectsSurchargeLineAndBumpsTotals();
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+    }
+
+    /* ---- TwoSurchargeCalculator (pure) ---- */
+
+    private static function testBuildBuyerFeeShareReturnsNullWhenDisabled(): void
+    {
+        TinyAssert::same(null, TwoSurchargeCalculator::buildBuyerFeeShare(['type' => 'none'], 30, 30, false));
+        TinyAssert::same(null, TwoSurchargeCalculator::buildBuyerFeeShare(['type' => 'garbage'], 30, 30, false));
+    }
+
+    private static function testBuildBuyerFeeSharePercentageOnly(): void
+    {
+        $settings = [
+            'type' => 'percentage',
+            'differential' => false,
+            'grid' => [30 => ['percentage' => 2.5, 'fixed' => 0, 'limit' => 0]],
+            'rounding_basis' => 'none',
+            'rounding_step' => null,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 30, 30, false);
+        TinyAssert::same(2.5, $share['percentage']);
+        TinyAssert::same('buyer_pays', $share['surcharge_basis']);
+        TinyAssert::false(isset($share['surcharge']), 'percentage-only must not send a fixed surcharge');
+        TinyAssert::false(isset($share['cap']), 'no cap when limit is 0');
+        TinyAssert::false(isset($share['rounding']), 'no rounding block when basis is none');
+        TinyAssert::false(isset($share['reference_terms']), 'no reference_terms outside differential mode');
+    }
+
+    private static function testBuildBuyerFeeShareFixedOnlyOmitsPercentageCapAndRounding(): void
+    {
+        $settings = [
+            'type' => 'fixed',
+            'differential' => false,
+            'grid' => [30 => ['percentage' => 5, 'fixed' => 4.5, 'limit' => 10]],
+            'rounding_basis' => 'up',
+            'rounding_step' => 1.0,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 30, 30, false);
+        TinyAssert::same(0.0, $share['percentage'], 'fixed-only sends 0.0 so the API 100% default never applies');
+        TinyAssert::same(4.5, $share['surcharge']);
+        TinyAssert::false(isset($share['cap']), 'fixed-only must not leak a stored cap');
+        TinyAssert::false(isset($share['rounding']), 'fixed-only must not leak a stored rounding');
+    }
+
+    private static function testBuildBuyerFeeShareFixedAndPercentage(): void
+    {
+        $settings = [
+            'type' => 'fixed_and_percentage',
+            'differential' => false,
+            'grid' => [30 => ['percentage' => 1.5, 'fixed' => 2.0, 'limit' => 0]],
+            'rounding_basis' => 'none',
+            'rounding_step' => null,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 30, 30, false);
+        TinyAssert::same(1.5, $share['percentage']);
+        TinyAssert::same(2.0, $share['surcharge']);
+    }
+
+    private static function testBuildBuyerFeeShareCapOnlyWithPositiveLimit(): void
+    {
+        $settings = [
+            'type' => 'percentage',
+            'differential' => false,
+            'grid' => [30 => ['percentage' => 3, 'fixed' => 0, 'limit' => 12.5]],
+            'rounding_basis' => 'none',
+            'rounding_step' => null,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 30, 30, false);
+        TinyAssert::same(12.5, $share['cap']);
+    }
+
+    private static function testBuildBuyerFeeShareRoundingOmittedForFixedOnly(): void
+    {
+        $settings = [
+            'type' => 'fixed',
+            'differential' => false,
+            'grid' => [30 => ['fixed' => 3.0]],
+            'rounding_basis' => 'standard',
+            'rounding_step' => 0.5,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 30, 30, false);
+        TinyAssert::false(isset($share['rounding']), 'rounding is percentage-modes only');
+    }
+
+    private static function testBuildBuyerFeeShareDifferentialAddsReferenceTerms(): void
+    {
+        $settings = [
+            'type' => 'percentage',
+            'differential' => true,
+            'grid' => [60 => ['percentage' => 4]],
+            'rounding_basis' => 'none',
+            'rounding_step' => null,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 60, 30, false);
+        TinyAssert::same(['type' => 'NET_TERMS', 'duration_days' => 30], $share['reference_terms']);
+    }
+
+    private static function testBuildBuyerFeeShareDifferentialReferenceTermsHonorsEndOfMonth(): void
+    {
+        $settings = [
+            'type' => 'percentage',
+            'differential' => true,
+            'grid' => [60 => ['percentage' => 4]],
+            'rounding_basis' => 'none',
+            'rounding_step' => null,
+        ];
+        $share = TwoSurchargeCalculator::buildBuyerFeeShare($settings, 60, 30, true);
+        TinyAssert::same('END_OF_MONTH', $share['reference_terms']['duration_days_calculated_from']);
+    }
+
+    private static function testBuildRoundingMapsBasisAndKeepsStep(): void
+    {
+        TinyAssert::same(['step' => 1.0, 'basis' => 'UP'], TwoSurchargeCalculator::buildRounding('up', 1.0));
+        TinyAssert::same(['step' => 0.5, 'basis' => 'DOWN'], TwoSurchargeCalculator::buildRounding('down', 0.5));
+        TinyAssert::same(['step' => 10.0, 'basis' => 'STANDARD'], TwoSurchargeCalculator::buildRounding('standard', 10.0));
+    }
+
+    private static function testBuildRoundingOmittedForNoneUnmappedOrNonPositiveStep(): void
+    {
+        TinyAssert::same(null, TwoSurchargeCalculator::buildRounding('none', 1.0));
+        TinyAssert::same(null, TwoSurchargeCalculator::buildRounding('sideways', 1.0));
+        TinyAssert::same(null, TwoSurchargeCalculator::buildRounding('up', null));
+        TinyAssert::same(null, TwoSurchargeCalculator::buildRounding('up', 0.0));
+        TinyAssert::same(null, TwoSurchargeCalculator::buildRounding('up', -1.0));
+    }
+
+    private static function testBuildTermsBlockEndOfMonth(): void
+    {
+        TinyAssert::same(['type' => 'NET_TERMS', 'duration_days' => 45], TwoSurchargeCalculator::buildTermsBlock(45, false));
+        TinyAssert::same(
+            ['type' => 'NET_TERMS', 'duration_days' => 45, 'duration_days_calculated_from' => 'END_OF_MONTH'],
+            TwoSurchargeCalculator::buildTermsBlock(45, true)
+        );
+    }
+
+    private static function testNormalizeTypeFallsBackToNone(): void
+    {
+        TinyAssert::same('percentage', TwoSurchargeCalculator::normalizeType('percentage'));
+        TinyAssert::same('none', TwoSurchargeCalculator::normalizeType(''));
+        TinyAssert::same('none', TwoSurchargeCalculator::normalizeType('wat'));
+    }
+
+    /* ---- Module wiring ---- */
+
+    private static function testGetSurchargeSettingsReadsConfigGrid(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'fixed_and_percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_DIFFERENTIAL', 1);
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', 'up');
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', '1.00');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2.5');
+        Configuration::updateValue('PS_TWO_SURCHARGE_FIXED_30', '3');
+        Configuration::updateValue('PS_TWO_SURCHARGE_CAP_30', '9');
+        $module = new TwopaymentTestHarness();
+        $settings = $module->getTwoSurchargeSettings();
+        TinyAssert::same('fixed_and_percentage', $settings['type']);
+        TinyAssert::true($settings['enabled']);
+        TinyAssert::true($settings['differential']);
+        TinyAssert::same(1.0, $settings['rounding_step']);
+        TinyAssert::same(2.5, $settings['grid'][30]['percentage']);
+        TinyAssert::same(3.0, $settings['grid'][30]['fixed']);
+        TinyAssert::same(9.0, $settings['grid'][30]['limit']);
+    }
+
+    private static function testBuildTwoBuyerFeeShareWiresConfigAndDefaultTerm(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_DIFFERENTIAL', 1);
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', 'standard');
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', '0.50');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        $module = new TwopaymentTestHarness();
+        $share = $module->buildTwoBuyerFeeShare(30);
+        TinyAssert::same(2.0, $share['percentage']);
+        TinyAssert::same(['step' => 0.5, 'basis' => 'STANDARD'], $share['rounding']);
+        // Only term 30 is offered, so the differential reference term is 30.
+        TinyAssert::same(['type' => 'NET_TERMS', 'duration_days' => 30], $share['reference_terms']);
+    }
+
+    private static function testRoundingStepOptionsAreBrandDrivenSortedAndFormatted(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $options = $module->getTwoRoundingStepOptions();
+        TinyAssert::same(['0.10', '0.50', '1.00', '5.00', '10.00'], array_keys($options));
+        TinyAssert::same('10.00', $options['10.00']);
+    }
+
+    private static function testSurchargeLineLabelTemplateBrandAndDefault(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        // Default (no config, brand label null).
+        TinyAssert::same('Service charge', $module->getTwoSurchargeLineLabel(30));
+        // Merchant template with %s term substitution.
+        Configuration::updateValue('PS_TWO_SURCHARGE_LINE_DESC', 'Financing fee (%s days)');
+        TinyAssert::same('Financing fee (30 days)', $module->getTwoSurchargeLineLabel(30));
+    }
+
+    private static function testFetchTermFeeFailsSoftOnHttpError(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 500, 'error' => 'boom'];
+            }
+        };
+        TinyAssert::same(null, $module->fetchTwoTermFee(30, 100.0, 'NO', 'NOK'));
+    }
+
+    private static function testFetchTermFeeFailsSoftOnCurrencyMismatch(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 200, 'buyer_fee_share' => '5.00', 'currency' => 'SEK'];
+            }
+        };
+        TinyAssert::same(null, $module->fetchTwoTermFee(30, 100.0, 'NO', 'NOK'));
+    }
+
+    private static function testFetchTermFeeParsesSuccess(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => '7.50',
+                    'total_fee_tax_rate' => '0.25',
+                    'currency' => 'NOK',
+                ];
+            }
+        };
+        $fee = $module->fetchTwoTermFee(30, 100.0, 'NO', 'NOK');
+        TinyAssert::same('7.50', $fee['buyer_fee_share']);
+        TinyAssert::same('0.25', $fee['total_fee_tax_rate']);
+        TinyAssert::same('NOK', $fee['currency']);
+    }
+
+    private static function testSurchargeLineItemPassesThroughApiTaxRate(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                // API returns the tax rate as a percentage form (25) — the fee
+                // line must normalise to the decimal convention, never zero.
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => '5.00',
+                    'total_fee_tax_rate' => '25',
+                    'currency' => 'EUR',
+                ];
+            }
+        };
+        $cart = new Cart(1);
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
+        $line = $module->buildTwoSurchargeLineItemForCart($cart, 100.0);
+        TinyAssert::same('SERVICE', $line['type']);
+        TinyAssert::same('Service charge', $line['name']);
+        TinyAssert::same('5.00', $line['net_amount']);
+        TinyAssert::same('0.25', $line['tax_rate'], 'API tax rate passes through (percentage normalised), never hard-coded zero');
+        TinyAssert::same('1.25', $line['tax_amount']);
+        TinyAssert::same('6.25', $line['gross_amount']);
+    }
+
+    private static function testSurchargeLineItemDisabledReturnsNull(): void
+    {
+        self::reset();
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                throw new RuntimeException('must not call the pricing API when surcharge disabled');
+            }
+        };
+        $cart = new Cart(1);
+        $cart->id_currency = 978;
+        TinyAssert::same(null, $module->buildTwoSurchargeLineItemForCart($cart, 100.0));
+    }
+
+    private static function testSurchargeLineItemRoundsTaxOnBoundary(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                // net 10.10 * 0.25 = 2.525 → lands exactly on a rounding
+                // boundary; must round half-up to 2.53 and keep gross = net+tax.
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => '10.10',
+                    'total_fee_tax_rate' => '0.25',
+                    'currency' => 'EUR',
+                ];
+            }
+        };
+        $cart = new Cart(1);
+        $cart->id_currency = 978;
+        $line = $module->buildTwoSurchargeLineItemForCart($cart, 500.0);
+        TinyAssert::same('10.10', $line['net_amount']);
+        TinyAssert::same('2.53', $line['tax_amount']);
+        TinyAssert::same('12.63', $line['gross_amount']);
+        // The constructed line must satisfy the Two line-item formulas.
+        TinyAssert::true($module->validateTwoLineItems([$line]));
+    }
+
+    private static function testOrderPayloadInjectsSurchargeLineAndBumpsTotals(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
+
+        StubStore::$customers[7001] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Eva',
+            'lastname' => 'Martin',
+            'secure_key' => 'secure-key-7001',
+            'loaded' => true,
+        ];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$addresses[7101] = [
+            'id_country' => 33,
+            'company' => 'Acme FR SAS',
+            'companyid' => 'FR123456789',
+            'address1' => '10 Rue de Paris',
+            'city' => 'Paris',
+            'postcode' => '75001',
+            'phone' => '+33100000000',
+            'loaded' => true,
+        ];
+        StubStore::$addresses[7102] = StubStore::$addresses[7101];
+        StubStore::$countries[33] = 'FR';
+
+        $cart = new Cart(7001);
+        $cart->id_customer = 7001;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 7101;
+        $cart->id_address_delivery = 7102;
+        $cart->id_carrier = 0;
+        $cart->id_lang = 1;
+
+        StubStore::$cartProducts[7001] = [[
+            'id_product' => 9301,
+            'link_rewrite' => 'reduced-vat-item',
+            'name' => 'Reduced VAT item',
+            'description_short' => 'Reduced VAT test',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 105.50,
+            'cart_quantity' => 1,
+            'rate' => 5.5,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[9301] = [['name' => 'Books']];
+        StubStore::$images[9301] = ['id_image' => 9301];
+        StubStore::$cartTotals[7001] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.0,
+                Cart::BOTH => 105.50,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.0,
+                Cart::BOTH => 100.00,
+            ],
+            'average_products_tax_rate' => 5.5,
+        ];
+
+        $module = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => '5.00',
+                    'total_fee_tax_rate' => '0.25',
+                    'currency' => 'EUR',
+                ];
+            }
+        };
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-7001', $cart, [
+            'merchant_confirmation_url' => 'https://shop.local/confirm',
+            'merchant_cancel_order_url' => 'https://shop.local/cancel',
+            'merchant_edit_order_url' => '',
+            'merchant_order_verification_failed_url' => '',
+            'merchant_invoice_url' => '',
+            'merchant_shipping_document_url' => '',
+        ]);
+
+        // Fee line appended: product (105.50) + fee gross (6.25) = 111.75.
+        TinyAssert::same('111.75', $payload['gross_amount']);
+        TinyAssert::same('105.00', $payload['net_amount']);
+        TinyAssert::same('6.75', $payload['tax_amount']);
+
+        $feeLines = array_values(array_filter($payload['line_items'], function ($item) {
+            return isset($item['type']) && $item['type'] === 'SERVICE' && $item['name'] === 'Service charge';
+        }));
+        TinyAssert::count(1, $feeLines);
+        TinyAssert::same('5.00', $feeLines[0]['net_amount']);
+        TinyAssert::same('0.25', $feeLines[0]['tax_rate']);
+        TinyAssert::same('6.25', $feeLines[0]['gross_amount']);
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -4574,6 +4574,7 @@ require __DIR__ . '/CustomerAddressFormatterOverrideSpec.php';
 require __DIR__ . '/TwoInvoiceRetrievalSpec.php';
 require __DIR__ . '/TrackingNumberSpec.php';
 require __DIR__ . '/RefundSpec.php';
+require __DIR__ . '/SurchargeSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -4581,6 +4582,7 @@ $tests = [
     'TwoInvoiceRetrievalSpec::runAll' => [TwoInvoiceRetrievalSpec::class, 'runAll'],
     'TrackingNumberSpec::runAll' => [TrackingNumberSpec::class, 'runAll'],
     'RefundSpec::runAll' => [RefundSpec::class, 'runAll'],
+    'SurchargeSpec::runAll' => [SurchargeSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -2687,7 +2687,7 @@ class Twopayment extends PaymentModule
      * @return array
      * @throws Exception
      */
-    private function buildTwoOrderPricingData($cart, $contextLabel = 'order payload', $strictReconciliation = false)
+    private function buildTwoOrderPricingData($cart, $contextLabel = 'order payload', $strictReconciliation = false, $paymentTermDays = null)
     {
         $line_items = $this->getTwoProductItems($cart);
         if (empty($line_items)) {
@@ -2746,7 +2746,7 @@ class Twopayment extends PaymentModule
         // shared pricing builder keeps the intent, create and update payloads
         // consistent, so the order-intent approval reconciles against the same
         // gross the create call sends. TWO-24752 / TWO-24893.
-        $surchargeLine = $this->buildTwoSurchargeLineItemForCart($cart, $subtotalsTotals['gross']);
+        $surchargeLine = $this->buildTwoSurchargeLineItemForCart($cart, $subtotalsTotals['gross'], $paymentTermDays);
         if ($surchargeLine !== null && $this->validateTwoLineItems(array($surchargeLine))) {
             $line_items[] = $surchargeLine;
             $tax_subtotals = $this->getTwoTaxSubtotals($line_items);
@@ -3399,7 +3399,14 @@ class Twopayment extends PaymentModule
         }
         $tracking_number = $this->getTwoOrderTrackingNumber($order);
 
-        $pricingData = $this->buildTwoOrderPricingData($cart, 'update order data (order_id=' . $order->id . ')');
+        // The update path runs in admin/webhook context with no buyer term
+        // cookie, so pass the persisted order term to the surcharge builder;
+        // otherwise the fee would be recomputed for the default term and the
+        // update gross would diverge from the created-order gross. TWO-24752.
+        $storedTerm = (isset($orderpaymentdata['two_day_on_invoice']) && $orderpaymentdata['two_day_on_invoice'] !== '')
+            ? (int) $orderpaymentdata['two_day_on_invoice']
+            : null;
+        $pricingData = $this->buildTwoOrderPricingData($cart, 'update order data (order_id=' . $order->id . ')', false, $storedTerm);
         $line_items = $pricingData['line_items'];
         $tax_subtotals = $pricingData['tax_subtotals'];
         $final_net = $pricingData['net_amount'];
@@ -6119,18 +6126,25 @@ class Twopayment extends PaymentModule
      * hard-coded zero, TWO-24752); net/tax/gross satisfy the Two line-item
      * formulas so validateTwoLineItems accepts it.
      *
-     * @param Cart  $cart
-     * @param float $gross_basis product + shipping gross (fee basis)
+     * @param Cart     $cart
+     * @param float    $gross_basis product + shipping gross (fee basis)
+     * @param int|null $paymentTermDays explicit term (update/admin context has no
+     *                 buyer cookie); null falls back to the selected term.
      * @return array|null
      */
-    public function buildTwoSurchargeLineItemForCart($cart, $gross_basis)
+    public function buildTwoSurchargeLineItemForCart($cart, $gross_basis, $paymentTermDays = null)
     {
         $settings = $this->getTwoSurchargeSettings();
         if (empty($settings['enabled'])) {
             return null;
         }
 
-        $days = $this->getSelectedPaymentTerm();
+        // In the create/intent (buyer) path the term comes from the buyer's
+        // cookie; in the update path (admin edit / tracking webhook) there is no
+        // cookie, so the caller passes the persisted order term instead —
+        // otherwise the fee would be recomputed for the default term and the
+        // update gross would diverge from the created-order gross. TWO-24752.
+        $days = $paymentTermDays !== null ? (int) $paymentTermDays : $this->getSelectedPaymentTerm();
         $currencyIso = '';
         $currency = new Currency((int) $cart->id_currency);
         if (Validate::isLoadedObject($currency)) {
@@ -6147,8 +6161,17 @@ class Twopayment extends PaymentModule
         if ($net <= 0) {
             return null;
         }
+        // Compute tax from the SAME rate string that is sent (formatTwoTaxRate
+        // snaps to TAX_RATE_PRECISION dp). Using the full-precision rate to
+        // compute tax while sending a rounded rate makes the line fail
+        // validateTwoLineItems (tax_amount vs net*sent_rate) for any rate that
+        // needs more than TAX_RATE_PRECISION decimals, silently dropping the
+        // whole surcharge line. Snapping first mirrors the product-line
+        // convention (snapped_product_rate). TWO-24752.
         $taxRate = $this->normalizeTwoFeeTaxRate($fee['total_fee_tax_rate']);
-        $tax = round($net * $taxRate, 2);
+        $taxRateString = $this->formatTwoTaxRate($taxRate);
+        $sentRate = (float) $taxRateString;
+        $tax = round($net * $sentRate, 2);
         $gross = round($net + $tax, 2);
         $label = $this->getTwoSurchargeLineLabel($days);
 
@@ -6159,8 +6182,8 @@ class Twopayment extends PaymentModule
             'net_amount' => (string) $this->getTwoRoundAmount($net),
             'discount_amount' => '0.00',
             'tax_amount' => (string) $this->getTwoRoundAmount($tax),
-            'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount(round($taxRate * 100, 2)) . '%',
-            'tax_rate' => $this->formatTwoTaxRate($taxRate),
+            'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount(round($sentRate * 100, 2)) . '%',
+            'tax_rate' => $taxRateString,
             'unit_price' => (string) $this->getTwoRoundAmount($net),
             'quantity' => 1,
             'quantity_unit' => 'item',

--- a/twopayment.php
+++ b/twopayment.php
@@ -11,6 +11,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
+
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic
@@ -1041,6 +1043,15 @@ class Twopayment extends PaymentModule
                 ),
             ),
         );
+
+        // Offset pricing fee (buyer surcharge) fields — appended so the
+        // per-term grid reflects the merchant's currently-offered terms.
+        // TWO-24752 / TWO-24893.
+        $fields_form['form']['input'] = array_merge(
+            $fields_form['form']['input'],
+            $this->getTwoSurchargeFormInputs()
+        );
+
         return $fields_form;
     }
 
@@ -1058,12 +1069,13 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         $fields_values['PS_TWO_DEBUG_MODE'] = Tools::getValue('PS_TWO_DEBUG_MODE', Configuration::get('PS_TWO_DEBUG_MODE'));
+        $fields_values = array_merge($fields_values, $this->getTwoSurchargeFormValues());
         return $fields_values;
     }
 
     protected function validTwoOtherFormValues()
     {
-        // No validation needed for current Other Settings
+        $this->validTwoSurchargeFormValues();
     }
 
     protected function saveTwoOtherFormValues()
@@ -1079,6 +1091,7 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
         Configuration::updateValue('PS_TWO_DEBUG_MODE', Tools::getValue('PS_TWO_DEBUG_MODE'));
+        $this->saveTwoSurchargeFormValues();
 
         $this->output .= $this->displayConfirmation($this->l('Other settings are updated.'));
     }
@@ -2724,6 +2737,20 @@ class Twopayment extends PaymentModule
                 3
             );
             throw new Exception('Tax subtotals do not reconcile with line items');
+        }
+
+        // Offset pricing fee (buyer surcharge) — appended AFTER product-line
+        // reconciliation so it never perturbs the cart-vs-lines gate. The fee
+        // is quoted from POST /v1/pricing/order/fee (fail-soft: a missing quote
+        // simply omits the line and never blocks checkout). Applying it in the
+        // shared pricing builder keeps the intent, create and update payloads
+        // consistent, so the order-intent approval reconciles against the same
+        // gross the create call sends. TWO-24752 / TWO-24893.
+        $surchargeLine = $this->buildTwoSurchargeLineItemForCart($cart, $subtotalsTotals['gross']);
+        if ($surchargeLine !== null && $this->validateTwoLineItems(array($surchargeLine))) {
+            $line_items[] = $surchargeLine;
+            $tax_subtotals = $this->getTwoTaxSubtotals($line_items);
+            $subtotalsTotals = $this->calculateOrderTotalsFromTaxSubtotals($tax_subtotals);
         }
 
         return [
@@ -5891,6 +5918,488 @@ class Twopayment extends PaymentModule
      * Get available payment terms filtered by term type (STANDARD or EOM)
      * @return array Array of available payment term durations (e.g., [30, 45, 60])
      */
+    /* ===================================================================
+     * Offset pricing fee (buyer surcharge) — TWO-24752 / TWO-24893.
+     *
+     * All fee decisioning lives here in PHP; templates/JS only render the
+     * results (ps_checkout compatibility, TWO-24770). Arithmetic is done
+     * server-side by POST /v1/pricing/order/fee — the plugin relays a
+     * buyer_fee_share block via TwoSurchargeCalculator, mirroring Magento's
+     * Service/Order/SurchargeCalculator and the WooCommerce plugin's
+     * WC_Twoinc_Payment_Terms::build_buyer_fee_share.
+     * =================================================================== */
+
+    /** @var array request-scoped fee-quote cache keyed by term|gross|country|currency */
+    protected $twoFeeCache = array();
+
+    /**
+     * Read a brand-config value (brands/two.php), cached per request. Returns
+     * null for unknown keys. A minimal seam pending the full brand-config
+     * foundation (TWO-24746); mirrors the WooCommerce plugin's WC_Twoinc_Brand.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getTwoBrandConfig($key)
+    {
+        static $brand = null;
+        if ($brand === null) {
+            $file = dirname(__FILE__) . '/brands/two.php';
+            $brand = is_file($file) ? (array) (require $file) : array();
+        }
+
+        return array_key_exists($key, $brand) ? $brand[$key] : null;
+    }
+
+    /**
+     * Resolve the surcharge settings from module Configuration into the shape
+     * TwoSurchargeCalculator expects. Mirrors the WooCommerce plugin's
+     * get_surcharge_settings.
+     *
+     * @return array
+     */
+    public function getTwoSurchargeSettings()
+    {
+        $type = TwoSurchargeCalculator::normalizeType(Configuration::get('PS_TWO_SURCHARGE_TYPE'));
+
+        $grid = array();
+        foreach ($this->getAvailablePaymentTerms() as $days) {
+            $days = (int) $days;
+            $grid[$days] = array(
+                'percentage' => (float) Configuration::get('PS_TWO_SURCHARGE_PCT_' . $days),
+                'fixed' => (float) Configuration::get('PS_TWO_SURCHARGE_FIXED_' . $days),
+                'limit' => (float) Configuration::get('PS_TWO_SURCHARGE_CAP_' . $days),
+            );
+        }
+
+        $step = (float) Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP');
+
+        return array(
+            'type' => $type,
+            'enabled' => $type !== 'none',
+            'differential' => (bool) Configuration::get('PS_TWO_SURCHARGE_DIFFERENTIAL'),
+            'grid' => $grid,
+            'rounding_basis' => (string) Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS'),
+            'rounding_step' => $step > 0 ? $step : null,
+        );
+    }
+
+    /**
+     * Build the buyer_fee_share block for one term (or null when no surcharge
+     * is configured), from module Configuration.
+     *
+     * @param int $days
+     * @return array|null
+     */
+    public function buildTwoBuyerFeeShare($days)
+    {
+        $settings = $this->getTwoSurchargeSettings();
+        $isEom = Configuration::get('PS_TWO_PAYMENT_TERM_TYPE') === 'EOM';
+        $default = $this->getDefaultPaymentTerm();
+
+        return TwoSurchargeCalculator::buildBuyerFeeShare($settings, (int) $days, $default, $isEom);
+    }
+
+    /**
+     * Quote the buyer's fee share for one term via POST /v1/pricing/order/fee.
+     * Fail-soft: returns null on any error (the fee line is simply omitted and
+     * checkout is never blocked on a quote, TWO-24752). Request-scoped cache.
+     *
+     * @param int    $days
+     * @param float  $gross_amount fee basis (product + shipping gross)
+     * @param string $buyer_country ISO-2 code
+     * @param string $currency_iso  store currency
+     * @return array|null {buyer_fee_share, total_fee_tax_rate, currency}
+     */
+    public function fetchTwoTermFee($days, $gross_amount, $buyer_country, $currency_iso)
+    {
+        $days = (int) $days;
+        $gross_amount = (float) $gross_amount;
+        $cacheKey = $days . '|' . $this->getTwoRoundAmount($gross_amount) . '|' . $buyer_country . '|' . $currency_iso;
+        if (array_key_exists($cacheKey, $this->twoFeeCache)) {
+            return $this->twoFeeCache[$cacheKey];
+        }
+
+        $share = $this->buildTwoBuyerFeeShare($days);
+        if ($share === null || $gross_amount <= 0) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+
+        $isEom = Configuration::get('PS_TWO_PAYMENT_TERM_TYPE') === 'EOM';
+        $payload = array(
+            'currency' => (string) $currency_iso,
+            'gross_amount' => $this->getTwoRoundAmount($gross_amount),
+            'buyer_country_code' => (string) $buyer_country,
+            // Hardcoded false for parity with Magento/WooCommerce — no admin
+            // recourse-pricing config on any plugin yet.
+            'approved_on_recourse' => false,
+            'order_terms' => TwoSurchargeCalculator::buildTermsBlock($days, $isEom),
+            'buyer_fee_share' => $share,
+        );
+
+        // Tight timeout: this sits on the checkout/order-build path and must
+        // never stall checkout on a slow pricing call.
+        $response = $this->setTwoPaymentRequest('/v1/pricing/order/fee', $payload, 'POST', array(), self::API_TIMEOUT_STATE_CHECK);
+        if (!is_array($response)) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+        $status = isset($response['http_status']) ? (int) $response['http_status'] : 0;
+        if ($status < 200 || $status >= 300) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+        if (!isset($response['buyer_fee_share'])) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+
+        // Guard against a reinterpreted currency — applying a figure quoted in
+        // a different currency would need FX the plugin does not do.
+        $respCurrency = isset($response['currency']) ? (string) $response['currency'] : (string) $currency_iso;
+        if ($currency_iso !== '' && $respCurrency !== (string) $currency_iso) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+
+        return $this->twoFeeCache[$cacheKey] = array(
+            'buyer_fee_share' => (string) $response['buyer_fee_share'],
+            'total_fee_tax_rate' => isset($response['total_fee_tax_rate']) ? (string) $response['total_fee_tax_rate'] : null,
+            'currency' => $respCurrency,
+        );
+    }
+
+    /**
+     * Normalise the API's fee tax rate to the plugin's decimal-fraction
+     * convention (e.g. 0.25 for 25%). Guards against a percentage form (25) by
+     * scaling anything > 1. Never hard-codes zero — the API rate passes
+     * through (TWO-24752).
+     *
+     * @param mixed $rate
+     * @return float
+     */
+    private function normalizeTwoFeeTaxRate($rate)
+    {
+        if ($rate === null || $rate === '') {
+            return 0.0;
+        }
+        $rate = (float) $rate;
+        if ($rate <= 0) {
+            return 0.0;
+        }
+        if ($rate > 1.0) {
+            $rate = $rate / 100.0;
+        }
+
+        return $rate;
+    }
+
+    /**
+     * Resolve the buyer's country ISO from the cart's invoice address.
+     *
+     * @param Cart $cart
+     * @return string
+     */
+    private function resolveTwoBuyerCountryIso($cart)
+    {
+        if (!Validate::isLoadedObject($cart)) {
+            return '';
+        }
+        $address = new Address((int) $cart->id_address_invoice);
+        if (Validate::isLoadedObject($address) && (int) $address->id_country > 0) {
+            $iso = Country::getIsoById((int) $address->id_country);
+            if (!empty($iso)) {
+                return (string) $iso;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Build the buyer-surcharge line item for the Two order payload, or null
+     * when no surcharge is configured / the quote fails / the fee is zero.
+     * The line's tax_rate carries the API's total_fee_tax_rate (never a
+     * hard-coded zero, TWO-24752); net/tax/gross satisfy the Two line-item
+     * formulas so validateTwoLineItems accepts it.
+     *
+     * @param Cart  $cart
+     * @param float $gross_basis product + shipping gross (fee basis)
+     * @return array|null
+     */
+    public function buildTwoSurchargeLineItemForCart($cart, $gross_basis)
+    {
+        $settings = $this->getTwoSurchargeSettings();
+        if (empty($settings['enabled'])) {
+            return null;
+        }
+
+        $days = $this->getSelectedPaymentTerm();
+        $currencyIso = '';
+        $currency = new Currency((int) $cart->id_currency);
+        if (Validate::isLoadedObject($currency)) {
+            $currencyIso = (string) $currency->iso_code;
+        }
+        $buyerCountry = $this->resolveTwoBuyerCountryIso($cart);
+
+        $fee = $this->fetchTwoTermFee($days, (float) $gross_basis, $buyerCountry, $currencyIso);
+        if ($fee === null) {
+            return null;
+        }
+
+        $net = round((float) $fee['buyer_fee_share'], 2);
+        if ($net <= 0) {
+            return null;
+        }
+        $taxRate = $this->normalizeTwoFeeTaxRate($fee['total_fee_tax_rate']);
+        $tax = round($net * $taxRate, 2);
+        $gross = round($net + $tax, 2);
+        $label = $this->getTwoSurchargeLineLabel($days);
+
+        return array(
+            'name' => $label,
+            'description' => Tools::substr(strip_tags($label), 0, 255),
+            'gross_amount' => (string) $this->getTwoRoundAmount($gross),
+            'net_amount' => (string) $this->getTwoRoundAmount($net),
+            'discount_amount' => '0.00',
+            'tax_amount' => (string) $this->getTwoRoundAmount($tax),
+            'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount(round($taxRate * 100, 2)) . '%',
+            'tax_rate' => $this->formatTwoTaxRate($taxRate),
+            'unit_price' => (string) $this->getTwoRoundAmount($net),
+            'quantity' => 1,
+            'quantity_unit' => 'item',
+            'type' => 'SERVICE',
+        );
+    }
+
+    /**
+     * Buyer-facing label for the surcharge line. A merchant-set description
+     * wins (with %s replaced by the term days, Magento/WooCommerce parity);
+     * else the brand label; else a translated default.
+     *
+     * @param int $days
+     * @return string
+     */
+    public function getTwoSurchargeLineLabel($days)
+    {
+        $template = trim((string) Configuration::get('PS_TWO_SURCHARGE_LINE_DESC'));
+        if ($template !== '') {
+            return str_replace('%s', (string) (int) $days, $template);
+        }
+        $brandLabel = $this->getTwoBrandConfig('fee_line_label');
+        if (!empty($brandLabel)) {
+            return $this->l((string) $brandLabel);
+        }
+
+        return $this->l('Service charge');
+    }
+
+    /**
+     * Brand-driven rounding-step options for the admin select, formatted to a
+     * canonical two-decimal string so the stored value round-trips. Mirrors the
+     * WooCommerce plugin's get_rounding_step_options and Magento's RoundingStep.
+     *
+     * @return array<string, string>
+     */
+    public function getTwoRoundingStepOptions()
+    {
+        $options = array();
+        $steps = $this->getTwoBrandConfig('rounding_steps');
+        foreach (is_array($steps) ? $steps : array() as $step) {
+            if (!is_numeric($step) || (float) $step <= 0) {
+                continue;
+            }
+            $value = number_format((float) $step, 2, '.', '');
+            $options[$value] = $value;
+        }
+        ksort($options, SORT_NUMERIC);
+
+        return $options;
+    }
+
+    /**
+     * Reset the request-scoped fee cache (tests).
+     */
+    public function resetTwoFeeCache()
+    {
+        $this->twoFeeCache = array();
+    }
+
+    /**
+     * HelperForm input entries for the surcharge settings (appended to the
+     * Other Settings form). Presentation only — all decisioning is in the
+     * methods above.
+     *
+     * @return array
+     */
+    protected function getTwoSurchargeFormInputs()
+    {
+        $inputs = array();
+        $inputs[] = array(
+            'type' => 'select',
+            'label' => $this->l('Buyer Surcharge Method'),
+            'name' => 'PS_TWO_SURCHARGE_TYPE',
+            'desc' => $this->l('Add an offset pricing fee to the buyer for the selected payment term. The fee amount is computed by Two; the plugin only sends the configuration.'),
+            'options' => array(
+                'query' => array(
+                    array('id' => 'none', 'name' => $this->l('No surcharge applied')),
+                    array('id' => 'percentage', 'name' => $this->l('Percentage')),
+                    array('id' => 'fixed', 'name' => $this->l('Fixed fee')),
+                    array('id' => 'fixed_and_percentage', 'name' => $this->l('Fixed fee and percentage')),
+                ),
+                'id' => 'id',
+                'name' => 'name',
+            ),
+        );
+        $inputs[] = array(
+            'type' => 'switch',
+            'label' => $this->l('Surcharge Calculation Basis'),
+            'name' => 'PS_TWO_SURCHARGE_DIFFERENTIAL',
+            'is_bool' => true,
+            'desc' => $this->l('Total fee charges the configured surcharge for the chosen term. Fee difference charges only the difference versus the default payment term.'),
+            'values' => array(
+                array('id' => 'PS_TWO_SURCHARGE_DIFFERENTIAL_ON', 'value' => 1, 'label' => $this->l('Fee difference vs default term')),
+                array('id' => 'PS_TWO_SURCHARGE_DIFFERENTIAL_OFF', 'value' => 0, 'label' => $this->l('Total fee for selected term')),
+            ),
+        );
+        $inputs[] = array(
+            'type' => 'text',
+            'label' => $this->l('Surcharge Line Description'),
+            'name' => 'PS_TWO_SURCHARGE_LINE_DESC',
+            'desc' => $this->l('Buyer-facing label for the surcharge line. Use %s for the term length in days. Leave blank to use the brand default.'),
+        );
+        $inputs[] = array(
+            'type' => 'select',
+            'label' => $this->l('Surcharge Rounding'),
+            'name' => 'PS_TWO_SURCHARGE_ROUNDING_BASIS',
+            'desc' => $this->l('Snap the buyer surcharge line to a clean increment. Select None for standard two-decimal amounts.'),
+            'options' => array(
+                'query' => array(
+                    array('id' => 'none', 'name' => $this->l('None')),
+                    array('id' => 'up', 'name' => $this->l('Up')),
+                    array('id' => 'down', 'name' => $this->l('Down')),
+                    array('id' => 'standard', 'name' => $this->l('Standard')),
+                ),
+                'id' => 'id',
+                'name' => 'name',
+            ),
+        );
+        $stepQuery = array(array('id' => '', 'name' => $this->l('No rounding')));
+        foreach ($this->getTwoRoundingStepOptions() as $value => $label) {
+            $stepQuery[] = array('id' => $value, 'name' => $label);
+        }
+        $inputs[] = array(
+            'type' => 'select',
+            'label' => $this->l('Rounding Step'),
+            'name' => 'PS_TWO_SURCHARGE_ROUNDING_STEP',
+            'desc' => $this->l('Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half). Applies only when a rounding direction is selected.'),
+            'options' => array('query' => $stepQuery, 'id' => 'id', 'name' => 'name'),
+        );
+        foreach ($this->getAvailablePaymentTerms() as $days) {
+            $days = (int) $days;
+            $inputs[] = array(
+                'type' => 'text',
+                'label' => sprintf($this->l('%d-day term: percentage'), $days),
+                'name' => 'PS_TWO_SURCHARGE_PCT_' . $days,
+                'class' => 'fixed-width-sm',
+                'suffix' => '%',
+            );
+            $inputs[] = array(
+                'type' => 'text',
+                'label' => sprintf($this->l('%d-day term: fixed fee'), $days),
+                'name' => 'PS_TWO_SURCHARGE_FIXED_' . $days,
+                'class' => 'fixed-width-sm',
+            );
+            $inputs[] = array(
+                'type' => 'text',
+                'label' => sprintf($this->l('%d-day term: cap on percentage'), $days),
+                'name' => 'PS_TWO_SURCHARGE_CAP_' . $days,
+                'class' => 'fixed-width-sm',
+            );
+        }
+
+        return $inputs;
+    }
+
+    /**
+     * Current values for the surcharge form fields.
+     *
+     * @return array
+     */
+    protected function getTwoSurchargeFormValues()
+    {
+        $values = array(
+            'PS_TWO_SURCHARGE_TYPE' => Tools::getValue('PS_TWO_SURCHARGE_TYPE', Configuration::get('PS_TWO_SURCHARGE_TYPE')),
+            'PS_TWO_SURCHARGE_DIFFERENTIAL' => Tools::getValue('PS_TWO_SURCHARGE_DIFFERENTIAL', Configuration::get('PS_TWO_SURCHARGE_DIFFERENTIAL')),
+            'PS_TWO_SURCHARGE_LINE_DESC' => Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', Configuration::get('PS_TWO_SURCHARGE_LINE_DESC')),
+            'PS_TWO_SURCHARGE_ROUNDING_BASIS' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS')),
+            'PS_TWO_SURCHARGE_ROUNDING_STEP' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP')),
+        );
+        foreach ($this->getAvailablePaymentTerms() as $days) {
+            $days = (int) $days;
+            foreach (array('PCT', 'FIXED', 'CAP') as $suffix) {
+                $name = 'PS_TWO_SURCHARGE_' . $suffix . '_' . $days;
+                $values[$name] = Tools::getValue($name, Configuration::get($name));
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Validate the surcharge form: enforce rounding-step membership and
+     * non-negative numeric grid values. Appends to $this->errors.
+     */
+    protected function validTwoSurchargeFormValues()
+    {
+        $type = TwoSurchargeCalculator::normalizeType(Tools::getValue('PS_TWO_SURCHARGE_TYPE'));
+        if ($type === 'none') {
+            return;
+        }
+        $step = trim((string) Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP'));
+        if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
+            $this->errors[] = $this->l('Rounding step must be one of the offered values.');
+        }
+        foreach ($this->getAvailablePaymentTerms() as $days) {
+            $days = (int) $days;
+            foreach (array('PCT', 'FIXED', 'CAP') as $suffix) {
+                $raw = Tools::getValue('PS_TWO_SURCHARGE_' . $suffix . '_' . $days);
+                if ($raw !== false && $raw !== '' && (!is_numeric($raw) || (float) $raw < 0)) {
+                    $this->errors[] = $this->l('Surcharge values must be non-negative numbers.');
+
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Persist the surcharge form values, coercing to safe stored forms.
+     */
+    protected function saveTwoSurchargeFormValues()
+    {
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', TwoSurchargeCalculator::normalizeType(Tools::getValue('PS_TWO_SURCHARGE_TYPE')));
+        Configuration::updateValue('PS_TWO_SURCHARGE_DIFFERENTIAL', (int) Tools::getValue('PS_TWO_SURCHARGE_DIFFERENTIAL', 0));
+        Configuration::updateValue('PS_TWO_SURCHARGE_LINE_DESC', (string) Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', ''));
+
+        $basis = (string) Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', 'none');
+        if ($basis !== 'none' && !array_key_exists($basis, TwoSurchargeCalculator::ROUNDING_BASIS_TO_API)) {
+            $basis = 'none';
+        }
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', $basis);
+
+        $step = trim((string) Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', ''));
+        if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
+            $step = '';
+        }
+        Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', $step);
+
+        foreach ($this->getAvailablePaymentTerms() as $days) {
+            $days = (int) $days;
+            foreach (array('PCT', 'FIXED', 'CAP') as $suffix) {
+                $name = 'PS_TWO_SURCHARGE_' . $suffix . '_' . $days;
+                $raw = Tools::getValue($name, '');
+                Configuration::updateValue($name, is_numeric($raw) ? (string) (float) $raw : '');
+            }
+        }
+    }
+
     public function getAvailablePaymentTerms()
     {
         $term_type = Configuration::get('PS_TWO_PAYMENT_TERM_TYPE');


### PR DESCRIPTION
## What

Adds the **offset pricing fee (buyer surcharge)** feature that PrestaShop lacked (**TWO-24752**, offset half) and the **brand-driven surcharge rounding relay** on top of it (**TWO-24893**, unblocked once the fee exists in this branch). At parity with the Magento `Service/Order/SurchargeCalculator` and WooCommerce `WC_Twoinc_Payment_Terms::build_buyer_fee_share` implementations.

## Part A — offset pricing fee (TWO-24752)

- **`classes/TwoSurchargeCalculator.php`** — dependency-free `buyer_fee_share` builder: `percentage` / `fixed` / `fixed_and_percentage`, `surcharge_basis`, `cap` (percentage modes only), differential `reference_terms`. No PrestaShop classes, so it is directly unit-testable and callable independently of the checkout render path (ps_checkout compatibility, TWO-24770).
- **`twopayment.php`**
  - `getTwoSurchargeSettings` / `buildTwoBuyerFeeShare` map module `Configuration` onto the calculator.
  - `fetchTwoTermFee` quotes the fee via `POST /v1/pricing/order/fee` — **fail-soft** (any error omits the line, checkout never blocked), request-scoped cache, tight timeout, currency-mismatch guard.
  - `buildTwoSurchargeLineItemForCart` builds a `SERVICE` fee line whose `tax_rate` carries the API's `total_fee_tax_rate` (**never a hard-coded zero**; a percentage form like `25` is normalised to `0.25`).
  - The fee line is injected in the shared pricing builder **after** product-line reconciliation, so it never perturbs the cart-vs-lines gate and the **intent / create / update** payloads stay consistent (intent approval reconciles against the same gross the create call sends).
  - Admin *Other Settings* gains surcharge method, calculation basis, line description and a per-term percentage/fixed/cap grid, with validation.

## Part B — buyer surcharge rounding (TWO-24893)

- **`brands/two.php`** — minimal brand seam exposing `rounding_steps` (mirrors the WooCommerce brand `available_rounding_steps`) and `fee_line_label`.
- Admin rounding basis (None/Up/Down/Standard) + brand-driven step select; the calculator relays `buyer_fee_share.rounding = {step, basis}` for percentage modes only. The backend does the arithmetic (server-side = TWO-24844, merged).

## Tests

`tests/SurchargeSpec.php` (offline runner): fee-share construction per term; rounding relay + edge cases (none / unmapped / zero / negative step); fail-soft fetch (HTTP error, currency mismatch); API tax-rate passthrough incl. percentage normalisation; a **rounding-boundary** amount (`10.10 x 0.25 = 2.525` → `2.53`); and end-to-end injection into the order payload with bumped totals. Surcharge defaults to `none`, so all existing tests remain green.

```
php tests/run.php  # all specs pass
```

## Notes for reviewer

- **Base-branch caveat:** the chip-selector half of TWO-24752 and the brand-config foundation (TWO-24746) live in the still-open PR #34, not on `staging`. This PR therefore introduces its own minimal `brands/two.php` seam (surcharge keys only) and drives the fee off the existing cookie/config term selection (`getSelectedPaymentTerm`). When PR #34 / TWO-24746 land, the brand seam should be reconciled with the fuller foundation.
- **PS-cart integration deferred:** the surcharge is added to the **Two order payload** (what the buyer is invoiced), not to PrestaShop's native cart total via a CartRule. Wiring it into the PS cart total touches the sensitive reconciliation gate and is a separate, riskier change — flagging for a follow-up decision rather than forcing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn