### PR TITLE
fix: live admin surcharge-grid rows on term toggle; never leak surcharge rate to buyer chips

### DIFF
--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -31,8 +31,8 @@ final class SurchargeSpec
         self::testBuildTwoBuyerFeeShareWiresConfigAndDefaultTerm();
         self::testRoundingStepOptionsAreBrandDrivenSortedAndFormatted();
         self::testSurchargeLineLabelTemplateBrandAndDefault();
-        self::testSurchargeChipPreviewAllZeroHiddenElseShownOnEveryTerm();
         self::testPaymentTermCheckboxLabelsNeverCarrySurchargePreview();
+        self::testSurchargeGridRendersEveryOfferableTermRowWithVisibilityState();
         self::testFetchTermFeeFailsSoftOnHttpError();
         self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
         self::testFetchTermFeeParsesSuccess();
@@ -250,58 +250,14 @@ final class SurchargeSpec
     }
 
     /**
-     * Chip fee preview mirrors Magento's "allZero" rule: hidden on every chip
-     * when all offered terms are zero-rated, shown on every chip (with a
-     * "No fee" marker for a zero-rate term) as soon as one term carries a fee.
-     * Preview parts are gated by the configured surcharge type.
-     */
-    private static function testSurchargeChipPreviewAllZeroHiddenElseShownOnEveryTerm(): void
-    {
-        // Offer two terms so "all zero" vs "some non-zero" is observable.
-        self::reset();
-        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
-        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
-        $module = new TwopaymentTestHarness();
-
-        // Surcharge disabled -> nothing to preview.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'none');
-        TinyAssert::same([], $module->getTwoSurchargeChipPreview());
-
-        // Percentage type, every offered term zero-rated -> hide on all chips.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
-        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '0');
-        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '0');
-        TinyAssert::same([], $module->getTwoSurchargeChipPreview());
-
-        // One term now carries a fee -> every chip shows a preview; the
-        // zero-rate term renders the "No fee" marker (Magento allZero parity).
-        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '2.5');
-        $preview = $module->getTwoSurchargeChipPreview();
-        TinyAssert::same('No fee', $preview[30]);
-        TinyAssert::same('+2.5%', $preview[60]);
-
-        // Type gating: a fixed-only surcharge must ignore a stray percentage
-        // value left over from a previous type, and preview the fixed amount.
-        self::reset();
-        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
-        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
-        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'fixed');
-        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5'); // stray, must be ignored
-        Configuration::updateValue('PS_TWO_SURCHARGE_FIXED_60', '10');
-        $moduleFixed = new TwopaymentTestHarness();
-        $previewFixed = $moduleFixed->getTwoSurchargeChipPreview();
-        TinyAssert::same('No fee', $previewFixed[30]);
-        TinyAssert::same('+10.00', $previewFixed[60]);
-    }
-
-    /**
      * Regression: the admin "Available Payment Terms" checkbox
-     * labels (buildPaymentTermCheckboxQuery) must never carry the buyer
+     * labels (buildPaymentTermCheckboxQuery) must never carry a buyer
      * surcharge preview, even when a non-zero surcharge is configured. That
      * screen is where the merchant picks which terms to OFFER, not a place
      * to preview what the BUYER will be charged - conflating the two showed
-     * the wrong fee concept next to each term. getTwoSurchargeChipPreview()
-     * itself (and its checkout-chip consumer) is untouched by this fix.
+     * the wrong fee concept next to each term. (The configured-rate preview
+     * itself has since been removed everywhere: the checkout chip now shows
+     * a loading indicator until the real quoted amount resolves.)
      */
     private static function testPaymentTermCheckboxLabelsNeverCarrySurchargePreview(): void
     {
@@ -318,13 +274,6 @@ final class SurchargeSpec
                 return $this->buildPaymentTermCheckboxQuery();
             }
         };
-
-        // Sanity check: the surcharge preview itself IS non-empty for these
-        // terms, so an empty checkbox result below is a real assertion, not
-        // an artefact of an unconfigured surcharge.
-        $preview = $module->getTwoSurchargeChipPreview();
-        TinyAssert::same('+2.5%', $preview[30]);
-        TinyAssert::same('+5%', $preview[60]);
 
         $rows = $module->buildPaymentTermCheckboxQueryPublic();
         TinyAssert::true(count($rows) > 0, 'expected at least one offered term');
@@ -343,6 +292,62 @@ final class SurchargeSpec
                 $row['name']
             );
         }
+    }
+
+    /**
+     * Regression: the admin per-term surcharge grid renders a row for EVERY
+     * offerable term (not just the saved/available subset), so the admin JS
+     * can show/hide rows live as term checkboxes are toggled. Initial
+     * visibility (inline display:none) mirrors getAvailablePaymentTerms():
+     * checkbox config truthy AND valid for the current term type.
+     */
+    private static function testSurchargeGridRendersEveryOfferableTermRowWithVisibilityState(): void
+    {
+        $harness = static function (): object {
+            return new class extends TwopaymentTestHarness {
+                public function getTwoSurchargeGridHtmlPublic(): string
+                {
+                    return $this->getTwoSurchargeGridHtml();
+                }
+            };
+        };
+        $rowPattern = static function (int $days, bool $visible): string {
+            $style = $visible ? '' : ' style="display:none"';
+            return '<tr class="two-surcharge-row two-surcharge-row-' . $days . ' '
+                . (in_array($days, Twopayment::EOM_PAYMENT_TERMS_OPTIONS, true) ? 'two-term-both' : 'two-term-standard')
+                . '" data-term="' . $days . '"' . $style . '>';
+        };
+
+        // STANDARD type: every offerable term gets a row; only checked terms
+        // start visible.
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', 1);
+        $html = $harness()->getTwoSurchargeGridHtmlPublic();
+        foreach (Twopayment::PAYMENT_TERMS_OPTIONS as $days) {
+            $days = (int) $days;
+            $visible = in_array($days, [30, 60], true);
+            TinyAssert::true(
+                strpos($html, $rowPattern($days, $visible)) !== false,
+                'expected ' . ($visible ? 'visible' : 'hidden') . ' grid row for ' . $days . ' days'
+            );
+            // Inputs exist for every offerable term regardless of visibility.
+            TinyAssert::true(
+                strpos($html, 'name="PS_TWO_SURCHARGE_PCT_' . $days . '"') !== false,
+                'expected percentage input for ' . $days . ' days'
+            );
+        }
+
+        // EOM type: a checked non-EOM term (90) starts hidden; a checked EOM
+        // term (30) starts visible; an unchecked EOM term (45) starts hidden.
+        self::reset();
+        Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'EOM');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_90', 1);
+        $html = $harness()->getTwoSurchargeGridHtmlPublic();
+        TinyAssert::true(strpos($html, $rowPattern(30, true)) !== false, 'checked EOM term row must start visible');
+        TinyAssert::true(strpos($html, $rowPattern(45, false)) !== false, 'unchecked EOM term row must start hidden');
+        TinyAssert::true(strpos($html, $rowPattern(90, false)) !== false, 'checked non-EOM term row must start hidden under EOM');
     }
 
     private static function testFetchTermFeeFailsSoftOnHttpError(): void

--- a/tests/TermSurchargeAmountsSpec.php
+++ b/tests/TermSurchargeAmountsSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  *    even EVERY term failing on a nonzero basis still returns success:true
  *    with all-zero amounts (the JS hides zero fees per chip).
  *  - {success: false} ONLY for: surcharge disabled, no loaded cart, or a
- *    zero/empty cart basis - the JS then keeps the static rate preview.
+ *    zero/empty cart basis - the JS then clears the chips' loading dots.
  *  - Never throws: this sits behind a checkout-render AJAX call.
  */
 final class TermSurchargeAmountsSpec
@@ -160,8 +160,8 @@ final class TermSurchargeAmountsSpec
 
     private static function testZeroCartBasisFailsWithoutWireCall(): void
     {
-        // Empty cart / anonymous probe: gross basis is 0 - the JS falls back
-        // to the static percentage preview entirely.
+        // Empty cart / anonymous probe: gross basis is 0 - the JS clears
+        // the chips' loading indicators to blank.
         self::reset(0.0);
         $module = self::moduleWithPerTermResponses([30 => self::okQuote('5.00')]);
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -689,7 +689,7 @@ class Twopayment extends PaymentModule
      * Each label carries an empty `.two-term-fee` placeholder span. The
      * figure that belongs on this screen is the FEE TWO CHARGES THE MERCHANT
      * for offering that term (NOT the buyer surcharge - a prior change
-     * wrongly appended getTwoSurchargeChipPreview() here and was reverted).
+     * wrongly appended a buyer-surcharge rate preview here and was reverted).
      * The span is populated live by admin AJAX against
      * POST /pricing/v1/merchant/rates (fetchTwoMerchantFeeRates /
      * ajaxProcessFetchMerchantFeeRates), mirroring magento-plugin's
@@ -2706,7 +2706,6 @@ class Twopayment extends PaymentModule
                 'available_payment_terms' => $this->getAvailablePaymentTerms(),
                 'default_payment_term' => $this->getDefaultPaymentTerm(),
                 'payment_term_type' => Configuration::get('PS_TWO_PAYMENT_TERM_TYPE'),
-                'payment_term_surcharge_preview' => $this->getTwoSurchargeChipPreview(),
                 'i18n' => $i18n,
                 'phone_i18n' => array(
                     'invalid_number' => $this->l('Invalid phone number'),
@@ -6519,84 +6518,6 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Per-term surcharge preview text keyed by days, for display alongside the
-     * term: the "Available Payment Terms" checkboxes in admin and the checkout
-     * chip selector share this single calculation.
-     *
-     * Deliberately NOT the live-quoted buyer_fee_share (that requires a real
-     * POST /v1/pricing/order/fee call per term via fetchTwoTermFee — fine for
-     * one term at order-intent time, too many synchronous calls to make on
-     * every checkout page load for a whole term list). This instead previews
-     * the raw configured rate (the same percentage/fixed values the merchant
-     * already sees in the admin grid, gated by the configured surcharge type),
-     * not the final rounded/capped amount.
-     *
-     * Display rule mirrors Magento's gateway_method.js term-chip "allZero"
-     * logic: when EVERY offered term has a zero fee, the fee is hidden on all
-     * chips (empty array); when AT LEAST ONE term carries a fee, every chip
-     * shows its fee — a zero-fee term in that set renders a "No fee" marker
-     * rather than being blank, so the row is consistent. (Magento renders the
-     * zero term as a formatted "+0.00"; because this preview is rate-based, not
-     * amount-based, a "No fee" marker is the closest faithful equivalent.) This
-     * also governs the admin checkbox suffix, so the merchant sees the same
-     * "no fee shown to buyer" signal the checkout chip will render.
-     *
-     * @return array<int, string> days => preview text; empty when all offered
-     *                            terms are zero-rated (Magento allZero-hide)
-     */
-    public function getTwoSurchargeChipPreview()
-    {
-        $settings = $this->getTwoSurchargeSettings();
-        if (!$settings['enabled']) {
-            return array();
-        }
-
-        // Gate the preview parts by the configured surcharge type, mirroring
-        // TwoSurchargeCalculator::buildBuyerFeeShare, so the chip never previews
-        // a component (percentage or fixed) the API will not actually charge.
-        $type = $settings['type'];
-        $hasPercentage = in_array($type, array('percentage', 'fixed_and_percentage'), true);
-        $hasFixed = in_array($type, array('fixed', 'fixed_and_percentage'), true);
-
-        $rawParts = array();
-        $anyNonZero = false;
-        foreach ($settings['grid'] as $days => $row) {
-            $parts = array();
-            if ($hasPercentage && (float) $row['percentage'] > 0) {
-                $parts[] = '+' . rtrim(rtrim(sprintf('%.2f', $row['percentage']), '0'), '.') . '%';
-            }
-            if ($hasFixed && (float) $row['fixed'] > 0) {
-                // Tools::displayPrice() needs the Symfony kernel container;
-                // fail-soft to a plain number rather than fatal the checkout
-                // page media hook if it's unavailable in some bootstrap path.
-                try {
-                    $parts[] = '+' . Tools::displayPrice($row['fixed']);
-                } catch (\Throwable $e) {
-                    $parts[] = '+' . sprintf('%.2f', $row['fixed']);
-                }
-            }
-            $rawParts[(int) $days] = $parts;
-            if (!empty($parts)) {
-                $anyNonZero = true;
-            }
-        }
-
-        // All offered terms zero-rated -> hide the fee on every chip (allZero).
-        if (!$anyNonZero) {
-            return array();
-        }
-
-        // At least one term carries a fee -> show every chip's fee; a zero-fee
-        // term renders the "No fee" marker so the row is not visually ragged.
-        $preview = array();
-        foreach ($rawParts as $days => $parts) {
-            $preview[$days] = !empty($parts) ? implode(' ', $parts) : $this->l('No fee');
-        }
-
-        return $preview;
-    }
-
-    /**
      * Build the buyer_fee_share block for one term (or null when no surcharge
      * is configured), from module Configuration.
      *
@@ -6889,16 +6810,18 @@ class Twopayment extends PaymentModule
      * Live per-term buyer surcharge amounts for the checkout term chips: the
      * REAL quoted fee (buyer_fee_share net, via POST /v1/pricing/order/fee per
      * offered term through fetchTwoTermFee) for the CURRENT cart, replacing
-     * the configured-rate text from getTwoSurchargeChipPreview() when it
-     * resolves. Mirrors magento-plugin's Model/Webapi/Surcharges.php: basis
+     * each chip's loading indicator when it resolves (the buyer is never
+     * shown the configured rate). Mirrors magento-plugin's
+     * Model/Webapi/Surcharges.php: basis
      * from the live cart, loop over every offered term, per-term failure
      * degrades that term to 0.0 while the others keep their quotes.
      *
      * Fail-soft contract (same discipline as fetchTwoMerchantFeeRates): this
      * sits behind a checkout-render AJAX call and must never throw and never
      * break checkout. {success:false} — surcharge disabled, no loaded cart,
-     * no offered terms, or a zero/empty cart basis — tells the JS to keep the
-     * static rate preview. A nonzero basis where every term's quote fails
+     * no offered terms, or a zero/empty cart basis — tells the JS to clear
+     * the chips' loading indicators (no fee text is shown; the buyer is never
+     * shown a configured rate). A nonzero basis where every term's quote fails
      * still returns {success:true} with all-zero amounts (per-term degrade,
      * Magento parity), NOT {success:false}.
      *
@@ -6929,7 +6852,7 @@ class Twopayment extends PaymentModule
             $gross_basis = round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
             if ($gross_basis <= 0) {
                 // Empty cart / anonymous probe: nothing to quote against —
-                // the JS keeps the static percentage preview entirely.
+                // the JS clears the chips' loading indicators to blank.
                 return array('success' => false);
             }
 
@@ -7116,6 +7039,16 @@ class Twopayment extends PaymentModule
      * save/validation path (saveTwoSurchargeFormValues / validTwoSurchargeFormValues)
      * is unchanged.
      *
+     * A row is rendered for EVERY offerable term (getOfferableTermSource — the
+     * same set the "Available Payment Terms" checkboxes render for), NOT just
+     * the saved/available subset, so the admin JS (configuration.tpl,
+     * updateSurchargeGridRows) can show/hide rows live as term checkboxes are
+     * toggled without a save+reload. Initial visibility is computed
+     * server-side with the same gates getAvailablePaymentTerms() applies: the
+     * term's checkbox config is truthy AND the term is valid for the current
+     * term type (EOM only allows EOM_PAYMENT_TERMS_OPTIONS). Row classes
+     * mirror the checkbox type split (two-term-both / two-term-standard).
+     *
      * @return string
      */
     protected function getTwoSurchargeGridHtml()
@@ -7132,7 +7065,10 @@ class Twopayment extends PaymentModule
             . '<th class="two-col-cap">' . $this->l('Cap on percentage') . '</th>'
             . '</tr></thead><tbody>';
 
-        foreach ($this->getAvailablePaymentTerms() as $days) {
+        $term_type = Configuration::get('PS_TWO_PAYMENT_TERM_TYPE');
+        $source = $this->getOfferableTermSource(false);
+        sort($source);
+        foreach ($source as $days) {
             $days = (int) $days;
             $pct_name = 'PS_TWO_SURCHARGE_PCT_' . $days;
             $fixed_name = 'PS_TWO_SURCHARGE_FIXED_' . $days;
@@ -7142,7 +7078,14 @@ class Twopayment extends PaymentModule
             $fixed = htmlspecialchars((string) Tools::getValue($fixed_name, Configuration::get($fixed_name)), ENT_QUOTES, 'UTF-8');
             $cap = htmlspecialchars((string) Tools::getValue($cap_name, Configuration::get($cap_name)), ENT_QUOTES, 'UTF-8');
 
-            $html .= '<tr>'
+            $is_eom_capable = in_array($days, self::EOM_PAYMENT_TERMS_OPTIONS, true);
+            $type_class = $is_eom_capable ? 'two-term-both' : 'two-term-standard';
+            $checked = (bool) Configuration::get('PS_TWO_PAYMENT_TERMS_' . $days);
+            $valid_for_type = $term_type !== 'EOM' || $is_eom_capable;
+            $row_style = ($checked && $valid_for_type) ? '' : ' style="display:none"';
+
+            $html .= '<tr class="two-surcharge-row two-surcharge-row-' . $days . ' ' . $type_class . '"'
+                . ' data-term="' . $days . '"' . $row_style . '>'
                 . '<td style="vertical-align:middle;">' . sprintf($this->l('%d days'), $days) . '</td>'
                 . '<td class="two-col-percentage"><div class="input-group" style="' . $cell_style . '">'
                 . '<input type="text" class="form-control" name="' . $pct_name . '" value="' . $pct . '">'

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -654,6 +654,31 @@
     opacity: 0.85;
 }
 
+/* Loading indicator shown in the chip's surcharge slot until the real quoted
+   fee amount resolves (magento-plugin style.css parity). currentColor keeps
+   the dots legible on both the default and --selected chip backgrounds. */
+.two-term-chip__loading {
+    display: inline-block;
+    letter-spacing: 2px;
+    color: currentColor;
+    font-size: 0.85em;
+    line-height: 1.3;
+    font-weight: 700;
+}
+
+.two-term-chip__loading > span {
+    display: inline-block;
+    animation: two-term-chip-dot 1.4s infinite ease-in-out both;
+}
+
+.two-term-chip__loading > span:nth-child(2) { animation-delay: 0.2s; }
+.two-term-chip__loading > span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes two-term-chip-dot {
+    0%, 80%, 100% { opacity: 0.2; }
+    40%          { opacity: 1; }
+}
+
 .two-terms-selected {
     display: flex;
     align-items: baseline;

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -1271,19 +1271,23 @@ class TwoCheckoutManager {
             termChip.title = formatChipLabel(days);
             termChip.appendChild(daysLabel);
 
-            // Per-term surcharge preview (configured-rate text, not a live quote
-            // — see getTwoSurchargeChipPreview() in twopayment.php). The PHP side
-            // decides show/hide (Magento allZero parity): the map is empty when
-            // all terms are zero-rated, and carries a non-empty string for every
-            // term otherwise (a "No fee" marker for zero-rate terms), so a simple
-            // presence check renders the fee on every chip or none.
-            const surchargePreview = this.config.payment_term_surcharge_preview;
-            if (surchargePreview && surchargePreview[days]) {
-                const surchargeLabel = document.createElement('span');
-                surchargeLabel.className = 'two-term-chip__surcharge';
-                surchargeLabel.textContent = surchargePreview[days];
-                termChip.appendChild(surchargeLabel);
+            // Per-term surcharge slot: starts as a loading indicator (three
+            // animated dots, Magento gateway_method.html parity) on EVERY
+            // chip, unconditionally. The buyer must never see the configured
+            // surcharge RATE — only the real quoted amount for this cart once
+            // refreshTermSurchargeAmounts() resolves, or nothing on failure.
+            const surchargeLabel = document.createElement('span');
+            surchargeLabel.className = 'two-term-chip__surcharge';
+            const loadingDots = document.createElement('span');
+            loadingDots.className = 'two-term-chip__loading';
+            loadingDots.setAttribute('aria-hidden', 'true');
+            for (let i = 0; i < 3; i++) {
+                const dot = document.createElement('span');
+                dot.textContent = '.';
+                loadingDots.appendChild(dot);
             }
+            surchargeLabel.appendChild(loadingDots);
+            termChip.appendChild(surchargeLabel);
 
             termChip.dataset.days = days;
 
@@ -1357,30 +1361,49 @@ class TwoCheckoutManager {
             selectedDays.textContent = formatPayInLabel(activeTerm);
         }
 
-        // Upgrade the static rate preview to the REAL quoted amount for this
-        // cart, asynchronously — the chips above already rendered with the
-        // configured-rate text as an instant fallback.
+        // Resolve each chip's loading indicator to the REAL quoted amount for
+        // this cart, asynchronously — or to blank if the quote fails.
         this.refreshTermSurchargeAmounts(termsContainer);
     }
 
     /**
-     * Replace each term chip's static configured-rate surcharge preview with
-     * the live quoted fee amount for the current cart (server proxies
+     * Clear every chip's surcharge slot (removes the loading dots) so a
+     * failed/absent quote reads as a deliberate empty state, never as a
+     * permanently-animating loader.
+     */
+    clearTermSurchargeLoading(termsContainer) {
+        if (!termsContainer) {
+            return;
+        }
+        termsContainer.querySelectorAll('.two-term-chip .two-term-chip__surcharge').forEach((label) => {
+            label.textContent = '';
+        });
+    }
+
+    /**
+     * Replace each term chip's loading indicator with the live quoted fee
+     * amount for the current cart (server proxies
      * POST /v1/pricing/order/fee per offered term — see
      * getTwoOfferedTermSurchargeAmounts() in twopayment.php). Magento parity:
      * gateway_method.js renders '+' + formatted amount per chip.
      *
-     * Fail-soft by design: any failure (network error, non-200, success:false)
-     * is a silent no-op — the already-rendered static rate preview stays as
-     * the fallback. A zero amount for a term hides that chip's fee text
+     * Fail-soft by design: any failure (network error, non-200, success:false,
+     * missing config) clears every chip's surcharge slot to blank — the buyer
+     * must never see the configured rate, and a loader that never resolves
+     * reads as broken. A zero amount for a term hides that chip's fee text
      * ("no fee" semantics), it is NOT a failure signal. Only the
-     * .two-term-chip__surcharge text nodes are touched — never the chip's
+     * .two-term-chip__surcharge nodes are touched — never the chip's
      * selected/aria state, so a buyer clicking before the fetch resolves is
      * never clobbered.
      */
     refreshTermSurchargeAmounts(termsContainer) {
         try {
-            if (!termsContainer || !window.twopayment || !window.twopayment.order_intent_url || !window.twopayment.ajax_token) {
+            if (!termsContainer) {
+                return;
+            }
+            if (!window.twopayment || !window.twopayment.order_intent_url || !window.twopayment.ajax_token) {
+                // Can't quote at all — don't leave the dots animating forever.
+                this.clearTermSurchargeLoading(termsContainer);
                 return;
             }
             $.ajax({
@@ -1391,7 +1414,8 @@ class TwoCheckoutManager {
                 timeout: 10000
             }).done((response) => {
                 if (!response || !response.success || !response.amounts) {
-                    return; // keep the static rate preview
+                    this.clearTermSurchargeLoading(termsContainer);
+                    return;
                 }
                 // Same amount + space + currency-code composition as the admin
                 // merchant-fee display (configuration.tpl) — deliberately plain
@@ -1399,34 +1423,28 @@ class TwoCheckoutManager {
                 const currency = String(response.currency || '').toUpperCase().replace(/^\s+|\s+$/g, '');
                 const suffix = currency !== '' ? ' ' + currency : '';
                 termsContainer.querySelectorAll('.two-term-chip').forEach((chip) => {
-                    const days = chip.dataset.days;
-                    if (!days || !(days in response.amounts)) {
-                        return; // no quote for this term — leave its fallback text
-                    }
-                    const amount = Number(response.amounts[days]);
-                    let surchargeLabel = chip.querySelector('.two-term-chip__surcharge');
-                    if (!isFinite(amount) || amount <= 0) {
-                        // Zero/invalid quote for THIS term only: show no fee
-                        // rather than "+0.00" (Magento zero-hide semantics).
-                        if (surchargeLabel) {
-                            surchargeLabel.textContent = '';
-                        }
+                    const surchargeLabel = chip.querySelector('.two-term-chip__surcharge');
+                    if (!surchargeLabel) {
                         return;
                     }
-                    if (!surchargeLabel) {
-                        // Chip rendered without a fallback label (all-zero
-                        // configured rates) but a real fee exists — add one.
-                        surchargeLabel = document.createElement('span');
-                        surchargeLabel.className = 'two-term-chip__surcharge';
-                        chip.appendChild(surchargeLabel);
+                    const days = chip.dataset.days;
+                    const amount = (days && (days in response.amounts)) ? Number(response.amounts[days]) : 0;
+                    if (!isFinite(amount) || amount <= 0) {
+                        // Zero/invalid/absent quote for THIS term: show no fee
+                        // rather than "+0.00" (Magento zero-hide semantics) —
+                        // and never leave the loading dots behind.
+                        surchargeLabel.textContent = '';
+                        return;
                     }
                     surchargeLabel.textContent = '+' + amount.toFixed(2) + suffix;
                 });
             }).fail(() => {
-                // Silent no-op: the static rate preview stays rendered.
+                this.clearTermSurchargeLoading(termsContainer);
             });
         } catch (e) {
-            // Never let a preview upgrade break the checkout render.
+            // Never let a fee-quote failure break the checkout render — but
+            // still clear the loaders so chips don't animate forever.
+            this.clearTermSurchargeLoading(termsContainer);
         }
     }
 

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -114,8 +114,7 @@
                 ajaxToken: twopayment.ajax_token,
                 available_payment_terms: twopayment.available_payment_terms || [30],
                 default_payment_term: twopayment.default_payment_term || 30,
-                payment_term_type: twopayment.payment_term_type,
-                payment_term_surcharge_preview: twopayment.payment_term_surcharge_preview || {}
+                payment_term_type: twopayment.payment_term_type
             });
             
             // Store global reference for modules
@@ -140,8 +139,7 @@
                             ajaxToken: twopayment.ajax_token,
                             available_payment_terms: twopayment.available_payment_terms || [30],
                             default_payment_term: twopayment.default_payment_term || 30,
-                            payment_term_type: twopayment.payment_term_type,
-                            payment_term_surcharge_preview: twopayment.payment_term_surcharge_preview || {}
+                            payment_term_type: twopayment.payment_term_type
                         });
                         window.TwoCheckoutManager_Instance = checkoutManager;
                     }

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -139,6 +139,32 @@
             updateSurchargeGridVisibility();
             $('select[name="PS_TWO_SURCHARGE_TYPE"]').on('change', updateSurchargeGridVisibility);
 
+            // Surcharge grid ROWS - one row is server-rendered per offerable
+            // term; show a row only while its "Available Payment Terms"
+            // checkbox is ticked AND the term is valid for the selected term
+            // type (EOM only allows the .two-term-both terms - same split the
+            // checkboxes use). Orthogonal to updateSurchargeGridVisibility(),
+            // which toggles COLUMNS by surcharge type: a cell is visible only
+            // when both its row and its column are (display:none on either
+            // axis wins), so the two functions compose without coordination.
+            function updateSurchargeGridRows() {
+                var termType = $('input[name="PS_TWO_PAYMENT_TERM_TYPE"]:checked').val();
+                $('#two-surcharge-grid .two-surcharge-row').each(function () {
+                    var $row = $(this);
+                    var term = parseInt($row.data('term'), 10);
+                    var checked = $('input[name="PS_TWO_PAYMENT_TERMS_' + term + '"]').is(':checked');
+                    var validForType = termType !== 'EOM' || $row.hasClass('two-term-both');
+                    $row.toggle(checked && validForType);
+                });
+            }
+            $('input[name^="PS_TWO_PAYMENT_TERMS_"]').on('change', updateSurchargeGridRows);
+            $('input[name="PS_TWO_PAYMENT_TERM_TYPE"]').on('change', updateSurchargeGridRows);
+            // Run once on load (after the checkbox-group and column-visibility
+            // passes above) so row state always derives from the live checkbox
+            // DOM, even if it disagrees with the server-rendered initial state
+            // (e.g. a failed-validation re-render with POSTed values).
+            updateSurchargeGridRows();
+
             // Inline merchant fee beside each "Available Payment Terms"
             // checkbox - the fee Two charges the merchant per term, fetched
             // live from the module's admin AJAX endpoint (which proxies


### PR DESCRIPTION
Two independent bugs, one PR.

## Bug 1 — admin surcharge grid didn't update on checkbox toggle
\`getTwoSurchargeGridHtml()\` looped the cached/saved \`getAvailablePaymentTerms()\` set, so toggling an "Available Payment Terms" checkbox didn't add/remove its fee-grid row until save+reload.

Fix: render a row for every offerable term up front (same set the checkboxes render for), each tagged \`data-term\`/type-class, initial visibility computed server-side from checkbox+term-type state. New \`updateSurchargeGridRows()\` in the admin JS shows/hides rows live from checkbox + term-type changes — orthogonal to the existing column-visibility toggle (by surcharge type), so the two compose via CSS alone. No field names/values changed, save path untouched.

## Bug 2 — checkout chips must never show the buyer the configured rate
Chips rendered the merchant's configured surcharge rate (e.g. "+2.50%") instantly, then swapped to the real quoted € amount a few seconds later once \`refreshTermSurchargeAmounts()\` resolved (shipped in #58) — meaning the buyer briefly saw internal pricing config. Confirmed via magento-plugin that the correct behavior is: never show a rate, show an animated loading indicator while the quote is in flight.

Fix:
- Chips now render Magento's three-dot loading indicator (\`.two-term-chip__loading\`, same CSS timing) unconditionally on every chip at creation.
- On successful quote: dots swap to the real amount (or blank if ~0, unchanged from #58).
- On ANY failure path — network error, timeout, \`success:false\`, malformed response, missing config, or a term absent from the response — the dots are explicitly cleared to blank via a new \`clearTermSurchargeLoading()\` helper, never left spinning and never falling back to a rate.
- Deleted \`getTwoSurchargeChipPreview()\` and its \`payment_term_surcharge_preview\` wiring entirely (confirmed via grep it had no other consumer) rather than leaving dead/wrong-behavior code around.

## Testing
\`php -l\` / \`node --check\` clean. \`make test\` — all specs pass, including a new grid-row-visibility regression test (STANDARD: all offerable rows exist, only checked ones visible; EOM: non-EOM rows hidden regardless of checked state).

---
*Reviewed by Claude prior to opening this PR — self-review-lane process.*