### PR TITLE
Fix: Available Payment Terms checkbox no longer shows buyer surcharge

### DIFF
--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -312,8 +312,8 @@ final class SurchargeSpec
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2.5');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '5');
 
-        $module = new class () extends TwopaymentTestHarness {
-            public function buildPaymentTermCheckboxQueryPublic()
+        $module = new class extends TwopaymentTestHarness {
+            public function buildPaymentTermCheckboxQueryPublic(): array
             {
                 return $this->buildPaymentTermCheckboxQuery();
             }

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -32,6 +32,7 @@ final class SurchargeSpec
         self::testRoundingStepOptionsAreBrandDrivenSortedAndFormatted();
         self::testSurchargeLineLabelTemplateBrandAndDefault();
         self::testSurchargeChipPreviewAllZeroHiddenElseShownOnEveryTerm();
+        self::testPaymentTermCheckboxLabelsNeverCarrySurchargePreview();
         self::testFetchTermFeeFailsSoftOnHttpError();
         self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
         self::testFetchTermFeeParsesSuccess();
@@ -291,6 +292,49 @@ final class SurchargeSpec
         $previewFixed = $moduleFixed->getTwoSurchargeChipPreview();
         TinyAssert::same('No fee', $previewFixed[30]);
         TinyAssert::same('+10.00', $previewFixed[60]);
+    }
+
+    /**
+     * Regression: the admin "Available Payment Terms" checkbox
+     * labels (buildPaymentTermCheckboxQuery) must never carry the buyer
+     * surcharge preview, even when a non-zero surcharge is configured. That
+     * screen is where the merchant picks which terms to OFFER, not a place
+     * to preview what the BUYER will be charged - conflating the two showed
+     * the wrong fee concept next to each term. getTwoSurchargeChipPreview()
+     * itself (and its checkout-chip consumer) is untouched by this fix.
+     */
+    private static function testPaymentTermCheckboxLabelsNeverCarrySurchargePreview(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2.5');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '5');
+
+        $module = new class () extends TwopaymentTestHarness {
+            public function buildPaymentTermCheckboxQueryPublic()
+            {
+                return $this->buildPaymentTermCheckboxQuery();
+            }
+        };
+
+        // Sanity check: the surcharge preview itself IS non-empty for these
+        // terms, so an empty checkbox result below is a real assertion, not
+        // an artefact of an unconfigured surcharge.
+        $preview = $module->getTwoSurchargeChipPreview();
+        TinyAssert::same('+2.5%', $preview[30]);
+        TinyAssert::same('+5%', $preview[60]);
+
+        $rows = $module->buildPaymentTermCheckboxQueryPublic();
+        TinyAssert::true(count($rows) > 0, 'expected at least one offered term');
+        foreach ($rows as $row) {
+            TinyAssert::false(
+                strpos($row['name'], '(') !== false,
+                'checkbox label must not carry a surcharge preview: ' . $row['name']
+            );
+            TinyAssert::same(sprintf('%d days', (int) $row['id']), $row['name']);
+        }
     }
 
     private static function testFetchTermFeeFailsSoftOnHttpError(): void

--- a/twopayment.php
+++ b/twopayment.php
@@ -670,29 +670,36 @@ class Twopayment extends PaymentModule
      * STANDARD-only. Refreshes the cache (admin config render is a sanctioned
      * refresh point).
      *
+     * Deliberately does NOT append a fee preview to the label. A prior change
+     * appended getTwoSurchargeChipPreview() here, but that helper previews the
+     * BUYER surcharge (computed from the merchant's own PS_TWO_SURCHARGE_*
+     * config) - the wrong concept for this screen. This admin form is where
+     * the merchant decides which terms to OFFER, so the figure that belongs
+     * here is the FEE TWO CHARGES THE MERCHANT for offering that term.
+     * Magento's admin equivalent sources percentage_fee/fixed_fee per term
+     * from a dedicated POST /pricing/v1/merchant/rates call (see
+     * Controller/Adminhtml/Config/Fees.php + payment-terms-config.js in
+     * magento-plugin) - entirely separate from its checkout-side
+     * buyer_fee_share. This plugin does not fetch that merchant-rates data
+     * anywhere yet, so rather than fabricate a number the label is left
+     * plain; wiring the real merchant-fee API call is follow-up work, not
+     * faked here.
+     *
      * @return array<int, array{id:string,name:string,val:string,class:string}>
      */
     protected function buildPaymentTermCheckboxQuery()
     {
         $source = $this->getOfferableTermSource(true);
         sort($source);
-        // Configured per-term fee preview (days => "+2.5%" / "+2.5% +$5.00"),
-        // only for terms with a non-zero surcharge. Appended to the checkbox
-        // label so the merchant sees the fee next to each offered term.
-        $fee_preview = $this->getTwoSurchargeChipPreview();
         $query = array();
         foreach ($source as $term) {
             $term = (int) $term;
             $type_class = in_array($term, self::EOM_PAYMENT_TERMS_OPTIONS, true)
                 ? 'two-term-both'
                 : 'two-term-standard';
-            $label = sprintf($this->l('%d days'), $term);
-            if (isset($fee_preview[$term]) && $fee_preview[$term] !== '') {
-                $label .= ' (' . $fee_preview[$term] . ')';
-            }
             $query[] = array(
                 'id' => (string) $term,
-                'name' => $label,
+                'name' => sprintf($this->l('%d days'), $term),
                 'val' => '1',
                 'class' => 'two-term-option two-term-' . $term . ' ' . $type_class,
             );


### PR DESCRIPTION
## Summary
- Root cause: the only "Available Payment Terms" fee-annotated list in this plugin is the admin config checkbox screen (`buildPaymentTermCheckboxQuery()`). A prior change appended `getTwoSurchargeChipPreview()` (buyer surcharge) to each label — wrong concept for a screen where the merchant decides which terms to *offer*.
- Magento's admin equivalent sources merchant fee from a dedicated `POST /pricing/v1/merchant/rates` call (`Fees.php` + `payment-terms-config.js`), entirely separate from its checkout-side buyer fee share. This plugin has no code path calling any merchant-rates equivalent at all — full parity requires new API work, out of scope for a safe fix here.
- Fix applied: reverted checkbox labels to plain "N days" (pre-regression behavior). `getTwoSurchargeChipPreview()` and its only other consumer (the checkout chip preview) are untouched — that usage is the correct buyer-surcharge display.

## Follow-up (not in this PR)
Full parity needs a new merchant-rates API call wired into the admin checkbox labels, mirroring Magento's `Fees.php`/`payment-terms-config.js`.

## Test plan
- [x] `php -l twopayment.php` clean
- [x] New regression test `testPaymentTermCheckboxLabelsNeverCarrySurchargePreview` — configures a real non-zero surcharge, confirms the surcharge preview itself is non-empty (not a vacuous pass), asserts checkbox labels stay plain
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)