### PR TITLE
feat: inline merchant fee display on admin payment-term checkboxes

### DIFF
--- a/tests/MerchantFeeRatesSpec.php
+++ b/tests/MerchantFeeRatesSpec.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * fetchTwoMerchantFeeRates() - the merchant-fee lookup behind the inline fee
+ * display on the admin "Available Payment Terms" checkboxes (Magento parity:
+ * Controller/Adminhtml/Config/Fees.php). Contract under test:
+ *
+ *  - POST /pricing/v1/merchant/rates with {buyer_country_code,
+ *    recourse_pricing: false, net_terms: int[]} on a tight render-path
+ *    timeout.
+ *  - Response normalised to {success, currency, fees: {"<days>":
+ *    {percentage, fixed}}}.
+ *  - Fail-soft: missing API key, empty term list, non-200, or malformed body
+ *    ALL return {success: false} - never throws, so the admin page never
+ *    breaks on an API outage.
+ */
+final class MerchantFeeRatesSpec
+{
+    public static function runAll(): void
+    {
+        self::testSuccessNormalisesRatesAndSendsExpectedRequest();
+        self::testBuyerCountryFallsBackToNlWhenNoDefaultCountry();
+        self::testMissingApiKeyFailsWithoutWireCall();
+        self::testEmptyOrInvalidTermsFailWithoutWireCall();
+        self::testNon200Fails();
+        self::testMalformedBodyFails();
+        self::testMalformedRateRowsAreSkipped();
+        self::testAbsentCurrencyNormalisesToEmptyString();
+    }
+
+    /**
+     * Harness with a stubbed, capturing setTwoPaymentRequest.
+     *
+     * @param mixed $response
+     */
+    private static function moduleWithRatesResponse($response): object
+    {
+        return new class ($response) extends TwopaymentTestHarness {
+            public int $fetchCount = 0;
+            public $lastEndpoint = null;
+            public $lastPayload = null;
+            public $lastMethod = null;
+            public $lastTimeout = null;
+            private $response;
+
+            public function __construct($response)
+            {
+                parent::__construct();
+                $this->response = $response;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->fetchCount++;
+                $this->lastEndpoint = $endpoint;
+                $this->lastPayload = $payload;
+                $this->lastMethod = $method;
+                $this->lastTimeout = $timeout;
+                return $this->response;
+            }
+        };
+    }
+
+    private static function configureMerchantIdentity(): void
+    {
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'm-123');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'test-api-key');
+    }
+
+    private static function okResponse(): array
+    {
+        return [
+            'http_status' => 200,
+            'currency' => 'NOK',
+            'rates' => [
+                // The API sends numeric values as strings.
+                ['net_terms' => '15', 'percentage_fee' => '1.50', 'fixed_fee' => '0.00'],
+                ['net_terms' => 30, 'percentage_fee' => '2.51', 'fixed_fee' => '0.10'],
+            ],
+        ];
+    }
+
+    private static function testSuccessNormalisesRatesAndSendsExpectedRequest(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        // StubStore country map: 47 => 'NO'.
+        Configuration::updateValue('PS_COUNTRY_DEFAULT', 47);
+
+        $module = self::moduleWithRatesResponse(self::okResponse());
+        // Unsorted, duplicated, mixed-type input must normalise to [15, 30].
+        $result = $module->fetchTwoMerchantFeeRates([30, '15', 30]);
+
+        TinyAssert::same('/pricing/v1/merchant/rates', $module->lastEndpoint);
+        TinyAssert::same('POST', $module->lastMethod);
+        TinyAssert::same(Twopayment::API_TIMEOUT_STATE_CHECK, $module->lastTimeout, 'render-path call must use the tight timeout');
+        TinyAssert::same('NO', $module->lastPayload['buyer_country_code']);
+        TinyAssert::false($module->lastPayload['recourse_pricing']);
+        TinyAssert::same([15, 30], $module->lastPayload['net_terms']);
+
+        TinyAssert::true($result['success']);
+        TinyAssert::same('NOK', $result['currency']);
+        TinyAssert::same(['percentage' => 1.5, 'fixed' => 0.0], $result['fees']['15']);
+        TinyAssert::same(['percentage' => 2.51, 'fixed' => 0.1], $result['fees']['30']);
+    }
+
+    private static function testBuyerCountryFallsBackToNlWhenNoDefaultCountry(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        // No PS_COUNTRY_DEFAULT configured at all.
+
+        $module = self::moduleWithRatesResponse(self::okResponse());
+        $result = $module->fetchTwoMerchantFeeRates([30]);
+
+        TinyAssert::same('NL', $module->lastPayload['buyer_country_code']);
+        TinyAssert::true($result['success']);
+
+        // Configured but unresolvable country id also falls back.
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        Configuration::updateValue('PS_COUNTRY_DEFAULT', 999);
+        $module = self::moduleWithRatesResponse(self::okResponse());
+        $module->fetchTwoMerchantFeeRates([30]);
+        TinyAssert::same('NL', $module->lastPayload['buyer_country_code']);
+    }
+
+    private static function testMissingApiKeyFailsWithoutWireCall(): void
+    {
+        StubStore::reset();
+        // No PS_TWO_MERCHANT_API_KEY configured.
+
+        $module = self::moduleWithRatesResponse(self::okResponse());
+        $result = $module->fetchTwoMerchantFeeRates([30]);
+
+        TinyAssert::false($result['success']);
+        TinyAssert::same(0, $module->fetchCount, 'must not hit the wire without an API key');
+    }
+
+    private static function testEmptyOrInvalidTermsFailWithoutWireCall(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+
+        $module = self::moduleWithRatesResponse(self::okResponse());
+
+        TinyAssert::false($module->fetchTwoMerchantFeeRates([])['success']);
+        // Non-numeric / non-positive entries normalise away to an empty set.
+        TinyAssert::false($module->fetchTwoMerchantFeeRates(['abc', -5, 0, null, [7]])['success']);
+        TinyAssert::same(0, $module->fetchCount, 'must not hit the wire with no valid terms');
+    }
+
+    private static function testNon200Fails(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+
+        foreach ([0, 401, 500] as $status) {
+            $module = self::moduleWithRatesResponse(['http_status' => $status, 'rates' => []]);
+            TinyAssert::false($module->fetchTwoMerchantFeeRates([30])['success'], 'HTTP ' . $status . ' must fail soft');
+            TinyAssert::same(1, $module->fetchCount);
+        }
+    }
+
+    private static function testMalformedBodyFails(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+
+        $malformed = [
+            ['http_status' => 200], // no rates key
+            ['http_status' => 200, 'rates' => 'oops'], // rates not an array
+            'not-an-array-at-all',
+            null,
+        ];
+        foreach ($malformed as $response) {
+            $module = self::moduleWithRatesResponse($response);
+            TinyAssert::false($module->fetchTwoMerchantFeeRates([30])['success'], 'malformed body must fail soft');
+        }
+    }
+
+    private static function testMalformedRateRowsAreSkipped(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+
+        $module = self::moduleWithRatesResponse([
+            'http_status' => 200,
+            'currency' => 'EUR',
+            'rates' => [
+                'not-a-row',
+                ['percentage_fee' => '9.99'], // no net_terms
+                ['net_terms' => 'soon'], // non-numeric net_terms
+                ['net_terms' => -30, 'percentage_fee' => '9.99'], // non-positive
+                ['net_terms' => 30], // valid but fee fields absent -> zeros
+                ['net_terms' => 60, 'percentage_fee' => 'oops', 'fixed_fee' => '1.25'], // non-numeric fee -> zero
+            ],
+        ]);
+        $result = $module->fetchTwoMerchantFeeRates([30, 60]);
+
+        TinyAssert::true($result['success']);
+        TinyAssert::count(2, $result['fees']);
+        TinyAssert::same(['percentage' => 0.0, 'fixed' => 0.0], $result['fees']['30']);
+        TinyAssert::same(['percentage' => 0.0, 'fixed' => 1.25], $result['fees']['60']);
+    }
+
+    private static function testAbsentCurrencyNormalisesToEmptyString(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+
+        $module = self::moduleWithRatesResponse([
+            'http_status' => 200,
+            'rates' => [['net_terms' => 30, 'percentage_fee' => '1.00', 'fixed_fee' => '0.00']],
+        ]);
+        $result = $module->fetchTwoMerchantFeeRates([30]);
+
+        TinyAssert::true($result['success']);
+        TinyAssert::same('', $result['currency'], 'absent currency must normalise to empty string, not be invented');
+    }
+}

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -333,7 +333,15 @@ final class SurchargeSpec
                 strpos($row['name'], '(') !== false,
                 'checkbox label must not carry a surcharge preview: ' . $row['name']
             );
-            TinyAssert::same(sprintf('%d days', (int) $row['id']), $row['name']);
+            // The label is the plain "%d days" text plus an EMPTY merchant-fee
+            // placeholder span - populated client-side from the merchant-rates
+            // AJAX endpoint (fetchTwoMerchantFeeRates), never pre-injected
+            // server-side, and never sourced from the buyer surcharge config.
+            TinyAssert::same(
+                sprintf('%d days', (int) $row['id'])
+                    . ' <span class="two-term-fee text-muted" data-term="' . (int) $row['id'] . '"></span>',
+                $row['name']
+            );
         }
     }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -4844,6 +4844,7 @@ require __DIR__ . '/RefundSpec.php';
 require __DIR__ . '/SurchargeSpec.php';
 require __DIR__ . '/DefaultPaymentTermSpec.php';
 require __DIR__ . '/DeployVersionInfoSpec.php';
+require __DIR__ . '/MerchantFeeRatesSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -4854,6 +4855,7 @@ $tests = [
     'SurchargeSpec::runAll' => [SurchargeSpec::class, 'runAll'],
     'DefaultPaymentTermSpec::runAll' => [DefaultPaymentTermSpec::class, 'runAll'],
     'DeployVersionInfoSpec::runAll' => [DeployVersionInfoSpec::class, 'runAll'],
+    'MerchantFeeRatesSpec::runAll' => [MerchantFeeRatesSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -563,6 +563,14 @@ class Twopayment extends PaymentModule
                 'two_merchant_id' => Configuration::get('PS_TWO_MERCHANT_ID'),
                 'two_merchant_short_name' => Configuration::get('PS_TWO_MERCHANT_SHORT_NAME'),
                 'two_env' => Configuration::get('PS_TWO_ENVIRONMENT'),
+                // Module admin AJAX endpoint for the inline merchant-fee
+                // display beside each payment-term checkbox. Dispatched by
+                // AdminController::postProcess() to
+                // ajaxProcessFetchMerchantFeeRates() on this module.
+                'two_fee_rates_url' => $this->context->link->getAdminLink('AdminModules', false)
+                    . '&configure=' . $this->name
+                    . '&token=' . Tools::getAdminTokenLite('AdminModules')
+                    . '&ajax=1&action=FetchMerchantFeeRates',
             )
         );
 
@@ -679,20 +687,18 @@ class Twopayment extends PaymentModule
      * STANDARD-only. Refreshes the cache (admin config render is a sanctioned
      * refresh point).
      *
-     * Deliberately does NOT append a fee preview to the label. A prior change
-     * appended getTwoSurchargeChipPreview() here, but that helper previews the
-     * BUYER surcharge (computed from the merchant's own PS_TWO_SURCHARGE_*
-     * config) - the wrong concept for this screen. This admin form is where
-     * the merchant decides which terms to OFFER, so the figure that belongs
-     * here is the FEE TWO CHARGES THE MERCHANT for offering that term.
-     * Magento's admin equivalent sources percentage_fee/fixed_fee per term
-     * from a dedicated POST /pricing/v1/merchant/rates call (see
-     * Controller/Adminhtml/Config/Fees.php + payment-terms-config.js in
-     * magento-plugin) - entirely separate from its checkout-side
-     * buyer_fee_share. This plugin does not fetch that merchant-rates data
-     * anywhere yet, so rather than fabricate a number the label is left
-     * plain; wiring the real merchant-fee API call is follow-up work, not
-     * faked here.
+     * Each label carries an empty `.two-term-fee` placeholder span. The
+     * figure that belongs on this screen is the FEE TWO CHARGES THE MERCHANT
+     * for offering that term (NOT the buyer surcharge - a prior change
+     * wrongly appended getTwoSurchargeChipPreview() here and was reverted).
+     * The span is populated live by admin AJAX against
+     * POST /pricing/v1/merchant/rates (fetchTwoMerchantFeeRates /
+     * ajaxProcessFetchMerchantFeeRates), mirroring magento-plugin's
+     * Controller/Adminhtml/Config/Fees.php + payment-terms-config.js: fees
+     * are never pre-fetched synchronously on page render, and on API failure
+     * the span silently stays empty so the admin page never breaks. The raw
+     * HTML is safe here: the core HelperForm checkbox template emits the
+     * label name unescaped ({$value[$input.values.name]}).
      *
      * @return array<int, array{id:string,name:string,val:string,class:string}>
      */
@@ -708,7 +714,8 @@ class Twopayment extends PaymentModule
                 : 'two-term-standard';
             $query[] = array(
                 'id' => (string) $term,
-                'name' => sprintf($this->l('%d days'), $term),
+                'name' => sprintf($this->l('%d days'), $term)
+                    . ' <span class="two-term-fee text-muted" data-term="' . $term . '"></span>',
                 'val' => '1',
                 'class' => 'two-term-option two-term-' . $term . ' ' . $type_class,
             );
@@ -6275,6 +6282,124 @@ class Twopayment extends PaymentModule
         // (TWO-24859). Shared timestamp reset last, forcing a re-fetch.
         Configuration::updateValue(self::CONFIG_MERCHANT_DUE_IN_DAYS, 0);
         Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, 0);
+    }
+
+    /**
+     * Fetch the merchant fee (what Two charges the merchant, NOT the buyer
+     * surcharge) per net-term via POST /pricing/v1/merchant/rates, for the
+     * inline fee display beside each "Available Payment Terms" checkbox on
+     * the admin config page. Mirrors magento-plugin's
+     * Controller/Adminhtml/Config/Fees.php.
+     *
+     * Fail-soft contract (identical to Magento's): ANY failure - missing API
+     * key, empty term list, connection error, non-200, malformed body -
+     * returns array('success' => false) and the admin page renders without
+     * fees. This method must never throw and never block long (tight
+     * timeout): it sits behind an AJAX call on a config-page render path.
+     *
+     * The buyer_country_code is a best-effort stand-in (store default
+     * country): there is no cart/buyer context on a config page. Magento
+     * uses its store's default country the same way.
+     *
+     * @param array $days Requested term day-counts (raw, will be normalised).
+     * @return array{success:bool,currency?:string,fees?:array<string,array{percentage:float,fixed:float}>}
+     */
+    public function fetchTwoMerchantFeeRates($days)
+    {
+        $net_terms = $this->normaliseMerchantTerms($days);
+        if (empty($net_terms)) {
+            return array('success' => false);
+        }
+        $api_key = Configuration::get('PS_TWO_MERCHANT_API_KEY');
+        if (Tools::isEmpty($api_key)) {
+            return array('success' => false);
+        }
+
+        $response = $this->setTwoPaymentRequest(
+            '/pricing/v1/merchant/rates',
+            array(
+                'buyer_country_code' => $this->getTwoAdminBuyerCountryCode(),
+                // No admin recourse-pricing config exists (Magento parity:
+                // its Fees controller hardcodes false too).
+                'recourse_pricing' => false,
+                'net_terms' => $net_terms,
+            ),
+            'POST',
+            array(),
+            // Render-path call: cap tight rather than block the admin page.
+            self::API_TIMEOUT_STATE_CHECK
+        );
+
+        $http_status = (is_array($response) && isset($response['http_status'])) ? (int) $response['http_status'] : 0;
+        if ($http_status !== self::HTTP_STATUS_OK || !isset($response['rates']) || !is_array($response['rates'])) {
+            return array('success' => false);
+        }
+
+        $fees = array();
+        foreach ($response['rates'] as $rate) {
+            if (!is_array($rate) || !isset($rate['net_terms']) || !is_numeric($rate['net_terms'])) {
+                continue;
+            }
+            $fee_days = (int) $rate['net_terms'];
+            if ($fee_days <= 0) {
+                continue;
+            }
+            $fees[(string) $fee_days] = array(
+                // API sends numbers as strings - cast for JSON numeric output.
+                'percentage' => isset($rate['percentage_fee']) && is_numeric($rate['percentage_fee']) ? (float) $rate['percentage_fee'] : 0.0,
+                'fixed' => isset($rate['fixed_fee']) && is_numeric($rate['fixed_fee']) ? (float) $rate['fixed_fee'] : 0.0,
+            );
+        }
+
+        return array(
+            'success' => true,
+            // Currency MUST come from the response - the fee amounts do too.
+            // The JS appends it as a code suffix; an empty value makes the JS
+            // drop the fixed component rather than guess its currency.
+            'currency' => isset($response['currency']) ? (string) $response['currency'] : '',
+            'fees' => $fees,
+        );
+    }
+
+    /**
+     * Buyer country stand-in for admin-side rate previews: the shop's default
+     * country (PS_COUNTRY_DEFAULT resolved to ISO), since a config page has
+     * no cart/buyer context. Falls back to 'NL' - the same stand-in
+     * magento-plugin's Fees controller uses when no country is configured.
+     *
+     * @return string Two-letter uppercase ISO country code.
+     */
+    private function getTwoAdminBuyerCountryCode()
+    {
+        $id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        if ($id_country > 0) {
+            $iso = Country::getIsoById($id_country);
+            if (is_string($iso) && trim($iso) !== '') {
+                return strtoupper(trim($iso));
+            }
+        }
+        return 'NL';
+    }
+
+    /**
+     * Admin AJAX entry point for the inline term-fee display. PrestaShop's
+     * AdminController::postProcess() dispatches
+     * index.php?controller=AdminModules&configure=twopayment&ajax=1&action=FetchMerchantFeeRates
+     * to this module method (core dispatches ajax actions to the configured
+     * module on the AdminModules controller; present in 1.7.x and 8.x). The
+     * admin token is validated by the controller before postProcess runs.
+     *
+     * Reads a JSON-encoded `terms` array from the request and echoes the
+     * normalised fee payload. Always responds 200 with {"success":false} on
+     * failure - the JS blanks the fee spans silently (Magento parity).
+     */
+    public function ajaxProcessFetchMerchantFeeRates()
+    {
+        $raw = Tools::getValue('terms', '');
+        $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+        $result = $this->fetchTwoMerchantFeeRates(is_array($decoded) ? $decoded : array());
+        header('Content-Type: application/json');
+        die(json_encode($result));
     }
 
     /**

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -59,6 +59,11 @@
     </div>
     <div class="clearfix"></div>
 </div>
+<script type="text/javascript">
+    // Module admin AJAX endpoint for the inline merchant-fee display
+    // (assigned outside the literal block so Smarty expands the URL).
+    var twoMerchantFeeRatesUrl = '{$two_fee_rates_url|escape:'javascript':'UTF-8'}';
+</script>
 {literal}
     <script type="text/javascript">
         $(document).ready(function () {
@@ -133,6 +138,97 @@
             }
             updateSurchargeGridVisibility();
             $('select[name="PS_TWO_SURCHARGE_TYPE"]').on('change', updateSurchargeGridVisibility);
+
+            // Inline merchant fee beside each "Available Payment Terms"
+            // checkbox - the fee Two charges the merchant per term, fetched
+            // live from the module's admin AJAX endpoint (which proxies
+            // POST /pricing/v1/merchant/rates). Mirrors magento-plugin's
+            // payment-terms-config.js loadFees(): fetch on page load and on
+            // any term-checkbox change, dedupe identical term-set requests,
+            // and on failure blank the fee spans silently - the config page
+            // must never break on an API outage.
+            var lastFeesKey = null;
+
+            function formatTwoFeeAmount(n) {
+                return Number(n).toFixed(2);
+            }
+
+            function loadTwoMerchantFees() {
+                if (typeof twoMerchantFeeRatesUrl === 'undefined' || !twoMerchantFeeRatesUrl) {
+                    return;
+                }
+                // Fees render beside EVERY rendered term option regardless of
+                // checked state (Magento parity), so collect all term inputs.
+                var terms = [];
+                $('input[name^="PS_TWO_PAYMENT_TERMS_"]').each(function () {
+                    var match = String($(this).attr('name') || '').match(/_(\d+)$/);
+                    var days = match ? parseInt(match[1], 10) : 0;
+                    if (days > 0 && terms.indexOf(days) === -1) {
+                        terms.push(days);
+                    }
+                });
+                terms.sort(function (a, b) { return a - b; });
+                if (!terms.length) {
+                    return;
+                }
+                var key = terms.join(',');
+                if (key === lastFeesKey) {
+                    return; // identical term set already requested
+                }
+                lastFeesKey = key;
+                $.ajax({
+                    url: twoMerchantFeeRatesUrl,
+                    type: 'POST',
+                    dataType: 'json',
+                    data: { terms: JSON.stringify(terms) }
+                }).done(function (response) {
+                    if (!response || !response.success || !response.fees) {
+                        $('.two-term-fee').text('');
+                        return;
+                    }
+                    // Currency must come from the API response - the fee
+                    // amounts do too. Without it, any fixed amount would be
+                    // ambiguous, so only the percentage is shown then.
+                    var currency = String(response.currency || '').toUpperCase().replace(/^\s+|\s+$/g, '');
+                    var suffix = currency !== '' ? ' ' + currency : '';
+                    $('.two-term-fee').each(function () {
+                        var $span = $(this);
+                        var fee = response.fees[String($span.data('term'))];
+                        if (!fee) {
+                            $span.text('');
+                            return;
+                        }
+                        var pctStr = formatTwoFeeAmount(fee.percentage || 0);
+                        var fixedStr = formatTwoFeeAmount(fee.fixed || 0);
+                        var zero = formatTwoFeeAmount(0);
+                        var pctZero = pctStr === zero;
+                        var fixedZero = fixedStr === zero;
+                        if (currency === '') {
+                            $span.text(pctZero ? '' : '(' + pctStr + '%)');
+                            return;
+                        }
+                        var inner;
+                        if (pctZero && fixedZero) {
+                            inner = zero + suffix;
+                        } else if (pctZero) {
+                            inner = fixedStr + suffix;
+                        } else if (fixedZero) {
+                            inner = pctStr + '%';
+                        } else {
+                            inner = pctStr + '% + ' + fixedStr + suffix;
+                        }
+                        $span.text('(' + inner + ')');
+                    });
+                }).fail(function () {
+                    // Allow a retry on the same term set after a transient
+                    // error, and clear any half-populated spans.
+                    lastFeesKey = null;
+                    $('.two-term-fee').text('');
+                });
+            }
+
+            $('input[name^="PS_TWO_PAYMENT_TERMS_"]').on('change', loadTwoMerchantFees);
+            loadTwoMerchantFees();
         });
     </script>
 {/literal}


### PR DESCRIPTION
## What

Adds the merchant-fee display beside each **Available Payment Terms** checkbox on the module config page — the fee Two charges the merchant for offering that term — fetched live from `POST /pricing/v1/merchant/rates`. This brings the PrestaShop plugin to parity with the Magento plugin's admin fee display (`Controller/Adminhtml/Config/Fees.php` + `view/adminhtml/web/js/payment-terms-config.js` in [magento-plugin](https://github.com/two-inc/magento-plugin)).

Note this is a **different value** from the buyer surcharge that was briefly (and wrongly) shown here and reverted in #54 — that previewed what the *buyer* pays; this shows what the *merchant* pays.

## How

- **`fetchTwoMerchantFeeRates(array $days)`** (twopayment.php) — calls `POST /pricing/v1/merchant/rates` with `{buyer_country_code, recourse_pricing: false, net_terms}` through the existing `setTwoPaymentRequest()` client on the tight `API_TIMEOUT_STATE_CHECK` timeout, and normalises the response to `{success, currency, fees: {"<days>": {percentage, fixed}}}`. Fail-soft contract mirrors Magento exactly: missing API key, empty term list, connection error, non-200 or malformed body all return `{success: false}` — the admin page never breaks on an API outage.
- **`ajaxProcessFetchMerchantFeeRates()`** — new module admin AJAX entry point at `index.php?controller=AdminModules&configure=twopayment&ajax=1&action=FetchMerchantFeeRates`. This uses PrestaShop core's built-in module-method dispatch: `AdminController::postProcess()` routes `ajax=1&action=<X>` on the AdminModules controller (with `configure` set) to the configured module's `ajaxProcess<X>()` method — verified present and identical in core source at both 1.7.8.11 and 8.2.x (this module's supported range). The admin token is validated by the controller before dispatch.
- **`buildPaymentTermCheckboxQuery()`** — each checkbox label now carries an empty `<span class="two-term-fee" data-term="N">` placeholder. Fees are never pre-fetched synchronously on page render; the span is populated by AJAX only (Magento parity), so a slow API cannot block the config page.
- **Config-page JS** (configuration.tpl) — fetches fees on page load and on any term-checkbox change, dedupes identical term-set requests (mirrors Magento's `lastFeesKey` guard), renders `(1.50% + 0.50 EUR)`-style text per term, and on any failure silently blanks the spans. Formatting is done client-side from the API's numeric values with the API-supplied currency code appended — same display format as Magento; `Tools::displayPrice()` was deliberately not used because it would stamp the shop's currency symbol on an amount denominated in the API's (possibly different) currency.

## Buyer country caveat

A config page has no cart or buyer context, so `buyer_country_code` is a **best-effort stand-in**: the shop's default country (`PS_COUNTRY_DEFAULT`), falling back to `NL` — the same stand-in the Magento plugin uses. Displayed fees are therefore indicative for the shop's home market.

## Tests

New `tests/MerchantFeeRatesSpec.php` covering the success path (request shape, term normalisation, timeout, response normalisation), country fallback, and every fail-soft branch (missing API key, empty/invalid terms, non-200, malformed body, malformed rate rows, absent currency). The existing SurchargeSpec label regression test was updated for the new placeholder span while keeping its original guarantee (no buyer-surcharge preview in the label). Full suite green: `php tests/run.php` — 9/9 PASS. (JS has no test harness in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn