### PR TITLE
Admin: trim health checklist, add merchant name + deploy version info

### DIFF
--- a/tests/DeployVersionInfoSpec.php
+++ b/tests/DeployVersionInfoSpec.php
@@ -14,6 +14,7 @@ final class DeployVersionInfoSpec
         self::testMissingGitDirReturnsNull();
         self::testRefHeadWithLooseRefReturnsShortSha();
         self::testRefHeadFallsBackToPackedRefs();
+        self::testPackedRefsExactMatchIgnoresSuffixDecoy();
         self::testDetachedHeadReturnsShortSha();
         self::testGarbageHeadReturnsNull();
         self::testMissingRefAndPackedRefsReturnsNull();
@@ -71,6 +72,26 @@ final class DeployVersionInfoSpec
             $git . '/packed-refs',
             "# pack-refs with: peeled fully-peeled sorted\n"
             . "1111111111111111111111111111111111111111 refs/heads/other\n"
+            . "fedcba9876543210fedcba9876543210fedcba98 refs/heads/staging\n"
+        );
+
+        TinyAssert::same('fedcba9', self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testPackedRefsExactMatchIgnoresSuffixDecoy(): void
+    {
+        // A packed-refs line whose full ref merely *ends with* the same string as our
+        // target ref (e.g. a nested/differently-prefixed namespace) must NOT be treated
+        // as a match — only an exact ref-path match is acceptable. The decoy is listed
+        // first (and would win under a naive suffix comparison since it breaks on first
+        // hit), the real ref is listed second with a different sha.
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+        file_put_contents(
+            $git . '/packed-refs',
+            "# pack-refs with: peeled fully-peeled sorted\n"
+            . "decadedecadedecadedecadedecadedecadedeca refs/namespaces/foo/refs/heads/staging\n"
             . "fedcba9876543210fedcba9876543210fedcba98 refs/heads/staging\n"
         );
 

--- a/tests/DeployVersionInfoSpec.php
+++ b/tests/DeployVersionInfoSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for the deploy-version helpers shown on the Plugin Information tab:
+ * getTwoDeployedCommitHash() (file-read-only .git inspection, fail-soft) and
+ * getTwoDeployedAtLabel() (module file mtime, fail-soft).
+ */
+final class DeployVersionInfoSpec
+{
+    public static function runAll(): void
+    {
+        self::testMissingGitDirReturnsNull();
+        self::testRefHeadWithLooseRefReturnsShortSha();
+        self::testRefHeadFallsBackToPackedRefs();
+        self::testDetachedHeadReturnsShortSha();
+        self::testGarbageHeadReturnsNull();
+        self::testMissingRefAndPackedRefsReturnsNull();
+        self::testDeployedAtLabelMatchesModuleFileMtime();
+    }
+
+    private static function callCommitHash(?string $gitDir): ?string
+    {
+        $module = new TwopaymentTestHarness();
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoDeployedCommitHash');
+
+        return $method->invoke($module, $gitDir);
+    }
+
+    private static function makeTempGitDir(): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'two-deploy-spec-' . uniqid('', true) . DIRECTORY_SEPARATOR . '.git';
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+
+    private static function removeDir(string $dir): void
+    {
+        foreach (new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        ) as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+
+    private static function testMissingGitDirReturnsNull(): void
+    {
+        TinyAssert::same(null, self::callCommitHash(sys_get_temp_dir() . '/two-deploy-spec-nonexistent-' . uniqid()));
+    }
+
+    private static function testRefHeadWithLooseRefReturnsShortSha(): void
+    {
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+        mkdir($git . '/refs/heads', 0777, true);
+        file_put_contents($git . '/refs/heads/staging', "abcdef0123456789abcdef0123456789abcdef01\n");
+
+        TinyAssert::same('abcdef0', self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testRefHeadFallsBackToPackedRefs(): void
+    {
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+        file_put_contents(
+            $git . '/packed-refs',
+            "# pack-refs with: peeled fully-peeled sorted\n"
+            . "1111111111111111111111111111111111111111 refs/heads/other\n"
+            . "fedcba9876543210fedcba9876543210fedcba98 refs/heads/staging\n"
+        );
+
+        TinyAssert::same('fedcba9', self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testDetachedHeadReturnsShortSha(): void
+    {
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "0123456789abcdef0123456789abcdef01234567\n");
+
+        TinyAssert::same('0123456', self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testGarbageHeadReturnsNull(): void
+    {
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "not-a-sha-or-ref\n");
+
+        TinyAssert::same(null, self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testMissingRefAndPackedRefsReturnsNull(): void
+    {
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+
+        TinyAssert::same(null, self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testDeployedAtLabelMatchesModuleFileMtime(): void
+    {
+        $module = new TwopaymentTestHarness();
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoDeployedAtLabel');
+        $label = $method->invoke($module);
+
+        $mtime = filemtime(dirname(__DIR__) . '/twopayment.php');
+        TinyAssert::same(date('Y-m-d H:i:s', $mtime), $label);
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -4808,6 +4808,7 @@ require __DIR__ . '/TrackingNumberSpec.php';
 require __DIR__ . '/RefundSpec.php';
 require __DIR__ . '/SurchargeSpec.php';
 require __DIR__ . '/DefaultPaymentTermSpec.php';
+require __DIR__ . '/DeployVersionInfoSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -4817,6 +4818,7 @@ $tests = [
     'RefundSpec::runAll' => [RefundSpec::class, 'runAll'],
     'SurchargeSpec::runAll' => [SurchargeSpec::class, 'runAll'],
     'DefaultPaymentTermSpec::runAll' => [DefaultPaymentTermSpec::class, 'runAll'],
+    'DeployVersionInfoSpec::runAll' => [DeployVersionInfoSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -1236,6 +1236,16 @@ class Twopayment extends PaymentModule
      */
     protected function renderTwoPluginInfo()
     {
+        $commit_hash = $this->getTwoDeployedCommitHash();
+        $deployed_at = $this->getTwoDeployedAtLabel();
+        $version_line = $this->l('Plugin Version:') . ' ' . $this->version . ' | ' . $this->l('PrestaShop:') . ' ' . _PS_VERSION_;
+        if ($commit_hash !== null) {
+            $version_line .= ' | ' . $this->l('Commit:') . ' ' . htmlspecialchars($commit_hash, ENT_QUOTES, 'UTF-8');
+        }
+        if ($deployed_at !== null) {
+            $version_line .= ' | ' . $this->l('Deployed:') . ' ' . htmlspecialchars($deployed_at, ENT_QUOTES, 'UTF-8');
+        }
+
         $html = '
         <div class="panel">
             <div class="panel-heading">
@@ -1306,11 +1316,90 @@ class Twopayment extends PaymentModule
                     <li><strong>' . $this->l('Documentation:') . '</strong> <a href="https://docs.two.inc" target="_blank">docs.two.inc</a></li>
                     <li><strong>' . $this->l('Merchant Portal:') . '</strong> <a href="' . $this->getTwoPortalUrl() . '" target="_blank">' . $this->l('Open Two Portal') . '</a></li>
                 </ul>
-                <p style="margin-top:15px;"><small class="text-muted">' . $this->l('Plugin Version:') . ' ' . $this->version . ' | ' . $this->l('PrestaShop:') . ' ' . _PS_VERSION_ . '</small></p>
+                <p style="margin-top:15px;"><small class="text-muted">' . $version_line . '</small></p>
             </div>
         </div>';
         
         return $html;
+    }
+
+    /**
+     * Best-effort short commit hash from a co-located .git directory, if one exists
+     * on disk (this plugin's git-sync deploy mechanism may or may not leave one).
+     * Plain file reads only — no exec. Returns null (never throws/fatals) if unavailable.
+     *
+     * @param string|null $git_dir Overridable for tests; defaults to this module's .git
+     *
+     * @return string|null
+     */
+    private function getTwoDeployedCommitHash($git_dir = null)
+    {
+        if ($git_dir === null) {
+            $git_dir = __DIR__ . '/.git';
+        }
+        if (!is_dir($git_dir) || !is_readable($git_dir)) {
+            return null;
+        }
+
+        $head_file = $git_dir . '/HEAD';
+        if (!is_file($head_file) || !is_readable($head_file)) {
+            return null;
+        }
+
+        $head_contents = trim((string) @file_get_contents($head_file));
+        if ($head_contents === '') {
+            return null;
+        }
+
+        $sha = null;
+        if (strpos($head_contents, 'ref:') === 0) {
+            $ref_path = trim(substr($head_contents, 4));
+            $ref_file = $git_dir . '/' . $ref_path;
+            if (is_file($ref_file) && is_readable($ref_file)) {
+                $sha = trim((string) @file_get_contents($ref_file));
+            } else {
+                // Fall back to packed-refs (loose ref file may not exist after a gc/pack).
+                $packed_refs_file = $git_dir . '/packed-refs';
+                if (is_file($packed_refs_file) && is_readable($packed_refs_file)) {
+                    $packed = @file($packed_refs_file, FILE_IGNORE_NEW_LINES);
+                    if (is_array($packed)) {
+                        foreach ($packed as $line) {
+                            if (substr($line, -strlen($ref_path)) === $ref_path) {
+                                $parts = explode(' ', $line);
+                                if (!empty($parts[0])) {
+                                    $sha = $parts[0];
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } elseif (preg_match('/^[0-9a-f]{40}$/i', $head_contents)) {
+            // Detached HEAD: file contains the sha directly.
+            $sha = $head_contents;
+        }
+
+        if (!$sha || !preg_match('/^[0-9a-f]{7,40}$/i', $sha)) {
+            return null;
+        }
+
+        return substr($sha, 0, 7);
+    }
+
+    /**
+     * Best-effort deployment timestamp label based on this file's mtime.
+     * Returns null (never throws/fatals) if unavailable.
+     *
+     * @return string|null
+     */
+    private function getTwoDeployedAtLabel()
+    {
+        $mtime = @filemtime(__FILE__);
+        if (!$mtime) {
+            return null;
+        }
+        return date('Y-m-d H:i:s', $mtime);
     }
 
     /**
@@ -1323,20 +1412,14 @@ class Twopayment extends PaymentModule
         $environment = (string) Configuration::get('PS_TWO_ENVIRONMENT', 'development');
         $api_verified = (bool) Configuration::get('PS_TWO_API_KEY_VERIFIED');
         $ssl_disabled = (bool) Configuration::get('PS_TWO_DISABLE_SSL_VERIFY');
-        $order_intent_enabled = true;
-        $use_account_type = (bool) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE');
-        $term_type = (string) Configuration::get('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD');
-        $available_terms = $this->getAvailablePaymentTerms();
-
-        $term_labels = array();
-        foreach ($available_terms as $term) {
-            $term_labels[] = (int) $term;
-        }
+        $merchant_short_name = (string) Configuration::get('PS_TWO_MERCHANT_SHORT_NAME');
 
         $status_rows = array(
             array(
                 'label' => $this->l('API key'),
-                'value' => $api_verified ? $this->l('Verified') : $this->l('Not verified'),
+                'value' => $api_verified
+                    ? $this->l('Verified') . ($merchant_short_name !== '' ? ' (' . htmlspecialchars($merchant_short_name, ENT_QUOTES, 'UTF-8') . ')' : '')
+                    : $this->l('Not verified'),
                 'ok' => $api_verified,
             ),
             array(
@@ -1348,21 +1431,6 @@ class Twopayment extends PaymentModule
                 'label' => $this->l('SSL verification'),
                 'value' => $ssl_disabled ? $this->l('Disabled') : $this->l('Enabled'),
                 'ok' => !$ssl_disabled,
-            ),
-            array(
-                'label' => $this->l('Order intent pre-check'),
-                'value' => $order_intent_enabled ? $this->l('Enabled') : $this->l('Disabled'),
-                'ok' => true,
-            ),
-            array(
-                'label' => $this->l('Account type mode'),
-                'value' => $use_account_type ? $this->l('Enabled') : $this->l('Disabled'),
-                'ok' => true,
-            ),
-            array(
-                'label' => $this->l('Payment terms'),
-                'value' => $term_type . ' (' . implode(', ', $term_labels) . ')',
-                'ok' => !empty($term_labels),
             ),
         );
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -1364,11 +1364,17 @@ class Twopayment extends PaymentModule
                     $packed = @file($packed_refs_file, FILE_IGNORE_NEW_LINES);
                     if (is_array($packed)) {
                         foreach ($packed as $line) {
-                            if (substr($line, -strlen($ref_path)) === $ref_path) {
-                                $parts = explode(' ', $line);
-                                if (!empty($parts[0])) {
-                                    $sha = $parts[0];
-                                }
+                            // Skip comments/pragmas ("# pack-refs...") and peeled-tag lines ("^<sha>").
+                            if ($line === '' || $line[0] === '#' || $line[0] === '^') {
+                                continue;
+                            }
+                            $space_pos = strpos($line, ' ');
+                            if ($space_pos === false) {
+                                continue;
+                            }
+                            $line_ref = substr($line, $space_pos + 1);
+                            if ($line_ref === $ref_path) {
+                                $sha = substr($line, 0, $space_pos);
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary
- Removed "Order intent pre-check", "Account type mode", "Payment terms" rows from the Plugin Information > Current Configuration Health checklist (dead-weight signal, per Doug).
- Added merchant short name beside the API key row — sourced from the existing `PS_TWO_MERCHANT_SHORT_NAME` config (already populated from the API-key verify response), no new API call.
- Extended the version line to match Magento's admin version panel: plugin version (existing) + commit hash + deployment timestamp.
  - Commit hash: plain file reads of `.git/HEAD` → loose ref → packed-refs fallback. No exec/shell_exec. Returns null (row omitted) if `.git` isn't present in the deployed layout.
  - Deployed-at: `filemtime()` of `twopayment.php` itself (analog of Magento's `registration.php` mtime).
  - **Open gap, not resolved by this PR:** whether git-sync's shallow clone actually leaves a `.git` dir in the staging pod's deployed module path is unconfirmed — `platform-tools/prestashop/chart/templates/deployment.yaml:229` does a `cp -RL` with no `.git` exclusion, so if git-sync produces one it will survive, but that's unverified without `kubectl exec` onto a live pod. Everything degrades gracefully either way (hash/timestamp rows simply don't show if unavailable).

## Test plan
- [x] `php -l twopayment.php` clean
- [x] New `tests/DeployVersionInfoSpec.php` (7 cases: no .git, loose ref, packed-refs fallback, detached HEAD, garbage HEAD, missing ref, mtime label)
- [x] Full suite (8/8 specs) green, verified independently in a clean worktree
- [ ] Confirm on a live staging pod whether `.git` actually exists in `modules/twopayment/` — if not, Commit row will just never render (acceptable, not a blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)