### PR TITLE
fix: read deployed commit hash from flat sidecar file

### DIFF
--- a/tests/DeployVersionInfoSpec.php
+++ b/tests/DeployVersionInfoSpec.php
@@ -18,15 +18,17 @@ final class DeployVersionInfoSpec
         self::testDetachedHeadReturnsShortSha();
         self::testGarbageHeadReturnsNull();
         self::testMissingRefAndPackedRefsReturnsNull();
+        self::testSidecarFileTakesPrecedenceOverGitDir();
+        self::testInvalidSidecarFallsBackToGitDir();
         self::testDeployedAtLabelMatchesModuleFileMtime();
     }
 
-    private static function callCommitHash(?string $gitDir): ?string
+    private static function callCommitHash(?string $gitDir, ?string $sidecarFile = null): ?string
     {
         $module = new TwopaymentTestHarness();
         $method = new ReflectionMethod(Twopayment::class, 'getTwoDeployedCommitHash');
 
-        return $method->invoke($module, $gitDir);
+        return $method->invoke($module, $gitDir, $sidecarFile);
     }
 
     private static function makeTempGitDir(): string
@@ -123,6 +125,36 @@ final class DeployVersionInfoSpec
         file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
 
         TinyAssert::same(null, self::callCommitHash($git));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testSidecarFileTakesPrecedenceOverGitDir(): void
+    {
+        // Deploy-time sidecar file (written by the git-sync materialise loop) must win
+        // over a co-located .git directory when both exist.
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+        mkdir($git . '/refs/heads', 0777, true);
+        file_put_contents($git . '/refs/heads/staging', "abcdef0123456789abcdef0123456789abcdef01\n");
+        $sidecar = dirname($git) . '/.two-deployed-commit';
+        file_put_contents($sidecar, "1234abc\n");
+
+        TinyAssert::same('1234abc', self::callCommitHash($git, $sidecar));
+        self::removeDir(dirname($git));
+    }
+
+    private static function testInvalidSidecarFallsBackToGitDir(): void
+    {
+        // A sidecar file with non-sha contents (or empty) must not short-circuit the
+        // .git-directory fallback.
+        $git = self::makeTempGitDir();
+        file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
+        mkdir($git . '/refs/heads', 0777, true);
+        file_put_contents($git . '/refs/heads/staging', "abcdef0123456789abcdef0123456789abcdef01\n");
+        $sidecar = dirname($git) . '/.two-deployed-commit';
+        file_put_contents($sidecar, "not a sha\n");
+
+        TinyAssert::same('abcdef0', self::callCommitHash($git, $sidecar));
         self::removeDir(dirname($git));
     }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -1340,16 +1340,29 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Best-effort short commit hash from a co-located .git directory, if one exists
-     * on disk (this plugin's git-sync deploy mechanism may or may not leave one).
+     * Best-effort short commit hash of the deployed module code.
+     * Checks a flat sidecar file first (written at deploy time by the git-sync
+     * materialise loop, where .git is a worktree gitlink file this method can't
+     * read), then falls back to a co-located .git directory (local dev).
      * Plain file reads only — no exec. Returns null (never throws/fatals) if unavailable.
      *
      * @param string|null $git_dir Overridable for tests; defaults to this module's .git
+     * @param string|null $sidecar_file Overridable for tests; defaults to this module's sidecar file
      *
      * @return string|null
      */
-    private function getTwoDeployedCommitHash($git_dir = null)
+    private function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
     {
+        if ($sidecar_file === null) {
+            $sidecar_file = __DIR__ . '/.two-deployed-commit';
+        }
+        if (is_file($sidecar_file) && is_readable($sidecar_file)) {
+            $sidecar_contents = trim((string) @file_get_contents($sidecar_file));
+            if ($sidecar_contents !== '' && preg_match('/^[0-9a-f]{7,40}$/i', $sidecar_contents)) {
+                return substr($sidecar_contents, 0, 7);
+            }
+        }
+
         if ($git_dir === null) {
             $git_dir = __DIR__ . '/.git';
         }


### PR DESCRIPTION
## Problem

The admin **Plugin Information** panel never shows a commit hash on staging. Root cause: the staging deploy uses a git-sync **worktree** layout, where the synced module's `.git` is a gitlink **file** (`gitdir: ../../.git/worktrees/<sha>`), not a directory. `getTwoDeployedCommitHash()` starts with `is_dir($git_dir)`, so it returns `null` immediately and the panel shows nothing.

## Fix

`getTwoDeployedCommitHash()` now checks a flat sidecar file `.two-deployed-commit` in the module root first, returning its trimmed (sha-validated) contents when present. The existing `.git`-directory logic (loose ref / packed-refs / detached HEAD) is preserved unchanged as the fallback, so:

- **staging** (git-sync worktree, sidecar written at deploy time) → fast path via sidecar
- **local dev** (real `.git` directory, no sidecar) → unchanged fallback path

The sidecar file is written by the deploy-time materialise loop in the chart — companion PR: two-inc/platform-tools (linked below). This is a companion fix to the already-merged #52.

## Tests

- New: sidecar file takes precedence over a co-located `.git` directory when both exist
- New: invalid/non-sha sidecar contents fall back to the `.git` lookup
- Full suite green: `php tests/run.php` → `All tests passed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn