### PR TITLE
TWO-25071: surcharge tax from merchant's real TaxRulesGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice
-  - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the admin-configured Surcharge Tax Rate through a module-managed tax rules group
+  - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the merchant-selected tax rules group (see TWO-25071 below)
   - Selecting any other payment method removes the line; add/remove is idempotent against re-clicks, reloads and resumed carts (front-controller stale-line guard)
   - Order creation self-heals the line server-side and fails closed if the cart's fee and the Two payload's fee ever diverge beyond rounding tolerance
 - **Graceful invoice retrieval when order is not yet fulfilled** (TWO-25042, part of TWO-25040)
   - Invoice PDF downloads (customer order page and admin order view) are now routed through module controllers instead of linking the browser directly to the payment API
   - On `400 ORDER_NOT_FULFILLED` the module checks the order state: `FULFILLING` shows an informational "not ready yet" notice, `FULFILLED` retries the fetch once, and any other state is reported with the state named
   - Customer downloads are protected by the same secure-key ownership guard as the cancel/confirmation callbacks (guest checkout included); admin downloads go through a permission-gated admin controller
+
+### Changed
+- **Surcharge tax now uses the merchant's own tax rules group** (TWO-25071)
+  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products, pre-selecting the group most of the catalog uses
+  - The hidden fee product carries the selected group on its `id_tax_rules_group` like any real product, so PrestaShop's native tax engine applies per-country/state rules, combined multi-rate stacking, and destination-based zero-rating (no rule for the destination = untaxed) to the fee line
+  - The tax rate reported to Two's order API is resolved through the same core machinery (`TaxManagerFactory`) for the cart's tax address, with the same shop-wide gates (taxes disabled, VAT-number B2B exemption), so the PrestaShop line and the Two payload cannot drift and the order-create parity gate holds on cross-border orders
+  - Selecting "No tax" (PrestaShop's built-in id-0 group) keeps the fee untaxed for every destination; an unset/invalid selection fails safe to "No tax"
+  - Removed: the module-managed synthetic Tax/TaxRulesGroup/TaxRule graph, its `PS_TWO_SURCHARGE_TAX_SETUP` tracking blob, self-heal/advisory-lock machinery and uninstall cleanup (never released; uninstall still deletes the legacy configuration rows). Uninstall never deletes the merchant's own tax rules group
 
 ## Latest Release: v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Surcharge tax now uses the merchant's own tax rules group** (TWO-25071)
-  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products, pre-selecting the group most of the catalog uses
+  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products; an unsaved config pre-selects "No tax" so taxing the fee is always an explicit merchant choice
+  - A deactivated tax rules group that is still the configured selection stays in the dropdown (flagged "(inactive)") so an unrelated settings save can never silently reset the surcharge tax to "No tax"
+  - Module version bumped to `2.5.0`; the upgrade script does NOT auto-convert a previously configured flat rate (inventing a tax rules group from a bare percentage is destination-blind) - instead shops that had the flat rate set and no group selected get a logged warning and a persistent module-config notice ("surcharge tax needs re-selection", surcharge untaxed until saved)
   - The hidden fee product carries the selected group on its `id_tax_rules_group` like any real product, so PrestaShop's native tax engine applies per-country/state rules, combined multi-rate stacking, and destination-based zero-rating (no rule for the destination = untaxed) to the fee line
   - The tax rate reported to Two's order API is resolved through the same core machinery (`TaxManagerFactory`) for the cart's tax address, with the same shop-wide gates (taxes disabled, VAT-number B2B exemption), so the PrestaShop line and the Two payload cannot drift and the order-create parity gate holds on cross-border orders
   - Selecting "No tax" (PrestaShop's built-in id-0 group) keeps the fee untaxed for every destination; an unset/invalid selection fails safe to "No tax"

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.4.0]]></version>
+    <version><![CDATA[2.5.0]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/tests/ConfirmationLegacyParitySpec.php
+++ b/tests/ConfirmationLegacyParitySpec.php
@@ -65,7 +65,11 @@ final class ConfirmationLegacyParitySpec
         StubStore::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant-selected tax rules group: covers the cart's destination
+        // (FR, country 33) at 25%.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRulesGroups[400] = ['name' => 'FR standard rate', 'active' => 1];
+        StubStore::$taxRuleRates[400] = [33 => 25.0];
         Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30]');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
         Configuration::updateValue('PS_TWO_OS_AWAITING_VERIFICATION', 12);

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -54,6 +54,7 @@ final class SurchargeCartLineSpec
         self::testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects();
         self::testFeeTaxFollowsDestinationRulesOfSelectedGroup();
         self::testNoTaxSentinelZeroesFeeTaxForEveryDestination();
+        self::testVatExemptB2BCartUntaxedOnBothCartLineAndPayload();
         self::testAdminManualAddOfFeeProductToOrderIsBlocked();
         self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
         self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
@@ -649,6 +650,55 @@ final class SurchargeCartLineSpec
             TinyAssert::same('0', $payloadLine['tax_rate']);
             TinyAssert::same('5.00', $payloadLine['gross_amount']);
         }
+    }
+
+    /**
+     * TWO-25071: vatnumber-module B2B exemption. A cross-border business
+     * buyer with a VAT number (management on) is untaxed by core's
+     * Product::priceCalculation on the PS cart line AND by
+     * getTwoSurchargeTaxRateForCart on the Two payload side - both sides of
+     * the SAME cart must agree, exactly like the destination-rules /
+     * multi-rate / no-tax cases above. Guards the hand-replicated exemption
+     * condition in getTwoSurchargeTaxRateForCart against drifting from the
+     * cart-line behaviour.
+     */
+    private static function testVatExemptB2BCartUntaxedOnBothCartLineAndPayload(): void
+    {
+        // Cross-border B2B: merchant country NO (47), buyer FR with a VAT
+        // number -> exempt. Untaxed on BOTH sides.
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', 47);
+        StubStore::$addresses[8201]['vat_number'] = 'FR999999999';
+        StubStore::$addresses[8202]['vat_number'] = 'FR999999999';
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'VAT-exempt B2B cart must carry an UNTAXED PS fee line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0', $payloadLine['tax_rate'], 'payload side must apply the same B2B exemption as the cart line');
+        TinyAssert::same('5.00', $payloadLine['gross_amount'], 'payload gross matches the untaxed PS line gross');
+
+        // Domestic B2B (buyer country == VATNUMBER_COUNTRY): NOT exempt -
+        // both sides tax at the group's FR rate (25%). Fresh fixture so the
+        // re-price cannot be masked by sync idempotency.
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', self::COUNTRY_FR);
+        StubStore::$addresses[8201]['vat_number'] = 'FR999999999';
+        StubStore::$addresses[8202]['vat_number'] = 'FR999999999';
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(6.25, round((float) $lines[0]['total_wt'], 2), 'domestic B2B stays taxed on the PS line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.25', $payloadLine['tax_rate'], 'domestic B2B stays taxed on the payload side');
+        TinyAssert::same('6.25', $payloadLine['gross_amount']);
     }
 
     /* ---- order-level guard: no manual/duplicate fee rows (BO order edit) ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
  *   computation path as the Two payload's fee line
  *   (buildTwoSurchargeLineItemForCart over the shared quote cache), asserted
  *   end-to-end through getTwoNewOrderData,
- * - tax: PrestaShop applies exactly getTwoSurchargeTaxRate() to the line via
- *   the module-managed Tax/TaxRulesGroup/TaxRule graph.
+ * - tax: PrestaShop applies the merchant-selected TaxRulesGroup
+ *   (CONFIG_SURCHARGE_TAX_RULES_GROUP) to the line natively - the hidden fee
+ *   product carries the group on its id_tax_rules_group field like any real
+ *   product, and the Two payload resolves the SAME group for the SAME
+ *   destination (getTwoSurchargeTaxRateForCart), so the sides cannot drift.
  *
  * Plus the money-protective guards: the order-create parity gate (fail
  * closed on cart-vs-payload fee divergence) and the front-controller
@@ -25,6 +28,10 @@ final class SurchargeCartLineSpec
     private const CART_ID = 8101;
     private const PRODUCT_NET = 100.00;
     private const PRODUCT_GROSS = 105.50;
+    /** Merchant's own (pre-existing) tax rules group used by the fixtures. */
+    private const TAX_GROUP_ID = 400;
+    /** Fixture buyer country (FR) covered by the group at 25%. */
+    private const COUNTRY_FR = 33;
 
     public static function runAll(): void
     {
@@ -44,7 +51,9 @@ final class SurchargeCartLineSpec
         self::testAuthoritativeSyncBypassesSequenceGuard();
         self::testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest();
         self::testConcurrentFirstUseCreatesNoDuplicateHiddenProduct();
-        self::testConcurrentFirstUseCreatesNoDuplicateTaxSetup();
+        self::testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects();
+        self::testFeeTaxFollowsDestinationRulesOfSelectedGroup();
+        self::testNoTaxSentinelZeroesFeeTaxForEveryDestination();
         self::testAdminManualAddOfFeeProductToOrderIsBlocked();
         self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
         self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
@@ -60,7 +69,12 @@ final class SurchargeCartLineSpec
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '8');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant's own tax rules group, selected in the module config:
+        // covers the fixture buyer's country (FR) at 25%. Destinations the
+        // group has no rule for resolve 0 (core behaviour).
+        StubStore::$taxRulesGroups[self::TAX_GROUP_ID] = ['name' => 'FR standard rate', 'active' => 1];
+        StubStore::$taxRuleRates[self::TAX_GROUP_ID] = [self::COUNTRY_FR => 25.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) self::TAX_GROUP_ID);
         Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30,60]');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', '1');
@@ -175,8 +189,8 @@ final class SurchargeCartLineSpec
         $lines = self::feeLines();
         TinyAssert::count(1, $lines);
         TinyAssert::same(1, (int) $lines[0]['cart_quantity']);
-        // Net = quoted buyer_fee_share (5.00); gross applies the ADMIN
-        // configured 25% surcharge tax rate through the tax rules group.
+        // Net = quoted buyer_fee_share (5.00); gross applies the merchant's
+        // selected tax rules group rate for the buyer's country (FR -> 25%).
         TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
         TinyAssert::same(6.25, round((float) $lines[0]['total_wt'], 2));
         TinyAssert::same(25.0, round((float) $lines[0]['rate'], 2));
@@ -521,33 +535,120 @@ final class SurchargeCartLineSpec
         TinyAssert::same($productsAfterWinner, count(StubStore::$products), 'no duplicate hidden product after the race');
     }
 
-    private static function testConcurrentFirstUseCreatesNoDuplicateTaxSetup(): void
+    /**
+     * TWO-25071: the module assigns the MERCHANT's selected TaxRulesGroup to
+     * the hidden product's id_tax_rules_group (the same field every real
+     * product uses) and never creates Tax/TaxRulesGroup/TaxRule objects of
+     * its own (the synthetic-graph machinery is gone).
+     */
+    private static function testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects(): void
+    {
+        $module = self::makeModule([30 => '5.00', 60 => '8.00']);
+        $cart = self::makeCart();
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $productId = (int) Configuration::get('PS_TWO_SURCHARGE_PRODUCT_ID');
+        TinyAssert::same(self::TAX_GROUP_ID, (int) (new Product($productId))->id_tax_rules_group, 'fee product carries the merchant-selected group');
+        TinyAssert::count(0, StubStore::$taxes, 'module must not create a Tax');
+        TinyAssert::count(1, StubStore::$taxRulesGroups, 'only the merchant-owned fixture group exists');
+        TinyAssert::count(0, StubStore::$taxRules, 'module must not create a TaxRule');
+
+        // Merchant re-points the selection in the module config: the next
+        // sync self-heals the product assignment (no new objects, ever).
+        StubStore::$taxRulesGroups[401] = ['name' => 'Reduced rate', 'active' => 1];
+        StubStore::$taxRuleRates[401] = [self::COUNTRY_FR => 10.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '401');
+        Context::getContext()->cookie->two_payment_term = 60; // amount change forces a re-ensure
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::same(401, (int) (new Product($productId))->id_tax_rules_group, 'selection change re-points the product on the next sync');
+        TinyAssert::count(0, StubStore::$taxes);
+        TinyAssert::count(0, StubStore::$taxRules);
+        // And the re-priced line applies the NEW group's FR rate (10%) to
+        // the 60-day quote (8.00 net -> 8.80 gross).
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(8.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(8.80, round((float) $lines[0]['total_wt'], 2));
+    }
+
+    /**
+     * TWO-25071: destination-based rates. The selected group taxes the fee
+     * for a covered destination and zero-rates it for a destination the
+     * group has NO rule for - and the Two payload line resolves the SAME
+     * rate as the PS cart line in both cases (parity by construction),
+     * including a genuine multi-rate stacking destination (6% + 2% -> 8%).
+     */
+    private static function testFeeTaxFollowsDestinationRulesOfSelectedGroup(): void
     {
         $module = self::makeModule();
         $cart = self::makeCart();
 
-        // Another request holds the tax-setup lock: ensure fails soft (sync
-        // reports failure, frontend retries) and creates NO tax objects.
-        StubStore::$dbLocks['two_surcharge_tax_setup'] = true;
-        $result = $module->syncTwoSurchargeCartLine($cart, true);
-        TinyAssert::false($result['success']);
-        TinyAssert::count(0, StubStore::$taxes, 'lock loser must not create a Tax');
-        TinyAssert::count(0, StubStore::$taxRulesGroups, 'lock loser must not create a TaxRulesGroup');
-        TinyAssert::count(0, StubStore::$taxRules, 'lock loser must not create a TaxRule');
-        TinyAssert::count(0, self::feeLines());
-        unset(StubStore::$dbLocks['two_surcharge_tax_setup']);
+        // Group covers FR at 25%, CA-style stacked 6%+2% for country 40,
+        // and has NO rule for country 47 (NO).
+        StubStore::$taxRuleRates[self::TAX_GROUP_ID] = [
+            self::COUNTRY_FR => 25.0,
+            40 => [6.0, 2.0],
+        ];
+        StubStore::$countries[40] = 'CA';
+        StubStore::$addresses[8203] = ['id_country' => 40, 'loaded' => true] + StubStore::$addresses[8201];
+        StubStore::$addresses[8204] = ['id_country' => 47, 'loaded' => true] + StubStore::$addresses[8201];
 
-        // Lock released (winner finished): setup proceeds and repeated syncs
-        // reuse the SAME single object graph.
+        // Covered destination (FR, 25%): 5.00 net -> 6.25 gross.
         $module->syncTwoSurchargeCartLine($cart, true);
-        TinyAssert::count(1, StubStore::$taxes);
-        TinyAssert::count(1, StubStore::$taxRulesGroups);
-        TinyAssert::count(1, StubStore::$taxRules);
-        Context::getContext()->cookie->two_payment_term = 60;
-        $module->syncTwoSurchargeCartLine($cart, true); // amount change forces a re-ensure
-        TinyAssert::count(1, StubStore::$taxes, 'tax graph must be reused, not duplicated');
-        TinyAssert::count(1, StubStore::$taxRulesGroups);
-        TinyAssert::count(1, StubStore::$taxRules);
+        TinyAssert::same(6.25, round((float) self::feeLines()[0]['total_wt'], 2));
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.25', $payloadLine['tax_rate']);
+        TinyAssert::same('6.25', $payloadLine['gross_amount']);
+
+        // Stacking destination (6% + 2% combined = 8%): both sides at 8%.
+        $cart->id_address_invoice = 8203;
+        $cart->id_address_delivery = 8203;
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.40, round((float) $lines[0]['total_wt'], 2), 'stacked 6%+2% must apply additively (8%)');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.08', $payloadLine['tax_rate']);
+        TinyAssert::same('0.40', $payloadLine['tax_amount']);
+        TinyAssert::same('5.40', $payloadLine['gross_amount'], 'payload gross matches the PS line gross for the stacked destination');
+
+        // Uncovered destination (NO rule): zero-rated on BOTH sides.
+        $cart->id_address_invoice = 8204;
+        $cart->id_address_delivery = 8204;
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'no rule for the destination -> untaxed line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0', $payloadLine['tax_rate']);
+        TinyAssert::same('5.00', $payloadLine['gross_amount']);
+    }
+
+    /**
+     * TWO-25071: selecting the "No tax" sentinel (id 0) zeroes the fee tax
+     * for EVERY destination - no special-case code, it is core's own
+     * untaxed-group semantics (live-container verified).
+     */
+    private static function testNoTaxSentinelZeroesFeeTaxForEveryDestination(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+
+        foreach ([self::COUNTRY_FR => 8201, 47 => 8205] as $countryId => $addressId) {
+            StubStore::$countries[47] = 'NO';
+            StubStore::$addresses[8205] = ['id_country' => 47, 'loaded' => true] + StubStore::$addresses[8201];
+            $cart->id_address_invoice = $addressId;
+            $cart->id_address_delivery = $addressId;
+            $module->syncTwoSurchargeCartLine($cart, true);
+            $lines = self::feeLines();
+            TinyAssert::count(1, $lines);
+            TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+            TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'No tax sentinel must produce an untaxed line for country ' . $countryId);
+            $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+            TinyAssert::same('0', $payloadLine['tax_rate']);
+            TinyAssert::same('5.00', $payloadLine['gross_amount']);
+        }
     }
 
     /* ---- order-level guard: no manual/duplicate fee rows (BO order edit) ---- */

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -41,6 +41,10 @@ final class SurchargeSpec
         self::testFetchTermFeeParsesSuccess();
         self::testSurchargeTaxRulesGroupIdReadsAdminConfig();
         self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
+        self::testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection();
+        self::testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice();
+        self::testUpgrade250FlagsFlatRateShopsForTaxReselection();
+        self::testSurchargeTaxMigrationNoticeLifecycle();
         self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
         self::testSurchargeLineItemIgnoresApiTaxRateEntirely();
         self::testSurchargeLineItemDisabledReturnsNull();
@@ -468,6 +472,166 @@ final class SurchargeSpec
         // "No tax" sentinel (id 0) resolves 0 for every destination.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
         TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'group id 0 must always resolve 0');
+    }
+
+    /** Harness exposing the protected config-form helpers under test. */
+    private static function makeConfigHarness(): TwopaymentTestHarness
+    {
+        return new class extends TwopaymentTestHarness {
+            public function optionsForTest(): array
+            {
+                return $this->getTwoSurchargeTaxRulesGroupOptions();
+            }
+
+            public function formDefaultForTest(): int
+            {
+                return $this->getTwoSurchargeTaxRulesGroupFormDefault();
+            }
+
+            public function saveSurchargeFormForTest(): void
+            {
+                $this->saveTwoSurchargeFormValues();
+            }
+        };
+    }
+
+    /**
+     * The currently-configured group must stay in the dropdown even when
+     * deactivated: if it dropped out, the browser would submit the first
+     * option ("No tax") on the next unrelated settings save and silently
+     * detax the surcharge.
+     */
+    private static function testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection(): void
+    {
+        self::reset();
+        StubStore::$taxRulesGroups[400] = ['name' => 'Standard rate', 'active' => 1];
+        StubStore::$taxRulesGroups[500] = ['name' => 'Retired rate', 'active' => 0];
+        StubStore::$taxRulesGroups[600] = ['name' => 'Unused retired rate', 'active' => 0];
+        $module = self::makeConfigHarness();
+
+        // Configured group deactivated -> injected with an "(inactive)" tag.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '500');
+        $options = $module->optionsForTest();
+        $byId = [];
+        foreach ($options as $option) {
+            $byId[(int) $option['id']] = (string) $option['name'];
+        }
+        TinyAssert::same(['No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'deactivated configured group must stay selectable, flagged inactive');
+        TinyAssert::same([0, 400, 500], array_keys($byId), 'inactive groups that are NOT configured stay hidden');
+
+        // Configured group active -> plain listing, no duplicate, no tag.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        $options = $module->optionsForTest();
+        TinyAssert::count(2, $options);
+        TinyAssert::same('Standard rate', (string) $options[1]['name'], 'active configured group is listed once, untagged');
+
+        // Configured group deleted entirely -> nothing to inject (runtime
+        // already fails safe to "No tax" for a nonexistent group).
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
+        TinyAssert::count(2, $module->optionsForTest());
+    }
+
+    /**
+     * Unsaved config pre-selects "No tax" (0), matching runtime behaviour -
+     * NOT Product::getIdTaxRulesGroupMostUsed(), whose full-catalog
+     * COUNT/GROUP BY would re-run on every config page render.
+     */
+    private static function testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice(): void
+    {
+        self::reset();
+        $module = self::makeConfigHarness();
+
+        TinyAssert::same(0, $module->formDefaultForTest(), 'unset config must pre-select "No tax"');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::same(0, $module->formDefaultForTest(), 'blank config must pre-select "No tax"');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same(400, $module->formDefaultForTest(), 'stored selection is the pre-selection');
+    }
+
+    /**
+     * upgrade-2.5.0.php: a shop upgrading with the pre-release flat rate
+     * (PS_TWO_SURCHARGE_TAX_RATE) configured and no TaxRulesGroup selected
+     * gets a logged warning + the persistent "needs re-selection" flag - it
+     * must never pass silently. Shops without the flat rate, or that already
+     * selected a group, are untouched.
+     */
+    private static function testUpgrade250FlagsFlatRateShopsForTaxReselection(): void
+    {
+        require_once __DIR__ . '/../upgrade/upgrade-2.5.0.php';
+
+        // Flat rate set, group unset -> warning log + persistent flag.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        $module = new TwopaymentTestHarness();
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::same('1', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'flat-rate shop without a group selection must be flagged');
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(2, PrestaShopLogger::$logs[0]['severity'], 'logged as a warning');
+        TinyAssert::true(strpos(PrestaShopLogger::$logs[0]['message'], 'UNTAXED') !== false, 'log spells out the consequence');
+
+        // Group already selected -> no flag, no log.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'a shop that already selected a group is not nagged');
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+
+        // No flat rate (fresh install / never configured) -> untouched.
+        self::reset();
+        PrestaShopLogger::reset();
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+
+        // Blank flat rate counts as unset.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '  ');
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+
+    /**
+     * The post-upgrade notice is persistent (re-renders on every config
+     * page load) until the merchant makes a selection: it self-retires if a
+     * selection exists, and any explicit surcharge-settings save - "No tax"
+     * included - clears the flag.
+     */
+    private static function testSurchargeTaxMigrationNoticeLifecycle(): void
+    {
+        self::reset();
+        Tools::resetTestValues();
+        $module = self::makeConfigHarness();
+
+        // No flag -> no notice.
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
+
+        // Flag + no selection -> notice, and it PERSISTS across renders.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
+        $notice = $module->getTwoSurchargeTaxMigrationNotice();
+        TinyAssert::true($notice !== '', 'flagged shop must see the warning');
+        TinyAssert::true(strpos($notice, 'NOT taxed') !== false, 'warning spells out the consequence');
+        TinyAssert::true($module->getTwoSurchargeTaxMigrationNotice() !== '', 'warning persists until a selection is saved');
+
+        // Selection appears (any save path) -> notice self-retires and the
+        // flag is cleared.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'self-retire clears the flag');
+
+        // Explicit surcharge-settings save clears the flag too, even when
+        // the merchant confirms "No tax" (no group submitted -> stored 0).
+        self::reset();
+        Tools::resetTestValues();
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
+        $module->saveSurchargeFormForTest();
+        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group stores the explicit "No tax" sentinel');
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit save retires the nag');
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
     }
 
     private static function testSurchargeLineItemUsesSelectedGroupDestinationRate(): void

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -8,8 +8,9 @@ declare(strict_types=1);
  *
  * Covers: buyer_fee_share payload construction per term, the rounding relay
  * and its edge cases, the fee-quote fetch (fail-soft), fee-line construction
- * with the admin-configured Surcharge Tax Rate (PS_TWO_SURCHARGE_TAX_RATE —
- * the pricing-preview response's total_fee_tax_rate is never a source), and
+ * with the merchant-selected TaxRulesGroup's destination-resolved rate
+ * (CONFIG_SURCHARGE_TAX_RULES_GROUP via getTwoSurchargeTaxRateForCart — the
+ * pricing-preview response's total_fee_tax_rate is never a source), and
  * end-to-end injection into the order payload including a rounding-boundary
  * amount.
  */
@@ -38,8 +39,9 @@ final class SurchargeSpec
         self::testFetchTermFeeFailsSoftOnHttpError();
         self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
         self::testFetchTermFeeParsesSuccess();
-        self::testSurchargeTaxRateReadsAdminConfig();
-        self::testSurchargeLineItemUsesAdminConfiguredTaxRate();
+        self::testSurchargeTaxRulesGroupIdReadsAdminConfig();
+        self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
+        self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
         self::testSurchargeLineItemIgnoresApiTaxRateEntirely();
         self::testSurchargeLineItemDisabledReturnsNull();
         self::testSurchargeLineItemRoundsTaxOnBoundary();
@@ -404,47 +406,85 @@ final class SurchargeSpec
         TinyAssert::same('NOK', $fee['currency']);
     }
 
-    private static function testSurchargeTaxRateReadsAdminConfig(): void
+    private static function testSurchargeTaxRulesGroupIdReadsAdminConfig(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
 
-        // Blank/unset → 0.0 (deliberate deviation from Magento's default-tax-
-        // class fallback: PrestaShop has no store-wide default tax rate).
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'unset config must yield 0.0');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'blank config must yield 0.0');
+        // Blank/unset/garbage/negative → 0, PrestaShop's "No tax" sentinel
+        // (fail-safe: never tax the fee on a selection the merchant did not
+        // make).
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'unset config must yield 0 (No tax)');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'blank config must yield 0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, 'abc');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'non-numeric config must yield 0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '-5');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'negative config must yield 0');
 
-        // Percentage form scales down (normalizeTwoFeeTaxRate convention).
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
-        TinyAssert::same(0.25, $module->getTwoSurchargeTaxRate(), 'stored "25" means 25% → 0.25');
-
-        // Already-fractional input passes through unscaled — the exact
-        // normalizeTwoFeeTaxRate edge behaviour (<= 1.0 is left as-is).
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '0.25');
-        TinyAssert::same(0.25, $module->getTwoSurchargeTaxRate(), 'fractional "0.25" stays 0.25');
-
-        // Garbage and negatives degrade to 0.0, never fatal.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', 'abc');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'non-numeric config must yield 0.0');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '-5');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'negative config must yield 0.0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same(400, $module->getTwoSurchargeTaxRulesGroupId(), 'stored group id is returned as int');
     }
 
-    private static function testSurchargeLineItemUsesAdminConfiguredTaxRate(): void
+    private static function testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates(): void
+    {
+        self::reset();
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true]; // ES
+        StubStore::$addresses[901] = ['id_country' => 47, 'loaded' => true]; // NO - group has no rule
+        StubStore::$taxRuleRates[400] = [34 => 21.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        $module = new TwopaymentTestHarness();
+        $cart = new Cart(1);
+        $cart->id_address_invoice = 900;
+        $cart->id_address_delivery = 901;
+
+        // Covered destination resolves the group's rate as a fraction.
+        TinyAssert::same(0.21, $module->getTwoSurchargeTaxRateForCart($cart), 'covered destination resolves the group rate');
+
+        // Destination without a matching rule -> 0 (core zero-rating).
+        $cart->id_address_invoice = 901;
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'no rule for the destination must resolve 0');
+        $cart->id_address_invoice = 900;
+
+        // PS_TAX_ADDRESS_TYPE=delivery: the DELIVERY address is the tax
+        // destination, exactly like core cart pricing.
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_delivery');
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'delivery-address tax destination must be honoured');
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_invoice');
+
+        // Shop-wide PS_TAX off zeroes the rate (core Tax::excludeTaxeOption).
+        Configuration::updateValue('PS_TAX', 0);
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'PS_TAX disabled must zero the rate');
+        Configuration::updateValue('PS_TAX', 1);
+
+        // vatnumber-module B2B exemption: foreign VAT number + management on.
+        StubStore::$addresses[900]['vat_number'] = 'NO999999999';
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', 8); // shop country != buyer country
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'VAT-exempt B2B buyer must resolve 0');
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 0);
+        TinyAssert::same(0.21, $module->getTwoSurchargeTaxRateForCart($cart), 'exemption only applies when the vatnumber module manages it');
+
+        // "No tax" sentinel (id 0) resolves 0 for every destination.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'group id 0 must always resolve 0');
+    }
+
+    private static function testSurchargeLineItemUsesSelectedGroupDestinationRate(): void
     {
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 25.0];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 // The response carries a WILDLY different total_fee_tax_rate —
-                // it must have zero influence on the line's tax: the admin
-                // config is the only source.
+                // it must have zero influence on the line's tax: the selected
+                // group's destination rate is the only source.
                 return [
                     'http_status' => 200,
                     'buyer_fee_share' => '5.00',
@@ -460,7 +500,7 @@ final class SurchargeSpec
         TinyAssert::same('SERVICE', $line['type']);
         TinyAssert::same('Payment terms fee - 30 days', $line['name']);
         TinyAssert::same('5.00', $line['net_amount']);
-        TinyAssert::same('0.25', $line['tax_rate'], 'tax rate comes from admin config, never the pricing response');
+        TinyAssert::same('0.25', $line['tax_rate'], 'tax rate comes from the selected group, never the pricing response');
         TinyAssert::same('1.25', $line['tax_amount']);
         TinyAssert::same('6.25', $line['gross_amount']);
     }
@@ -475,8 +515,8 @@ final class SurchargeSpec
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
-                // Response has a rate but the admin field is blank: the line
-                // must be untaxed (0), proving the response rate is dead.
+                // Response has a rate but no tax rules group is selected: the
+                // line must be untaxed (0), proving the response rate is dead.
                 return [
                     'http_status' => 200,
                     'buyer_fee_share' => '5.00',
@@ -490,7 +530,7 @@ final class SurchargeSpec
         $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 100.0);
         TinyAssert::same('5.00', $line['net_amount']);
-        TinyAssert::same('0', $line['tax_rate'], 'blank admin config means untaxed line even when the response carries a rate');
+        TinyAssert::same('0', $line['tax_rate'], 'no selected group means untaxed line even when the response carries a rate');
         TinyAssert::same('0.00', $line['tax_amount']);
         TinyAssert::same('5.00', $line['gross_amount']);
     }
@@ -514,7 +554,9 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 25.0];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
@@ -530,6 +572,7 @@ final class SurchargeSpec
         };
         $cart = new Cart(1);
         $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 500.0);
         TinyAssert::same('10.10', $line['net_amount']);
         TinyAssert::same('2.53', $line['tax_amount']);
@@ -543,11 +586,13 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        // Configured rate needing more than TAX_RATE_PRECISION (3dp) decimals
+        // Group rate needing more than TAX_RATE_PRECISION (3dp) decimals
         // as a fraction (21.0098% → 0.210098). Tax must be computed from the
         // SNAPPED rate that is actually sent, else the line fails
         // validateTwoLineItems and is dropped.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '21.0098');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 21.0098];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
@@ -561,6 +606,7 @@ final class SurchargeSpec
         };
         $cart = new Cart(1);
         $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 5000.0);
         TinyAssert::same('0.21', $line['tax_rate'], 'rate is snapped to the sent precision');
         TinyAssert::same('210.00', $line['tax_amount'], 'tax computed from the sent (snapped) rate, not full precision');
@@ -601,7 +647,10 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant-selected group: FR (country 33, the cart's destination)
+        // at 25%.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [33 => 25.0];
 
         StubStore::$customers[7001] = [
             'email' => 'buyer@example.com',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -281,6 +281,11 @@ namespace {
             return (string) $message;
         }
 
+        public function displayWarning($message): string
+        {
+            return (string) $message;
+        }
+
         public function display($file, $template): string
         {
             return '';
@@ -406,6 +411,12 @@ namespace {
         public static function updateValue($key, $value): bool
         {
             StubStore::$configuration[$key] = $value;
+            return true;
+        }
+
+        public static function deleteByName($key): bool
+        {
+            unset(StubStore::$configuration[$key]);
             return true;
         }
     }
@@ -1140,7 +1151,13 @@ namespace {
                 ? 'id_address_delivery'
                 : 'id_address_invoice';
             $taxAddress = new Address((int) $this->{$taxAddressField});
-            $rate = Configuration::get('PS_TAX')
+            // vatnumber-module B2B exemption, exactly like core
+            // Product::priceCalculation: VAT number present, buyer country
+            // differs from the module's configured country, management on.
+            $vatExempt = !empty($taxAddress->vat_number)
+                && (int) $taxAddress->id_country !== (int) Configuration::get('VATNUMBER_COUNTRY')
+                && Configuration::get('VATNUMBER_MANAGEMENT');
+            $rate = (Configuration::get('PS_TAX') && !$vatExempt)
                 ? StubStore::resolveTaxRate((int) $product->id_tax_rules_group, (int) $taxAddress->id_country)
                 : 0.0;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,18 @@ namespace {
         public static array $moduleCurrencies = [];
         public static array $productCategories = [];
         public static array $images = [];
+        /**
+         * Effective tax rates by tax rules group, mirroring core's
+         * TaxManagerFactory resolution (live-container verified on PS 8.2.6):
+         *   - float: flat rate for EVERY destination (legacy shape)
+         *   - array<int,float|float[]>: rate by COUNTRY id; a missing country
+         *     resolves 0 (core: no matching TaxRule -> untaxed destination);
+         *     a float[] value SUMS (core: combined multi-rate rules stack
+         *     additively, e.g. 6% + 2% -> 8%).
+         * Group id 0 always resolves 0 (core "No tax" sentinel).
+         *
+         * @var array<int,float|array<int,float|float[]>>
+         */
         public static array $taxRuleRates = [];
         public static array $dbExecuteSResponses = [];
         public static array $dbLastExecuteS = [];
@@ -55,6 +67,34 @@ namespace {
         public static array $tabIds = ['AdminTwopaymentInvoice' => 1];
         /** @var string[] Class names passed to Tab::add() */
         public static array $tabAddCalls = [];
+
+        /**
+         * Resolve a tax rules group's effective rate for a destination
+         * country - the stub twin of core's
+         * TaxManagerFactory::getManager($address, $groupId)
+         *     ->getTaxCalculator()->getTotalRate().
+         * See $taxRuleRates for the fixture shapes.
+         */
+        public static function resolveTaxRate(int $groupId, int $countryId): float
+        {
+            if ($groupId <= 0 || !isset(self::$taxRuleRates[$groupId])) {
+                return 0.0;
+            }
+            $entry = self::$taxRuleRates[$groupId];
+            if (is_array($entry)) {
+                $entry = $entry[$countryId] ?? 0.0;
+            }
+            if (is_array($entry)) {
+                // Combined multi-rate rules stack additively (core-verified).
+                $sum = 0.0;
+                foreach ($entry as $rate) {
+                    $sum += (float) $rate;
+                }
+                return $sum;
+            }
+
+            return (float) $entry;
+        }
         /** @var array<int,array> Catalog products by id (surcharge cart-line feature) */
         public static array $products = [];
         /** @var array<int,array> Specific prices by id */
@@ -90,6 +130,7 @@ namespace {
                 'PS_TWO_ENVIRONMENT' => 'development',
                 'PS_OS_SHIPPING' => 4,
                 'PS_OS_CANCELED' => 6,
+                'PS_TAX' => 1, // core default: taxes enabled shop-wide
             ];
             self::$countries = [34 => 'ES', 47 => 'NO', 56 => 'BE'];
             self::$states = [
@@ -706,6 +747,23 @@ namespace {
             StubStore::$taxRulesGroups[$this->id] = ['name' => $this->name, 'active' => $this->active];
             return true;
         }
+
+        /** Core-shape rows: id_tax_rules_group / name / active. */
+        public static function getTaxRulesGroups($onlyActive = true): array
+        {
+            $rows = [];
+            foreach (StubStore::$taxRulesGroups as $id => $data) {
+                if ($onlyActive && empty($data['active'])) {
+                    continue;
+                }
+                $rows[] = [
+                    'id_tax_rules_group' => $id,
+                    'name' => (string) ($data['name'] ?? ''),
+                    'active' => (int) ($data['active'] ?? 0),
+                ];
+            }
+            return $rows;
+        }
     }
 
     class TaxRule
@@ -754,10 +812,6 @@ namespace {
             $data = get_object_vars($this);
             unset($data['loaded']);
             StubStore::$taxRules[$this->id] = $data;
-            // Mirror core behavior for the TaxManager stub: the group now
-            // applies the referenced tax's rate.
-            $tax = new Tax((int) $this->id_tax);
-            StubStore::$taxRuleRates[(int) $this->id_tax_rules_group] = (float) $tax->rate;
         }
     }
 
@@ -795,15 +849,17 @@ namespace {
     class TaxManager
     {
         private int $groupId;
+        private int $countryId;
 
-        public function __construct(int $groupId)
+        public function __construct(int $groupId, int $countryId)
         {
             $this->groupId = $groupId;
+            $this->countryId = $countryId;
         }
 
         public function getTaxCalculator(): TaxCalculator
         {
-            return new TaxCalculator((float) (StubStore::$taxRuleRates[$this->groupId] ?? 0.0));
+            return new TaxCalculator(StubStore::resolveTaxRate($this->groupId, $this->countryId));
         }
     }
 
@@ -811,7 +867,8 @@ namespace {
     {
         public static function getManager($address, $taxRulesGroupId): TaxManager
         {
-            return new TaxManager((int) $taxRulesGroupId);
+            $countryId = is_object($address) && isset($address->id_country) ? (int) $address->id_country : 0;
+            return new TaxManager((int) $taxRulesGroupId, $countryId);
         }
     }
 
@@ -1076,7 +1133,16 @@ namespace {
             if ($net === null) {
                 $net = $product->loaded ? (float) $product->price : 0.0;
             }
-            $rate = (float) (StubStore::$taxRuleRates[(int) $product->id_tax_rules_group] ?? 0.0);
+            // Destination-based rate, exactly like core Product::priceCalculation:
+            // the product's tax rules group resolved against the cart's
+            // PS_TAX_ADDRESS_TYPE address (invoice unless configured delivery).
+            $taxAddressField = Configuration::get('PS_TAX_ADDRESS_TYPE') === 'id_address_delivery'
+                ? 'id_address_delivery'
+                : 'id_address_invoice';
+            $taxAddress = new Address((int) $this->{$taxAddressField});
+            $rate = Configuration::get('PS_TAX')
+                ? StubStore::resolveTaxRate((int) $product->id_tax_rules_group, (int) $taxAddress->id_country)
+                : 0.0;
 
             $found = false;
             foreach ($rows as $i => $row) {

--- a/twopayment.php
+++ b/twopayment.php
@@ -6901,11 +6901,7 @@ class Twopayment extends PaymentModule
             return '';
         }
 
-        return $this->l(
-            'Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate,'
-            . ' which has been replaced by a tax rules group. Until you select and save a'
-            . ' "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.'
-        );
+        return $this->l('Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate, which has been replaced by a tax rules group. Until you select and save a "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.');
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -78,6 +78,12 @@ class Twopayment extends PaymentModule
     // sentinel. TWO-25071 (replaces the module-managed synthetic
     // Tax/TaxRulesGroup/TaxRule graph + flat PS_TWO_SURCHARGE_TAX_RATE).
     const CONFIG_SURCHARGE_TAX_RULES_GROUP = 'PS_TWO_SURCHARGE_TAX_RULES_GROUP';
+    // Set by upgrade-2.5.0.php when a pre-release flat surcharge tax rate
+    // (PS_TWO_SURCHARGE_TAX_RATE) was configured but no TaxRulesGroup has
+    // been selected yet: on upgrade the fee silently became untaxed, so a
+    // persistent back-office warning nags until the merchant saves a
+    // selection (any explicit save - including "No tax" - clears it).
+    const CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE = 'PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE';
 
     // Constants for delivery dates
     const DEFAULT_DELIVERY_DAYS_OFFSET = 7; // Default expected delivery date offset
@@ -111,7 +117,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.4.0';
+        $this->version = '2.5.0';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -540,6 +546,7 @@ class Twopayment extends PaymentModule
         // are no longer created and no longer cleaned up here.
         Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_RATE');
         Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_SETUP');
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE);
         return true;
     }
 
@@ -617,6 +624,15 @@ class Twopayment extends PaymentModule
         if (((bool) Tools::isSubmit('submitTwoOrderStatusForm')) == true) {
             Configuration::updateValue('PS_TWO_TAB_VALUE', 3);
             $this->saveTwoOrderStatusFormValues();
+        }
+
+        // Post-upgrade nag (upgrade-2.5.0.php): a pre-release flat surcharge
+        // tax rate existed but no TaxRulesGroup is selected - the fee is
+        // untaxed until the merchant re-selects. Rendered on every config
+        // page load until a surcharge-settings save clears the flag.
+        $migrationNotice = $this->getTwoSurchargeTaxMigrationNotice();
+        if ($migrationNotice !== '') {
+            $this->output .= $this->displayWarning($migrationNotice);
         }
 
         $this->context->smarty->assign(
@@ -6864,6 +6880,35 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Post-upgrade "surcharge tax needs re-selection" warning text, or ''
+     * when no warning is due. Due when upgrade-2.5.0.php flagged a shop that
+     * had the pre-release flat rate (PS_TWO_SURCHARGE_TAX_RATE) configured
+     * and no TaxRulesGroup has been saved since: the surcharge is silently
+     * untaxed until the merchant picks a group. Self-retires if a selection
+     * exists (covers saves made outside this module's own form path).
+     *
+     * @return string
+     */
+    public function getTwoSurchargeTaxMigrationNotice()
+    {
+        if (!Configuration::get(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE)) {
+            return '';
+        }
+        $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($stored !== false && $stored !== null && trim((string) $stored) !== '') {
+            Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+
+            return '';
+        }
+
+        return $this->l(
+            'Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate,'
+            . ' which has been replaced by a tax rules group. Until you select and save a'
+            . ' "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.'
+        );
+    }
+
+    /**
      * Effective tax rate (decimal FRACTION, e.g. 0.25) the selected
      * TaxRulesGroup applies to the surcharge for THIS cart's tax destination
      * - resolved through the SAME core machinery PrestaShop's own cart
@@ -8288,7 +8333,11 @@ class Twopayment extends PaymentModule
      * groups - the same list core's own product-edit page offers (its
      * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
      * rate, so the deduplicated getTaxRulesGroups source is used with the
-     * same manual "No tax" prepend).
+     * same manual "No tax" prepend). The currently-configured group is
+     * ALWAYS present even when deactivated (suffixed "(inactive)"): if a
+     * stale selection dropped out of the list, the browser would submit the
+     * first option ("No tax", id 0) on the next unrelated settings save and
+     * silently detax the surcharge.
      *
      * @return array<int,array{id:int,name:string}>
      */
@@ -8298,14 +8347,28 @@ class Twopayment extends PaymentModule
             array('id' => 0, 'name' => $this->l('No tax')),
         );
         $groups = TaxRulesGroup::getTaxRulesGroups(true);
+        $seen = array(0 => true);
         foreach ((array) $groups as $group) {
             if (!isset($group['id_tax_rules_group'])) {
                 continue;
             }
+            $id = (int) $group['id_tax_rules_group'];
             $options[] = array(
-                'id' => (int) $group['id_tax_rules_group'],
+                'id' => $id,
                 'name' => (string) $group['name'],
             );
+            $seen[$id] = true;
+        }
+
+        $configuredId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ($configuredId > 0 && !isset($seen[$configuredId])) {
+            $configured = new TaxRulesGroup($configuredId);
+            if (Validate::isLoadedObject($configured)) {
+                $options[] = array(
+                    'id' => $configuredId,
+                    'name' => (string) $configured->name . ' (' . $this->l('inactive') . ')',
+                );
+            }
         }
 
         return $options;
@@ -8313,12 +8376,12 @@ class Twopayment extends PaymentModule
 
     /**
      * Pre-selection for the surcharge tax rules group dropdown: the stored
-     * selection, else the merchant's "standard" group - the one most of
-     * their catalog uses (Product::getIdTaxRulesGroupMostUsed, the same
-     * default heuristic core's product page uses for new products). Display
-     * default only: runtime behaviour for an UNSAVED config stays "No tax"
-     * (getTwoSurchargeTaxRulesGroupId) - the module never taxes the fee on
-     * a rate the merchant did not confirm by saving.
+     * selection, else "No tax" (0) - the merchant must make an explicit
+     * choice. Deliberately NOT Product::getIdTaxRulesGroupMostUsed(): that
+     * is a full-catalog COUNT/GROUP BY re-run on every unsaved config page
+     * render, and pre-selecting a taxing group the merchant never chose
+     * invites an accidental save. Matches runtime behaviour for an UNSAVED
+     * config (getTwoSurchargeTaxRulesGroupId falls back to "No tax").
      *
      * @return int
      */
@@ -8327,9 +8390,6 @@ class Twopayment extends PaymentModule
         $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
         if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
             return max(0, (int) $stored);
-        }
-        if (method_exists('Product', 'getIdTaxRulesGroupMostUsed')) {
-            return max(0, (int) Product::getIdTaxRulesGroupMostUsed());
         }
 
         return 0;
@@ -8428,6 +8488,9 @@ class Twopayment extends PaymentModule
             $groupId = 0;
         }
         Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
+        // Explicit merchant save (any value, "No tax" included) retires the
+        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php.
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
 
         // Apply the selection to the hidden fee product immediately (the
         // same id_tax_rules_group field every real Product uses); if the

--- a/twopayment.php
+++ b/twopayment.php
@@ -70,10 +70,14 @@ class Twopayment extends PaymentModule
     // on first use; identified by Configuration id + reference cross-check.
     const TWO_SURCHARGE_PRODUCT_REFERENCE = 'TWO-SURCHARGE-FEE';
     const CONFIG_SURCHARGE_PRODUCT_ID = 'PS_TWO_SURCHARGE_PRODUCT_ID';
-    // JSON snapshot of the Tax/TaxRulesGroup/TaxRule objects backing the
-    // surcharge product's tax, keyed by configured rate + covered countries,
-    // so tax setup is validated/id-driven instead of fuzzy DB lookups.
-    const CONFIG_SURCHARGE_TAX_SETUP = 'PS_TWO_SURCHARGE_TAX_SETUP';
+    // Merchant-selected TaxRulesGroup applied to the hidden surcharge
+    // product - the SAME id_tax_rules_group field every real Product uses,
+    // so the fee line gets PrestaShop's full native tax capability
+    // (per-country/state rules, additive stacking, destination-based
+    // zero-rating when no rule matches). 0 is core's first-class "No tax"
+    // sentinel. TWO-25071 (replaces the module-managed synthetic
+    // Tax/TaxRulesGroup/TaxRule graph + flat PS_TWO_SURCHARGE_TAX_RATE).
+    const CONFIG_SURCHARGE_TAX_RULES_GROUP = 'PS_TWO_SURCHARGE_TAX_RULES_GROUP';
 
     // Constants for delivery dates
     const DEFAULT_DELIVERY_DAYS_OFFSET = 7; // Default expected delivery date offset
@@ -526,63 +530,17 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         $this->deleteTwoSurchargeCartProduct();
-        $this->deleteTwoSurchargeTaxSetup();
         Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
-        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_SETUP);
+        // The merchant's own TaxRulesGroup referenced by this config is NOT
+        // module-owned: delete only the reference, never the group.
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        // Legacy config rows from the retired synthetic-tax implementation
+        // (pre-release builds only; the surcharge feature never shipped with
+        // them). The synthetic Tax/TaxRulesGroup/TaxRule objects themselves
+        // are no longer created and no longer cleaned up here.
+        Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_RATE');
+        Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_SETUP');
         return true;
-    }
-
-    /**
-     * Best-effort removal of the module-managed Tax/TaxRulesGroup/TaxRule
-     * graph tracked in CONFIG_SURCHARGE_TAX_SETUP at uninstall. Historical
-     * orders keep their own copied tax rates on order_detail rows, so
-     * deleting the objects does not damage them. Never blocks uninstall.
-     */
-    protected function deleteTwoSurchargeTaxSetup()
-    {
-        try {
-            $setup = json_decode((string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP), true);
-            if (!is_array($setup)) {
-                return;
-            }
-
-            foreach ((array) (isset($setup['rules']) ? $setup['rules'] : array()) as $ruleId) {
-                try {
-                    if ((int) $ruleId > 0 && class_exists('TaxRule')) {
-                        $rule = new TaxRule((int) $ruleId);
-                        if (Validate::isLoadedObject($rule) && method_exists($rule, 'delete')) {
-                            $rule->delete();
-                        }
-                    }
-                } catch (Exception $e) {
-                    PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRule ' . (int) $ruleId . ' at uninstall - ' . $e->getMessage(), 2);
-                }
-            }
-
-            try {
-                if (!empty($setup['id_group']) && class_exists('TaxRulesGroup')) {
-                    $group = new TaxRulesGroup((int) $setup['id_group']);
-                    if (Validate::isLoadedObject($group) && method_exists($group, 'delete')) {
-                        $group->delete();
-                    }
-                }
-            } catch (Exception $e) {
-                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRulesGroup at uninstall - ' . $e->getMessage(), 2);
-            }
-
-            try {
-                if (!empty($setup['id_tax']) && class_exists('Tax')) {
-                    $tax = new Tax((int) $setup['id_tax']);
-                    if (Validate::isLoadedObject($tax) && method_exists($tax, 'delete')) {
-                        $tax->delete();
-                    }
-                }
-            } catch (Exception $e) {
-                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge Tax at uninstall - ' . $e->getMessage(), 2);
-            }
-        } catch (Exception $e) {
-            PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge tax setup at uninstall - ' . $e->getMessage(), 2);
-        }
     }
 
     /**
@@ -6887,42 +6845,83 @@ class Twopayment extends PaymentModule
      * @param mixed $rate
      * @return float
      */
-    private function normalizeTwoFeeTaxRate($rate)
+    /**
+     * Merchant-selected TaxRulesGroup id for the hidden surcharge product
+     * (CONFIG_SURCHARGE_TAX_RULES_GROUP). 0 - also the unset/blank/garbage
+     * fallback - is PrestaShop's first-class "No tax" sentinel: fail-safe is
+     * an untaxed fee, never an invented rate. TWO-25071.
+     *
+     * @return int
+     */
+    public function getTwoSurchargeTaxRulesGroupId()
     {
-        if ($rate === null || $rate === '') {
-            return 0.0;
-        }
-        $rate = (float) $rate;
-        if ($rate <= 0) {
-            return 0.0;
-        }
-        if ($rate > 1.0) {
-            $rate = $rate / 100.0;
+        $raw = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($raw === false || $raw === null || !is_numeric($raw)) {
+            return 0;
         }
 
-        return $rate;
+        return max(0, (int) $raw);
     }
 
     /**
-     * Admin-configured Surcharge Tax Rate for the Two order-creation fee line
-     * (Magento parity: Config\Repository::getSurchargeTaxRate /
-     * XML_PATH_SURCHARGE_TAX_RATE), as a decimal FRACTION (stored "25" →
-     * 0.25) via the same normalizeTwoFeeTaxRate scaling convention the rest
-     * of the file uses. Returns 0.0 when the field is blank/unset/
-     * non-numeric/negative — deliberate deviation from Magento, whose blank
-     * fallback is the store's default product tax class rate: PrestaShop has
-     * no equivalent store-wide default tax rate concept.
+     * Effective tax rate (decimal FRACTION, e.g. 0.25) the selected
+     * TaxRulesGroup applies to the surcharge for THIS cart's tax destination
+     * - resolved through the SAME core machinery PrestaShop's own cart
+     * pricing uses for the hidden fee product (Product::priceCalculation):
+     * TaxManagerFactory over the cart's PS_TAX_ADDRESS_TYPE address, with
+     * the same shop-wide gates (PS_TAX off, vatnumber-module B2B exemption).
+     * Using one resolution for both the PS cart line and the Two payload is
+     * what makes the PR #64 parity gate unable to trip on destination-based
+     * rates. Empirically verified on PS 8.2.6 core: no matching rule for the
+     * destination -> 0 (zero-rating for free), combined multi-rate rules sum
+     * (6%+2% -> 8), group id 0 -> 0 everywhere.
      *
+     * @param Cart $cart
      * @return float
      */
-    public function getTwoSurchargeTaxRate()
+    public function getTwoSurchargeTaxRateForCart($cart)
     {
-        $raw = trim((string) Configuration::get('PS_TWO_SURCHARGE_TAX_RATE'));
-        if ($raw === '' || !is_numeric($raw)) {
+        $groupId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ($groupId <= 0 || !Validate::isLoadedObject($cart)) {
             return 0.0;
         }
 
-        return $this->normalizeTwoFeeTaxRate($raw);
+        // Shop-wide "disable taxes" switch (core: Tax::excludeTaxeOption
+        // inside Product::priceCalculation zeroes every product's tax).
+        if (class_exists('Tax') && method_exists('Tax', 'excludeTaxeOption')) {
+            if (Tax::excludeTaxeOption()) {
+                return 0.0;
+            }
+        } elseif (!Configuration::get('PS_TAX')) {
+            return 0.0;
+        }
+
+        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
+        if ($taxAddressField !== 'id_address_delivery') {
+            $taxAddressField = 'id_address_invoice';
+        }
+        $address = new Address((int) $cart->{$taxAddressField});
+        if (!Validate::isLoadedObject($address)) {
+            // No usable tax destination. Cannot legitimately happen at the
+            // payment step (PS requires addresses first); if it ever does,
+            // the payload carries no tax and the fail-closed parity gate /
+            // post-write sync verification blocks any divergence.
+            return 0.0;
+        }
+
+        // vatnumber-module B2B exemption - the exact condition core's
+        // Product::priceCalculation flips usetax off with.
+        if (
+            !empty($address->vat_number)
+            && (int) $address->id_country !== (int) Configuration::get('VATNUMBER_COUNTRY')
+            && Configuration::get('VATNUMBER_MANAGEMENT')
+        ) {
+            return 0.0;
+        }
+
+        $calculator = TaxManagerFactory::getManager($address, $groupId)->getTaxCalculator();
+
+        return max(0.0, (float) $calculator->getTotalRate()) / 100.0;
     }
 
     /**
@@ -6950,12 +6949,13 @@ class Twopayment extends PaymentModule
     /**
      * Build the buyer-surcharge line item for the Two order payload, or null
      * when no surcharge is configured / the quote fails / the fee is zero.
-     * The line's tax_rate carries the admin-configured Surcharge Tax Rate
-     * (PS_TWO_SURCHARGE_TAX_RATE via getTwoSurchargeTaxRate, Magento parity:
-     * XML_PATH_SURCHARGE_TAX_RATE) — NOT the pricing-preview response's
-     * total_fee_tax_rate, which the plugin never populates in its own
-     * /v1/pricing/order/fee request and is therefore always empty; net/tax/
-     * gross satisfy the Two line-item formulas so validateTwoLineItems
+     * The line's tax_rate is the merchant-selected TaxRulesGroup's effective
+     * rate for THIS cart's tax destination (getTwoSurchargeTaxRateForCart -
+     * the same core resolution PrestaShop applies to the hidden fee cart
+     * line, so the two sides cannot drift) — NOT the pricing-preview
+     * response's total_fee_tax_rate, which the plugin never populates in its
+     * own /v1/pricing/order/fee request and is therefore always empty; net/
+     * tax/gross satisfy the Two line-item formulas so validateTwoLineItems
      * accepts it.
      *
      * @param Cart     $cart
@@ -6993,10 +6993,11 @@ class Twopayment extends PaymentModule
         if ($net <= 0) {
             return null;
         }
-        // The rate comes from the admin-configured Surcharge Tax Rate — the
-        // pricing-preview response's total_fee_tax_rate is never populated
-        // (the plugin sends no tax-rate field in its own fee request), so it
-        // is NOT a usable source. Compute tax from the SAME rate string that
+        // The rate is the selected TaxRulesGroup's destination-resolved rate
+        // (getTwoSurchargeTaxRateForCart) — the pricing-preview response's
+        // total_fee_tax_rate is never populated (the plugin sends no
+        // tax-rate field in its own fee request), so it is NOT a usable
+        // source. Compute tax from the SAME rate string that
         // is sent (formatTwoTaxRate snaps to TAX_RATE_PRECISION dp). Using
         // the full-precision rate to compute tax while sending a rounded rate
         // makes the line fail validateTwoLineItems (tax_amount vs
@@ -7004,7 +7005,7 @@ class Twopayment extends PaymentModule
         // decimals, silently dropping the whole surcharge line. Snapping
         // first mirrors the product-line convention (snapped_product_rate).
         // TWO-24752.
-        $taxRate = $this->getTwoSurchargeTaxRate();
+        $taxRate = $this->getTwoSurchargeTaxRateForCart($cart);
         $taxRateString = $this->formatTwoTaxRate($taxRate);
         $sentRate = (float) $taxRateString;
         $tax = round($net * $sentRate, 2);
@@ -7248,7 +7249,7 @@ class Twopayment extends PaymentModule
         }
         $product->reference = self::TWO_SURCHARGE_PRODUCT_REFERENCE;
         $product->price = 0;
-        $product->id_tax_rules_group = 0;
+        $product->id_tax_rules_group = $this->getTwoSurchargeTaxRulesGroupId();
         $product->active = 1;
         $product->available_for_order = 1;
         $product->visibility = 'none';
@@ -7275,169 +7276,33 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Ensure the surcharge product carries a TaxRulesGroup whose rule for the
-     * cart's tax country applies exactly the admin-configured Surcharge Tax
-     * Rate (getTwoSurchargeTaxRate). Object graph (Tax + group + per-country
-     * rules) is tracked by id in CONFIG_SURCHARGE_TAX_SETUP and validated on
-     * every call, so a merchant deleting objects in the BO self-heals here.
-     * A configured-rate change creates a NEW Tax and re-points the rules
-     * (historical orders keep their order_detail rate copies).
+     * Ensure the hidden surcharge product carries the merchant-selected
+     * TaxRulesGroup (CONFIG_SURCHARGE_TAX_RULES_GROUP) - the exact same
+     * id_tax_rules_group assignment PrestaShop's own product-edit page
+     * makes, so core resolves the fee line's tax natively (per-destination
+     * rules, stacking, "No tax" id 0). Idempotent single-row self-heal: a
+     * merchant re-pointing or clearing the selection is picked up on the
+     * next cart sync. No synthetic Tax/TaxRulesGroup/TaxRule objects are
+     * created any more (TWO-25071); if the merchant deletes the selected
+     * group in the BO, core resolves 0 for every destination on BOTH the
+     * cart line and the Two payload (same resolution path), so parity holds.
      *
-     * @param Cart $cart
      * @param int $productId
-     * @return bool false when the tax setup could not be ensured
+     * @return bool false when the product could not be loaded/updated
      */
-    public function ensureTwoSurchargeTaxSetupForCart($cart, $productId)
+    public function ensureTwoSurchargeProductTaxRulesGroup($productId)
     {
-        $ratePercent = round($this->getTwoSurchargeTaxRate() * 100, 3);
-
         $product = new Product((int) $productId);
         if (!Validate::isLoadedObject($product)) {
             return false;
         }
 
-        if ($ratePercent <= 0) {
-            if ((int) $product->id_tax_rules_group !== 0) {
-                $product->id_tax_rules_group = 0;
-                $product->update();
-                $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
-            }
-            return true;
-        }
-
-        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
-        if ($taxAddressField !== 'id_address_delivery') {
-            $taxAddressField = 'id_address_invoice';
-        }
-        $address = new Address((int) $cart->{$taxAddressField});
-        $countryId = Validate::isLoadedObject($address) ? (int) $address->id_country : 0;
-        if ($countryId <= 0) {
-            return false;
-        }
-
-        // Advisory lock around the whole read-validate-create sequence: two
-        // concurrent first-time carts would otherwise both see an empty
-        // setup and create duplicate Tax/TaxRulesGroup/TaxRule graphs, with
-        // only one surviving in Configuration and the rest orphaned.
-        if (!$this->acquireTwoDbLock('two_surcharge_tax_setup')) {
-            PrestaShopLogger::addLog('TwoPayment: Surcharge tax setup lock not acquired', 2);
-            return false;
-        }
-        try {
-            return $this->ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId);
-        } finally {
-            $this->releaseTwoDbLock('two_surcharge_tax_setup');
-        }
-    }
-
-    /**
-     * Body of ensureTwoSurchargeTaxSetupForCart, executed while holding the
-     * two_surcharge_tax_setup advisory lock.
-     *
-     * @param Product $product
-     * @param float $ratePercent
-     * @param int $countryId
-     * @return bool
-     */
-    protected function ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId)
-    {
-        // Read the tracked setup UNDER the lock, straight from the DB: a
-        // concurrent winner's Configuration write is invisible to this
-        // request's per-request Configuration cache.
-        $setupJson = Db::getInstance()->getValue(
-            'SELECT `value` FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = '" . pSQL(self::CONFIG_SURCHARGE_TAX_SETUP) . "'"
-        );
-        if ($setupJson === false || $setupJson === null || $setupJson === '') {
-            $setupJson = (string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP);
-        }
-        $setup = json_decode((string) $setupJson, true);
-        if (!is_array($setup)) {
-            $setup = array();
-        }
-        $setup += array('rate_percent' => null, 'id_tax' => 0, 'id_group' => 0, 'rules' => array());
-
-        // Group: validate stored id, else create.
-        $group = $setup['id_group'] > 0 ? new TaxRulesGroup((int) $setup['id_group']) : null;
-        if ($group === null || !Validate::isLoadedObject($group)) {
-            $group = new TaxRulesGroup();
-            $group->name = 'Two payment terms fee tax';
-            $group->active = 1;
-            if (!$group->add()) {
+        $groupId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ((int) $product->id_tax_rules_group !== $groupId) {
+            $product->id_tax_rules_group = $groupId;
+            if (!$product->update()) {
                 return false;
             }
-            $setup['id_group'] = (int) $group->id;
-            $setup['rules'] = array(); // stale rules belonged to the lost group
-        }
-
-        // Tax at the configured rate: validate stored id + rate, else create.
-        $tax = $setup['id_tax'] > 0 ? new Tax((int) $setup['id_tax']) : null;
-        $taxValid = $tax !== null && Validate::isLoadedObject($tax)
-            && abs(round((float) $tax->rate, 3) - $ratePercent) < 0.0005;
-        if (!$taxValid) {
-            $tax = new Tax();
-            $tax->name = array();
-            $languageIds = array();
-            foreach ((array) Language::getLanguages(false) as $lang) {
-                if (isset($lang['id_lang'])) {
-                    $languageIds[] = (int) $lang['id_lang'];
-                }
-            }
-            if (empty($languageIds)) {
-                $languageIds[] = isset($this->context->language->id) ? (int) $this->context->language->id : 1;
-            }
-            foreach ($languageIds as $idLang) {
-                $tax->name[$idLang] = 'Two surcharge VAT ' . $this->getTwoRoundAmount($ratePercent) . '%';
-            }
-            $tax->rate = $ratePercent;
-            $tax->active = 1;
-            if (!$tax->add()) {
-                return false;
-            }
-            $setup['id_tax'] = (int) $tax->id;
-
-            // Rate changed: re-point every existing per-country rule at the
-            // new Tax so previously-served countries keep working.
-            foreach ((array) $setup['rules'] as $ruleCountryId => $ruleId) {
-                $rule = new TaxRule((int) $ruleId);
-                if (Validate::isLoadedObject($rule)) {
-                    $rule->id_tax = (int) $tax->id;
-                    $rule->update();
-                } else {
-                    unset($setup['rules'][$ruleCountryId]);
-                }
-            }
-        }
-
-        // Rule for the cart's tax country: validate stored id, else create.
-        $ruleId = isset($setup['rules'][$countryId]) ? (int) $setup['rules'][$countryId] : 0;
-        $rule = $ruleId > 0 ? new TaxRule($ruleId) : null;
-        if ($rule === null || !Validate::isLoadedObject($rule) || (int) $rule->id_tax !== (int) $setup['id_tax']) {
-            if ($rule !== null && Validate::isLoadedObject($rule)) {
-                $rule->id_tax = (int) $setup['id_tax'];
-                $rule->update();
-            } else {
-                $rule = new TaxRule();
-                $rule->id_tax_rules_group = (int) $setup['id_group'];
-                $rule->id_country = $countryId;
-                $rule->id_state = 0;
-                $rule->zipcode_from = 0;
-                $rule->zipcode_to = 0;
-                $rule->id_tax = (int) $setup['id_tax'];
-                $rule->behavior = 0;
-                $rule->description = '';
-                if (!$rule->add()) {
-                    return false;
-                }
-                $setup['rules'][$countryId] = (int) $rule->id;
-            }
-        }
-
-        $setup['rate_percent'] = $ratePercent;
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_SETUP, json_encode($setup));
-
-        if ((int) $product->id_tax_rules_group !== (int) $setup['id_group']) {
-            $product->id_tax_rules_group = (int) $setup['id_group'];
-            $product->update();
             $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
         }
 
@@ -7451,9 +7316,9 @@ class Twopayment extends PaymentModule
      * the product's group via Product::getIdTaxRulesGroupByIdProduct, which
      * memoises 'product_id_tax_rules_group_{id}_{shop}' in Cache. The value
      * gets primed with 0 during product creation, and Product::update does
-     * NOT clean it - so the very first request that creates the tax setup
-     * would price the fee line WITHOUT tax (gross == net) while the Two
-     * payload carries tax, and the stale line would then never self-correct
+     * NOT clean it - so the very first request that re-points the product's
+     * tax rules group would price the fee line WITHOUT tax (gross == net)
+     * while the Two payload carries tax, and the stale line would then never self-correct
      * (the sync no-op check compares net, which matches). Cleaning the exact
      * key here makes the first request price correctly.
      *
@@ -7899,8 +7764,8 @@ class Twopayment extends PaymentModule
                 return $result;
             }
 
-            if (!$this->ensureTwoSurchargeTaxSetupForCart($cart, $productId)) {
-                PrestaShopLogger::addLog('TwoPayment: Surcharge cart line skipped - tax setup could not be ensured for cart ' . (int) $cart->id, 3);
+            if (!$this->ensureTwoSurchargeProductTaxRulesGroup($productId)) {
+                PrestaShopLogger::addLog('TwoPayment: Surcharge cart line skipped - tax rules group could not be applied to product ' . (int) $productId . ' for cart ' . (int) $cart->id, 3);
                 return $result;
             }
 
@@ -7935,7 +7800,7 @@ class Twopayment extends PaymentModule
                     ' - expected (net/gross)=(' . $this->getTwoRoundAmount($expectedNet) . '/' . $this->getTwoRoundAmount($expectedGross) .
                     '), cart applied ' . ($written === null ? 'no line' :
                         '(net/gross)=(' . $this->getTwoRoundAmount($written['net']) . '/' . $this->getTwoRoundAmount($written['gross']) . ')') .
-                    '. Line removed; check the shop tax configuration for the surcharge tax rate.',
+                    '. Line removed; check the selected surcharge tax rules group configuration.',
                     3
                 );
                 $this->removeTwoSurchargeCartLineInternal($cart, $productId);
@@ -8327,11 +8192,15 @@ class Twopayment extends PaymentModule
             'options' => array('query' => $stepQuery, 'id' => 'id', 'name' => 'name'),
         );
         $inputs[] = array(
-            'type' => 'text',
-            'label' => $this->l('Surcharge Tax Rate (%)'),
-            'name' => 'PS_TWO_SURCHARGE_TAX_RATE',
-            'suffix' => '%',
-            'desc' => $this->l('Tax rate applied to the surcharge line sent to Two (e.g. 25 for 25%). Leave blank for no tax on the surcharge line.'),
+            'type' => 'select',
+            'label' => $this->l('Surcharge Tax Rules Group'),
+            'name' => self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
+            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee.'),
+            'options' => array(
+                'query' => $this->getTwoSurchargeTaxRulesGroupOptions(),
+                'id' => 'id',
+                'name' => 'name',
+            ),
         );
         $inputs[] = array(
             'type' => 'html',
@@ -8414,6 +8283,59 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Dropdown options for the surcharge tax rules group: PrestaShop's
+     * "No tax" sentinel (id 0) followed by the merchant's active tax rules
+     * groups - the same list core's own product-edit page offers (its
+     * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
+     * rate, so the deduplicated getTaxRulesGroups source is used with the
+     * same manual "No tax" prepend).
+     *
+     * @return array<int,array{id:int,name:string}>
+     */
+    protected function getTwoSurchargeTaxRulesGroupOptions()
+    {
+        $options = array(
+            array('id' => 0, 'name' => $this->l('No tax')),
+        );
+        $groups = TaxRulesGroup::getTaxRulesGroups(true);
+        foreach ((array) $groups as $group) {
+            if (!isset($group['id_tax_rules_group'])) {
+                continue;
+            }
+            $options[] = array(
+                'id' => (int) $group['id_tax_rules_group'],
+                'name' => (string) $group['name'],
+            );
+        }
+
+        return $options;
+    }
+
+    /**
+     * Pre-selection for the surcharge tax rules group dropdown: the stored
+     * selection, else the merchant's "standard" group - the one most of
+     * their catalog uses (Product::getIdTaxRulesGroupMostUsed, the same
+     * default heuristic core's product page uses for new products). Display
+     * default only: runtime behaviour for an UNSAVED config stays "No tax"
+     * (getTwoSurchargeTaxRulesGroupId) - the module never taxes the fee on
+     * a rate the merchant did not confirm by saving.
+     *
+     * @return int
+     */
+    protected function getTwoSurchargeTaxRulesGroupFormDefault()
+    {
+        $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
+            return max(0, (int) $stored);
+        }
+        if (method_exists('Product', 'getIdTaxRulesGroupMostUsed')) {
+            return max(0, (int) Product::getIdTaxRulesGroupMostUsed());
+        }
+
+        return 0;
+    }
+
+    /**
      * Current values for the surcharge form fields.
      *
      * @return array
@@ -8426,7 +8348,10 @@ class Twopayment extends PaymentModule
             'PS_TWO_SURCHARGE_LINE_DESC' => Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', Configuration::get('PS_TWO_SURCHARGE_LINE_DESC')),
             'PS_TWO_SURCHARGE_ROUNDING_BASIS' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS')),
             'PS_TWO_SURCHARGE_ROUNDING_STEP' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP')),
-            'PS_TWO_SURCHARGE_TAX_RATE' => Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE', Configuration::get('PS_TWO_SURCHARGE_TAX_RATE')),
+            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (int) Tools::getValue(
+                self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
+                $this->getTwoSurchargeTaxRulesGroupFormDefault()
+            ),
         );
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;
@@ -8453,9 +8378,12 @@ class Twopayment extends PaymentModule
         if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
             $this->errors[] = $this->l('Rounding step must be one of the offered values.');
         }
-        $taxRate = Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE');
-        if ($taxRate !== false && $taxRate !== '' && (!is_numeric($taxRate) || (float) $taxRate < 0)) {
-            $this->errors[] = $this->l('Surcharge tax rate must be a non-negative number.');
+        $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($groupRaw !== false && $groupRaw !== '') {
+            $groupId = is_numeric($groupRaw) ? (int) $groupRaw : -1;
+            if ($groupId < 0 || ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId)))) {
+                $this->errors[] = $this->l('Surcharge tax rules group must be "No tax" or one of the shop\'s existing tax rules groups.');
+            }
         }
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;
@@ -8491,13 +8419,23 @@ class Twopayment extends PaymentModule
         }
         Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', $step);
 
-        // Same coercion discipline as the grid: invalid input is stored as
-        // blank (→ getTwoSurchargeTaxRate() falls back to 0.0), never fatal.
-        $taxRateRaw = trim((string) Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE', ''));
-        Configuration::updateValue(
-            'PS_TWO_SURCHARGE_TAX_RATE',
-            (is_numeric($taxRateRaw) && (float) $taxRateRaw >= 0) ? (string) (float) $taxRateRaw : ''
-        );
+        // Same coercion discipline as the grid: invalid/unknown input is
+        // stored as 0 ("No tax" - getTwoSurchargeTaxRulesGroupId's fail-safe),
+        // never fatal. A group id is only stored when the group exists.
+        $groupRaw = trim((string) Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, ''));
+        $groupId = (is_numeric($groupRaw) && (int) $groupRaw > 0) ? (int) $groupRaw : 0;
+        if ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
+            $groupId = 0;
+        }
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
+
+        // Apply the selection to the hidden fee product immediately (the
+        // same id_tax_rules_group field every real Product uses); if the
+        // product does not exist yet, lazy creation picks the config up.
+        $productId = (int) Configuration::get(self::CONFIG_SURCHARGE_PRODUCT_ID);
+        if ($productId > 0) {
+            $this->ensureTwoSurchargeProductTaxRulesGroup($productId);
+        }
 
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;

--- a/upgrade/upgrade-2.5.0.php
+++ b/upgrade/upgrade-2.5.0.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.5.0
+ *
+ * Surcharge tax migration visibility (TWO-25071):
+ * The flat "Surcharge Tax Rate (%)" (PS_TWO_SURCHARGE_TAX_RATE, pre-release
+ * builds only) is replaced by a merchant-selected TaxRulesGroup
+ * (PS_TWO_SURCHARGE_TAX_RULES_GROUP). No automatic conversion is attempted:
+ * inventing a TaxRulesGroup to match a bare percentage is destination-blind
+ * and risks taxing orders wrongly. Instead, when a shop upgrades with the
+ * flat rate configured and no group selected yet, this script:
+ * - logs a warning via PrestaShopLogger, and
+ * - sets a persistent flag (PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE) that the
+ *   module config page renders as a visible "surcharge tax needs
+ *   re-selection" warning until the merchant saves a selection.
+ *
+ * Created: 2026-07-11
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_5_0($module)
+{
+    $flatRate = Configuration::get('PS_TWO_SURCHARGE_TAX_RATE');
+    $group = Configuration::get('PS_TWO_SURCHARGE_TAX_RULES_GROUP');
+
+    $flatRateWasConfigured = ($flatRate !== false && $flatRate !== null && trim((string) $flatRate) !== '');
+    $groupIsConfigured = ($group !== false && $group !== null && trim((string) $group) !== '');
+
+    if ($flatRateWasConfigured && !$groupIsConfigured) {
+        PrestaShopLogger::addLog(
+            'TwoPayment Upgrade 2.5.0: A flat surcharge tax rate (PS_TWO_SURCHARGE_TAX_RATE='
+            . trim((string) $flatRate)
+            . ') was configured but is no longer used. The surcharge is UNTAXED until a'
+            . ' Surcharge Tax Rules Group is selected and saved in the module Payment settings.',
+            2,
+            null,
+            'Module',
+            $module->id
+        );
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE', '1');
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
Replaces the auto-created synthetic Tax/TaxRulesGroup (single flat rate) with direct assignment of the surcharge's hidden product to a merchant-selected, real, existing TaxRulesGroup — enabling destination-aware/additive tax resolution instead of a flat rate baked in at setup time (TWO-25069). Net simplification: deletes ~170 lines of self-heal/advisory-lock machinery that existed only to safely create the old synthetic objects.

- Admin dropdown of the shop's real tax rule groups (id 0 = "No tax" sentinel for force-always-zero)
- `getTwoSurchargeTaxRateForCart()` replicates the same core tax gates (PS_TAX off, address type, B2B VAT exemption) used to resolve the actual cart-line rate, so cart line and Two-payload can't drift
- Deactivated-but-selected group stays visible in the dropdown (tagged inactive) instead of silently reverting to "No tax" on an unrelated save
- Upgrade script flags (log + persistent admin notice) any shop with a pre-existing flat rate and no group configured post-upgrade, rather than silently going untaxed
- Both-sides test coverage (cart line + payload) for destination rules, multi-rate stacking, B2B VAT exemption, and the "No tax" sentinel

Went through 2 rounds of 4-persona adversarial review + 1 fix pass before this PR (found and fixed: no-migration silent detax, deactivated-group dropdown loss, expensive default-selection query, untested B2B VAT both-sides parity).

## Test plan
- [x] Full spec suite passes (`php tests/run.php`, PHP 8.2 docker + local 8.5)
- [x] `php -l` clean
- [ ] Staging spot-check on a shop with an existing flat rate configured, to confirm the migration notice surfaces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)