### PR TITLE
fix: add staging environment support to API host resolution

### DIFF
--- a/tests/run.php
+++ b/tests/run.php
@@ -3436,7 +3436,7 @@ final class OrderBuilderSpec
         TinyAssert::same('https://buyer.sandbox.two.inc/login', $module->getTwoBuyerPortalUrl());
 
         Configuration::updateValue('PS_TWO_ENVIRONMENT', 'staging');
-        TinyAssert::same('https://buyer.sandbox.two.inc/login', $module->getTwoBuyerPortalUrl());
+        TinyAssert::same('https://buyer.staging.two.inc/login', $module->getTwoBuyerPortalUrl());
     }
 
     private static function testResolveTwoAttemptOrderIdForCancellationPrefersAttemptOrderId(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -728,8 +728,8 @@ class Twopayment extends PaymentModule
         
         // Validate environment
         $environment = Tools::getValue('PS_TWO_ENVIRONMENT');
-        if (Tools::isEmpty($environment) || !in_array($environment, array('production', 'development'))) {
-            $this->errors[] = $this->l('Please select a valid environment (Production or Development).');
+        if (Tools::isEmpty($environment) || !in_array($environment, array('production', 'development', 'staging'))) {
+            $this->errors[] = $this->l('Please select a valid environment (Production, Development or Staging).');
         }
         
         // Validate payment terms
@@ -747,7 +747,7 @@ class Twopayment extends PaymentModule
         // Verify API key with Two against selected environment and capture merchant id and short name
         $apiKey = trim(Tools::getValue('PS_TWO_MERCHANT_API_KEY'));
         $env = Tools::getValue('PS_TWO_ENVIRONMENT');
-        if (!empty($apiKey) && in_array($env, array('production','development'))) {
+        if (!empty($apiKey) && in_array($env, array('production','development','staging'))) {
             $verify = $this->verifyTwoApiKey($apiKey, $env);
             if ($verify === false) {
                 $this->errors[] = $this->l('API key verification failed. Please check your API key.');
@@ -5667,6 +5667,26 @@ class Twopayment extends PaymentModule
     );
 
     /**
+     * Explicit environment -> merchant portal host map, mirroring ENVIRONMENT_HOSTS.
+     * Any value not in this map (legacy 'development', empty/unset) falls back to
+     * the sandbox portal.
+     */
+    private const PORTAL_HOSTS = array(
+        'production' => 'https://portal.two.inc',
+        'staging' => 'https://portal.staging.two.inc',
+    );
+
+    /**
+     * Explicit environment -> buyer portal login URL map, mirroring ENVIRONMENT_HOSTS.
+     * Any value not in this map (legacy 'development', empty/unset) falls back to
+     * the sandbox buyer portal.
+     */
+    private const BUYER_PORTAL_HOSTS = array(
+        'production' => 'https://buyer.two.inc/login',
+        'staging' => 'https://buyer.staging.two.inc/login',
+    );
+
+    /**
      * Get base API host for a specific environment value (without relying on saved config)
      */
     private function getTwoCheckoutHostUrlForEnvironment($environment)
@@ -5760,11 +5780,8 @@ class Twopayment extends PaymentModule
         if ($override !== null) {
             return $override;
         }
-        $environment = Configuration::get('PS_TWO_ENVIRONMENT');
-        if ($environment === 'production') {
-            return 'https://portal.two.inc';
-        }
-        return 'https://portal.sandbox.two.inc';
+        $environment = strtolower((string) Configuration::get('PS_TWO_ENVIRONMENT'));
+        return self::PORTAL_HOSTS[$environment] ?? 'https://portal.sandbox.two.inc';
     }
 
     /**
@@ -5774,12 +5791,8 @@ class Twopayment extends PaymentModule
     public function getTwoBuyerPortalUrl()
     {
         $environment = strtolower((string) Configuration::get('PS_TWO_ENVIRONMENT'));
-        if ($environment === 'production') {
-            return 'https://buyer.two.inc/login';
-        }
-
-        // Development/non-production environments use the sandbox buyer portal.
-        return 'https://buyer.sandbox.two.inc/login';
+        // Development/non-production environments fall back to the sandbox buyer portal.
+        return self::BUYER_PORTAL_HOSTS[$environment] ?? 'https://buyer.sandbox.two.inc/login';
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -5695,7 +5695,7 @@ class Twopayment extends PaymentModule
         if ($override !== null) {
             return $override;
         }
-        return self::ENVIRONMENT_HOSTS[$environment] ?? 'https://api.sandbox.two.inc';
+        return self::ENVIRONMENT_HOSTS[strtolower((string) $environment)] ?? 'https://api.sandbox.two.inc';
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -606,11 +606,12 @@ class Twopayment extends PaymentModule
                         'type' => 'select',
                         'label' => $this->l('Environment'),
                         'name' => 'PS_TWO_ENVIRONMENT',
-                        'desc' => $this->l('Select the Two API environment to use. Production for live transactions, Development for testing.'),
+                        'desc' => $this->l('Select the Two API environment to use. Production for live transactions, Staging/Development for testing.'),
                         'required' => true,
                         'options' => array(
                             'query' => array(
                                 array('id_option' => 'development', 'name' => $this->l('Development')),
+                                array('id_option' => 'staging', 'name' => $this->l('Staging')),
                                 array('id_option' => 'production', 'name' => $this->l('Production')),
                             ),
                             'id' => 'id_option',
@@ -5654,6 +5655,18 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Explicit environment -> API host map, mirroring the Woo/Magento plugins'
+     * templated 'api.<mode>.two.inc' host builder. Any value not in this map
+     * (including the legacy 'development' option and empty/unset config)
+     * falls back to sandbox — the same default this plugin has always used
+     * for "not production".
+     */
+    private const ENVIRONMENT_HOSTS = array(
+        'production' => 'https://api.two.inc',
+        'staging' => 'https://api.staging.two.inc',
+    );
+
+    /**
      * Get base API host for a specific environment value (without relying on saved config)
      */
     private function getTwoCheckoutHostUrlForEnvironment($environment)
@@ -5662,7 +5675,7 @@ class Twopayment extends PaymentModule
         if ($override !== null) {
             return $override;
         }
-        return ($environment === 'production') ? 'https://api.two.inc' : 'https://api.sandbox.two.inc';
+        return self::ENVIRONMENT_HOSTS[$environment] ?? 'https://api.sandbox.two.inc';
     }
 
     /**


### PR DESCRIPTION
## Summary
- `PS_TWO_ENVIRONMENT` could already be set to `staging` (the plugin's own CLI-seed script defaults to it), but `getTwoCheckoutHostUrlForEnvironment()` only branched on `production` vs sandbox-for-everything-else, so a `staging` config value silently resolved to `api.sandbox.two.inc`.
- Adds an explicit `production`/`staging` host map, falling back to sandbox for anything else (including the legacy `development` option) — mirrors Woo/Magento's mode-to-host templating, which already support all three.
- Exposes `Staging` as a real dropdown option in the module's General Settings, instead of a config value nothing in the UI could actually select.

## Test plan
- [x] `php -l twopayment.php` clean
- [x] Verified locally against a live staging pod: `PS_TWO_ENVIRONMENT=staging` now resolves to `https://api.staging.two.inc` instead of sandbox
- [ ] Doug to confirm the merchant admin dropdown shows and saves "Staging" correctly on prestashop-dev.staging.two.inc after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)