### PR TITLE
Fix: company search race condition causes stale/missing first-search results

### DIFF
--- a/twopayment.php
+++ b/twopayment.php
@@ -2571,6 +2571,7 @@ class Twopayment extends PaymentModule
             'days' => $this->l('days'),
             'from_end_of_month' => $this->l('from end of month'),
             'end_of_month_plus_days' => $this->l('End of Month + %s days'),
+            'company_search_searching' => $this->l('Searching...'),
         );
 
         // Checkout media render is a sanctioned refresh point for the backend

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -15,7 +15,11 @@ class TwoCompanySearch {
         this.organizationField = null;
         this.isInitialized = false;
         this.countryListener = null;
-        
+
+        // Race-condition guards for company search (see searchCompanies())
+        this._companySearchSeq = 0;
+        this._companySearchXhr = null;
+
         this.init();
     }
     
@@ -262,6 +266,23 @@ class TwoCompanySearch {
             list.style.display = 'block';
         };
 
+        // Minimal loading indicator so a slow-but-alive request is visually
+        // distinguishable from a dead one (goal: no spinner component, just
+        // a text row matching the existing list rendering).
+        const searchingText = (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_searching)
+            || 'Searching...';
+        const renderLoading = () => {
+            list.innerHTML = '';
+            const row = document.createElement('div');
+            row.className = 'two-autocomplete-item two-autocomplete-loading';
+            row.style.padding = '6px 10px';
+            row.style.color = '#888';
+            row.style.fontStyle = 'italic';
+            row.textContent = searchingText;
+            list.appendChild(row);
+            list.style.display = 'block';
+        };
+
         // Debounced input
         let debounceId = null;
         inputEl.addEventListener('input', () => {
@@ -278,7 +299,14 @@ class TwoCompanySearch {
                     renderResults(cached.v);
                     return;
                 }
+                renderLoading();
                 this.searchCompanies(term, (results) => {
+                    // Discard results if the input has moved on to a different
+                    // term since this request was fired (belt-and-braces on
+                    // top of the sequence/abort guard in searchCompanies()).
+                    if ((inputEl.value || '') !== term) {
+                        return;
+                    }
                     cache.set(key, { v: results, t: now() });
                     renderResults(results);
                 });
@@ -294,24 +322,65 @@ class TwoCompanySearch {
     }
     
     /**
-     * Search for companies via Two API
+     * Abort any in-flight company search request. Used both when a new
+     * search fires (to stop a stale request racing a fresh one) and on
+     * teardown.
+     */
+    _abortPendingCompanySearch() {
+        if (this._companySearchXhr && typeof this._companySearchXhr.abort === 'function') {
+            try {
+                this._companySearchXhr.abort();
+            } catch (e) {
+                // no-op
+            }
+        }
+        this._companySearchXhr = null;
+    }
+
+    /**
+     * Search for companies via Two API.
+     *
+     * Race-condition fix: successive keystrokes across the debounce boundary
+     * (jQuery UI's `delay`, or the custom fallback's setTimeout) can have
+     * multiple requests in flight at once. Without cancellation, responses
+     * can arrive out of order and whichever resolves LAST wins - even if
+     * it's for a stale/shorter search term typed earlier. select2 (used by
+     * the Magento/Woo plugins) avoids this natively by aborting the previous
+     * in-flight request whenever a new query fires; we replicate that
+     * behavior here without introducing a new dependency:
+     *   1. Bump a monotonically increasing sequence number BEFORE aborting
+     *      the previous request, so if abort() synchronously invokes the
+     *      old request's error handler, it already sees a stale sequence
+     *      number and discards itself silently (no flicker to empty state).
+     *   2. Abort the previous jqXHR so the network request itself is
+     *      cancelled, not just ignored.
+     *   3. Guard both success and error handlers with the sequence check so
+     *      even a response that arrives after abort (or a response that
+     *      raced in before the abort took effect) is discarded unless it
+     *      matches the CURRENT request.
      */
     searchCompanies(term, responseCallback) {
         if (term.length < 3) {
+            // Empty/short term cancels any pending search rather than racing it.
+            this._companySearchSeq += 1;
+            this._abortPendingCompanySearch();
             responseCallback([]);
             return;
         }
-        
+
         // Get country ISO from the selected option if available; otherwise omit
         const country = this.getCurrentCountry();
-        
+
         // Build URL with correct API parameters
         const params = new URLSearchParams({ q: term });
         if (country) params.set('country', country);
         // Direct Two API call from frontend as required
         const searchUrl = `${this.config.checkoutHost}/companies/v2/company?${params}`;
-        
-        $.ajax({
+
+        const seq = (this._companySearchSeq += 1);
+        this._abortPendingCompanySearch();
+
+        this._companySearchXhr = $.ajax({
             url: searchUrl,
             method: 'GET',
             crossDomain: true,
@@ -320,6 +389,12 @@ class TwoCompanySearch {
             beforeSend: this.buildPublicApiBeforeSend(),
             timeout: 10000,
             success: (data) => {
+                if (seq !== this._companySearchSeq) {
+                    // Stale response for a superseded request; discard.
+                    return;
+                }
+                this._companySearchXhr = null;
+
                 const companies = data.items || [];
                 const formattedResults = companies.map(company => {
                     // Prefer various keys for broader country support (GB, etc.)
@@ -340,11 +415,16 @@ class TwoCompanySearch {
                         organization_number: orgNumber
                     };
                 });
-                
+
                 responseCallback(formattedResults);
             },
             error: (xhr, status, error) => {
-                
+                if (seq !== this._companySearchSeq) {
+                    // Aborted (superseded) or otherwise stale; nothing to report.
+                    return;
+                }
+                this._companySearchXhr = null;
+
                 responseCallback([]);
             }
         });
@@ -728,6 +808,10 @@ class TwoCompanySearch {
 
     destroy() {
         try {
+            // Cancel any in-flight company search so it can't resolve after teardown.
+            this._companySearchSeq += 1;
+            this._abortPendingCompanySearch();
+
             // Remove country change listener
             const countryField = document.querySelector("select[name='id_country']");
             if (countryField && this.countryListener) {


### PR DESCRIPTION
## Summary
Root cause: `TwoCompanySearch.js` had no request cancellation on successive keystrokes across the debounce boundary — out-of-order XHR responses could let a stale (earlier, shorter-term) response overwrite a fresher one, or silently arrive after the user moved on. Explains Doug's report ("first search never returns, retype and it works") — the first search's response was likely being raced/discarded by a second in-flight request from typing continuing.

Fix mirrors what select2 (used by Woo/Magento) does natively:
- Monotonic `_companySearchSeq` bumped BEFORE aborting the previous in-flight request (so a synchronous abort-triggered error handler already sees itself as stale).
- Previous jqXHR aborted via `_companySearchXhr`, not just ignored.
- Both success and error handlers discard unless their sequence number matches current.
- Belt-and-braces: debounce closure also discards if the input value has moved on from the fired term.
- Added minimal "Searching…" loading row so a slow-but-alive request is visually distinct from a dead one.
- `destroy()` also bumps+aborts on teardown.

## Test plan
- [x] `node --check` clean
- [x] `php -l twopayment.php` clean (one new i18n key)
- [ ] **No automated JS test harness exists in this repo at all** (tests/run.php is PHP-only) — this fix has zero automated coverage. **Manual browser QA is still owed**: throttled network, type a company name across multiple keystrokes, confirm the first search that lands is never overwritten by a stale one and no result flicker/loss occurs. Flagging explicitly rather than merging on code-review confidence alone for a live checkout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)