### PR TITLE
fix: pre-fill fulfilled-status multi-select via the [] key HelperForm renders

### DIFF
--- a/twopayment.php
+++ b/twopayment.php
@@ -1662,11 +1662,13 @@ class Twopayment extends PaymentModule
                 // Backward compatibility: if it's a single ID, convert to array
                 $fulfilled_ids = array($fulfilled_map);
             }
-            $fields_values['PS_TWO_OS_FULFILLED_MAP'] = $fulfilled_ids;
+            $fulfilled_ids_value = $fulfilled_ids;
         } else {
             // Default to Shipped status
-            $fields_values['PS_TWO_OS_FULFILLED_MAP'] = array(Configuration::get('PS_OS_SHIPPING'));
+            $fulfilled_ids_value = array(Configuration::get('PS_OS_SHIPPING'));
         }
+        $fields_values['PS_TWO_OS_FULFILLED_MAP'] = $fulfilled_ids_value;
+        $fields_values['PS_TWO_OS_FULFILLED_MAP[]'] = $fulfilled_ids_value;
         
         $fields_values['PS_TWO_OS_PAYMENT_ERROR_MAP'] = Tools::getValue('PS_TWO_OS_PAYMENT_ERROR_MAP', Configuration::get('PS_TWO_OS_PAYMENT_ERROR_MAP'));
         $fields_values['PS_TWO_OS_CANCELLED_MAP'] = Tools::getValue('PS_TWO_OS_CANCELLED_MAP', Configuration::get('PS_TWO_OS_CANCELLED_MAP'));


### PR DESCRIPTION
## Bug
Admin config page threw a PHP warning on every render:
\`Undefined array key "PS_TWO_OS_FULFILLED_MAP[]"\`

## Root cause
PrestaShop core's \`HelperForm.php\` (classes/helper/HelperForm.php:131-133) auto-appends \`[]\` to a field's \`name\` at render time whenever \`multiple => true\` and the name doesn't already end in \`[]\`. \`PS_TWO_OS_FULFILLED_MAP\` is defined with \`multiple => true\`, so the compiled template looks up \`\$fields_value['PS_TWO_OS_FULFILLED_MAP[]']\` to determine which options are pre-selected — but \`getTwoOrderStatusFormValues()\` only ever populated the plain key.

Pre-existing bug, unrelated to any recent PR — surfaced now while testing locally.

## Fix
\`getTwoOrderStatusFormValues()\` now assigns the resolved fulfilled-status array to both the plain key and the \`[]\`-suffixed key. POST-side reading is untouched — PHP already collects \`name="...[]"\` submissions into \`\$_POST\` under the plain key.

\`php -l\` clean.

---
*Reviewed by Claude prior to opening this PR — self-review-lane process.*