### PR TITLE
Fix: cache buyer fee-share quote across order-intent polls

### DIFF
--- a/tests/run.php
+++ b/tests/run.php
@@ -165,6 +165,7 @@ final class OrderBuilderSpec
         self::testGetMerchantAvailableTermsSkipsFetchWithoutIdentity();
         self::testInvalidateMerchantAvailableTermsClearsCache();
         self::testSaveGeneralFormPreservesHiddenBackendWithdrawnTermPreference();
+        self::testStoreTwoFeeQuoteInSessionForcesImmediateCookieWrite();
     }
 
     private static function reset(): void
@@ -4374,6 +4375,40 @@ final class OrderBuilderSpec
         // 30 stays on; 60's preference is PRESERVED, not silently zeroed.
         TinyAssert::same(1, (int) Configuration::get('PS_TWO_PAYMENT_TERMS_30'));
         TinyAssert::same(1, (int) Configuration::get('PS_TWO_PAYMENT_TERMS_60'));
+    }
+
+    /**
+     * Regression: storeTwoFeeQuoteInSession() must not rely solely on Cookie's
+     * destructor to persist the cache - AJAX controllers (order-intent polling)
+     * end the request via ajaxDie()/exit, which is not guaranteed to run
+     * __destruct() in every PHP/webserver configuration. write() must be
+     * called explicitly so the cache is durable.
+     */
+    private static function testStoreTwoFeeQuoteInSessionForcesImmediateCookieWrite(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $spyCookie = new class extends Cookie {
+            public $writeCalls = 0;
+            public function write(): void
+            {
+                $this->writeCalls++;
+            }
+        };
+        $module->context->cookie = $spyCookie;
+
+        // storeTwoFeeQuoteInSession() is private; invoke via reflection rather
+        // than widening its visibility just for the test.
+        $method = new ReflectionMethod(Twopayment::class, 'storeTwoFeeQuoteInSession');
+        $method->invoke($module, '7|100.00|GB|GBP', [
+            'buyer_fee_share' => '1.23',
+            'total_fee_tax_rate' => '0.20',
+            'currency' => 'GBP',
+        ]);
+
+        TinyAssert::same(1, $spyCookie->writeCalls);
+        TinyAssert::same('7|100.00|GB|GBP', (string) $spyCookie->two_fee_quote_key);
     }
 
     private static function testSyncTwoAdminOrderPaymentDataFromProviderPullsLatestTermsFromTwo(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -6522,6 +6522,17 @@ class Twopayment extends PaymentModule
             $this->context->cookie->two_fee_quote_key = $cacheKey;
             $this->context->cookie->two_fee_quote_data = json_encode($quote);
             $this->context->cookie->two_fee_quote_ts = (string) time();
+
+            // AJAX controllers (e.g. order-intent polling in orderintent.php's
+            // ajaxProcessCheckOrderIntent()) end the request via ajaxDie()/exit
+            // rather than returning normally, which is not guaranteed to run
+            // PrestaShop's Cookie::__destruct() in every PHP/webserver
+            // configuration. Force an immediate write so the quote is durably
+            // cached rather than relying on destructor timing (precedent:
+            // getTwoValidatedSessionCompanyData() above does the same).
+            if (method_exists($this->context->cookie, 'write')) {
+                $this->context->cookie->write();
+            }
         } catch (Exception $e) {
             PrestaShopLogger::addLog('TwoPayment: Failed to cache fee quote in session - ' . $e->getMessage(), 2);
         }

--- a/twopayment.php
+++ b/twopayment.php
@@ -78,6 +78,15 @@ class Twopayment extends PaymentModule
     const COOKIE_EXPIRY_ONE_HOUR = 3600; // 1 hour
     const ATTEMPT_RETENTION_DAYS = 90; // Keep attempt telemetry for 90 days
     const ATTEMPT_CLEANUP_INTERVAL_SECONDS = 86400; // Run cleanup at most once per day
+    // Cross-request cache for the buyer fee-share quote (POST /v1/pricing/order/fee).
+    // fetchTwoTermFee() already request-scopes the quote via $this->twoFeeCache, but
+    // that array is rebuilt from scratch on every HTTP request (e.g. each order-intent
+    // poll from the Payment step), so repeat polls with an unchanged cart/address/term
+    // were re-quoting the fee every time. Session-cache the quote for a short TTL,
+    // keyed on the same signature (days|gross|country|currency) already used for the
+    // request-scoped cache, so it is invalidated the instant any of those change.
+    // TWO-25040 / order-intent poll perf.
+    const FEE_QUOTE_CACHE_TTL_SECONDS = 60;
 
     protected $output = '';
     protected $errors = array();
@@ -6395,6 +6404,11 @@ class Twopayment extends PaymentModule
             return $this->twoFeeCache[$cacheKey];
         }
 
+        $sessionCached = $this->getTwoFeeQuoteFromSession($cacheKey);
+        if ($sessionCached !== null) {
+            return $this->twoFeeCache[$cacheKey] = $sessionCached;
+        }
+
         $share = $this->buildTwoBuyerFeeShare($days);
         if ($share === null || $gross_amount <= 0) {
             return $this->twoFeeCache[$cacheKey] = null;
@@ -6433,11 +6447,84 @@ class Twopayment extends PaymentModule
             return $this->twoFeeCache[$cacheKey] = null;
         }
 
-        return $this->twoFeeCache[$cacheKey] = array(
+        $quote = array(
             'buyer_fee_share' => (string) $response['buyer_fee_share'],
             'total_fee_tax_rate' => isset($response['total_fee_tax_rate']) ? (string) $response['total_fee_tax_rate'] : null,
             'currency' => $respCurrency,
         );
+        $this->storeTwoFeeQuoteInSession($cacheKey, $quote);
+
+        return $this->twoFeeCache[$cacheKey] = $quote;
+    }
+
+    /**
+     * Read a cross-request-cached fee quote from the session cookie, honouring
+     * FEE_QUOTE_CACHE_TTL_SECONDS and requiring an exact signature match
+     * (days|gross|country|currency) — any change in cart total, term, buyer
+     * country or currency invalidates the cache immediately regardless of TTL.
+     * Fail-soft: any malformed/missing cache data is treated as a miss.
+     *
+     * @param string $cacheKey
+     * @return array|null
+     */
+    private function getTwoFeeQuoteFromSession($cacheKey)
+    {
+        if (!isset($this->context->cookie)) {
+            return null;
+        }
+        $cachedKey = isset($this->context->cookie->two_fee_quote_key) ? (string) $this->context->cookie->two_fee_quote_key : '';
+        if ($cachedKey === '' || $cachedKey !== $cacheKey) {
+            return null;
+        }
+        $cachedTs = isset($this->context->cookie->two_fee_quote_ts) ? (int) $this->context->cookie->two_fee_quote_ts : 0;
+        if ($cachedTs <= 0 || (time() - $cachedTs) > self::FEE_QUOTE_CACHE_TTL_SECONDS) {
+            return null;
+        }
+        $cachedData = isset($this->context->cookie->two_fee_quote_data) ? (string) $this->context->cookie->two_fee_quote_data : '';
+        if ($cachedData === '') {
+            return null;
+        }
+        $decoded = json_decode($cachedData, true);
+        if (!is_array($decoded) || !isset($decoded['buyer_fee_share'])) {
+            return null;
+        }
+
+        return array(
+            'buyer_fee_share' => (string) $decoded['buyer_fee_share'],
+            'total_fee_tax_rate' => isset($decoded['total_fee_tax_rate']) ? $decoded['total_fee_tax_rate'] : null,
+            'currency' => isset($decoded['currency']) ? (string) $decoded['currency'] : '',
+        );
+    }
+
+    /**
+     * Persist a freshly-fetched fee quote to the session cookie for reuse by
+     * subsequent requests within FEE_QUOTE_CACHE_TTL_SECONDS (e.g. repeat
+     * order-intent polls on the Payment step). Best-effort: failures to write
+     * the cookie never block the quote itself being returned to the caller.
+     *
+     * @param string $cacheKey
+     * @param array  $quote
+     * @return void
+     */
+    private function storeTwoFeeQuoteInSession($cacheKey, array $quote)
+    {
+        if (!isset($this->context->cookie)) {
+            return;
+        }
+        try {
+            // Deliberately do NOT call $this->context->cookie->setExpire() here:
+            // PrestaShop's cookie has a single expiry for the whole cookie (not
+            // per-key), and other code paths rely on it being COOKIE_EXPIRY_ONE_HOUR
+            // (company verification cache, rate limiting, order-intent-approved
+            // flag). Shortening it to this cache's TTL would silently truncate
+            // those. Staleness here is bounded instead by the two_fee_quote_ts
+            // field checked in getTwoFeeQuoteFromSession().
+            $this->context->cookie->two_fee_quote_key = $cacheKey;
+            $this->context->cookie->two_fee_quote_data = json_encode($quote);
+            $this->context->cookie->two_fee_quote_ts = (string) time();
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Failed to cache fee quote in session - ' . $e->getMessage(), 2);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Investigated Doug's report of slow order-intent checks on the Payment step.
- `TwoOrderIntent.startMonitoring()` (the suspected 5s poll loop) is confirmed dead code — grepped, never called anywhere. Not touched.
- The actual `_selectionCheckInterval` scheduler in `TwoCheckoutManager.js` already gates correctly (stops re-firing once `lastResult` is set); company-verify session cache already correct. Neither needed a fix.
- Real gap found: `fetchTwoTermFee()`'s fee-quote cache was request-scoped only, so every repeat poll re-quoted `POST /v1/pricing/order/fee` live. Added a session-cookie-backed cache, 60s TTL, keyed on the existing days|gross|country|currency signature so any real change invalidates instantly.
- Deliberately did not touch cookie expiry (PrestaShop's Cookie has one expiry for the whole cookie — shortening it would've truncated the 1hr company-verify/rate-limit/order-intent-approved caches).

## Test plan
- [x] `php -l twopayment.php` clean
- [x] `php tests/run.php` — all existing specs pass
- [ ] No new automated test for the session-cache path itself (nit — logic is simple and fail-soft, flagged for reviewer awareness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)