### PR TITLE
feat: require explicit surcharge tax treatment selection

### DIFF
--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -43,6 +43,7 @@ final class SurchargeSpec
         self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
         self::testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection();
         self::testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice();
+        self::testSurchargeTaxTreatmentRequiredWhenSurchargesEnabled();
         self::testUpgrade250FlagsFlatRateShopsForTaxReselection();
         self::testSurchargeTaxMigrationNoticeLifecycle();
         self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
@@ -483,7 +484,7 @@ final class SurchargeSpec
                 return $this->getTwoSurchargeTaxRulesGroupOptions();
             }
 
-            public function formDefaultForTest(): int
+            public function formDefaultForTest(): string
             {
                 return $this->getTwoSurchargeTaxRulesGroupFormDefault();
             }
@@ -492,14 +493,22 @@ final class SurchargeSpec
             {
                 $this->saveTwoSurchargeFormValues();
             }
+
+            public function validateSurchargeFormForTest(): array
+            {
+                $this->errors = [];
+                $this->validTwoSurchargeFormValues();
+
+                return $this->errors;
+            }
         };
     }
 
     /**
      * The currently-configured group must stay in the dropdown even when
      * deactivated: if it dropped out, the browser would submit the first
-     * option ("No tax") on the next unrelated settings save and silently
-     * detax the surcharge.
+     * option (the unselected placeholder) on the next unrelated settings
+     * save and silently unset the treatment.
      */
     private static function testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection(): void
     {
@@ -510,42 +519,115 @@ final class SurchargeSpec
         $module = self::makeConfigHarness();
 
         // Configured group deactivated -> injected with an "(inactive)" tag.
+        // Ids are strings, and the unselected placeholder ('') leads.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '500');
         $options = $module->optionsForTest();
         $byId = [];
         foreach ($options as $option) {
-            $byId[(int) $option['id']] = (string) $option['name'];
+            TinyAssert::true(is_string($option['id']), 'option ids must be strings (PHP 7 template loose == would conflate \'\' with 0)');
+            $byId[$option['id']] = (string) $option['name'];
         }
-        TinyAssert::same(['No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'deactivated configured group must stay selectable, flagged inactive');
-        TinyAssert::same([0, 400, 500], array_keys($byId), 'inactive groups that are NOT configured stay hidden');
+        TinyAssert::same(['-- Select surcharge tax treatment --', 'No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'placeholder leads; deactivated configured group must stay selectable, flagged inactive');
+        TinyAssert::same(['', '0', '400', '500'], array_map('strval', array_keys($byId)), 'inactive groups that are NOT configured stay hidden');
 
         // Configured group active -> plain listing, no duplicate, no tag.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
         $options = $module->optionsForTest();
-        TinyAssert::count(2, $options);
-        TinyAssert::same('Standard rate', (string) $options[1]['name'], 'active configured group is listed once, untagged');
+        TinyAssert::count(3, $options);
+        TinyAssert::same('Standard rate', (string) $options[2]['name'], 'active configured group is listed once, untagged');
 
         // Configured group deleted entirely -> nothing to inject (runtime
         // already fails safe to "No tax" for a nonexistent group).
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
-        TinyAssert::count(2, $module->optionsForTest());
+        TinyAssert::count(3, $module->optionsForTest());
     }
 
     /**
-     * Unsaved config pre-selects "No tax" (0), matching runtime behaviour -
-     * NOT Product::getIdTaxRulesGroupMostUsed(), whose full-catalog
-     * COUNT/GROUP BY would re-run on every config page render.
+     * Unsaved config pre-selects NOTHING - the dropdown renders on the
+     * unselected placeholder (''). Never an auto-default: not
+     * Product::getIdTaxRulesGroupMostUsed() (full-catalog COUNT/GROUP BY on
+     * every config page render), and not "No tax" either - the merchant
+     * must pick explicitly. A stored selection ("No tax" included) is the
+     * pre-selection.
      */
     private static function testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice(): void
     {
         self::reset();
         $module = self::makeConfigHarness();
 
-        TinyAssert::same(0, $module->formDefaultForTest(), 'unset config must pre-select "No tax"');
+        TinyAssert::same('', $module->formDefaultForTest(), 'unset config must stay on the unselected placeholder');
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
-        TinyAssert::same(0, $module->formDefaultForTest(), 'blank config must pre-select "No tax"');
+        TinyAssert::same('', $module->formDefaultForTest(), 'blank config must stay on the unselected placeholder');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::same('0', $module->formDefaultForTest(), 'an explicitly saved "No tax" IS a selection and pre-selects');
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
-        TinyAssert::same(400, $module->formDefaultForTest(), 'stored selection is the pre-selection');
+        TinyAssert::same('400', $module->formDefaultForTest(), 'stored selection is the pre-selection');
+    }
+
+    /**
+     * While surcharges are enabled (type !== 'none') the save is blocked
+     * server-side until an explicit tax treatment is submitted: the
+     * unselected placeholder ('' / absent) is a validation error, never a
+     * silent "No tax" fallback. With surcharges disabled no selection is
+     * required, and an invalid submission is stored as '' (unselected),
+     * not coerced to 0.
+     */
+    private static function testSurchargeTaxTreatmentRequiredWhenSurchargesEnabled(): void
+    {
+        self::reset();
+        Tools::resetTestValues();
+        StubStore::$taxRulesGroups[400] = ['name' => 'Standard rate', 'active' => 1];
+        $module = self::makeConfigHarness();
+
+        // Neutralise the unrelated grid checks (the Tools stub defaults
+        // absent keys to null, unlike core's false).
+        foreach (['PCT', 'FIXED', 'CAP'] as $suffix) {
+            Tools::setTestValue('PS_TWO_SURCHARGE_' . $suffix . '_30', '');
+        }
+
+        // Enabled + nothing submitted -> blocked.
+        Tools::setTestValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        $errors = $module->validateSurchargeFormForTest();
+        TinyAssert::count(1, $errors);
+        TinyAssert::true(strpos((string) $errors[0], 'Select a surcharge tax treatment') !== false, 'error names the missing selection');
+
+        // Enabled + blank submitted (the placeholder) -> blocked.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + whitespace submitted -> blocked.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, ' ');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + explicit "No tax" -> allowed.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Enabled + existing group -> allowed.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Enabled + nonexistent group -> blocked (pre-existing rule intact).
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + decimal/negative -> blocked, never truncated into a
+        // selection the merchant did not make.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0.5');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '-5');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Disabled -> no selection required, save allowed.
+        Tools::resetTestValues();
+        Tools::setTestValue('PS_TWO_SURCHARGE_TYPE', 'none');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Disabled + garbage submitted -> stored '' (unselected), never 0.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, 'abc');
+        $module->saveSurchargeFormForTest();
+        TinyAssert::same('', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'garbage never coerces to "No tax"');
+        Tools::resetTestValues();
     }
 
     /**
@@ -623,14 +705,23 @@ final class SurchargeSpec
         TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
         TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'self-retire clears the flag');
 
-        // Explicit surcharge-settings save clears the flag too, even when
-        // the merchant confirms "No tax" (no group submitted -> stored 0).
+        // A save WITHOUT a submitted group stores '' (still unselected) and
+        // does NOT retire the nag - it is accurate until a real choice is
+        // made. No silent "No tax" fallback.
         self::reset();
         Tools::resetTestValues();
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
         $module->saveSurchargeFormForTest();
-        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group stores the explicit "No tax" sentinel');
-        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit save retires the nag');
+        TinyAssert::same('', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group must stay unselected, never silently "No tax"');
+        TinyAssert::same('1', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'an unselected save must NOT retire the nag');
+        TinyAssert::true($module->getTwoSurchargeTaxMigrationNotice() !== '', 'notice persists after an unselected save');
+
+        // An explicit "No tax" submission stores '0' and retires the nag.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        $module->saveSurchargeFormForTest();
+        Tools::resetTestValues();
+        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'explicit "No tax" submission stores the sentinel');
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit selection retires the nag');
         TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
     }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -8236,7 +8236,7 @@ class Twopayment extends PaymentModule
             'type' => 'select',
             'label' => $this->l('Surcharge Tax Rules Group'),
             'name' => self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
-            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee.'),
+            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee. A selection is required while surcharges are enabled.'),
             'options' => array(
                 'query' => $this->getTwoSurchargeTaxRulesGroupOptions(),
                 'id' => 'id',
@@ -8324,23 +8324,28 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Dropdown options for the surcharge tax rules group: PrestaShop's
-     * "No tax" sentinel (id 0) followed by the merchant's active tax rules
-     * groups - the same list core's own product-edit page offers (its
+     * Dropdown options for the surcharge tax rules group: an unselected
+     * placeholder (id '' - never a valid selection, save-blocked while
+     * surcharges are enabled, see validTwoSurchargeFormValues), then
+     * PrestaShop's "No tax" sentinel (id 0), then the merchant's active tax
+     * rules groups - the same list core's own product-edit page offers (its
      * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
      * rate, so the deduplicated getTaxRulesGroups source is used with the
-     * same manual "No tax" prepend). The currently-configured group is
-     * ALWAYS present even when deactivated (suffixed "(inactive)"): if a
-     * stale selection dropped out of the list, the browser would submit the
-     * first option ("No tax", id 0) on the next unrelated settings save and
-     * silently detax the surcharge.
+     * same manual "No tax" prepend). Ids are emitted as STRINGS so the
+     * form template's loose == never conflates the placeholder ('') with
+     * "No tax" ('0') on PHP 7 shops ('' == 0 is true there). The
+     * currently-configured group is ALWAYS present even when deactivated
+     * (suffixed "(inactive)"): if a stale selection dropped out of the
+     * list, the browser would submit the first option (the placeholder) on
+     * the next unrelated settings save and silently unset the treatment.
      *
-     * @return array<int,array{id:int,name:string}>
+     * @return array<int,array{id:string,name:string}>
      */
     protected function getTwoSurchargeTaxRulesGroupOptions()
     {
         $options = array(
-            array('id' => 0, 'name' => $this->l('No tax')),
+            array('id' => '', 'name' => $this->l('-- Select surcharge tax treatment --')),
+            array('id' => '0', 'name' => $this->l('No tax')),
         );
         $groups = TaxRulesGroup::getTaxRulesGroups(true);
         $seen = array(0 => true);
@@ -8350,7 +8355,7 @@ class Twopayment extends PaymentModule
             }
             $id = (int) $group['id_tax_rules_group'];
             $options[] = array(
-                'id' => $id,
+                'id' => (string) $id,
                 'name' => (string) $group['name'],
             );
             $seen[$id] = true;
@@ -8361,7 +8366,7 @@ class Twopayment extends PaymentModule
             $configured = new TaxRulesGroup($configuredId);
             if (Validate::isLoadedObject($configured)) {
                 $options[] = array(
-                    'id' => $configuredId,
+                    'id' => (string) $configuredId,
                     'name' => (string) $configured->name . ' (' . $this->l('inactive') . ')',
                 );
             }
@@ -8372,23 +8377,25 @@ class Twopayment extends PaymentModule
 
     /**
      * Pre-selection for the surcharge tax rules group dropdown: the stored
-     * selection, else "No tax" (0) - the merchant must make an explicit
-     * choice. Deliberately NOT Product::getIdTaxRulesGroupMostUsed(): that
-     * is a full-catalog COUNT/GROUP BY re-run on every unsaved config page
-     * render, and pre-selecting a taxing group the merchant never chose
-     * invites an accidental save. Matches runtime behaviour for an UNSAVED
-     * config (getTwoSurchargeTaxRulesGroupId falls back to "No tax").
+     * selection, else '' - the unselected placeholder. NEVER auto-defaults:
+     * not Product::getIdTaxRulesGroupMostUsed() (a full-catalog COUNT/GROUP
+     * BY re-run on every unsaved config page render, pre-selecting a taxing
+     * group the merchant never chose), and not "No tax" either - untaxed is
+     * a tax treatment, not an absence of one, and pre-selecting it invites
+     * an accidental save. The merchant must pick explicitly; while
+     * surcharges are enabled the save is blocked until they do
+     * (validTwoSurchargeFormValues).
      *
-     * @return int
+     * @return string '' (unselected) or the stored group id ('0' = No tax)
      */
     protected function getTwoSurchargeTaxRulesGroupFormDefault()
     {
         $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
         if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
-            return max(0, (int) $stored);
+            return (string) max(0, (int) $stored);
         }
 
-        return 0;
+        return '';
     }
 
     /**
@@ -8404,7 +8411,10 @@ class Twopayment extends PaymentModule
             'PS_TWO_SURCHARGE_LINE_DESC' => Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', Configuration::get('PS_TWO_SURCHARGE_LINE_DESC')),
             'PS_TWO_SURCHARGE_ROUNDING_BASIS' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS')),
             'PS_TWO_SURCHARGE_ROUNDING_STEP' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP')),
-            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (int) Tools::getValue(
+            // Kept a STRING ('' = unselected placeholder): an (int) cast
+            // would turn the unselected state into 0 and silently
+            // pre-select "No tax".
+            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (string) Tools::getValue(
                 self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
                 $this->getTwoSurchargeTaxRulesGroupFormDefault()
             ),
@@ -8434,9 +8444,19 @@ class Twopayment extends PaymentModule
         if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
             $this->errors[] = $this->l('Rounding step must be one of the offered values.');
         }
+        // Surcharges are enabled (type !== 'none' - the early return above):
+        // an explicit tax treatment is REQUIRED. The unselected placeholder
+        // ('' / absent) blocks the save server-side - never silently falls
+        // back to "No tax".
         $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
-        if ($groupRaw !== false && $groupRaw !== '') {
-            $groupId = is_numeric($groupRaw) ? (int) $groupRaw : -1;
+        $groupTrimmed = is_string($groupRaw) ? trim($groupRaw) : '';
+        if ($groupTrimmed === '') {
+            $this->errors[] = $this->l('Select a surcharge tax treatment: surcharges are enabled, so you must explicitly choose a tax rules group (or "No tax") before saving.');
+        } else {
+            // ctype_digit: a whole non-negative integer only - '0.5', '-5'
+            // and friends are rejected, never truncated into a selection
+            // the merchant did not make.
+            $groupId = ctype_digit($groupTrimmed) ? (int) $groupTrimmed : -1;
             if ($groupId < 0 || ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId)))) {
                 $this->errors[] = $this->l('Surcharge tax rules group must be "No tax" or one of the shop\'s existing tax rules groups.');
             }
@@ -8475,18 +8495,30 @@ class Twopayment extends PaymentModule
         }
         Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', $step);
 
-        // Same coercion discipline as the grid: invalid/unknown input is
-        // stored as 0 ("No tax" - getTwoSurchargeTaxRulesGroupId's fail-safe),
-        // never fatal. A group id is only stored when the group exists.
-        $groupRaw = trim((string) Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, ''));
-        $groupId = (is_numeric($groupRaw) && (int) $groupRaw > 0) ? (int) $groupRaw : 0;
-        if ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
-            $groupId = 0;
+        // NEVER silently coerce to "No tax": absent/blank/invalid input is
+        // stored as '' (unselected - the dropdown re-renders on its
+        // placeholder). While surcharges are enabled this path is
+        // unreachable with '' (validTwoSurchargeFormValues blocks the save
+        // first); while disabled, staying unselected is the point - the
+        // merchant must pick explicitly before enabling. '0' ("No tax") is
+        // only ever stored when the merchant submitted it.
+        $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        $groupTrimmed = is_string($groupRaw) ? trim($groupRaw) : '';
+        $groupValue = '';
+        if ($groupTrimmed !== '' && ctype_digit($groupTrimmed)) {
+            $groupId = (int) $groupTrimmed;
+            if ($groupId === 0 || Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
+                $groupValue = (string) $groupId;
+            }
         }
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
-        // Explicit merchant save (any value, "No tax" included) retires the
-        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php.
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, $groupValue);
+        // An explicit merchant selection ("No tax" included) retires the
+        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php. A
+        // save that stored '' (still unselected) does NOT - the nag is
+        // accurate until a real choice is made.
+        if ($groupValue !== '') {
+            Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+        }
 
         // Apply the selection to the hidden fee product immediately (the
         // same id_tax_rules_group field every real Product uses); if the


### PR DESCRIPTION
## What

Unified cross-platform rule (PrestaShop leg; WooCommerce and Magento handled separately): the surcharge tax-treatment selector is NEVER auto-defaulted.

- The "Surcharge Tax Rules Group" dropdown starts unselected on a placeholder option: `-- Select surcharge tax treatment --`. Previously an unsaved config pre-selected "No tax" (0).
- Server-side save blocking: while surcharges are enabled (`PS_TWO_SURCHARGE_TYPE` != none), submitting the payment-settings form without an explicit treatment appends a validation error and the save does not run (existing `getContent` gate: errors block `saveTwoPaymentSettingsFormValues`). Explicitly choosing "No tax" is a valid selection.
- No silent fallback: a save without a submitted group (surcharges disabled) now stores `''` (still unselected) instead of silently storing the "No tax" sentinel `0`. Invalid input (`abc`, `0.5`, `-5`) is likewise never coerced into a selection.
- The post-upgrade "surcharge tax needs re-selection" nag now only retires on a real selection, not on any save.
- Option ids are emitted as strings so PHP 7's loose `==` in the HelperForm select template cannot conflate the placeholder (`''`) with "No tax" (`0`).

## What was actually shipped before (verified, not assumed)

The prior default was "No tax" (0) — pre-selected on an unsaved config form AND silently stored by `saveTwoSurchargeFormValues` when no group was submitted. `Product::getIdTaxRulesGroupMostUsed()` was never live: PR #65 explicitly rejected it (full-catalog COUNT/GROUP BY per render + accidental-save risk).

## Unchanged (deliberate)

- Checkout runtime fail-safe: `getTwoSurchargeTaxRulesGroupId()` still resolves unset/garbage to 0 (untaxed) — config UX must block, checkout must never crash or invent a rate.
- Shops that previously saved the form (silently storing `0`) keep that stored value and render "No tax" selected — a stored value is treated as an explicit selection; no migration unsets it.

## Tests

`php tests/run.php` green. Updated the options/form-default/migration-notice specs for the new semantics and added `testSurchargeTaxTreatmentRequiredWhenSurchargesEnabled` covering the save-block matrix (absent/blank/whitespace/decimal/negative/nonexistent blocked; "No tax" and existing groups allowed; disabled saves stay unselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)