### PR TITLE
Checkout: chip fee preview + surcharge line-item label rename

### DIFF
--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -31,6 +31,7 @@ final class SurchargeSpec
         self::testBuildTwoBuyerFeeShareWiresConfigAndDefaultTerm();
         self::testRoundingStepOptionsAreBrandDrivenSortedAndFormatted();
         self::testSurchargeLineLabelTemplateBrandAndDefault();
+        self::testSurchargeChipPreviewAllZeroHiddenElseShownOnEveryTerm();
         self::testFetchTermFeeFailsSoftOnHttpError();
         self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
         self::testFetchTermFeeParsesSuccess();
@@ -239,11 +240,57 @@ final class SurchargeSpec
     {
         self::reset();
         $module = new TwopaymentTestHarness();
-        // Default (no config, brand label null).
-        TinyAssert::same('Service charge', $module->getTwoSurchargeLineLabel(30));
-        // Merchant template with %s term substitution.
+        // Default (no config, brand label null): term-naming default label.
+        TinyAssert::same('Payment terms fee - 30 days', $module->getTwoSurchargeLineLabel(30));
+        TinyAssert::same('Payment terms fee - 60 days', $module->getTwoSurchargeLineLabel(60));
+        // Merchant template with %s term substitution still wins over the default.
         Configuration::updateValue('PS_TWO_SURCHARGE_LINE_DESC', 'Financing fee (%s days)');
         TinyAssert::same('Financing fee (30 days)', $module->getTwoSurchargeLineLabel(30));
+    }
+
+    /**
+     * Chip fee preview mirrors Magento's "allZero" rule: hidden on every chip
+     * when all offered terms are zero-rated, shown on every chip (with a
+     * "No fee" marker for a zero-rate term) as soon as one term carries a fee.
+     * Preview parts are gated by the configured surcharge type.
+     */
+    private static function testSurchargeChipPreviewAllZeroHiddenElseShownOnEveryTerm(): void
+    {
+        // Offer two terms so "all zero" vs "some non-zero" is observable.
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        $module = new TwopaymentTestHarness();
+
+        // Surcharge disabled -> nothing to preview.
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'none');
+        TinyAssert::same([], $module->getTwoSurchargeChipPreview());
+
+        // Percentage type, every offered term zero-rated -> hide on all chips.
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '0');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '0');
+        TinyAssert::same([], $module->getTwoSurchargeChipPreview());
+
+        // One term now carries a fee -> every chip shows a preview; the
+        // zero-rate term renders the "No fee" marker (Magento allZero parity).
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '2.5');
+        $preview = $module->getTwoSurchargeChipPreview();
+        TinyAssert::same('No fee', $preview[30]);
+        TinyAssert::same('+2.5%', $preview[60]);
+
+        // Type gating: a fixed-only surcharge must ignore a stray percentage
+        // value left over from a previous type, and preview the fixed amount.
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'fixed');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5'); // stray, must be ignored
+        Configuration::updateValue('PS_TWO_SURCHARGE_FIXED_60', '10');
+        $moduleFixed = new TwopaymentTestHarness();
+        $previewFixed = $moduleFixed->getTwoSurchargeChipPreview();
+        TinyAssert::same('No fee', $previewFixed[30]);
+        TinyAssert::same('+10.00', $previewFixed[60]);
     }
 
     private static function testFetchTermFeeFailsSoftOnHttpError(): void
@@ -321,7 +368,7 @@ final class SurchargeSpec
         $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 100.0);
         TinyAssert::same('SERVICE', $line['type']);
-        TinyAssert::same('Service charge', $line['name']);
+        TinyAssert::same('Payment terms fee - 30 days', $line['name']);
         TinyAssert::same('5.00', $line['net_amount']);
         TinyAssert::same('0.25', $line['tax_rate'], 'API tax rate passes through (percentage normalised), never hard-coded zero');
         TinyAssert::same('1.25', $line['tax_amount']);
@@ -519,7 +566,7 @@ final class SurchargeSpec
         TinyAssert::same('6.75', $payload['tax_amount']);
 
         $feeLines = array_values(array_filter($payload['line_items'], function ($item) {
-            return isset($item['type']) && $item['type'] === 'SERVICE' && $item['name'] === 'Service charge';
+            return isset($item['type']) && $item['type'] === 'SERVICE' && $item['name'] === 'Payment terms fee - 30 days';
         }));
         TinyAssert::count(1, $feeLines);
         TinyAssert::same('5.00', $feeLines[0]['net_amount']);

--- a/twopayment.php
+++ b/twopayment.php
@@ -2596,6 +2596,7 @@ class Twopayment extends PaymentModule
                 'available_payment_terms' => $this->getAvailablePaymentTerms(),
                 'default_payment_term' => $this->getDefaultPaymentTerm(),
                 'payment_term_type' => Configuration::get('PS_TWO_PAYMENT_TERM_TYPE'),
+                'payment_term_surcharge_preview' => $this->getTwoSurchargeChipPreview(),
                 'i18n' => $i18n,
                 'phone_i18n' => array(
                     'invalid_number' => $this->l('Invalid phone number'),
@@ -6282,18 +6283,29 @@ class Twopayment extends PaymentModule
 
     /**
      * Per-term surcharge preview text keyed by days, for display alongside the
-     * term (e.g. the "Available Payment Terms" checkboxes and the checkout chip
-     * selector).
+     * term: the "Available Payment Terms" checkboxes in admin and the checkout
+     * chip selector share this single calculation.
      *
      * Deliberately NOT the live-quoted buyer_fee_share (that requires a real
      * POST /v1/pricing/order/fee call per term via fetchTwoTermFee — fine for
      * one term at order-intent time, too many synchronous calls to make on
      * every checkout page load for a whole term list). This instead previews
      * the raw configured rate (the same percentage/fixed values the merchant
-     * already sees in the admin grid), not the final rounded/capped amount.
+     * already sees in the admin grid, gated by the configured surcharge type),
+     * not the final rounded/capped amount.
      *
-     * @return array<int, string> days => preview text, only for terms with a
-     *                            non-zero configured rate
+     * Display rule mirrors Magento's gateway_method.js term-chip "allZero"
+     * logic: when EVERY offered term has a zero fee, the fee is hidden on all
+     * chips (empty array); when AT LEAST ONE term carries a fee, every chip
+     * shows its fee — a zero-fee term in that set renders a "No fee" marker
+     * rather than being blank, so the row is consistent. (Magento renders the
+     * zero term as a formatted "+0.00"; because this preview is rate-based, not
+     * amount-based, a "No fee" marker is the closest faithful equivalent.) This
+     * also governs the admin checkbox suffix, so the merchant sees the same
+     * "no fee shown to buyer" signal the checkout chip will render.
+     *
+     * @return array<int, string> days => preview text; empty when all offered
+     *                            terms are zero-rated (Magento allZero-hide)
      */
     public function getTwoSurchargeChipPreview()
     {
@@ -6302,13 +6314,21 @@ class Twopayment extends PaymentModule
             return array();
         }
 
-        $preview = array();
+        // Gate the preview parts by the configured surcharge type, mirroring
+        // TwoSurchargeCalculator::buildBuyerFeeShare, so the chip never previews
+        // a component (percentage or fixed) the API will not actually charge.
+        $type = $settings['type'];
+        $hasPercentage = in_array($type, array('percentage', 'fixed_and_percentage'), true);
+        $hasFixed = in_array($type, array('fixed', 'fixed_and_percentage'), true);
+
+        $rawParts = array();
+        $anyNonZero = false;
         foreach ($settings['grid'] as $days => $row) {
             $parts = array();
-            if ((float) $row['percentage'] > 0) {
+            if ($hasPercentage && (float) $row['percentage'] > 0) {
                 $parts[] = '+' . rtrim(rtrim(sprintf('%.2f', $row['percentage']), '0'), '.') . '%';
             }
-            if ((float) $row['fixed'] > 0) {
+            if ($hasFixed && (float) $row['fixed'] > 0) {
                 // Tools::displayPrice() needs the Symfony kernel container;
                 // fail-soft to a plain number rather than fatal the checkout
                 // page media hook if it's unavailable in some bootstrap path.
@@ -6318,9 +6338,22 @@ class Twopayment extends PaymentModule
                     $parts[] = '+' . sprintf('%.2f', $row['fixed']);
                 }
             }
+            $rawParts[(int) $days] = $parts;
             if (!empty($parts)) {
-                $preview[(int) $days] = implode(' ', $parts);
+                $anyNonZero = true;
             }
+        }
+
+        // All offered terms zero-rated -> hide the fee on every chip (allZero).
+        if (!$anyNonZero) {
+            return array();
+        }
+
+        // At least one term carries a fee -> show every chip's fee; a zero-fee
+        // term renders the "No fee" marker so the row is not visually ragged.
+        $preview = array();
+        foreach ($rawParts as $days => $parts) {
+            $preview[$days] = !empty($parts) ? implode(' ', $parts) : $this->l('No fee');
         }
 
         return $preview;
@@ -6529,7 +6562,11 @@ class Twopayment extends PaymentModule
     /**
      * Buyer-facing label for the surcharge line. A merchant-set description
      * wins (with %s replaced by the term days, Magento/WooCommerce parity);
-     * else the brand label; else a translated default.
+     * else the brand label; else a translated default that names the term.
+     *
+     * The default is "Payment terms fee - <n> days" (with the selected term's
+     * day count); a merchant who has typed their own Surcharge Line Description
+     * keeps it — this default only applies when that field is left blank.
      *
      * @param int $days
      * @return string
@@ -6545,7 +6582,7 @@ class Twopayment extends PaymentModule
             return $this->l((string) $brandLabel);
         }
 
-        return $this->l('Service charge');
+        return sprintf($this->l('Payment terms fee - %d days'), (int) $days);
     }
 
     /**

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -1271,6 +1271,20 @@ class TwoCheckoutManager {
             termChip.title = formatChipLabel(days);
             termChip.appendChild(daysLabel);
 
+            // Per-term surcharge preview (configured-rate text, not a live quote
+            // — see getTwoSurchargeChipPreview() in twopayment.php). The PHP side
+            // decides show/hide (Magento allZero parity): the map is empty when
+            // all terms are zero-rated, and carries a non-empty string for every
+            // term otherwise (a "No fee" marker for zero-rate terms), so a simple
+            // presence check renders the fee on every chip or none.
+            const surchargePreview = this.config.payment_term_surcharge_preview;
+            if (surchargePreview && surchargePreview[days]) {
+                const surchargeLabel = document.createElement('span');
+                surchargeLabel.className = 'two-term-chip__surcharge';
+                surchargeLabel.textContent = surchargePreview[days];
+                termChip.appendChild(surchargeLabel);
+            }
+
             termChip.dataset.days = days;
 
             // Set default term: use configured default, or if only one term, make it selected, or first term

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -114,7 +114,8 @@
                 ajaxToken: twopayment.ajax_token,
                 available_payment_terms: twopayment.available_payment_terms || [30],
                 default_payment_term: twopayment.default_payment_term || 30,
-                payment_term_type: twopayment.payment_term_type
+                payment_term_type: twopayment.payment_term_type,
+                payment_term_surcharge_preview: twopayment.payment_term_surcharge_preview || {}
             });
             
             // Store global reference for modules
@@ -138,7 +139,9 @@
                             orderIntentUrl: twopayment.order_intent_url,
                             ajaxToken: twopayment.ajax_token,
                             available_payment_terms: twopayment.available_payment_terms || [30],
-                            default_payment_term: twopayment.default_payment_term || 30
+                            default_payment_term: twopayment.default_payment_term || 30,
+                            payment_term_type: twopayment.payment_term_type,
+                            payment_term_surcharge_preview: twopayment.payment_term_surcharge_preview || {}
                         });
                         window.TwoCheckoutManager_Instance = checkoutManager;
                     }


### PR DESCRIPTION
## Summary
- Payment-term chips at checkout show a rate-based fee preview (e.g. "+2.5%", "No fee"); hidden entirely when every offered term is zero-rated, matching Magento's allZero rule.
- Surcharge line-item default label changed from "Service charge" to "Payment terms fee - N days". Merchant-editable `PS_TWO_SURCHARGE_LINE_DESC` and brand override still take precedence over the default.

## Not in this PR
Adding the surcharge as a real PrestaShop order line (so PS's own total/invoice/refund base reflects it) is a separate, higher-risk change — the CartRule mechanism originally proposed doesn't work in PS 8 (can't represent a positive fee), and the correct approach needs decisions on dynamic per-order tax-rate reconciliation and refund/proration policy first. Not guessing on a money path — will follow up once those are decided.

## Test plan
- [x] `php -l` / `node --check` clean
- [x] `php tests/run.php` green, including new coverage for allZero / mixed-zero / type-gating chip preview behavior
- [ ] Manual checkout spot-check (chip rendering is DOM/JS-driven, not exercised by the offline suite)

🤖 Generated with Claude Code