### PR TITLE
feat: show real quoted fee amount on checkout term chips

### DIFF
--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -58,6 +58,9 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             case 'savePaymentTerm':
                 $this->ajaxProcessSavePaymentTerm();
                 break;
+            case 'fetchTermSurcharges':
+                $this->ajaxProcessFetchTermSurcharges();
+                break;
             case 'checkOrderIntent':
                 $this->ajaxProcessCheckOrderIntent();
                 break;
@@ -97,6 +100,22 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         $this->context->cookie->setExpire(time() + Twopayment::COOKIE_EXPIRY_ONE_HOUR);
         PrestaShopLogger::addLog('TwoPayment: Saved selected payment term ' . $days . ' days in cookie', 1);
         $this->sendJsonResponse(json_encode(['success' => true]));
+    }
+
+    /**
+     * Live per-term buyer surcharge amounts for the checkout term chips.
+     * Reads nothing from POST beyond the token - the current cart is ambient
+     * via the context. Fail-soft: any failure inside the module method yields
+     * {success:false} and the frontend keeps its static rate preview (always
+     * a 200 JSON response, never breaks checkout).
+     */
+    public function ajaxProcessFetchTermSurcharges()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        $this->sendJsonResponse(json_encode($this->module->getTwoOfferedTermSurchargeAmounts()));
     }
 
     /**

--- a/tests/TermSurchargeAmountsSpec.php
+++ b/tests/TermSurchargeAmountsSpec.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * getTwoOfferedTermSurchargeAmounts() - the live per-term buyer surcharge
+ * quote behind the checkout term chips (Magento parity:
+ * Model/Webapi/Surcharges.php). Contract under test:
+ *
+ *  - Basis from the LIVE cart (getOrderTotal(true, Cart::BOTH)); one
+ *    POST /v1/pricing/order/fee per offered term via fetchTwoTermFee.
+ *  - {success: true, currency, amounts: {days: net-rounded-2dp}}.
+ *  - Per-term degrade: a single term's quote failure zeroes THAT term only;
+ *    even EVERY term failing on a nonzero basis still returns success:true
+ *    with all-zero amounts (the JS hides zero fees per chip).
+ *  - {success: false} ONLY for: surcharge disabled, no loaded cart, or a
+ *    zero/empty cart basis - the JS then keeps the static rate preview.
+ *  - Never throws: this sits behind a checkout-render AJAX call.
+ */
+final class TermSurchargeAmountsSpec
+{
+    public static function runAll(): void
+    {
+        self::testSuccessReturnsRoundedNetAmountPerOfferedTerm();
+        self::testSingleTermFailureDegradesThatTermToZeroOnly();
+        self::testSurchargeDisabledFailsWithoutWireCall();
+        self::testMissingOrUnloadedCartFailsWithoutWireCall();
+        self::testZeroCartBasisFailsWithoutWireCall();
+        self::testTotalApiFailureWithNonzeroBasisStillSucceedsAllZero();
+    }
+
+    /**
+     * Common fixture: percentage surcharge on offered terms 30 and 60, a
+     * loaded EUR cart in context with a nonzero gross, ES invoice address.
+     */
+    private static function reset(float $cartGross = 250.0): void
+    {
+        StubStore::reset();
+        // Fresh cookie: the fee-quote session cache must not leak across tests.
+        Context::getContext()->cookie = new Cookie();
+        Context::getContext()->cart = null;
+
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '3');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
+
+        $cart = new Cart(7);
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
+        StubStore::$cartTotals[7][true][Cart::BOTH] = $cartGross;
+        Context::getContext()->cart = $cart;
+    }
+
+    /**
+     * Harness whose pricing API answers per term (keyed by
+     * order_terms.duration_days), capturing every request.
+     *
+     * @param array<int,mixed> $responsesByDays
+     */
+    private static function moduleWithPerTermResponses(array $responsesByDays): object
+    {
+        return new class ($responsesByDays) extends TwopaymentTestHarness {
+            public int $fetchCount = 0;
+            public array $payloads = [];
+            private array $responsesByDays;
+
+            public function __construct(array $responsesByDays)
+            {
+                parent::__construct();
+                $this->responsesByDays = $responsesByDays;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->fetchCount++;
+                $this->payloads[] = $payload;
+                $days = isset($payload['order_terms']['duration_days']) ? (int) $payload['order_terms']['duration_days'] : 0;
+                return $this->responsesByDays[$days] ?? ['http_status' => 500];
+            }
+        };
+    }
+
+    private static function okQuote(string $net): array
+    {
+        return [
+            'http_status' => 200,
+            'buyer_fee_share' => $net,
+            'total_fee_tax_rate' => '0.21',
+            'currency' => 'EUR',
+        ];
+    }
+
+    private static function testSuccessReturnsRoundedNetAmountPerOfferedTerm(): void
+    {
+        self::reset();
+        $module = self::moduleWithPerTermResponses([
+            30 => self::okQuote('5.00'),
+            // Must round to 2dp in the response map.
+            60 => self::okQuote('7.505'),
+        ]);
+
+        $result = $module->getTwoOfferedTermSurchargeAmounts();
+
+        TinyAssert::true($result['success']);
+        TinyAssert::same('EUR', $result['currency']);
+        TinyAssert::same([30 => 5.0, 60 => 7.51], $result['amounts']);
+        TinyAssert::same(2, $module->fetchCount, 'one pricing call per offered term');
+        // The basis must be the live cart gross (products + shipping, tax
+        // incl.), sent to every per-term quote.
+        TinyAssert::same('250.00', (string) $module->payloads[0]['gross_amount']);
+        TinyAssert::same('ES', $module->payloads[0]['buyer_country_code']);
+        TinyAssert::same('EUR', $module->payloads[0]['currency']);
+    }
+
+    private static function testSingleTermFailureDegradesThatTermToZeroOnly(): void
+    {
+        self::reset();
+        $module = self::moduleWithPerTermResponses([
+            30 => self::okQuote('5.00'),
+            60 => ['http_status' => 500, 'error' => 'boom'],
+        ]);
+
+        $result = $module->getTwoOfferedTermSurchargeAmounts();
+
+        TinyAssert::true($result['success'], 'a single term failure must not fail the whole response');
+        TinyAssert::same([30 => 5.0, 60 => 0.0], $result['amounts']);
+    }
+
+    private static function testSurchargeDisabledFailsWithoutWireCall(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'none');
+        $module = self::moduleWithPerTermResponses([30 => self::okQuote('5.00')]);
+
+        TinyAssert::same(['success' => false], $module->getTwoOfferedTermSurchargeAmounts());
+        TinyAssert::same(0, $module->fetchCount);
+    }
+
+    private static function testMissingOrUnloadedCartFailsWithoutWireCall(): void
+    {
+        self::reset();
+        $module = self::moduleWithPerTermResponses([30 => self::okQuote('5.00')]);
+
+        Context::getContext()->cart = null;
+        TinyAssert::same(['success' => false], $module->getTwoOfferedTermSurchargeAmounts());
+
+        $unloaded = new Cart(7);
+        $unloaded->loaded = false;
+        Context::getContext()->cart = $unloaded;
+        $module->resetTwoFeeCache();
+        TinyAssert::same(['success' => false], $module->getTwoOfferedTermSurchargeAmounts());
+
+        TinyAssert::same(0, $module->fetchCount);
+    }
+
+    private static function testZeroCartBasisFailsWithoutWireCall(): void
+    {
+        // Empty cart / anonymous probe: gross basis is 0 - the JS falls back
+        // to the static percentage preview entirely.
+        self::reset(0.0);
+        $module = self::moduleWithPerTermResponses([30 => self::okQuote('5.00')]);
+
+        TinyAssert::same(['success' => false], $module->getTwoOfferedTermSurchargeAmounts());
+        TinyAssert::same(0, $module->fetchCount);
+    }
+
+    private static function testTotalApiFailureWithNonzeroBasisStillSucceedsAllZero(): void
+    {
+        // Distinct from the zero-basis case above: a nonzero basis where
+        // EVERY quote fails is a per-term degrade, NOT a fallback signal.
+        self::reset();
+        $module = self::moduleWithPerTermResponses([
+            30 => ['http_status' => 500],
+            60 => ['http_status' => 500],
+        ]);
+
+        $result = $module->getTwoOfferedTermSurchargeAmounts();
+
+        TinyAssert::true($result['success']);
+        TinyAssert::same('EUR', $result['currency']);
+        TinyAssert::same([30 => 0.0, 60 => 0.0], $result['amounts']);
+        TinyAssert::same(2, $module->fetchCount, 'every term must still be attempted');
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -5013,6 +5013,7 @@ require __DIR__ . '/SurchargeSpec.php';
 require __DIR__ . '/DefaultPaymentTermSpec.php';
 require __DIR__ . '/DeployVersionInfoSpec.php';
 require __DIR__ . '/MerchantFeeRatesSpec.php';
+require __DIR__ . '/TermSurchargeAmountsSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5024,6 +5025,7 @@ $tests = [
     'DefaultPaymentTermSpec::runAll' => [DefaultPaymentTermSpec::class, 'runAll'],
     'DeployVersionInfoSpec::runAll' => [DeployVersionInfoSpec::class, 'runAll'],
     'MerchantFeeRatesSpec::runAll' => [MerchantFeeRatesSpec::class, 'runAll'],
+    'TermSurchargeAmountsSpec::runAll' => [TermSurchargeAmountsSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -6886,6 +6886,83 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Live per-term buyer surcharge amounts for the checkout term chips: the
+     * REAL quoted fee (buyer_fee_share net, via POST /v1/pricing/order/fee per
+     * offered term through fetchTwoTermFee) for the CURRENT cart, replacing
+     * the configured-rate text from getTwoSurchargeChipPreview() when it
+     * resolves. Mirrors magento-plugin's Model/Webapi/Surcharges.php: basis
+     * from the live cart, loop over every offered term, per-term failure
+     * degrades that term to 0.0 while the others keep their quotes.
+     *
+     * Fail-soft contract (same discipline as fetchTwoMerchantFeeRates): this
+     * sits behind a checkout-render AJAX call and must never throw and never
+     * break checkout. {success:false} — surcharge disabled, no loaded cart,
+     * no offered terms, or a zero/empty cart basis — tells the JS to keep the
+     * static rate preview. A nonzero basis where every term's quote fails
+     * still returns {success:true} with all-zero amounts (per-term degrade,
+     * Magento parity), NOT {success:false}.
+     *
+     * @return array{success:bool,currency?:string,amounts?:array<int,float>}
+     */
+    public function getTwoOfferedTermSurchargeAmounts()
+    {
+        try {
+            $settings = $this->getTwoSurchargeSettings();
+            if (empty($settings['enabled'])) {
+                return array('success' => false);
+            }
+
+            $cart = isset($this->context->cart) ? $this->context->cart : null;
+            if (!Validate::isLoadedObject($cart)) {
+                return array('success' => false);
+            }
+
+            $terms = $this->getAvailablePaymentTerms();
+            if (empty($terms)) {
+                return array('success' => false);
+            }
+
+            // Lightweight cart-gross read (products + shipping, tax incl.) —
+            // the same idiom the order builder uses for its reconciliation
+            // gross (getTwoNewOrderData) — NOT the full line-item pipeline,
+            // which is far too heavy for a render-time preview call.
+            $gross_basis = round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
+            if ($gross_basis <= 0) {
+                // Empty cart / anonymous probe: nothing to quote against —
+                // the JS keeps the static percentage preview entirely.
+                return array('success' => false);
+            }
+
+            $currencyIso = '';
+            $currency = new Currency((int) $cart->id_currency);
+            if (Validate::isLoadedObject($currency)) {
+                $currencyIso = (string) $currency->iso_code;
+            }
+            $buyerCountry = $this->resolveTwoBuyerCountryIso($cart);
+
+            $amounts = array();
+            foreach ($terms as $days) {
+                $days = (int) $days;
+                $fee = $this->fetchTwoTermFee($days, $gross_basis, $buyerCountry, $currencyIso);
+                // Per-term degrade: a failed quote zeroes THAT chip's fee
+                // (the JS hides a zero fee) without failing the whole map.
+                $amounts[$days] = ($fee !== null && isset($fee['buyer_fee_share']))
+                    ? round((float) $fee['buyer_fee_share'], 2)
+                    : 0.0;
+            }
+
+            return array(
+                'success' => true,
+                'currency' => $currencyIso,
+                'amounts' => $amounts,
+            );
+        } catch (\Throwable $e) {
+            // Checkout render must never break on a preview quote.
+            return array('success' => false);
+        }
+    }
+
+    /**
      * Buyer-facing label for the surcharge line. A merchant-set description
      * wins (with %s replaced by the term days, Magento/WooCommerce parity);
      * else the brand label; else a translated default that names the term.

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -1356,8 +1356,80 @@ class TwoCheckoutManager {
         if (selectedDays && activeTerm) {
             selectedDays.textContent = formatPayInLabel(activeTerm);
         }
+
+        // Upgrade the static rate preview to the REAL quoted amount for this
+        // cart, asynchronously — the chips above already rendered with the
+        // configured-rate text as an instant fallback.
+        this.refreshTermSurchargeAmounts(termsContainer);
     }
-    
+
+    /**
+     * Replace each term chip's static configured-rate surcharge preview with
+     * the live quoted fee amount for the current cart (server proxies
+     * POST /v1/pricing/order/fee per offered term — see
+     * getTwoOfferedTermSurchargeAmounts() in twopayment.php). Magento parity:
+     * gateway_method.js renders '+' + formatted amount per chip.
+     *
+     * Fail-soft by design: any failure (network error, non-200, success:false)
+     * is a silent no-op — the already-rendered static rate preview stays as
+     * the fallback. A zero amount for a term hides that chip's fee text
+     * ("no fee" semantics), it is NOT a failure signal. Only the
+     * .two-term-chip__surcharge text nodes are touched — never the chip's
+     * selected/aria state, so a buyer clicking before the fetch resolves is
+     * never clobbered.
+     */
+    refreshTermSurchargeAmounts(termsContainer) {
+        try {
+            if (!termsContainer || !window.twopayment || !window.twopayment.order_intent_url || !window.twopayment.ajax_token) {
+                return;
+            }
+            $.ajax({
+                url: window.twopayment.order_intent_url,
+                type: 'POST',
+                dataType: 'json',
+                data: { ajax: 1, action: 'fetchTermSurcharges', token: window.twopayment.ajax_token },
+                timeout: 10000
+            }).done((response) => {
+                if (!response || !response.success || !response.amounts) {
+                    return; // keep the static rate preview
+                }
+                // Same amount + space + currency-code composition as the admin
+                // merchant-fee display (configuration.tpl) — deliberately plain
+                // number formatting, no client-side price-locale guessing.
+                const currency = String(response.currency || '').toUpperCase().replace(/^\s+|\s+$/g, '');
+                const suffix = currency !== '' ? ' ' + currency : '';
+                termsContainer.querySelectorAll('.two-term-chip').forEach((chip) => {
+                    const days = chip.dataset.days;
+                    if (!days || !(days in response.amounts)) {
+                        return; // no quote for this term — leave its fallback text
+                    }
+                    const amount = Number(response.amounts[days]);
+                    let surchargeLabel = chip.querySelector('.two-term-chip__surcharge');
+                    if (!isFinite(amount) || amount <= 0) {
+                        // Zero/invalid quote for THIS term only: show no fee
+                        // rather than "+0.00" (Magento zero-hide semantics).
+                        if (surchargeLabel) {
+                            surchargeLabel.textContent = '';
+                        }
+                        return;
+                    }
+                    if (!surchargeLabel) {
+                        // Chip rendered without a fallback label (all-zero
+                        // configured rates) but a real fee exists — add one.
+                        surchargeLabel = document.createElement('span');
+                        surchargeLabel.className = 'two-term-chip__surcharge';
+                        chip.appendChild(surchargeLabel);
+                    }
+                    surchargeLabel.textContent = '+' + amount.toFixed(2) + suffix;
+                });
+            }).fail(() => {
+                // Silent no-op: the static rate preview stays rendered.
+            });
+        } catch (e) {
+            // Never let a preview upgrade break the checkout render.
+        }
+    }
+
     /**
      * Update payment terms description based on term type
      * Separated for reusability and early initialization


### PR DESCRIPTION
## Problem
Checkout term chips show the configured surcharge **rate** (e.g. "+2.50%"), not the actual quoted amount for the buyer's cart — unlike magento-plugin, which quotes the real fee per term against the live cart and shows an amount.

## Fix
- New `getTwoOfferedTermSurchargeAmounts()` (twopayment.php): fail-soft method computing a lightweight cart gross basis (`Cart::getOrderTotal(true, Cart::BOTH)`, NOT the full order-payload pipeline) and calling the existing `fetchTwoTermFee()` once per offered term. Per-term failure degrades that term to 0.0 (Magento parity); total failure / disabled surcharge / no cart / zero basis returns `success:false` and the frontend keeps today's static rate preview.
- New AJAX action `fetchTermSurcharges` on the existing `orderintent.php` front controller (same URL/token pattern as `savePaymentTerm`).
- `TwoCheckoutManager.js`: after chips render with the static preview (instant, unchanged), fires one async request and swaps in the real amount per chip. Any failure is a silent no-op — static preview stays. Only touches `.two-term-chip__surcharge` text nodes, never selected/aria state, so a mid-flight click isn't clobbered.
- New `TermSurchargeAmountsSpec.php` covering success, per-term degrade, disabled, no-cart, zero-basis, and all-terms-fail cases.

## Testing
`make test` — all 10 specs pass, including the new one. `php -l` / `node --check` clean on all changed files.

---
*Reviewed by Claude prior to opening this PR — self-review-lane process.*