### PR TITLE
TWO-24755/feat: sole trader checkout via third account_type option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db
 
 
 .worktrees/
+.review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
+  - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice
+  - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the admin-configured Surcharge Tax Rate through a module-managed tax rules group
+  - Selecting any other payment method removes the line; add/remove is idempotent against re-clicks, reloads and resumed carts (front-controller stale-line guard)
+  - Order creation self-heals the line server-side and fails closed if the cart's fee and the Two payload's fee ever diverge beyond rounding tolerance
 - **Graceful invoice retrieval when order is not yet fulfilled** (TWO-25042, part of TWO-25040)
   - Invoice PDF downloads (customer order page and admin order view) are now routed through module controllers instead of linking the browser directly to the payment API
   - On `400 ORDER_NOT_FULFILLED` the module checks the order state: `FULFILLING` shows an informational "not ready yet" notice, `FULFILLED` retries the fetch once, and any other state is reported with the state named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice
-  - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the admin-configured Surcharge Tax Rate through a module-managed tax rules group
+  - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the merchant-selected tax rules group (see TWO-25071 below)
   - Selecting any other payment method removes the line; add/remove is idempotent against re-clicks, reloads and resumed carts (front-controller stale-line guard)
   - Order creation self-heals the line server-side and fails closed if the cart's fee and the Two payload's fee ever diverge beyond rounding tolerance
 - **Graceful invoice retrieval when order is not yet fulfilled** (TWO-25042, part of TWO-25040)
   - Invoice PDF downloads (customer order page and admin order view) are now routed through module controllers instead of linking the browser directly to the payment API
   - On `400 ORDER_NOT_FULFILLED` the module checks the order state: `FULFILLING` shows an informational "not ready yet" notice, `FULFILLED` retries the fetch once, and any other state is reported with the state named
   - Customer downloads are protected by the same secure-key ownership guard as the cancel/confirmation callbacks (guest checkout included); admin downloads go through a permission-gated admin controller
+
+### Changed
+- **Surcharge tax now uses the merchant's own tax rules group** (TWO-25071)
+  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products, pre-selecting the group most of the catalog uses
+  - The hidden fee product carries the selected group on its `id_tax_rules_group` like any real product, so PrestaShop's native tax engine applies per-country/state rules, combined multi-rate stacking, and destination-based zero-rating (no rule for the destination = untaxed) to the fee line
+  - The tax rate reported to Two's order API is resolved through the same core machinery (`TaxManagerFactory`) for the cart's tax address, with the same shop-wide gates (taxes disabled, VAT-number B2B exemption), so the PrestaShop line and the Two payload cannot drift and the order-create parity gate holds on cross-border orders
+  - Selecting "No tax" (PrestaShop's built-in id-0 group) keeps the fee untaxed for every destination; an unset/invalid selection fails safe to "No tax"
+  - Removed: the module-managed synthetic Tax/TaxRulesGroup/TaxRule graph, its `PS_TWO_SURCHARGE_TAX_SETUP` tracking blob, self-heal/advisory-lock machinery and uninstall cleanup (never released; uninstall still deletes the legacy configuration rows). Uninstall never deletes the merchant's own tax rules group
 
 ## Latest Release: v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sole trader checkout** (TWO-24755, WooCommerce/Magento parity)
+  - Buyers in countries where Two's registry supports sole traders (`GET /registry/v1/supported-company-types/<ISO>`) get a Sole Trader option on the existing Personal/Business account-type selector, gated by a new "Enable sole trader checkout" admin toggle (default off, requires Account Type selection to be enabled)
+  - At the payment step, choosing Sole Trader mints delegation + autofill tokens server-side with the merchant API key and opens Two's hosted signup popup; on completion the buyer's company data autofills from `GET /autofill/v1/buyer/current` (case-insensitive email match) and persists through the existing company-save path, so order-intent and payment run unchanged
+  - Module version bumped to `2.5.1`; the upgrade script sets an explicit default (off) for the new toggle on existing installs
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice
   - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the merchant-selected tax rules group (see TWO-25071 below)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Surcharge tax now uses the merchant's own tax rules group** (TWO-25071)
-  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products, pre-selecting the group most of the catalog uses
+  - The flat "Surcharge Tax Rate (%)" field is replaced by a "Surcharge Tax Rules Group" dropdown - the same tax rules groups assigned to products; an unsaved config pre-selects "No tax" so taxing the fee is always an explicit merchant choice
+  - A deactivated tax rules group that is still the configured selection stays in the dropdown (flagged "(inactive)") so an unrelated settings save can never silently reset the surcharge tax to "No tax"
+  - Module version bumped to `2.5.0`; the upgrade script does NOT auto-convert a previously configured flat rate (inventing a tax rules group from a bare percentage is destination-blind) - instead shops that had the flat rate set and no group selected get a logged warning and a persistent module-config notice ("surcharge tax needs re-selection", surcharge untaxed until saved)
   - The hidden fee product carries the selected group on its `id_tax_rules_group` like any real product, so PrestaShop's native tax engine applies per-country/state rules, combined multi-rate stacking, and destination-based zero-rating (no rule for the destination = untaxed) to the fee line
   - The tax rate reported to Two's order API is resolved through the same core machinery (`TaxManagerFactory`) for the cart's tax address, with the same shop-wide gates (taxes disabled, VAT-number B2B exemption), so the PrestaShop line and the Two payload cannot drift and the order-create parity gate holds on cross-border orders
   - Selecting "No tax" (PrestaShop's built-in id-0 group) keeps the fee untaxed for every destination; an unset/invalid selection fails safe to "No tax"

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Sole trader checkout support — business logic (TWO-24755).
+ *
+ * All decisioning lives here; the address-form override and the JS layer
+ * only render what these methods return.
+ *
+ * Sole Trader is a third option on the existing Personal/Business
+ * account_type selector (PS_TWO_USE_ACCOUNT_TYPE mode). Two gates decide
+ * whether it is offered for a billing country, and both must pass:
+ *  - country-level legal truth from the registry endpoint
+ *    GET /registry/v1/supported-company-types/<ISO> (TWO-24753), and
+ *  - the merchant's PS_TWO_ENABLE_SOLE_TRADER admin toggle (default off,
+ *    and dependent on account-type mode, since the option rides that
+ *    selector).
+ *
+ * The flow mirrors the WooCommerce/Magento plugins: the buyer picks Sole
+ * Trader, the module server-side mints two delegated-authority tokens
+ * with the merchant API key, the buyer registers or logs in through
+ * Two's hosted signup popup, and the checkout autofills the company data
+ * from GET /autofill/v1/buyer/current. No sole-trader-specific fields
+ * are collected and the order payload is unchanged — an enrolled sole
+ * trader's organization number (TWO:ST…) carries the semantics and the
+ * backend derives the company type from it (TWO-24749 spike).
+ */
+class TwoSoleTrader
+{
+    const SOLE_TRADER = 'SOLE_TRADER';
+
+    /** Cookie key prefix; full key is prefix + ISO country code. */
+    const COOKIE_KEY_PREFIX = 'two_company_types_';
+
+    /** Matches the registry endpoint's Cache-Control max-age. */
+    const CACHE_TTL_SECONDS = 3600;
+
+    /** @var array<string, string[]> request-scoped cache, keyed by country */
+    private static $types_cache = array();
+
+    /**
+     * Whether the merchant has opted into sole trader checkout. The option
+     * rides the account_type selector, so account-type mode is a hard
+     * prerequisite — without it the feature cannot surface no matter what
+     * the toggle says.
+     */
+    public static function isEnabled()
+    {
+        return (int) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') === 1
+            && (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE') === 1;
+    }
+
+    /**
+     * Whether the Sole Trader option should be offered for a billing
+     * country: merchant toggle on AND the country legally supports it.
+     *
+     * @param Twopayment $module
+     * @param string $countryIso
+     *
+     * @return bool
+     */
+    public static function isAvailable($module, $countryIso)
+    {
+        return self::isEnabled()
+            && in_array(self::SOLE_TRADER, self::getSupportedCompanyTypes($module, $countryIso), true);
+    }
+
+    /**
+     * Whether an account type is allowed to pay with Two. Business always
+     * is; sole trader only when the feature is available for the country;
+     * anything else (personal, empty) fails closed.
+     *
+     * @param Twopayment $module
+     * @param string $accountType
+     * @param string $countryIso
+     *
+     * @return bool
+     */
+    public static function isAccountTypeAllowed($module, $accountType, $countryIso)
+    {
+        if ($accountType === 'business') {
+            return true;
+        }
+        if ($accountType === 'sole_trader') {
+            return self::isAvailable($module, $countryIso);
+        }
+        return false;
+    }
+
+    /**
+     * The buyer company types the Two registry supports for a country,
+     * from GET /registry/v1/supported-company-types/<ISO> — only the
+     * types that need registry enrollment before they can buy (sole
+     * traders). Registered businesses need no enrollment and are always
+     * supported, so the endpoint deliberately omits them: an empty list
+     * means business-only checkout. Cached in the context cookie for the
+     * endpoint's own max-age. Fail-soft: any error (network, non-200,
+     * malformed body) also resolves to an empty list — checkout never
+     * blocks, the option just doesn't show.
+     *
+     * @param Twopayment $module
+     * @param string $countryIso
+     *
+     * @return string[]
+     */
+    public static function getSupportedCompanyTypes($module, $countryIso)
+    {
+        $countryIso = strtoupper(trim((string) $countryIso));
+        if (!preg_match('/^[A-Z]{2}$/', $countryIso)) {
+            return array();
+        }
+
+        if (array_key_exists($countryIso, self::$types_cache)) {
+            return self::$types_cache[$countryIso];
+        }
+
+        $cookie = Context::getContext()->cookie;
+        $cookieKey = self::COOKIE_KEY_PREFIX . $countryIso;
+        if ($cookie && !empty($cookie->{$cookieKey})) {
+            $cached = json_decode($cookie->{$cookieKey}, true);
+            if (
+                is_array($cached)
+                && isset($cached['types'], $cached['fetched_at'])
+                && is_array($cached['types'])
+                && time() - (int) $cached['fetched_at'] < self::CACHE_TTL_SECONDS
+            ) {
+                return self::$types_cache[$countryIso] = $cached['types'];
+            }
+        }
+
+        $types = self::fetchSupportedCompanyTypes($module, $countryIso);
+
+        if ($cookie) {
+            $cookie->{$cookieKey} = json_encode(array(
+                'types' => $types,
+                'fetched_at' => time(),
+            ));
+        }
+        return self::$types_cache[$countryIso] = $types;
+    }
+
+    /**
+     * Uncached registry call. @see getSupportedCompanyTypes()
+     *
+     * @return string[]
+     */
+    private static function fetchSupportedCompanyTypes($module, $countryIso)
+    {
+        $response = $module->setTwoPaymentRequest(
+            '/registry/v1/supported-company-types/' . $countryIso,
+            null,
+            'GET'
+        );
+        if (
+            !is_array($response)
+            || (int) ($response['http_status'] ?? 0) !== 200
+            || !isset($response['supported_company_types'])
+            || !is_array($response['supported_company_types'])
+        ) {
+            return array();
+        }
+        return array_values(array_filter($response['supported_company_types'], 'is_string'));
+    }
+
+    /**
+     * Mint the two delegated-authority tokens the sole-trader flow needs,
+     * server-side with the merchant API key (the key never reaches the
+     * browser). The Two API returns each token in the
+     * `two-delegated-authority-token` response HEADER, not the body —
+     * hence a dedicated request here rather than setTwoPaymentRequest,
+     * which discards response headers. Fail-closed: if either mint fails
+     * the pair is void — never hand the browser half a flow.
+     *
+     * @param Twopayment $module
+     *
+     * @return array{delegation_token: string, autofill_token: string}|null
+     */
+    public static function mintTokens($module)
+    {
+        $delegationToken = self::mintToken($module, '/registry/v1/delegation', array(
+            'create_proposal' => true,
+            'read_current_business' => true,
+        ));
+        $autofillToken = self::mintToken($module, '/autofill/v1/delegation', array(
+            'read_current_buyer' => true,
+            'write_current_buyer' => true,
+        ));
+        if ($delegationToken === null || $autofillToken === null) {
+            return null;
+        }
+        return array(
+            'delegation_token' => $delegationToken,
+            'autofill_token' => $autofillToken,
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    private static function mintToken($module, $endpoint, array $payload)
+    {
+        $result = self::postCapturingHeaders($module, $endpoint, $payload);
+        if ($result === null || $result['status'] >= 300) {
+            return null;
+        }
+        $token = isset($result['headers']['two-delegated-authority-token'])
+            ? trim($result['headers']['two-delegated-authority-token'])
+            : '';
+        return $token !== '' ? $token : null;
+    }
+
+    /**
+     * POST to the Two API capturing response headers (lower-cased keys).
+     * Seam for tests: overridable transport via the static $transport hook.
+     *
+     * @return array{status: int, headers: array<string, string>}|null
+     */
+    private static function postCapturingHeaders($module, $endpoint, array $payload)
+    {
+        if (self::$transport !== null) {
+            return call_user_func(self::$transport, $endpoint, $payload);
+        }
+
+        $url = $module->getTwoCheckoutHostUrl() . $endpoint;
+        $responseHeaders = array();
+
+        $ch = curl_init();
+        curl_setopt_array($ch, array(
+            CURLOPT_URL => $url,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($payload),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTPHEADER => array(
+                'Content-Type: application/json',
+                'X-API-Key: ' . Configuration::get('PS_TWO_MERCHANT_API_KEY'),
+            ),
+            CURLOPT_HEADERFUNCTION => function ($ch, $header) use (&$responseHeaders) {
+                $parts = explode(':', $header, 2);
+                if (count($parts) === 2) {
+                    $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+                }
+                return strlen($header);
+            },
+        ));
+        // Honour the merchant's SSL-verify setting (and its production
+        // hardening) the same way every other Two API call does, rather
+        // than leaving this curl on libcurl defaults.
+        $module->configureSslVerification($ch);
+        $body = curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($body === false || $error) {
+            PrestaShopLogger::addLog('TwoPayment: sole trader token mint failed - ' . $error, 2);
+            return null;
+        }
+        return array('status' => $status, 'headers' => $responseHeaders);
+    }
+
+    /**
+     * Explicit environment -> checkout-page host map for Two's hosted
+     * sole-trader signup page (the checkout-page app, not the API).
+     * Mirrors Twopayment::ENVIRONMENT_HOSTS: anything not in the map
+     * (legacy 'development', empty/unset) falls back to sandbox.
+     */
+    private static $signup_hosts = array(
+        'production' => 'https://checkout.two.inc',
+        'staging' => 'https://checkout.staging.two.inc',
+    );
+
+    /**
+     * Full URL of Two's hosted sole-trader signup page for the configured
+     * environment.
+     *
+     * @return string
+     */
+    public static function getSignupPageUrl()
+    {
+        $env = strtolower((string) Configuration::get('PS_TWO_ENVIRONMENT'));
+        $host = isset(self::$signup_hosts[$env])
+            ? self::$signup_hosts[$env]
+            : 'https://checkout.sandbox.two.inc';
+        return $host . '/soletrader/signup';
+    }
+
+    /** @var callable|null test seam for postCapturingHeaders */
+    public static $transport = null;
+
+    /**
+     * Test seam: clear the request-scoped types cache and transport hook.
+     */
+    public static function resetCache()
+    {
+        self::$types_cache = array();
+        self::$transport = null;
+    }
+}

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -23,18 +23,49 @@
  * trader's organization number (TWO:ST…) carries the semantics and the
  * backend derives the company type from it (TWO-24749 spike).
  */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class TwoSoleTrader
 {
     const SOLE_TRADER = 'SOLE_TRADER';
 
-    /** Cookie key prefix; full key is prefix + ISO country code. */
-    const COOKIE_KEY_PREFIX = 'two_company_types_';
+    /**
+     * Single cookie key for the registry-answer cache. Deliberately one
+     * slot, not one key per country: the checkout only ever cares about
+     * the buyer's currently-selected country, and a per-country key
+     * (keyed on unvalidated client input) would let a caller with a
+     * valid ajax token grow the single PrestaShop session cookie without
+     * bound by requesting many ISO codes. Overwriting on every lookup
+     * caps growth at one entry, at the cost of a re-fetch when the buyer
+     * switches country back and forth within the TTL - an acceptable
+     * trade for a value that changes at most a few times per checkout.
+     */
+    const COOKIE_KEY = 'two_sole_trader_types';
 
     /** Matches the registry endpoint's Cache-Control max-age. */
     const CACHE_TTL_SECONDS = 3600;
 
     /** @var array<string, string[]> request-scoped cache, keyed by country */
     private static $types_cache = array();
+
+    /** @var callable|null test seam for postCapturingHeaders */
+    public static $transport = null;
+
+    /**
+     * Explicit environment -> checkout-page host map for Two's hosted
+     * sole-trader signup page (the checkout-page app, not the API).
+     * Mirrors Twopayment::ENVIRONMENT_HOSTS: anything not in the map
+     * (legacy 'development', empty/unset) falls back to sandbox.
+     *
+     * @var array<string, string>
+     */
+    private static $signup_hosts = array(
+        'production' => 'https://checkout.two.inc',
+        'staging' => 'https://checkout.staging.two.inc',
+    );
 
     /**
      * Whether the merchant has opted into sole trader checkout. The option
@@ -91,10 +122,13 @@ class TwoSoleTrader
      * types that need registry enrollment before they can buy (sole
      * traders). Registered businesses need no enrollment and are always
      * supported, so the endpoint deliberately omits them: an empty list
-     * means business-only checkout. Cached in the context cookie for the
-     * endpoint's own max-age. Fail-soft: any error (network, non-200,
-     * malformed body) also resolves to an empty list — checkout never
-     * blocks, the option just doesn't show.
+     * is a legitimate answer meaning business-only checkout for that
+     * country. Cached in the context cookie for the endpoint's own
+     * max-age (single slot - see COOKIE_KEY). A fetch ERROR (network,
+     * non-200, malformed body) is fail-soft for the current lookup
+     * (resolves to an empty list, checkout never blocks) but is
+     * deliberately NOT cached, so a transient registry blip does not
+     * suppress the option for the rest of the TTL window.
      *
      * @param Twopayment $module
      * @param string $countryIso
@@ -113,12 +147,12 @@ class TwoSoleTrader
         }
 
         $cookie = Context::getContext()->cookie;
-        $cookieKey = self::COOKIE_KEY_PREFIX . $countryIso;
-        if ($cookie && !empty($cookie->{$cookieKey})) {
-            $cached = json_decode($cookie->{$cookieKey}, true);
+        if ($cookie && !empty($cookie->{self::COOKIE_KEY})) {
+            $cached = json_decode($cookie->{self::COOKIE_KEY}, true);
             if (
                 is_array($cached)
-                && isset($cached['types'], $cached['fetched_at'])
+                && isset($cached['country'], $cached['types'], $cached['fetched_at'])
+                && $cached['country'] === $countryIso
                 && is_array($cached['types'])
                 && time() - (int) $cached['fetched_at'] < self::CACHE_TTL_SECONDS
             ) {
@@ -128,19 +162,24 @@ class TwoSoleTrader
 
         $types = self::fetchSupportedCompanyTypes($module, $countryIso);
 
-        if ($cookie) {
-            $cookie->{$cookieKey} = json_encode(array(
+        if ($cookie && $types !== null) {
+            $cookie->{self::COOKIE_KEY} = json_encode(array(
+                'country' => $countryIso,
                 'types' => $types,
                 'fetched_at' => time(),
             ));
         }
-        return self::$types_cache[$countryIso] = $types;
+        return self::$types_cache[$countryIso] = ($types ?? array());
     }
 
     /**
      * Uncached registry call. @see getSupportedCompanyTypes()
      *
-     * @return string[]
+     * Null distinguishes a fetch ERROR (network, non-200, malformed body -
+     * not cached by the caller) from a real empty answer (business-only
+     * country - cached normally).
+     *
+     * @return string[]|null
      */
     private static function fetchSupportedCompanyTypes($module, $countryIso)
     {
@@ -155,7 +194,7 @@ class TwoSoleTrader
             || !isset($response['supported_company_types'])
             || !is_array($response['supported_company_types'])
         ) {
-            return array();
+            return null;
         }
         return array_values(array_filter($response['supported_company_types'], 'is_string'));
     }
@@ -258,17 +297,6 @@ class TwoSoleTrader
     }
 
     /**
-     * Explicit environment -> checkout-page host map for Two's hosted
-     * sole-trader signup page (the checkout-page app, not the API).
-     * Mirrors Twopayment::ENVIRONMENT_HOSTS: anything not in the map
-     * (legacy 'development', empty/unset) falls back to sandbox.
-     */
-    private static $signup_hosts = array(
-        'production' => 'https://checkout.two.inc',
-        'staging' => 'https://checkout.staging.two.inc',
-    );
-
-    /**
      * Full URL of Two's hosted sole-trader signup page for the configured
      * environment.
      *
@@ -282,9 +310,6 @@ class TwoSoleTrader
             : 'https://checkout.sandbox.two.inc';
         return $host . '/soletrader/signup';
     }
-
-    /** @var callable|null test seam for postCapturingHeaders */
-    public static $transport = null;
 
     /**
      * Test seam: clear the request-scoped types cache and transport hook.

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.4.0]]></version>
+    <version><![CDATA[2.5.0]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.5.0]]></version>
+    <version><![CDATA[2.5.1]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/controllers/front/confirmation.php
+++ b/controllers/front/confirmation.php
@@ -120,9 +120,18 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
         }
 
         $stored_snapshot_hash = isset($attempt['cart_snapshot_hash']) ? trim((string)$attempt['cart_snapshot_hash']) : '';
+        // Records which URL variant (with/without secure key) the stored hash
+        // matched, so the final pre-validateOrder re-check compares like with
+        // like. Null until a variant matches.
+        $snapshot_includes_secure_key = null;
         if (!Tools::isEmpty($stored_snapshot_hash)) {
             try {
-                $current_snapshot_hash = $this->buildAttemptSnapshotHash($attempt_token, $attempt, $cart, true);
+                // EXPLICIT CHOICE: this initial check self-heals the cart's
+                // surcharge line (sync=true) before hashing, so a missed
+                // frontend sync (broken theme JS) reconverges to the state
+                // the stored snapshot was built from instead of failing the
+                // whole checkout on a healable divergence.
+                $current_snapshot_hash = $this->buildAttemptSnapshotHash($attempt_token, $attempt, $cart, true, true);
             } catch (Exception $e) {
                 $this->module->updateTwoCheckoutAttemptStatus($attempt_token, 'FAILED');
                 PrestaShopLogger::addLog(
@@ -134,16 +143,21 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
                 $this->redirectWithNotifications('index.php?controller=order');
             }
 
-            if (!hash_equals($stored_snapshot_hash, $current_snapshot_hash)) {
+            if (hash_equals($stored_snapshot_hash, $current_snapshot_hash)) {
+                $snapshot_includes_secure_key = true;
+            } else {
                 // Compatibility fallback: allow old attempts created before callback key was added.
+                // Comparison-only rebuild: the sync above already ran, do not
+                // mutate the cart again just to compute a hash.
                 try {
-                    $legacy_snapshot_hash = $this->buildAttemptSnapshotHash($attempt_token, $attempt, $cart, false);
+                    $legacy_snapshot_hash = $this->buildAttemptSnapshotHash($attempt_token, $attempt, $cart, false, false);
                 } catch (Exception $e) {
                     $legacy_snapshot_hash = '';
                 }
 
                 if (!Tools::isEmpty($legacy_snapshot_hash) && hash_equals($stored_snapshot_hash, $legacy_snapshot_hash)) {
                     $current_snapshot_hash = $legacy_snapshot_hash;
+                    $snapshot_includes_secure_key = false;
                 } else {
                     // Cart changed between provider order creation and callback finalization.
                     $this->module->setTwoPaymentRequest('/v1/order/' . $attempt['two_order_id'] . '/cancel', [], 'POST');
@@ -266,6 +280,55 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
                 if ($this->abortConfirmationIfAttemptCancelled($attempt_token, $attempt)) {
                     return;
                 }
+            }
+
+            // FINAL PARITY RE-CHECK, adjacent to the charge: the earlier
+            // snapshot check is separated from validateOrder by two provider
+            // round-trips (GET /v1/order, POST /confirm) during which the
+            // cart could theoretically drift (another tab, a stale-guard
+            // hook). Re-run the self-healing snapshot build (sync=true also
+            // enforces cart-vs-payload fee parity, failing closed) and
+            // require the stored hash to still match, so the gate's last
+            // word is issued immediately before the money moves.
+            if (!Tools::isEmpty($stored_snapshot_hash) && $snapshot_includes_secure_key !== null) {
+                try {
+                    $final_snapshot_hash = $this->buildAttemptSnapshotHash(
+                        $attempt_token,
+                        $attempt,
+                        $cart,
+                        $snapshot_includes_secure_key,
+                        true
+                    );
+                } catch (Exception $e) {
+                    $this->module->updateTwoCheckoutAttemptStatus($attempt_token, 'FAILED');
+                    PrestaShopLogger::addLog(
+                        'TwoPayment: Final pre-order snapshot rebuild failed for attempt ' . $attempt_token . ' - ' . $e->getMessage(),
+                        3
+                    );
+                    $message = $this->module->l('Unable to validate cart consistency for this payment. Please try again.');
+                    $this->errors[] = $message;
+                    $this->redirectWithNotifications('index.php?controller=order');
+                    return;
+                }
+
+                if (!hash_equals($stored_snapshot_hash, $final_snapshot_hash)) {
+                    $this->module->setTwoPaymentRequest('/v1/order/' . $attempt['two_order_id'] . '/cancel', [], 'POST');
+                    $this->module->updateTwoCheckoutAttemptStatus($attempt_token, 'FAILED');
+                    PrestaShopLogger::addLog(
+                        'TwoPayment: Cart snapshot drifted between verification and order creation for attempt ' . $attempt_token .
+                        '. Stored=' . $stored_snapshot_hash . ', Final=' . $final_snapshot_hash,
+                        3
+                    );
+                    $message = $this->module->l('Your cart changed during payment verification. Please review your cart and try again.');
+                    $this->errors[] = $message;
+                    $this->redirectWithNotifications('index.php?controller=order');
+                    return;
+                }
+            } else {
+                // Legacy attempt without a stored snapshot hash: still force
+                // the authoritative surcharge self-heal adjacent to the
+                // charge (the validateOrder amount check remains the gate).
+                $this->module->syncTwoSurchargeCartLine($cart, true);
             }
 
             $initial_status = $this->getInitialAwaitingStatus();
@@ -443,8 +506,19 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
 
     /**
      * Rebuild snapshot hash using current cart and expected callback URL format.
+     *
+     * @param string $attempt_token
+     * @param array $attempt
+     * @param Cart $cart
+     * @param bool $include_secure_key
+     * @param bool $sync_surcharge_cart_line default FALSE: computing a
+     *        comparison hash must not mutate the cart as a side effect. The
+     *        two self-healing call sites (initial check, final pre-order
+     *        re-check) opt in explicitly - with sync enabled the underlying
+     *        payload build also ENFORCES cart-vs-payload fee parity and
+     *        throws on divergence.
      */
-    private function buildAttemptSnapshotHash($attempt_token, $attempt, $cart, $include_secure_key)
+    private function buildAttemptSnapshotHash($attempt_token, $attempt, $cart, $include_secure_key, $sync_surcharge_cart_line = false)
     {
         $confirm_params = array('attempt_token' => $attempt_token);
         $cancel_params = array('attempt_token' => $attempt_token);
@@ -461,7 +535,12 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
             'merchant_invoice_url' => '',
             'merchant_shipping_document_url' => '',
         );
-        $comparison_payload = $this->module->getTwoNewOrderData($attempt['merchant_order_id'], $cart, $comparison_urls);
+        $comparison_payload = $this->module->getTwoNewOrderData(
+            $attempt['merchant_order_id'],
+            $cart,
+            $comparison_urls,
+            (bool) $sync_surcharge_cart_line
+        );
 
         return $this->module->calculateTwoCheckoutSnapshotHash($cart, $comparison_payload);
     }

--- a/controllers/front/confirmation.php
+++ b/controllers/front/confirmation.php
@@ -325,10 +325,27 @@ class TwopaymentConfirmationModuleFrontController extends ModuleFrontController
                     return;
                 }
             } else {
-                // Legacy attempt without a stored snapshot hash: still force
-                // the authoritative surcharge self-heal adjacent to the
-                // charge (the validateOrder amount check remains the gate).
-                $this->module->syncTwoSurchargeCartLine($cart, true);
+                // Legacy attempt without a stored snapshot hash: run the SAME
+                // fail-closed parity gate as the hashed path above. Building
+                // the comparison payload with sync=true both self-heals the
+                // cart's surcharge line AND enforces cart-vs-payload fee
+                // parity, throwing on divergence (core validateOrder performs
+                // NO such check itself - a bare sync here would let a genuine
+                // divergence charge the buyer). The hash result is discarded:
+                // with no stored hash there is nothing to compare it against.
+                try {
+                    $this->buildAttemptSnapshotHash($attempt_token, $attempt, $cart, false, true);
+                } catch (Exception $e) {
+                    $this->module->updateTwoCheckoutAttemptStatus($attempt_token, 'FAILED');
+                    PrestaShopLogger::addLog(
+                        'TwoPayment: Legacy (no stored hash) pre-order parity gate failed for attempt ' . $attempt_token . ' - ' . $e->getMessage(),
+                        3
+                    );
+                    $message = $this->module->l('Unable to validate cart consistency for this payment. Please try again.');
+                    $this->errors[] = $message;
+                    $this->redirectWithNotifications('index.php?controller=order');
+                    return;
+                }
             }
 
             $initial_status = $this->getInitialAwaitingStatus();

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -73,12 +73,81 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             case 'clearOrderIntentResult':
                 $this->ajaxProcessClearOrderIntentResult();
                 break;
+            case 'soleTraderAvailability':
+                $this->ajaxProcessSoleTraderAvailability();
+                break;
+            case 'soleTraderTokens':
+                $this->ajaxProcessSoleTraderTokens();
+                break;
             default:
                 $this->sendJsonResponse(json_encode([
                     'success' => false,
                     'error' => $this->module->l('Unknown action requested.')
                 ]));
         }
+    }
+
+    /**
+     * Whether the sole trader account type applies for a billing country
+     * (TWO-24755). Combines the registry endpoint's country answer with the
+     * merchant toggle, both server-side; JS only renders the result.
+     */
+    public function ajaxProcessSoleTraderAvailability()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        $country = (string) Tools::getValue('country');
+        $this->sendJsonResponse(json_encode([
+            'success' => true,
+            'available' => TwoSoleTrader::isAvailable($this->module, $country),
+        ]));
+    }
+
+    /**
+     * Mint the delegation + autofill tokens for the sole-trader flow
+     * (TWO-24755) and hand the browser what it needs to open the hosted
+     * signup popup and autofill the buyer. The merchant API key stays
+     * server-side; tokens are scoped and short-lived by the Two API.
+     * Defence-in-depth: minting requires the flow to actually be available
+     * for the cart's billing country, so this endpoint cannot be used as a
+     * token oracle where the feature is off or the country is ineligible.
+     */
+    public function ajaxProcessSoleTraderTokens()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        if (!$this->isPost()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Only POST requests allowed')]));
+            return;
+        }
+        $countryIso = '';
+        $cart = $this->context->cart;
+        if ($cart && (int) $cart->id_address_invoice) {
+            $address = new Address((int) $cart->id_address_invoice);
+            $countryIso = (string) Country::getIsoById((int) $address->id_country);
+        }
+        if ($countryIso === '') {
+            $countryIso = (string) Tools::getValue('country');
+        }
+        if (!TwoSoleTrader::isAvailable($this->module, $countryIso)) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Sole trader checkout is not available')]));
+            return;
+        }
+        $tokens = TwoSoleTrader::mintTokens($this->module);
+        if ($tokens === null) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Could not initialise the sole trader flow')]));
+            return;
+        }
+        $this->sendJsonResponse(json_encode([
+            'success' => true,
+            'delegation_token' => $tokens['delegation_token'],
+            'autofill_token' => $tokens['autofill_token'],
+            'signup_url' => TwoSoleTrader::getSignupPageUrl(),
+        ]));
     }
 
     /**
@@ -332,9 +401,13 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         }
         
 
-        // SECURITY LAYER: Verify account type (kept for defense-in-depth)
-        if (empty($accountType) || $accountType !== 'business') {
-            PrestaShopLogger::addLog('TwoPayment: Order intent blocked - non-business account type: ' . $accountType, 2);
+        // SECURITY LAYER: Verify account type (kept for defense-in-depth).
+        // Business always passes; sole trader only where the feature is
+        // available for the billing country (TWO-24755); anything else
+        // (personal, empty) is blocked in strict account-type mode.
+        $countryIso = (string) Country::getIsoById((int) $address->id_country);
+        if (empty($accountType) || !TwoSoleTrader::isAccountTypeAllowed($this->module, $accountType, $countryIso)) {
+            PrestaShopLogger::addLog('TwoPayment: Order intent blocked - ineligible account type: ' . $accountType, 2);
             $this->sendJsonResponse(json_encode([
                 'success' => false,
                 'error' => $this->module->l('Two payment is only available for business accounts')

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -142,7 +142,13 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             return;
         }
         $selected = (int) Tools::getValue('selected') === 1;
-        $result = $this->module->syncTwoSurchargeCartLine($this->context->cart, $selected);
+        // Ordering guard: the checkout JS sends a monotonically increasing
+        // sequence number so a slower, older request (rapid method switches)
+        // cannot overwrite a newer one server-side. Absent/invalid seq
+        // (legacy cached JS) falls back to unguarded behaviour.
+        $seqRaw = Tools::getValue('seq');
+        $syncSeq = (is_numeric($seqRaw) && (float) $seqRaw > 0) ? (int) $seqRaw : null;
+        $result = $this->module->syncTwoSurchargeCartLine($this->context->cart, $selected, $syncSeq);
         $this->sendJsonResponse(json_encode($result));
     }
 

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -61,6 +61,9 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             case 'fetchTermSurcharges':
                 $this->ajaxProcessFetchTermSurcharges();
                 break;
+            case 'syncSurchargeLine':
+                $this->ajaxProcessSyncSurchargeLine();
+                break;
             case 'checkOrderIntent':
                 $this->ajaxProcessCheckOrderIntent();
                 break;
@@ -116,6 +119,31 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             return;
         }
         $this->sendJsonResponse(json_encode($this->module->getTwoOfferedTermSurchargeAmounts()));
+    }
+
+    /**
+     * Reconcile the cart's hidden surcharge line with the buyer's payment
+     * selection (selected=1 -> exactly one line at the current quoted fee,
+     * selected=0 -> no line). Idempotent by contract of
+     * Twopayment::syncTwoSurchargeCartLine: repeat calls with the same
+     * selection are no-ops ({changed:false}), so re-clicks, reloads and
+     * re-fired change events can never stack duplicate lines. Fail-soft:
+     * always answers 200 JSON; a {success:false} tells the JS nothing was
+     * reconciled (the create-time parity gate remains the hard guarantee).
+     */
+    public function ajaxProcessSyncSurchargeLine()
+    {
+        if (!$this->validateAjaxToken()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Invalid token')]));
+            return;
+        }
+        if (!$this->isPost()) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Only POST requests allowed')]));
+            return;
+        }
+        $selected = (int) Tools::getValue('selected') === 1;
+        $result = $this->module->syncTwoSurchargeCartLine($this->context->cart, $selected);
+        $this->sendJsonResponse(json_encode($result));
     }
 
     /**

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -111,8 +111,11 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
      * signup popup and autofill the buyer. The merchant API key stays
      * server-side; tokens are scoped and short-lived by the Two API.
      * Defence-in-depth: minting requires the flow to actually be available
-     * for the cart's billing country, so this endpoint cannot be used as a
-     * token oracle where the feature is off or the country is ineligible.
+     * for the CART'S billing country (never a client-supplied one), so
+     * this endpoint cannot be used as a token oracle where the feature is
+     * off, the country is ineligible, or there is no invoice address yet
+     * to check against - fails closed in that last case rather than
+     * trusting an unvalidated 'country' request param.
      */
     public function ajaxProcessSoleTraderTokens()
     {
@@ -124,15 +127,13 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Only POST requests allowed')]));
             return;
         }
-        $countryIso = '';
         $cart = $this->context->cart;
-        if ($cart && (int) $cart->id_address_invoice) {
-            $address = new Address((int) $cart->id_address_invoice);
-            $countryIso = (string) Country::getIsoById((int) $address->id_country);
+        if (!$cart || !(int) $cart->id_address_invoice) {
+            $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('No billing address set for this order')]));
+            return;
         }
-        if ($countryIso === '') {
-            $countryIso = (string) Tools::getValue('country');
-        }
+        $address = new Address((int) $cart->id_address_invoice);
+        $countryIso = (string) Country::getIsoById((int) $address->id_country);
         if (!TwoSoleTrader::isAvailable($this->module, $countryIso)) {
             $this->sendJsonResponse(json_encode(['success' => false, 'error' => $this->module->l('Sole trader checkout is not available')]));
             return;
@@ -147,6 +148,11 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             'delegation_token' => $tokens['delegation_token'],
             'autofill_token' => $tokens['autofill_token'],
             'signup_url' => TwoSoleTrader::getSignupPageUrl(),
+            // Server-resolved invoice-address country (TWO-24755 F2): the
+            // JS must use THIS, not a DOM guess, when it later saves the
+            // enrolled company - getTwoValidatedSessionCompanyData()
+            // wipes the session company on any country mismatch.
+            'country' => $countryIso,
         ]));
     }
 

--- a/override/classes/form/CustomerAddressFormatter.php
+++ b/override/classes/form/CustomerAddressFormatter.php
@@ -48,6 +48,12 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
                 ->addAvailableValue('personal', $this->getFieldLabel('personal_type'))
                 ->addAvailableValue('business', $this->getFieldLabel('business_type'))
                 ->setLabel($this->getFieldLabel('account_type'));
+            // Sole trader (TWO-24755): third option, only where the country
+            // legally supports it AND the merchant opted in. The address form
+            // re-renders per country, so the decision stays server-side.
+            if ($this->isSoleTraderAvailable()) {
+                $accountTypeField->addAvailableValue('sole_trader', $this->getFieldLabel('sole_trader_type'));
+            }
             $this->applyFieldDefinitionMetadata($accountTypeField, 'account_type');
             $format = $this->insertFieldAfter($format, 'token', 'account_type', $accountTypeField);
         }
@@ -85,6 +91,28 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
         }
 
         return $format;
+    }
+
+    /**
+     * Whether the Sole Trader account type applies for this form's country.
+     * Delegates to the module's business-logic class (TWO-24755); rendering
+     * stays here, decisioning there.
+     */
+    private function isSoleTraderAvailable()
+    {
+        if (!class_exists('TwoSoleTrader')) {
+            $classFile = _PS_MODULE_DIR_ . 'twopayment/classes/TwoSoleTrader.php';
+            if (!file_exists($classFile)) {
+                return false;
+            }
+            require_once $classFile;
+        }
+        $module = Module::getInstanceByName('twopayment');
+        $country = $this->getCountry();
+        if (!$module || !$country || empty($country->iso_code)) {
+            return false;
+        }
+        return TwoSoleTrader::isAvailable($module, $country->iso_code);
     }
 
     private function insertFieldAfter(array $format, $afterKey, $newKey, FormField $field)
@@ -214,6 +242,8 @@ class CustomerAddressFormatter extends CustomerAddressFormatterCore
                 return $this->translator->trans('Personal', [], 'Shop.Forms.Labels');
             case 'business_type':
                 return $this->translator->trans('Business', [], 'Shop.Forms.Labels');
+            case 'sole_trader_type':
+                return $this->translator->trans('Sole trader', [], 'Shop.Forms.Labels');
             case 'companyid':
                 return $this->translator->trans('Company ID', [], 'Shop.Forms.Labels');
             case 'department':

--- a/tests/ConfirmationLegacyParitySpec.php
+++ b/tests/ConfirmationLegacyParitySpec.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../controllers/front/confirmation.php';
+
+/**
+ * The LEGACY confirmation path (attempt without a stored snapshot hash) must
+ * run the SAME fail-closed surcharge parity gate as the hashed path before
+ * validateOrder charges the buyer. Core PaymentModule::validateOrder performs
+ * NO cart-vs-payload fee comparison itself, so a bare surcharge self-heal
+ * adjacent to the charge (the previous behaviour) would let a genuine,
+ * un-healable divergence create an order whose PrestaShop total differs from
+ * the Two invoice.
+ *
+ * These specs drive the real controller (handleAttemptTokenConfirmation via
+ * reflection - it is private) over the stub core, with the module's payload
+ * builders REAL so the actual parity gate in buildTwoOrderPricingData is what
+ * decides the outcome.
+ */
+final class ConfirmationLegacyParitySpec
+{
+    private const CART_ID = 8301;
+    private const CUSTOMER_ID = 8001;
+    private const ORDER_ID = 7777;
+    private const PRODUCT_NET = 100.00;
+    private const PRODUCT_GROSS = 105.50;
+
+    public static function runAll(): void
+    {
+        self::testLegacyNoHashAttemptFailsClosedOnGenuineDivergence();
+        self::testLegacyNoHashAttemptProceedsWhenParityHolds();
+    }
+
+    /* ---- fixtures ---- */
+
+    private static function makeAttempt(): array
+    {
+        return [
+            'attempt_token' => 'attempt-legacy-1',
+            'id_cart' => self::CART_ID,
+            'id_customer' => self::CUSTOMER_ID,
+            'id_order' => 0,
+            'two_order_id' => 'two-order-legacy-1',
+            'two_order_reference' => 'ref-legacy-1',
+            'two_order_state' => '',
+            'two_order_status' => '',
+            'two_day_on_invoice' => '30',
+            'two_payment_term_type' => 'STANDARD',
+            'two_invoice_url' => '',
+            'two_invoice_id' => '',
+            'cart_snapshot_hash' => '', // <- the legacy/degraded case under test
+            'merchant_order_id' => 'merchant-legacy-1',
+            'customer_secure_key' => 'secure-key-8001',
+            'status' => 'CREATED',
+        ];
+    }
+
+    /**
+     * Module double: provider I/O and attempt persistence are canned, but
+     * every payload/pricing/parity method is the REAL implementation.
+     */
+    private static function makeModule(): Twopayment
+    {
+        StubStore::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30]');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
+        Configuration::updateValue('PS_TWO_OS_AWAITING_VERIFICATION', 12);
+        Configuration::updateValue('PS_TWO_OS_VERIFIED_PENDING_FULFILLMENT', 13);
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[33] = 'FR';
+        StubStore::$addresses[8201] = [
+            'id_country' => 33,
+            'company' => 'Acme FR SAS',
+            'companyid' => 'FR123456789',
+            'address1' => '10 Rue de Paris',
+            'city' => 'Paris',
+            'postcode' => '75001',
+            'phone' => '+33100000000',
+            'loaded' => true,
+        ];
+        StubStore::$addresses[8202] = StubStore::$addresses[8201];
+        StubStore::$customers[self::CUSTOMER_ID] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Eva',
+            'lastname' => 'Martin',
+            'secure_key' => 'secure-key-8001',
+            'loaded' => true,
+        ];
+        StubStore::$carts[self::CART_ID] = [
+            'id_customer' => self::CUSTOMER_ID,
+            'id_currency' => 978,
+            'id_address_invoice' => 8201,
+            'id_address_delivery' => 8202,
+            'id_carrier' => 0,
+            'id_lang' => 1,
+        ];
+        StubStore::$cartProducts[self::CART_ID] = [[
+            'id_product' => 9401,
+            'link_rewrite' => 'plain-item',
+            'name' => 'Plain item',
+            'description_short' => '',
+            'manufacturer_name' => '',
+            'ean13' => '',
+            'upc' => '',
+            'cart_quantity' => 1,
+            'price' => self::PRODUCT_NET,
+            'total' => self::PRODUCT_NET,
+            'total_wt' => self::PRODUCT_GROSS,
+            'rate' => 5.5,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[9401] = [['name' => 'Books']];
+        StubStore::$images[9401] = ['id_image' => 9401];
+        StubStore::$cartTotals[self::CART_ID] = [
+            true => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_GROSS],
+            false => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],
+            'average_products_tax_rate' => 5.5,
+        ];
+        StubStore::$orders[self::ORDER_ID] = [
+            'id_cart' => self::CART_ID,
+            'id_customer' => self::CUSTOMER_ID,
+            'total_paid' => 110.78,
+        ];
+
+        return new class(self::makeAttempt()) extends TwopaymentTestHarness {
+            public array $attempt;
+            /** @var array<int,array{status:string,extra:array}> */
+            public array $statusUpdates = [];
+            public int $createOrderCalls = 0;
+            /** Simulates a self-heal that cannot reconcile (broken tax setup). */
+            public bool $syncDisabled = false;
+
+            public function syncTwoSurchargeCartLine($cart, $selected, $syncSeq = null)
+            {
+                if ($this->syncDisabled) {
+                    return ['success' => false, 'changed' => false, 'present' => true];
+                }
+                return parent::syncTwoSurchargeCartLine($cart, $selected, $syncSeq);
+            }
+
+            public function __construct(array $attempt)
+            {
+                parent::__construct();
+                $this->attempt = $attempt;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $endpoint = (string) $endpoint;
+                if ($method === 'GET' && strpos($endpoint, '/v1/order/') === 0) {
+                    // Provider order already CONFIRMED: the flow skips the
+                    // confirm round-trip and heads straight for validateOrder.
+                    return [
+                        'http_status' => 200,
+                        'id' => $this->attempt['two_order_id'],
+                        'state' => 'CONFIRMED',
+                        'status' => 'APPROVED',
+                        'gross_amount' => '110.78',
+                        'merchant_reference' => 'ref-legacy-1',
+                    ];
+                }
+                if (strpos($endpoint, '/cancel') !== false || $method === 'PUT') {
+                    return ['http_status' => 200];
+                }
+                // Fee quote for the surcharge line (5% of 105.50 = 5.28).
+                return ['http_status' => 200, 'buyer_fee_share' => '5.28', 'currency' => 'EUR'];
+            }
+
+            public function getTwoCheckoutAttempt($attempt_token)
+            {
+                return $this->attempt;
+            }
+
+            public function updateTwoCheckoutAttemptStatus($attempt_token, $status, $extra_data = array())
+            {
+                $this->statusUpdates[] = ['status' => (string) $status, 'extra' => (array) $extra_data];
+                $this->attempt['status'] = (string) $status;
+                return true;
+            }
+
+            public function isTwoAttemptCallbackAuthorized($attempt, $provided_secure_key = '', $context_customer_id = 0, $context_customer_secure_key = '')
+            {
+                return true;
+            }
+
+            public function resolveTwoAttemptOrderIdForCancellation($attempt)
+            {
+                return 0;
+            }
+
+            public function getTwoOrderIdByCart($cart_id)
+            {
+                return 0;
+            }
+
+            public function getTwoOrderPaymentData($order_id)
+            {
+                return false;
+            }
+
+            public function createTwoLocalOrderAfterProviderVerification($cart, $customer, $initial_status, $provider_gross_amount)
+            {
+                $this->createOrderCalls++;
+                return ['success' => true, 'id_order' => 7777];
+            }
+
+            public function setTwoOrderPaymentData($order_id, $payment_data)
+            {
+                return true;
+            }
+
+            public function getTwoUpdateOrderData($order, $payment_data = null)
+            {
+                return [];
+            }
+
+            public function setTwoCheckoutAttemptMerchantOrderId($attempt_token, $merchant_order_id)
+            {
+                return true;
+            }
+
+            public function changeOrderStatus($order_id, $status)
+            {
+                return true;
+            }
+
+            public function syncLocalOrderStatusFromTwoState($order_id, $state)
+            {
+                return true;
+            }
+
+            public function cancelTwoOrderBestEffort($two_order_id, $reason = '')
+            {
+                return true;
+            }
+        };
+    }
+
+    private static function makeController(Twopayment $module): TwopaymentConfirmationModuleFrontController
+    {
+        Context::getContext()->cookie->two_payment_term = 30;
+        $controller = new TwopaymentConfirmationModuleFrontController();
+        $controller->module = $module;
+        return $controller;
+    }
+
+    private static function runConfirmation(TwopaymentConfirmationModuleFrontController $controller): StubRedirect
+    {
+        $handle = new ReflectionMethod($controller, 'handleAttemptTokenConfirmation');
+        $handle->setAccessible(true);
+        try {
+            $handle->invoke($controller, 'attempt-legacy-1');
+        } catch (StubRedirect $redirect) {
+            return $redirect;
+        }
+        throw new RuntimeException('Confirmation flow ended without redirecting');
+    }
+
+    private static function lastStatus(Twopayment $module): string
+    {
+        $updates = $module->statusUpdates;
+        return $updates === [] ? '' : (string) end($updates)['status'];
+    }
+
+    /* ---- specs ---- */
+
+    private static function testLegacyNoHashAttemptFailsClosedOnGenuineDivergence(): void
+    {
+        $module = self::makeModule();
+
+        // Seed the fee line, then corrupt it to a stale amount and disable
+        // the self-heal (a sync that cannot reconcile, e.g. broken tax
+        // setup) - the same genuine-divergence construction as the
+        // order-create parity gate spec, now arriving via the LEGACY
+        // confirmation path.
+        $cart = new Cart(self::CART_ID);
+        Context::getContext()->cart = $cart;
+        $module->syncTwoSurchargeCartLine($cart, true);
+        foreach (StubStore::$cartProducts[self::CART_ID] as $i => $row) {
+            if ((int) $row['id_product'] === (int) Configuration::get('PS_TWO_SURCHARGE_PRODUCT_ID')) {
+                $netDelta = 2.00 - (float) $row['total'];
+                $grossDelta = 2.50 - (float) $row['total_wt'];
+                StubStore::$cartProducts[self::CART_ID][$i]['total'] = 2.00;
+                StubStore::$cartProducts[self::CART_ID][$i]['total_wt'] = 2.50;
+                StubStore::$cartTotals[self::CART_ID][false][Cart::BOTH] = round(
+                    (float) StubStore::$cartTotals[self::CART_ID][false][Cart::BOTH] + $netDelta,
+                    2
+                );
+                StubStore::$cartTotals[self::CART_ID][true][Cart::BOTH] = round(
+                    (float) StubStore::$cartTotals[self::CART_ID][true][Cart::BOTH] + $grossDelta,
+                    2
+                );
+            }
+        }
+        $module->syncDisabled = true;
+
+        $controller = self::makeController($module);
+        $redirect = self::runConfirmation($controller);
+
+        TinyAssert::same(0, $module->createOrderCalls, 'no order may be created past a failed parity gate');
+        TinyAssert::same('FAILED', self::lastStatus($module), 'attempt must be marked FAILED');
+        TinyAssert::true(strpos($redirect->getMessage(), 'controller=order') !== false, 'buyer returned to checkout');
+    }
+
+    private static function testLegacyNoHashAttemptProceedsWhenParityHolds(): void
+    {
+        $module = self::makeModule();
+
+        // Healthy cart: the buyer selected Two, the fee line synced normally.
+        $cart = new Cart(self::CART_ID);
+        Context::getContext()->cart = $cart;
+        $module->syncTwoSurchargeCartLine($cart, true);
+
+        $controller = self::makeController($module);
+        $redirect = self::runConfirmation($controller);
+
+        TinyAssert::same(1, $module->createOrderCalls, 'order creation must proceed when parity holds');
+        TinyAssert::same('CONFIRMED', self::lastStatus($module), 'attempt confirmed');
+        TinyAssert::true(strpos($redirect->getMessage(), 'order-confirmation') !== false, 'buyer lands on order confirmation');
+    }
+}

--- a/tests/ConfirmationLegacyParitySpec.php
+++ b/tests/ConfirmationLegacyParitySpec.php
@@ -65,7 +65,11 @@ final class ConfirmationLegacyParitySpec
         StubStore::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant-selected tax rules group: covers the cart's destination
+        // (FR, country 33) at 25%.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRulesGroups[400] = ['name' => 'FR standard rate', 'active' => 1];
+        StubStore::$taxRuleRates[400] = [33 => 25.0];
         Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30]');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
         Configuration::updateValue('PS_TWO_OS_AWAITING_VERIFICATION', 12);

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -54,6 +54,7 @@ final class SurchargeCartLineSpec
         self::testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects();
         self::testFeeTaxFollowsDestinationRulesOfSelectedGroup();
         self::testNoTaxSentinelZeroesFeeTaxForEveryDestination();
+        self::testVatExemptB2BCartUntaxedOnBothCartLineAndPayload();
         self::testAdminManualAddOfFeeProductToOrderIsBlocked();
         self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
         self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
@@ -649,6 +650,55 @@ final class SurchargeCartLineSpec
             TinyAssert::same('0', $payloadLine['tax_rate']);
             TinyAssert::same('5.00', $payloadLine['gross_amount']);
         }
+    }
+
+    /**
+     * TWO-25071: vatnumber-module B2B exemption. A cross-border business
+     * buyer with a VAT number (management on) is untaxed by core's
+     * Product::priceCalculation on the PS cart line AND by
+     * getTwoSurchargeTaxRateForCart on the Two payload side - both sides of
+     * the SAME cart must agree, exactly like the destination-rules /
+     * multi-rate / no-tax cases above. Guards the hand-replicated exemption
+     * condition in getTwoSurchargeTaxRateForCart against drifting from the
+     * cart-line behaviour.
+     */
+    private static function testVatExemptB2BCartUntaxedOnBothCartLineAndPayload(): void
+    {
+        // Cross-border B2B: merchant country NO (47), buyer FR with a VAT
+        // number -> exempt. Untaxed on BOTH sides.
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', 47);
+        StubStore::$addresses[8201]['vat_number'] = 'FR999999999';
+        StubStore::$addresses[8202]['vat_number'] = 'FR999999999';
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'VAT-exempt B2B cart must carry an UNTAXED PS fee line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0', $payloadLine['tax_rate'], 'payload side must apply the same B2B exemption as the cart line');
+        TinyAssert::same('5.00', $payloadLine['gross_amount'], 'payload gross matches the untaxed PS line gross');
+
+        // Domestic B2B (buyer country == VATNUMBER_COUNTRY): NOT exempt -
+        // both sides tax at the group's FR rate (25%). Fresh fixture so the
+        // re-price cannot be masked by sync idempotency.
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', self::COUNTRY_FR);
+        StubStore::$addresses[8201]['vat_number'] = 'FR999999999';
+        StubStore::$addresses[8202]['vat_number'] = 'FR999999999';
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(6.25, round((float) $lines[0]['total_wt'], 2), 'domestic B2B stays taxed on the PS line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.25', $payloadLine['tax_rate'], 'domestic B2B stays taxed on the payload side');
+        TinyAssert::same('6.25', $payloadLine['gross_amount']);
     }
 
     /* ---- order-level guard: no manual/duplicate fee rows (BO order edit) ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -48,6 +48,8 @@ final class SurchargeCartLineSpec
         self::testAdminManualAddOfFeeProductToOrderIsBlocked();
         self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
         self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
+        self::testFeeGuardTriggerDdlInstalledIdempotentlyAndDropped();
+        self::testFeeGuardTriggerEnsuredLazilyOnCartSync();
     }
 
     /* ---- fixtures ---- */
@@ -631,6 +633,66 @@ final class SurchargeCartLineSpec
         $module->hookActionObjectOrderDetailAddBefore([
             'object' => self::makeOrderDetailStub(12345, 7005),
         ]);
+    }
+
+    /* ---- DB-level fee-guard trigger (the ACTUAL enforcement layer) ---- */
+
+    /**
+     * TESTING-LAYER NOTE: the stub Db has no SQL engine, so these tests can
+     * only assert the DDL the module issues (shape, idempotence, drop). The
+     * trigger's REJECTION semantics - duplicate fee row rejected, fee row on
+     * a fee-less-cart order rejected, legitimate first row and ordinary
+     * products unaffected - CANNOT be exercised by stubs and are verified
+     * against a live PS8 + MariaDB container (real CREATE TRIGGER, real
+     * INSERTs); see the commit message for the verified scenarios.
+     */
+    private static function testFeeGuardTriggerDdlInstalledIdempotentlyAndDropped(): void
+    {
+        $module = self::makeModule();
+        $triggerName = _DB_PREFIX_ . 'twopayment_fee_guard';
+
+        TinyAssert::true($module->installTwoOrderDetailFeeGuardTrigger());
+        TinyAssert::true(isset(StubStore::$dbTriggers[$triggerName]), 'trigger DDL issued');
+        $ddl = StubStore::$dbTriggers[$triggerName];
+        TinyAssert::true(strpos($ddl, 'BEFORE INSERT ON `' . _DB_PREFIX_ . 'order_detail`') !== false, 'guards order_detail inserts');
+        TinyAssert::same(2, substr_count($ddl, "SIGNAL SQLSTATE '45000'"), 'both rules reject via SIGNAL: duplicate row + fee-less-cart order');
+        TinyAssert::true(strpos($ddl, Twopayment::CONFIG_SURCHARGE_PRODUCT_ID) !== false, 'fee product id resolved live from configuration (survives product recreation)');
+        TinyAssert::true(strpos($ddl, '`' . _DB_PREFIX_ . 'cart_product`') !== false, 'fee row only accepted for an order whose cart carries the fee line');
+
+        // Idempotent: a second install sees the existing trigger and issues
+        // no DDL at all.
+        $executedBefore = count(StubStore::$dbExecuted);
+        TinyAssert::true($module->installTwoOrderDetailFeeGuardTrigger());
+        TinyAssert::same($executedBefore, count(StubStore::$dbExecuted), 'no duplicate CREATE TRIGGER');
+
+        // Uninstall drops it (via deleteTwoTables -> dropTwoOrderDetailFeeGuardTrigger).
+        $drop = new ReflectionMethod($module, 'dropTwoOrderDetailFeeGuardTrigger');
+        $drop->setAccessible(true);
+        $drop->invoke($module);
+        TinyAssert::false(isset(StubStore::$dbTriggers[$triggerName]), 'trigger dropped at uninstall');
+    }
+
+    private static function testFeeGuardTriggerEnsuredLazilyOnCartSync(): void
+    {
+        // Upgrade path: install() never re-ran, so the trigger is absent -
+        // the first checkout cart sync must (re)install it.
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $triggerName = _DB_PREFIX_ . 'twopayment_fee_guard';
+        TinyAssert::false(isset(StubStore::$dbTriggers[$triggerName]));
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true(isset(StubStore::$dbTriggers[$triggerName]), 'lazy ensure installs the trigger on first sync');
+
+        // Once per request only: a second sync issues no further trigger DDL.
+        $createCount = static function (): int {
+            return count(array_filter(StubStore::$dbExecuted, static function ($sql) {
+                return strpos($sql, 'CREATE TRIGGER') !== false;
+            }));
+        };
+        $before = $createCount();
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::same($before, $createCount(), 'ensure is memoised per request');
     }
 
     /* ---- requirement 1: hidden product shape ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Buyer surcharge as a REAL PrestaShop cart line (hidden virtual product).
+ *
+ * Covers the three hardest correctness bars of the feature:
+ * - idempotent add/remove wiring (select Two twice -> one line; switch away
+ *   -> removed; switch back -> one line; fresh request replays -> no dupes,
+ *   no stale leftovers),
+ * - net-amount parity: the cart line's net is produced by the SAME
+ *   computation path as the Two payload's fee line
+ *   (buildTwoSurchargeLineItemForCart over the shared quote cache), asserted
+ *   end-to-end through getTwoNewOrderData,
+ * - tax: PrestaShop applies exactly getTwoSurchargeTaxRate() to the line via
+ *   the module-managed Tax/TaxRulesGroup/TaxRule graph.
+ *
+ * Plus the money-protective guards: the order-create parity gate (fail
+ * closed on cart-vs-payload fee divergence) and the front-controller
+ * stale-line guard (other payment module / lost session marker).
+ */
+final class SurchargeCartLineSpec
+{
+    private const CART_ID = 8101;
+    private const PRODUCT_NET = 100.00;
+    private const PRODUCT_GROSS = 105.50;
+
+    public static function runAll(): void
+    {
+        self::testSelectAddsExactlyOneLineWithConfiguredTaxRate();
+        self::testRepeatedSelectionIsIdempotent();
+        self::testDeselectRemovesLineAndReselectReaddsOnce();
+        self::testFreshRequestReplayLeavesNoDuplicateOrStaleLine();
+        self::testTermChangeUpdatesAmountWithoutDuplicating();
+        self::testQuoteFailureRemovesLineAndStaysConsistent();
+        self::testCartLineNetMatchesTwoPayloadFeeLine();
+        self::testOrderCreateParityGateFailsClosedOnDivergence();
+        self::testStaleGuardRemovesLineForOtherPaymentModuleController();
+        self::testStaleGuardRemovesLineWhenSessionMarkerLost();
+        self::testStaleGuardKeepsLegitimateLine();
+        self::testHiddenProductShapeAndLazyCreation();
+    }
+
+    /* ---- fixtures ---- */
+
+    private static function makeModule(array $feePerDays = [30 => '5.00']): Twopayment
+    {
+        StubStore::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '8');
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30,60]');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', '1');
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$addresses[8201] = [
+            'id_country' => 33,
+            'company' => 'Acme FR SAS',
+            'companyid' => 'FR123456789',
+            'address1' => '10 Rue de Paris',
+            'city' => 'Paris',
+            'postcode' => '75001',
+            'phone' => '+33100000000',
+            'loaded' => true,
+        ];
+        StubStore::$addresses[8202] = StubStore::$addresses[8201];
+        StubStore::$countries[33] = 'FR';
+        StubStore::$customers[8001] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Eva',
+            'lastname' => 'Martin',
+            'secure_key' => 'secure-key-8001',
+            'loaded' => true,
+        ];
+
+        StubStore::$cartProducts[self::CART_ID] = [[
+            'id_product' => 9401,
+            'link_rewrite' => 'plain-item',
+            'name' => 'Plain item',
+            'description_short' => '',
+            'manufacturer_name' => '',
+            'ean13' => '',
+            'upc' => '',
+            'cart_quantity' => 1,
+            'price' => self::PRODUCT_NET,
+            'total' => self::PRODUCT_NET,
+            'total_wt' => self::PRODUCT_GROSS,
+            'rate' => 5.5,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[9401] = [['name' => 'Books']];
+        StubStore::$images[9401] = ['id_image' => 9401];
+        StubStore::$cartTotals[self::CART_ID] = [
+            true => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_GROSS],
+            false => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],
+            'average_products_tax_rate' => 5.5,
+        ];
+
+        $module = new class($feePerDays) extends TwopaymentTestHarness {
+            private array $feePerDays;
+            public array $feeRequests = [];
+            public $forcedFeeResponse = null;
+
+            public function __construct(array $feePerDays)
+            {
+                parent::__construct();
+                $this->feePerDays = $feePerDays;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->feeRequests[] = $payload;
+                if ($this->forcedFeeResponse !== null) {
+                    return $this->forcedFeeResponse;
+                }
+                $days = isset($payload['order_terms']['duration_days']) ? (int) $payload['order_terms']['duration_days'] : 30;
+                return [
+                    'http_status' => 200,
+                    'buyer_fee_share' => $this->feePerDays[$days] ?? '5.00',
+                    'currency' => 'EUR',
+                ];
+            }
+        };
+
+        return $module;
+    }
+
+    private static function makeCart(): Cart
+    {
+        $cart = new Cart(self::CART_ID);
+        $cart->id_customer = 8001;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 8201;
+        $cart->id_address_delivery = 8202;
+        $cart->id_carrier = 0;
+        $cart->id_lang = 1;
+        Context::getContext()->cart = $cart;
+        return $cart;
+    }
+
+    private static function feeLines(): array
+    {
+        $productId = (int) Configuration::get('PS_TWO_SURCHARGE_PRODUCT_ID');
+        return array_values(array_filter(
+            StubStore::$cartProducts[self::CART_ID] ?? [],
+            static fn (array $row): bool => (int) $row['id_product'] === $productId
+        ));
+    }
+
+    /* ---- requirement 2 + 6: add wiring, tax rate ---- */
+
+    private static function testSelectAddsExactlyOneLineWithConfiguredTaxRate(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        $result = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($result['success']);
+        TinyAssert::true($result['changed']);
+        TinyAssert::true($result['present']);
+
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(1, (int) $lines[0]['cart_quantity']);
+        // Net = quoted buyer_fee_share (5.00); gross applies the ADMIN
+        // configured 25% surcharge tax rate through the tax rules group.
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(6.25, round((float) $lines[0]['total_wt'], 2));
+        TinyAssert::same(25.0, round((float) $lines[0]['rate'], 2));
+
+        // Cart totals carry the fee line.
+        TinyAssert::same(111.75, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+        TinyAssert::same(105.00, round((float) $cart->getOrderTotal(false, Cart::BOTH), 2));
+    }
+
+    /* ---- requirement 3: idempotency ---- */
+
+    private static function testRepeatedSelectionIsIdempotent(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $second = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($second['success']);
+        TinyAssert::false($second['changed'], 'repeat selection must be a no-op');
+        TinyAssert::true($second['present']);
+        TinyAssert::count(1, self::feeLines());
+        TinyAssert::same(111.75, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+    }
+
+    private static function testDeselectRemovesLineAndReselectReaddsOnce(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $removed = $module->syncTwoSurchargeCartLine($cart, false);
+        TinyAssert::true($removed['success']);
+        TinyAssert::true($removed['changed']);
+        TinyAssert::false($removed['present']);
+        TinyAssert::count(0, self::feeLines());
+        TinyAssert::same(self::PRODUCT_GROSS, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+
+        // Deselect again: nothing left to remove, still a clean no-op.
+        $removedAgain = $module->syncTwoSurchargeCartLine($cart, false);
+        TinyAssert::true($removedAgain['success']);
+        TinyAssert::false($removedAgain['changed']);
+
+        $readded = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($readded['changed']);
+        TinyAssert::count(1, self::feeLines());
+        TinyAssert::same(111.75, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+    }
+
+    private static function testFreshRequestReplayLeavesNoDuplicateOrStaleLine(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+
+        // Simulate the browser reloading mid-selection: a NEW module instance
+        // (fresh request state, fresh fee cache) replays the same selection
+        // against the persisted cart.
+        $reloadedModule = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 200, 'buyer_fee_share' => '5.00', 'currency' => 'EUR'];
+            }
+        };
+        $replay = $reloadedModule->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($replay['success']);
+        TinyAssert::false($replay['changed'], 'reload replay must not stack a second line');
+        TinyAssert::count(1, self::feeLines());
+    }
+
+    private static function testTermChangeUpdatesAmountWithoutDuplicating(): void
+    {
+        $module = self::makeModule([30 => '5.00', 60 => '8.00']);
+        $cart = self::makeCart();
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::same(5.00, round((float) self::feeLines()[0]['total'], 2));
+
+        // Buyer flips the term chip to 60 days -> higher quoted fee.
+        Context::getContext()->cookie->two_payment_term = 60;
+        $updated = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($updated['changed'], 'stale amount must be corrected');
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(8.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(10.00, round((float) $lines[0]['total_wt'], 2)); // 25% on 8.00
+    }
+
+    private static function testQuoteFailureRemovesLineAndStaysConsistent(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::count(1, self::feeLines());
+
+        // Fee quote becomes unavailable: the Two payload would carry no fee
+        // line, so the cart line must go too (consistency over stickiness).
+        $module->forcedFeeResponse = ['http_status' => 500];
+        // New quote signature (term change) bypasses the request/session cache.
+        Context::getContext()->cookie->two_payment_term = 60;
+        $result = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($result['success']);
+        TinyAssert::true($result['changed']);
+        TinyAssert::false($result['present']);
+        TinyAssert::count(0, self::feeLines());
+    }
+
+    /* ---- requirement 2 + 5: single computation path, parity gate ---- */
+
+    private static function testCartLineNetMatchesTwoPayloadFeeLine(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        // Frontend selection first (the normal flow) ...
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $cartLine = self::feeLines()[0];
+
+        // ... then the order-create payload built from the same cart.
+        $payload = $module->getTwoNewOrderData('merchant-attempt-8101', $cart, [
+            'merchant_confirmation_url' => 'https://shop.local/confirm',
+            'merchant_cancel_order_url' => 'https://shop.local/cancel',
+            'merchant_edit_order_url' => '',
+            'merchant_order_verification_failed_url' => '',
+            'merchant_invoice_url' => '',
+            'merchant_shipping_document_url' => '',
+        ]);
+
+        $feeLines = array_values(array_filter($payload['line_items'], static function ($item) {
+            return isset($item['type']) && $item['type'] === 'SERVICE';
+        }));
+        TinyAssert::count(1, $feeLines);
+        TinyAssert::same(round((float) $cartLine['total'], 2), round((float) $feeLines[0]['net_amount'], 2));
+        TinyAssert::same(round((float) $cartLine['total_wt'], 2), round((float) $feeLines[0]['gross_amount'], 2));
+        TinyAssert::same('0.25', $feeLines[0]['tax_rate']);
+        // Payload totals equal the cart totals INCLUDING the fee line: the
+        // buyer's PrestaShop total and the Two invoice are the same money.
+        TinyAssert::same('111.75', $payload['gross_amount']);
+        TinyAssert::same(
+            round((float) $cart->getOrderTotal(true, Cart::BOTH), 2),
+            round((float) $payload['gross_amount'], 2)
+        );
+    }
+
+    private static function testOrderCreateParityGateFailsClosedOnDivergence(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+
+        // Corrupt the cart line to a stale amount AND disable the self-heal,
+        // simulating a sync that cannot reconcile (e.g. broken tax setup).
+        foreach (StubStore::$cartProducts[self::CART_ID] as $i => $row) {
+            if ((int) $row['id_product'] === (int) Configuration::get('PS_TWO_SURCHARGE_PRODUCT_ID')) {
+                $netDelta = 2.00 - (float) $row['total'];
+                $grossDelta = 2.50 - (float) $row['total_wt'];
+                StubStore::$cartProducts[self::CART_ID][$i]['total'] = 2.00;
+                StubStore::$cartProducts[self::CART_ID][$i]['total_wt'] = 2.50;
+                // Keep cart totals coherent with the corrupted line so the
+                // generic totals reconciliation passes and the FEE parity
+                // gate is what trips.
+                StubStore::$cartTotals[self::CART_ID][false][Cart::BOTH] = round(
+                    (float) StubStore::$cartTotals[self::CART_ID][false][Cart::BOTH] + $netDelta,
+                    2
+                );
+                StubStore::$cartTotals[self::CART_ID][true][Cart::BOTH] = round(
+                    (float) StubStore::$cartTotals[self::CART_ID][true][Cart::BOTH] + $grossDelta,
+                    2
+                );
+            }
+        }
+        $gatedModule = new class extends TwopaymentTestHarness {
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 200, 'buyer_fee_share' => '5.00', 'currency' => 'EUR'];
+            }
+
+            public function syncTwoSurchargeCartLine($cart, $selected)
+            {
+                return ['success' => false, 'changed' => false, 'present' => true];
+            }
+        };
+
+        TinyAssert::throws(static function () use ($gatedModule, $cart) {
+            $gatedModule->getTwoNewOrderData('merchant-attempt-8102', $cart, [
+                'merchant_confirmation_url' => 'https://shop.local/confirm',
+                'merchant_cancel_order_url' => 'https://shop.local/cancel',
+                'merchant_edit_order_url' => '',
+                'merchant_order_verification_failed_url' => '',
+                'merchant_invoice_url' => '',
+                'merchant_shipping_document_url' => '',
+            ]);
+        }, 'Surcharge line mismatch');
+    }
+
+    /* ---- requirement 3: stale-line guards ---- */
+
+    private static function testStaleGuardRemovesLineForOtherPaymentModuleController(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::count(1, self::feeLines());
+
+        // Another payment module's validation controller executes: the fee
+        // must be stripped before that module computes its totals - even
+        // though the session marker is still valid.
+        $otherController = new \stdClass();
+        $otherController->module = (object) ['name' => 'ps_wirepayment'];
+        $module->hookActionFrontControllerInitAfter(['controller' => $otherController]);
+        TinyAssert::count(0, self::feeLines());
+        TinyAssert::same(self::PRODUCT_GROSS, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+    }
+
+    private static function testStaleGuardRemovesLineWhenSessionMarkerLost(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+
+        // Abandoned cart resumed in a fresh session: cookie marker is gone.
+        Context::getContext()->cookie = new Cookie();
+        $coreController = new \stdClass(); // core controller, no ->module
+        $module->hookActionFrontControllerInitAfter(['controller' => $coreController]);
+        TinyAssert::count(0, self::feeLines());
+    }
+
+    private static function testStaleGuardKeepsLegitimateLine(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        $module->syncTwoSurchargeCartLine($cart, true);
+
+        // Valid marker + core controller (checkout page render): keep.
+        $coreController = new \stdClass();
+        $module->hookActionFrontControllerInitAfter(['controller' => $coreController]);
+        TinyAssert::count(1, self::feeLines());
+
+        // Own module controller (payment/confirmation/sync endpoint): keep
+        // even without inspecting the marker.
+        $ownController = new \stdClass();
+        $ownController->module = (object) ['name' => 'twopayment'];
+        $module->hookActionFrontControllerInitAfter(['controller' => $ownController]);
+        TinyAssert::count(1, self::feeLines());
+    }
+
+    /* ---- requirement 1: hidden product shape ---- */
+
+    private static function testHiddenProductShapeAndLazyCreation(): void
+    {
+        $module = self::makeModule();
+        self::makeCart();
+
+        TinyAssert::same(0, $module->getTwoSurchargeCartProductId(false), 'no eager creation');
+
+        $productId = $module->getTwoSurchargeCartProductId(true);
+        TinyAssert::true($productId > 0);
+        $product = new Product($productId);
+        TinyAssert::same('none', (string) $product->visibility);
+        TinyAssert::same(0, (int) $product->indexed);
+        TinyAssert::same(1, (int) $product->is_virtual);
+        TinyAssert::same(1, (int) $product->active);
+        TinyAssert::same(1, (int) $product->available_for_order);
+        TinyAssert::same(1, (int) $product->out_of_stock);
+        TinyAssert::same(Twopayment::TWO_SURCHARGE_PRODUCT_REFERENCE, (string) $product->reference);
+
+        // Lazy-create is itself idempotent: same id on every subsequent call.
+        TinyAssert::same($productId, $module->getTwoSurchargeCartProductId(true));
+        TinyAssert::same($productId, $module->getTwoSurchargeCartProductId(false));
+
+        // A stale stored id pointing at a DIFFERENT product is rejected and
+        // recreated (reference cross-check).
+        Configuration::updateValue('PS_TWO_SURCHARGE_PRODUCT_ID', 9401);
+        $recreated = $module->getTwoSurchargeCartProductId(true);
+        TinyAssert::notSame(9401, $recreated);
+        TinyAssert::true($recreated > 0);
+    }
+}

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -43,6 +43,8 @@ final class SurchargeCartLineSpec
         self::testStaleSequencedSyncRequestIsIgnoredServerSide();
         self::testAuthoritativeSyncBypassesSequenceGuard();
         self::testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest();
+        self::testConcurrentFirstUseCreatesNoDuplicateHiddenProduct();
+        self::testConcurrentFirstUseCreatesNoDuplicateTaxSetup();
     }
 
     /* ---- fixtures ---- */
@@ -484,6 +486,63 @@ final class SurchargeCartLineSpec
         TinyAssert::false($result['changed']);
         TinyAssert::count(0, self::feeLines());
         unset(StubStore::$dbLocks['two_surcharge_sync_' . self::CART_ID]);
+    }
+
+    /* ---- concurrent first-use creation guards (advisory locks) ---- */
+
+    private static function testConcurrentFirstUseCreatesNoDuplicateHiddenProduct(): void
+    {
+        $module = self::makeModule();
+        self::makeCart();
+
+        // Scenario 1: another request holds the creation lock RIGHT NOW.
+        // This request must not create a second product; it backs off (0)
+        // and the next sync retries.
+        StubStore::$dbLocks['two_surcharge_product_create'] = true;
+        $productsBefore = count(StubStore::$products);
+        TinyAssert::same(0, $module->getTwoSurchargeCartProductId(true));
+        TinyAssert::same($productsBefore, count(StubStore::$products), 'lock loser must not create a product');
+        unset(StubStore::$dbLocks['two_surcharge_product_create']);
+
+        // Scenario 2: the concurrent winner finished and wrote the id to the
+        // configuration TABLE (this request's Configuration cache is stale -
+        // the stub's shared store stands in for the DB read under the lock).
+        // The double-check under the lock must adopt the winner's product
+        // instead of creating a duplicate.
+        $winnerId = $module->getTwoSurchargeCartProductId(true);
+        TinyAssert::true($winnerId > 0);
+        $productsAfterWinner = count(StubStore::$products);
+        TinyAssert::same($winnerId, $module->getTwoSurchargeCartProductId(true));
+        TinyAssert::same($productsAfterWinner, count(StubStore::$products), 'no duplicate hidden product after the race');
+    }
+
+    private static function testConcurrentFirstUseCreatesNoDuplicateTaxSetup(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        // Another request holds the tax-setup lock: ensure fails soft (sync
+        // reports failure, frontend retries) and creates NO tax objects.
+        StubStore::$dbLocks['two_surcharge_tax_setup'] = true;
+        $result = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::false($result['success']);
+        TinyAssert::count(0, StubStore::$taxes, 'lock loser must not create a Tax');
+        TinyAssert::count(0, StubStore::$taxRulesGroups, 'lock loser must not create a TaxRulesGroup');
+        TinyAssert::count(0, StubStore::$taxRules, 'lock loser must not create a TaxRule');
+        TinyAssert::count(0, self::feeLines());
+        unset(StubStore::$dbLocks['two_surcharge_tax_setup']);
+
+        // Lock released (winner finished): setup proceeds and repeated syncs
+        // reuse the SAME single object graph.
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::count(1, StubStore::$taxes);
+        TinyAssert::count(1, StubStore::$taxRulesGroups);
+        TinyAssert::count(1, StubStore::$taxRules);
+        Context::getContext()->cookie->two_payment_term = 60;
+        $module->syncTwoSurchargeCartLine($cart, true); // amount change forces a re-ensure
+        TinyAssert::count(1, StubStore::$taxes, 'tax graph must be reused, not duplicated');
+        TinyAssert::count(1, StubStore::$taxRulesGroups);
+        TinyAssert::count(1, StubStore::$taxRules);
     }
 
     /* ---- requirement 1: hidden product shape ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -40,6 +40,9 @@ final class SurchargeCartLineSpec
         self::testStaleGuardRemovesLineWhenSessionMarkerLost();
         self::testStaleGuardKeepsLegitimateLine();
         self::testHiddenProductShapeAndLazyCreation();
+        self::testStaleSequencedSyncRequestIsIgnoredServerSide();
+        self::testAuthoritativeSyncBypassesSequenceGuard();
+        self::testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest();
     }
 
     /* ---- fixtures ---- */
@@ -344,7 +347,7 @@ final class SurchargeCartLineSpec
                 return ['http_status' => 200, 'buyer_fee_share' => '5.00', 'currency' => 'EUR'];
             }
 
-            public function syncTwoSurchargeCartLine($cart, $selected)
+            public function syncTwoSurchargeCartLine($cart, $selected, $syncSeq = null)
             {
                 return ['success' => false, 'changed' => false, 'present' => true];
             }
@@ -411,6 +414,76 @@ final class SurchargeCartLineSpec
         $ownController->module = (object) ['name' => 'twopayment'];
         $module->hookActionFrontControllerInitAfter(['controller' => $ownController]);
         TinyAssert::count(1, self::feeLines());
+    }
+
+    /* ---- server-side request-ordering guard (rapid method switches) ---- */
+
+    private static function testStaleSequencedSyncRequestIsIgnoredServerSide(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        // Buyer clicks: away from Two (seq 100, still in flight), then back
+        // to Two (seq 200). The NEWER request completes first ...
+        $newer = $module->syncTwoSurchargeCartLine($cart, true, 200);
+        TinyAssert::true($newer['success']);
+        TinyAssert::true($newer['present']);
+        TinyAssert::count(1, self::feeLines());
+
+        // ... then the OLDER "remove" request lands: it must be a no-op that
+        // reports the CURRENT state, not strip the line the newer click added.
+        $older = $module->syncTwoSurchargeCartLine($cart, false, 100);
+        TinyAssert::true($older['success']);
+        TinyAssert::false($older['changed'], 'stale request must not mutate the cart');
+        TinyAssert::true($older['present'], 'stale request reports the current state');
+        TinyAssert::count(1, self::feeLines());
+        TinyAssert::same(111.75, round((float) $cart->getOrderTotal(true, Cart::BOTH), 2));
+
+        // Equal seq (transport retry of an already-applied request) is stale too.
+        $replay = $module->syncTwoSurchargeCartLine($cart, true, 200);
+        TinyAssert::true($replay['success']);
+        TinyAssert::false($replay['changed']);
+
+        // A genuinely newer request still applies.
+        $newest = $module->syncTwoSurchargeCartLine($cart, false, 300);
+        TinyAssert::true($newest['success']);
+        TinyAssert::true($newest['changed']);
+        TinyAssert::count(0, self::feeLines());
+    }
+
+    private static function testAuthoritativeSyncBypassesSequenceGuard(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        // Buyer AJAX stored seq 500 and removed the line.
+        $module->syncTwoSurchargeCartLine($cart, true, 400);
+        $module->syncTwoSurchargeCartLine($cart, false, 500);
+        TinyAssert::count(0, self::feeLines());
+
+        // The order-create self-heal (buildTwoOrderPricingData) passes NO
+        // seq: it is the final authoritative sync before charging and must
+        // always apply, whatever the stored sequence says.
+        $selfHeal = $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::true($selfHeal['success']);
+        TinyAssert::true($selfHeal['changed']);
+        TinyAssert::count(1, self::feeLines());
+    }
+
+    private static function testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+
+        // Another request holds this cart's sync lock: the sequenced call
+        // reports success=false (frontend retries / server gate stays
+        // authoritative) and mutates nothing.
+        StubStore::$dbLocks['two_surcharge_sync_' . self::CART_ID] = true;
+        $result = $module->syncTwoSurchargeCartLine($cart, true, 100);
+        TinyAssert::false($result['success']);
+        TinyAssert::false($result['changed']);
+        TinyAssert::count(0, self::feeLines());
+        unset(StubStore::$dbLocks['two_surcharge_sync_' . self::CART_ID]);
     }
 
     /* ---- requirement 1: hidden product shape ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -45,6 +45,9 @@ final class SurchargeCartLineSpec
         self::testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest();
         self::testConcurrentFirstUseCreatesNoDuplicateHiddenProduct();
         self::testConcurrentFirstUseCreatesNoDuplicateTaxSetup();
+        self::testAdminManualAddOfFeeProductToOrderIsBlocked();
+        self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
+        self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
     }
 
     /* ---- fixtures ---- */
@@ -543,6 +546,91 @@ final class SurchargeCartLineSpec
         TinyAssert::count(1, StubStore::$taxes, 'tax graph must be reused, not duplicated');
         TinyAssert::count(1, StubStore::$taxRulesGroups);
         TinyAssert::count(1, StubStore::$taxRules);
+    }
+
+    /* ---- order-level guard: no manual/duplicate fee rows (BO order edit) ---- */
+
+    /** Minimal stand-in for the OrderDetail the hook receives. */
+    private static function makeOrderDetailStub(int $productId, int $idOrder): \stdClass
+    {
+        $orderDetail = new \stdClass();
+        $orderDetail->product_id = $productId;
+        $orderDetail->id_order = $idOrder;
+        return $orderDetail;
+    }
+
+    private static function testAdminManualAddOfFeeProductToOrderIsBlocked(): void
+    {
+        $module = self::makeModule();
+        self::makeCart();
+        $feeProductId = $module->getTwoSurchargeCartProductId(true);
+
+        // Back-office order edit: employee finds the hidden product through
+        // the AdminOrders "Add product" search. Must throw - even as the
+        // FIRST row (this product is module-managed only).
+        $adminController = new \stdClass();
+        $adminController->controller_type = 'admin';
+        Context::getContext()->controller = $adminController;
+
+        TinyAssert::throws(static function () use ($module, $feeProductId) {
+            $module->hookActionObjectOrderDetailAddBefore([
+                'object' => self::makeOrderDetailStub($feeProductId, 7001),
+            ]);
+        }, 'cannot be added to an order manually');
+
+        // Ordinary catalog products are untouched by the guard.
+        $module->hookActionObjectOrderDetailAddBefore([
+            'object' => self::makeOrderDetailStub(9401, 7001),
+        ]);
+    }
+
+    private static function testDuplicateFeeOrderDetailRowIsRejectedInAnyContext(): void
+    {
+        $module = self::makeModule();
+        self::makeCart();
+        $feeProductId = $module->getTwoSurchargeCartProductId(true);
+
+        // Front context (order-creation pipeline), but the order ALREADY
+        // carries the fee row: a second one is always a duplicate charge.
+        $frontController = new \stdClass();
+        $frontController->controller_type = 'front';
+        Context::getContext()->controller = $frontController;
+        StubStore::$orderDetails[] = ['id_order' => 7002, 'product_id' => $feeProductId];
+
+        TinyAssert::throws(static function () use ($module, $feeProductId) {
+            $module->hookActionObjectOrderDetailAddBefore([
+                'object' => self::makeOrderDetailStub($feeProductId, 7002),
+            ]);
+        }, 'refusing to add a duplicate fee row');
+
+        // A DIFFERENT order without a fee row is unaffected.
+        $module->hookActionObjectOrderDetailAddBefore([
+            'object' => self::makeOrderDetailStub($feeProductId, 7003),
+        ]);
+    }
+
+    private static function testFirstFeeOrderDetailRowFromOrderCreationIsAllowed(): void
+    {
+        $module = self::makeModule();
+        self::makeCart();
+        $feeProductId = $module->getTwoSurchargeCartProductId(true);
+
+        // Legitimate path: validateOrder creating the order's FIRST fee row
+        // in a front context - the hook must not interfere.
+        $frontController = new \stdClass();
+        $frontController->controller_type = 'front';
+        Context::getContext()->controller = $frontController;
+
+        $module->hookActionObjectOrderDetailAddBefore([
+            'object' => self::makeOrderDetailStub($feeProductId, 7004),
+        ]);
+
+        // And when the hidden product was never created (module never used),
+        // the guard is inert for every product.
+        StubStore::reset();
+        $module->hookActionObjectOrderDetailAddBefore([
+            'object' => self::makeOrderDetailStub(12345, 7005),
+        ]);
     }
 
     /* ---- requirement 1: hidden product shape ---- */

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
  *   computation path as the Two payload's fee line
  *   (buildTwoSurchargeLineItemForCart over the shared quote cache), asserted
  *   end-to-end through getTwoNewOrderData,
- * - tax: PrestaShop applies exactly getTwoSurchargeTaxRate() to the line via
- *   the module-managed Tax/TaxRulesGroup/TaxRule graph.
+ * - tax: PrestaShop applies the merchant-selected TaxRulesGroup
+ *   (CONFIG_SURCHARGE_TAX_RULES_GROUP) to the line natively - the hidden fee
+ *   product carries the group on its id_tax_rules_group field like any real
+ *   product, and the Two payload resolves the SAME group for the SAME
+ *   destination (getTwoSurchargeTaxRateForCart), so the sides cannot drift.
  *
  * Plus the money-protective guards: the order-create parity gate (fail
  * closed on cart-vs-payload fee divergence) and the front-controller
@@ -25,6 +28,10 @@ final class SurchargeCartLineSpec
     private const CART_ID = 8101;
     private const PRODUCT_NET = 100.00;
     private const PRODUCT_GROSS = 105.50;
+    /** Merchant's own (pre-existing) tax rules group used by the fixtures. */
+    private const TAX_GROUP_ID = 400;
+    /** Fixture buyer country (FR) covered by the group at 25%. */
+    private const COUNTRY_FR = 33;
 
     public static function runAll(): void
     {
@@ -44,7 +51,9 @@ final class SurchargeCartLineSpec
         self::testAuthoritativeSyncBypassesSequenceGuard();
         self::testSequencedSyncFailsSoftWhenLockHeldByConcurrentRequest();
         self::testConcurrentFirstUseCreatesNoDuplicateHiddenProduct();
-        self::testConcurrentFirstUseCreatesNoDuplicateTaxSetup();
+        self::testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects();
+        self::testFeeTaxFollowsDestinationRulesOfSelectedGroup();
+        self::testNoTaxSentinelZeroesFeeTaxForEveryDestination();
         self::testAdminManualAddOfFeeProductToOrderIsBlocked();
         self::testDuplicateFeeOrderDetailRowIsRejectedInAnyContext();
         self::testFirstFeeOrderDetailRowFromOrderCreationIsAllowed();
@@ -60,7 +69,12 @@ final class SurchargeCartLineSpec
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_60', '8');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant's own tax rules group, selected in the module config:
+        // covers the fixture buyer's country (FR) at 25%. Destinations the
+        // group has no rule for resolve 0 (core behaviour).
+        StubStore::$taxRulesGroups[self::TAX_GROUP_ID] = ['name' => 'FR standard rate', 'active' => 1];
+        StubStore::$taxRuleRates[self::TAX_GROUP_ID] = [self::COUNTRY_FR => 25.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) self::TAX_GROUP_ID);
         Configuration::updateValue(Twopayment::CONFIG_MERCHANT_AVAILABLE_TERMS, '[30,60]');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', '1');
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_60', '1');
@@ -175,8 +189,8 @@ final class SurchargeCartLineSpec
         $lines = self::feeLines();
         TinyAssert::count(1, $lines);
         TinyAssert::same(1, (int) $lines[0]['cart_quantity']);
-        // Net = quoted buyer_fee_share (5.00); gross applies the ADMIN
-        // configured 25% surcharge tax rate through the tax rules group.
+        // Net = quoted buyer_fee_share (5.00); gross applies the merchant's
+        // selected tax rules group rate for the buyer's country (FR -> 25%).
         TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
         TinyAssert::same(6.25, round((float) $lines[0]['total_wt'], 2));
         TinyAssert::same(25.0, round((float) $lines[0]['rate'], 2));
@@ -521,33 +535,120 @@ final class SurchargeCartLineSpec
         TinyAssert::same($productsAfterWinner, count(StubStore::$products), 'no duplicate hidden product after the race');
     }
 
-    private static function testConcurrentFirstUseCreatesNoDuplicateTaxSetup(): void
+    /**
+     * TWO-25071: the module assigns the MERCHANT's selected TaxRulesGroup to
+     * the hidden product's id_tax_rules_group (the same field every real
+     * product uses) and never creates Tax/TaxRulesGroup/TaxRule objects of
+     * its own (the synthetic-graph machinery is gone).
+     */
+    private static function testSyncAppliesSelectedTaxRulesGroupToFeeProductAndNeverCreatesTaxObjects(): void
+    {
+        $module = self::makeModule([30 => '5.00', 60 => '8.00']);
+        $cart = self::makeCart();
+
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $productId = (int) Configuration::get('PS_TWO_SURCHARGE_PRODUCT_ID');
+        TinyAssert::same(self::TAX_GROUP_ID, (int) (new Product($productId))->id_tax_rules_group, 'fee product carries the merchant-selected group');
+        TinyAssert::count(0, StubStore::$taxes, 'module must not create a Tax');
+        TinyAssert::count(1, StubStore::$taxRulesGroups, 'only the merchant-owned fixture group exists');
+        TinyAssert::count(0, StubStore::$taxRules, 'module must not create a TaxRule');
+
+        // Merchant re-points the selection in the module config: the next
+        // sync self-heals the product assignment (no new objects, ever).
+        StubStore::$taxRulesGroups[401] = ['name' => 'Reduced rate', 'active' => 1];
+        StubStore::$taxRuleRates[401] = [self::COUNTRY_FR => 10.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '401');
+        Context::getContext()->cookie->two_payment_term = 60; // amount change forces a re-ensure
+        $module->syncTwoSurchargeCartLine($cart, true);
+        TinyAssert::same(401, (int) (new Product($productId))->id_tax_rules_group, 'selection change re-points the product on the next sync');
+        TinyAssert::count(0, StubStore::$taxes);
+        TinyAssert::count(0, StubStore::$taxRules);
+        // And the re-priced line applies the NEW group's FR rate (10%) to
+        // the 60-day quote (8.00 net -> 8.80 gross).
+        $lines = self::feeLines();
+        TinyAssert::count(1, $lines);
+        TinyAssert::same(8.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(8.80, round((float) $lines[0]['total_wt'], 2));
+    }
+
+    /**
+     * TWO-25071: destination-based rates. The selected group taxes the fee
+     * for a covered destination and zero-rates it for a destination the
+     * group has NO rule for - and the Two payload line resolves the SAME
+     * rate as the PS cart line in both cases (parity by construction),
+     * including a genuine multi-rate stacking destination (6% + 2% -> 8%).
+     */
+    private static function testFeeTaxFollowsDestinationRulesOfSelectedGroup(): void
     {
         $module = self::makeModule();
         $cart = self::makeCart();
 
-        // Another request holds the tax-setup lock: ensure fails soft (sync
-        // reports failure, frontend retries) and creates NO tax objects.
-        StubStore::$dbLocks['two_surcharge_tax_setup'] = true;
-        $result = $module->syncTwoSurchargeCartLine($cart, true);
-        TinyAssert::false($result['success']);
-        TinyAssert::count(0, StubStore::$taxes, 'lock loser must not create a Tax');
-        TinyAssert::count(0, StubStore::$taxRulesGroups, 'lock loser must not create a TaxRulesGroup');
-        TinyAssert::count(0, StubStore::$taxRules, 'lock loser must not create a TaxRule');
-        TinyAssert::count(0, self::feeLines());
-        unset(StubStore::$dbLocks['two_surcharge_tax_setup']);
+        // Group covers FR at 25%, CA-style stacked 6%+2% for country 40,
+        // and has NO rule for country 47 (NO).
+        StubStore::$taxRuleRates[self::TAX_GROUP_ID] = [
+            self::COUNTRY_FR => 25.0,
+            40 => [6.0, 2.0],
+        ];
+        StubStore::$countries[40] = 'CA';
+        StubStore::$addresses[8203] = ['id_country' => 40, 'loaded' => true] + StubStore::$addresses[8201];
+        StubStore::$addresses[8204] = ['id_country' => 47, 'loaded' => true] + StubStore::$addresses[8201];
 
-        // Lock released (winner finished): setup proceeds and repeated syncs
-        // reuse the SAME single object graph.
+        // Covered destination (FR, 25%): 5.00 net -> 6.25 gross.
         $module->syncTwoSurchargeCartLine($cart, true);
-        TinyAssert::count(1, StubStore::$taxes);
-        TinyAssert::count(1, StubStore::$taxRulesGroups);
-        TinyAssert::count(1, StubStore::$taxRules);
-        Context::getContext()->cookie->two_payment_term = 60;
-        $module->syncTwoSurchargeCartLine($cart, true); // amount change forces a re-ensure
-        TinyAssert::count(1, StubStore::$taxes, 'tax graph must be reused, not duplicated');
-        TinyAssert::count(1, StubStore::$taxRulesGroups);
-        TinyAssert::count(1, StubStore::$taxRules);
+        TinyAssert::same(6.25, round((float) self::feeLines()[0]['total_wt'], 2));
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.25', $payloadLine['tax_rate']);
+        TinyAssert::same('6.25', $payloadLine['gross_amount']);
+
+        // Stacking destination (6% + 2% combined = 8%): both sides at 8%.
+        $cart->id_address_invoice = 8203;
+        $cart->id_address_delivery = 8203;
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.40, round((float) $lines[0]['total_wt'], 2), 'stacked 6%+2% must apply additively (8%)');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0.08', $payloadLine['tax_rate']);
+        TinyAssert::same('0.40', $payloadLine['tax_amount']);
+        TinyAssert::same('5.40', $payloadLine['gross_amount'], 'payload gross matches the PS line gross for the stacked destination');
+
+        // Uncovered destination (NO rule): zero-rated on BOTH sides.
+        $cart->id_address_invoice = 8204;
+        $cart->id_address_delivery = 8204;
+        $module->syncTwoSurchargeCartLine($cart, true);
+        $lines = self::feeLines();
+        TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+        TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'no rule for the destination -> untaxed line');
+        $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+        TinyAssert::same('0', $payloadLine['tax_rate']);
+        TinyAssert::same('5.00', $payloadLine['gross_amount']);
+    }
+
+    /**
+     * TWO-25071: selecting the "No tax" sentinel (id 0) zeroes the fee tax
+     * for EVERY destination - no special-case code, it is core's own
+     * untaxed-group semantics (live-container verified).
+     */
+    private static function testNoTaxSentinelZeroesFeeTaxForEveryDestination(): void
+    {
+        $module = self::makeModule();
+        $cart = self::makeCart();
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+
+        foreach ([self::COUNTRY_FR => 8201, 47 => 8205] as $countryId => $addressId) {
+            StubStore::$countries[47] = 'NO';
+            StubStore::$addresses[8205] = ['id_country' => 47, 'loaded' => true] + StubStore::$addresses[8201];
+            $cart->id_address_invoice = $addressId;
+            $cart->id_address_delivery = $addressId;
+            $module->syncTwoSurchargeCartLine($cart, true);
+            $lines = self::feeLines();
+            TinyAssert::count(1, $lines);
+            TinyAssert::same(5.00, round((float) $lines[0]['total'], 2));
+            TinyAssert::same(5.00, round((float) $lines[0]['total_wt'], 2), 'No tax sentinel must produce an untaxed line for country ' . $countryId);
+            $payloadLine = $module->buildTwoSurchargeLineItemForCart($cart, self::PRODUCT_GROSS);
+            TinyAssert::same('0', $payloadLine['tax_rate']);
+            TinyAssert::same('5.00', $payloadLine['gross_amount']);
+        }
     }
 
     /* ---- order-level guard: no manual/duplicate fee rows (BO order edit) ---- */

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -41,6 +41,10 @@ final class SurchargeSpec
         self::testFetchTermFeeParsesSuccess();
         self::testSurchargeTaxRulesGroupIdReadsAdminConfig();
         self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
+        self::testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection();
+        self::testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice();
+        self::testUpgrade250FlagsFlatRateShopsForTaxReselection();
+        self::testSurchargeTaxMigrationNoticeLifecycle();
         self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
         self::testSurchargeLineItemIgnoresApiTaxRateEntirely();
         self::testSurchargeLineItemDisabledReturnsNull();
@@ -468,6 +472,166 @@ final class SurchargeSpec
         // "No tax" sentinel (id 0) resolves 0 for every destination.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
         TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'group id 0 must always resolve 0');
+    }
+
+    /** Harness exposing the protected config-form helpers under test. */
+    private static function makeConfigHarness(): TwopaymentTestHarness
+    {
+        return new class extends TwopaymentTestHarness {
+            public function optionsForTest(): array
+            {
+                return $this->getTwoSurchargeTaxRulesGroupOptions();
+            }
+
+            public function formDefaultForTest(): int
+            {
+                return $this->getTwoSurchargeTaxRulesGroupFormDefault();
+            }
+
+            public function saveSurchargeFormForTest(): void
+            {
+                $this->saveTwoSurchargeFormValues();
+            }
+        };
+    }
+
+    /**
+     * The currently-configured group must stay in the dropdown even when
+     * deactivated: if it dropped out, the browser would submit the first
+     * option ("No tax") on the next unrelated settings save and silently
+     * detax the surcharge.
+     */
+    private static function testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection(): void
+    {
+        self::reset();
+        StubStore::$taxRulesGroups[400] = ['name' => 'Standard rate', 'active' => 1];
+        StubStore::$taxRulesGroups[500] = ['name' => 'Retired rate', 'active' => 0];
+        StubStore::$taxRulesGroups[600] = ['name' => 'Unused retired rate', 'active' => 0];
+        $module = self::makeConfigHarness();
+
+        // Configured group deactivated -> injected with an "(inactive)" tag.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '500');
+        $options = $module->optionsForTest();
+        $byId = [];
+        foreach ($options as $option) {
+            $byId[(int) $option['id']] = (string) $option['name'];
+        }
+        TinyAssert::same(['No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'deactivated configured group must stay selectable, flagged inactive');
+        TinyAssert::same([0, 400, 500], array_keys($byId), 'inactive groups that are NOT configured stay hidden');
+
+        // Configured group active -> plain listing, no duplicate, no tag.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        $options = $module->optionsForTest();
+        TinyAssert::count(2, $options);
+        TinyAssert::same('Standard rate', (string) $options[1]['name'], 'active configured group is listed once, untagged');
+
+        // Configured group deleted entirely -> nothing to inject (runtime
+        // already fails safe to "No tax" for a nonexistent group).
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
+        TinyAssert::count(2, $module->optionsForTest());
+    }
+
+    /**
+     * Unsaved config pre-selects "No tax" (0), matching runtime behaviour -
+     * NOT Product::getIdTaxRulesGroupMostUsed(), whose full-catalog
+     * COUNT/GROUP BY would re-run on every config page render.
+     */
+    private static function testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice(): void
+    {
+        self::reset();
+        $module = self::makeConfigHarness();
+
+        TinyAssert::same(0, $module->formDefaultForTest(), 'unset config must pre-select "No tax"');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::same(0, $module->formDefaultForTest(), 'blank config must pre-select "No tax"');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same(400, $module->formDefaultForTest(), 'stored selection is the pre-selection');
+    }
+
+    /**
+     * upgrade-2.5.0.php: a shop upgrading with the pre-release flat rate
+     * (PS_TWO_SURCHARGE_TAX_RATE) configured and no TaxRulesGroup selected
+     * gets a logged warning + the persistent "needs re-selection" flag - it
+     * must never pass silently. Shops without the flat rate, or that already
+     * selected a group, are untouched.
+     */
+    private static function testUpgrade250FlagsFlatRateShopsForTaxReselection(): void
+    {
+        require_once __DIR__ . '/../upgrade/upgrade-2.5.0.php';
+
+        // Flat rate set, group unset -> warning log + persistent flag.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        $module = new TwopaymentTestHarness();
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::same('1', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'flat-rate shop without a group selection must be flagged');
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+        TinyAssert::same(2, PrestaShopLogger::$logs[0]['severity'], 'logged as a warning');
+        TinyAssert::true(strpos(PrestaShopLogger::$logs[0]['message'], 'UNTAXED') !== false, 'log spells out the consequence');
+
+        // Group already selected -> no flag, no log.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'a shop that already selected a group is not nagged');
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+
+        // No flat rate (fresh install / never configured) -> untouched.
+        self::reset();
+        PrestaShopLogger::reset();
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+
+        // Blank flat rate counts as unset.
+        self::reset();
+        PrestaShopLogger::reset();
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '  ');
+        TinyAssert::true(upgrade_module_2_5_0($module));
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+
+    /**
+     * The post-upgrade notice is persistent (re-renders on every config
+     * page load) until the merchant makes a selection: it self-retires if a
+     * selection exists, and any explicit surcharge-settings save - "No tax"
+     * included - clears the flag.
+     */
+    private static function testSurchargeTaxMigrationNoticeLifecycle(): void
+    {
+        self::reset();
+        Tools::resetTestValues();
+        $module = self::makeConfigHarness();
+
+        // No flag -> no notice.
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
+
+        // Flag + no selection -> notice, and it PERSISTS across renders.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
+        $notice = $module->getTwoSurchargeTaxMigrationNotice();
+        TinyAssert::true($notice !== '', 'flagged shop must see the warning');
+        TinyAssert::true(strpos($notice, 'NOT taxed') !== false, 'warning spells out the consequence');
+        TinyAssert::true($module->getTwoSurchargeTaxMigrationNotice() !== '', 'warning persists until a selection is saved');
+
+        // Selection appears (any save path) -> notice self-retires and the
+        // flag is cleared.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'self-retire clears the flag');
+
+        // Explicit surcharge-settings save clears the flag too, even when
+        // the merchant confirms "No tax" (no group submitted -> stored 0).
+        self::reset();
+        Tools::resetTestValues();
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
+        $module->saveSurchargeFormForTest();
+        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group stores the explicit "No tax" sentinel');
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit save retires the nag');
+        TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
     }
 
     private static function testSurchargeLineItemUsesSelectedGroupDestinationRate(): void

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -43,6 +43,7 @@ final class SurchargeSpec
         self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
         self::testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection();
         self::testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice();
+        self::testSurchargeTaxTreatmentRequiredWhenSurchargesEnabled();
         self::testUpgrade250FlagsFlatRateShopsForTaxReselection();
         self::testSurchargeTaxMigrationNoticeLifecycle();
         self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
@@ -483,7 +484,7 @@ final class SurchargeSpec
                 return $this->getTwoSurchargeTaxRulesGroupOptions();
             }
 
-            public function formDefaultForTest(): int
+            public function formDefaultForTest(): string
             {
                 return $this->getTwoSurchargeTaxRulesGroupFormDefault();
             }
@@ -492,14 +493,22 @@ final class SurchargeSpec
             {
                 $this->saveTwoSurchargeFormValues();
             }
+
+            public function validateSurchargeFormForTest(): array
+            {
+                $this->errors = [];
+                $this->validTwoSurchargeFormValues();
+
+                return $this->errors;
+            }
         };
     }
 
     /**
      * The currently-configured group must stay in the dropdown even when
      * deactivated: if it dropped out, the browser would submit the first
-     * option ("No tax") on the next unrelated settings save and silently
-     * detax the surcharge.
+     * option (the unselected placeholder) on the next unrelated settings
+     * save and silently unset the treatment.
      */
     private static function testSurchargeTaxRulesGroupOptionsNeverDropTheConfiguredSelection(): void
     {
@@ -510,42 +519,115 @@ final class SurchargeSpec
         $module = self::makeConfigHarness();
 
         // Configured group deactivated -> injected with an "(inactive)" tag.
+        // Ids are strings, and the unselected placeholder ('') leads.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '500');
         $options = $module->optionsForTest();
         $byId = [];
         foreach ($options as $option) {
-            $byId[(int) $option['id']] = (string) $option['name'];
+            TinyAssert::true(is_string($option['id']), 'option ids must be strings (PHP 7 template loose == would conflate \'\' with 0)');
+            $byId[$option['id']] = (string) $option['name'];
         }
-        TinyAssert::same(['No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'deactivated configured group must stay selectable, flagged inactive');
-        TinyAssert::same([0, 400, 500], array_keys($byId), 'inactive groups that are NOT configured stay hidden');
+        TinyAssert::same(['-- Select surcharge tax treatment --', 'No tax', 'Standard rate', 'Retired rate (inactive)'], array_values($byId), 'placeholder leads; deactivated configured group must stay selectable, flagged inactive');
+        TinyAssert::same(['', '0', '400', '500'], array_map('strval', array_keys($byId)), 'inactive groups that are NOT configured stay hidden');
 
         // Configured group active -> plain listing, no duplicate, no tag.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
         $options = $module->optionsForTest();
-        TinyAssert::count(2, $options);
-        TinyAssert::same('Standard rate', (string) $options[1]['name'], 'active configured group is listed once, untagged');
+        TinyAssert::count(3, $options);
+        TinyAssert::same('Standard rate', (string) $options[2]['name'], 'active configured group is listed once, untagged');
 
         // Configured group deleted entirely -> nothing to inject (runtime
         // already fails safe to "No tax" for a nonexistent group).
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
-        TinyAssert::count(2, $module->optionsForTest());
+        TinyAssert::count(3, $module->optionsForTest());
     }
 
     /**
-     * Unsaved config pre-selects "No tax" (0), matching runtime behaviour -
-     * NOT Product::getIdTaxRulesGroupMostUsed(), whose full-catalog
-     * COUNT/GROUP BY would re-run on every config page render.
+     * Unsaved config pre-selects NOTHING - the dropdown renders on the
+     * unselected placeholder (''). Never an auto-default: not
+     * Product::getIdTaxRulesGroupMostUsed() (full-catalog COUNT/GROUP BY on
+     * every config page render), and not "No tax" either - the merchant
+     * must pick explicitly. A stored selection ("No tax" included) is the
+     * pre-selection.
      */
     private static function testSurchargeTaxRulesGroupFormDefaultRequiresExplicitChoice(): void
     {
         self::reset();
         $module = self::makeConfigHarness();
 
-        TinyAssert::same(0, $module->formDefaultForTest(), 'unset config must pre-select "No tax"');
+        TinyAssert::same('', $module->formDefaultForTest(), 'unset config must stay on the unselected placeholder');
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
-        TinyAssert::same(0, $module->formDefaultForTest(), 'blank config must pre-select "No tax"');
+        TinyAssert::same('', $module->formDefaultForTest(), 'blank config must stay on the unselected placeholder');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::same('0', $module->formDefaultForTest(), 'an explicitly saved "No tax" IS a selection and pre-selects');
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
-        TinyAssert::same(400, $module->formDefaultForTest(), 'stored selection is the pre-selection');
+        TinyAssert::same('400', $module->formDefaultForTest(), 'stored selection is the pre-selection');
+    }
+
+    /**
+     * While surcharges are enabled (type !== 'none') the save is blocked
+     * server-side until an explicit tax treatment is submitted: the
+     * unselected placeholder ('' / absent) is a validation error, never a
+     * silent "No tax" fallback. With surcharges disabled no selection is
+     * required, and an invalid submission is stored as '' (unselected),
+     * not coerced to 0.
+     */
+    private static function testSurchargeTaxTreatmentRequiredWhenSurchargesEnabled(): void
+    {
+        self::reset();
+        Tools::resetTestValues();
+        StubStore::$taxRulesGroups[400] = ['name' => 'Standard rate', 'active' => 1];
+        $module = self::makeConfigHarness();
+
+        // Neutralise the unrelated grid checks (the Tools stub defaults
+        // absent keys to null, unlike core's false).
+        foreach (['PCT', 'FIXED', 'CAP'] as $suffix) {
+            Tools::setTestValue('PS_TWO_SURCHARGE_' . $suffix . '_30', '');
+        }
+
+        // Enabled + nothing submitted -> blocked.
+        Tools::setTestValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
+        $errors = $module->validateSurchargeFormForTest();
+        TinyAssert::count(1, $errors);
+        TinyAssert::true(strpos((string) $errors[0], 'Select a surcharge tax treatment') !== false, 'error names the missing selection');
+
+        // Enabled + blank submitted (the placeholder) -> blocked.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + whitespace submitted -> blocked.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, ' ');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + explicit "No tax" -> allowed.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Enabled + existing group -> allowed.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Enabled + nonexistent group -> blocked (pre-existing rule intact).
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '999');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Enabled + decimal/negative -> blocked, never truncated into a
+        // selection the merchant did not make.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0.5');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '-5');
+        TinyAssert::count(1, $module->validateSurchargeFormForTest());
+
+        // Disabled -> no selection required, save allowed.
+        Tools::resetTestValues();
+        Tools::setTestValue('PS_TWO_SURCHARGE_TYPE', 'none');
+        TinyAssert::count(0, $module->validateSurchargeFormForTest());
+
+        // Disabled + garbage submitted -> stored '' (unselected), never 0.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, 'abc');
+        $module->saveSurchargeFormForTest();
+        TinyAssert::same('', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'garbage never coerces to "No tax"');
+        Tools::resetTestValues();
     }
 
     /**
@@ -623,14 +705,23 @@ final class SurchargeSpec
         TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
         TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'self-retire clears the flag');
 
-        // Explicit surcharge-settings save clears the flag too, even when
-        // the merchant confirms "No tax" (no group submitted -> stored 0).
+        // A save WITHOUT a submitted group stores '' (still unselected) and
+        // does NOT retire the nag - it is accurate until a real choice is
+        // made. No silent "No tax" fallback.
         self::reset();
         Tools::resetTestValues();
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '1');
         $module->saveSurchargeFormForTest();
-        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group stores the explicit "No tax" sentinel');
-        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit save retires the nag');
+        TinyAssert::same('', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'save without a submitted group must stay unselected, never silently "No tax"');
+        TinyAssert::same('1', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'an unselected save must NOT retire the nag');
+        TinyAssert::true($module->getTwoSurchargeTaxMigrationNotice() !== '', 'notice persists after an unselected save');
+
+        // An explicit "No tax" submission stores '0' and retires the nag.
+        Tools::setTestValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        $module->saveSurchargeFormForTest();
+        Tools::resetTestValues();
+        TinyAssert::same('0', (string) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP), 'explicit "No tax" submission stores the sentinel');
+        TinyAssert::false((bool) Configuration::get(Twopayment::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE), 'explicit selection retires the nag');
         TinyAssert::same('', $module->getTwoSurchargeTaxMigrationNotice());
     }
 

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -8,8 +8,9 @@ declare(strict_types=1);
  *
  * Covers: buyer_fee_share payload construction per term, the rounding relay
  * and its edge cases, the fee-quote fetch (fail-soft), fee-line construction
- * with the admin-configured Surcharge Tax Rate (PS_TWO_SURCHARGE_TAX_RATE —
- * the pricing-preview response's total_fee_tax_rate is never a source), and
+ * with the merchant-selected TaxRulesGroup's destination-resolved rate
+ * (CONFIG_SURCHARGE_TAX_RULES_GROUP via getTwoSurchargeTaxRateForCart — the
+ * pricing-preview response's total_fee_tax_rate is never a source), and
  * end-to-end injection into the order payload including a rounding-boundary
  * amount.
  */
@@ -38,8 +39,9 @@ final class SurchargeSpec
         self::testFetchTermFeeFailsSoftOnHttpError();
         self::testFetchTermFeeFailsSoftOnCurrencyMismatch();
         self::testFetchTermFeeParsesSuccess();
-        self::testSurchargeTaxRateReadsAdminConfig();
-        self::testSurchargeLineItemUsesAdminConfiguredTaxRate();
+        self::testSurchargeTaxRulesGroupIdReadsAdminConfig();
+        self::testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates();
+        self::testSurchargeLineItemUsesSelectedGroupDestinationRate();
         self::testSurchargeLineItemIgnoresApiTaxRateEntirely();
         self::testSurchargeLineItemDisabledReturnsNull();
         self::testSurchargeLineItemRoundsTaxOnBoundary();
@@ -404,47 +406,85 @@ final class SurchargeSpec
         TinyAssert::same('NOK', $fee['currency']);
     }
 
-    private static function testSurchargeTaxRateReadsAdminConfig(): void
+    private static function testSurchargeTaxRulesGroupIdReadsAdminConfig(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
 
-        // Blank/unset → 0.0 (deliberate deviation from Magento's default-tax-
-        // class fallback: PrestaShop has no store-wide default tax rate).
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'unset config must yield 0.0');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'blank config must yield 0.0');
+        // Blank/unset/garbage/negative → 0, PrestaShop's "No tax" sentinel
+        // (fail-safe: never tax the fee on a selection the merchant did not
+        // make).
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'unset config must yield 0 (No tax)');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'blank config must yield 0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, 'abc');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'non-numeric config must yield 0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '-5');
+        TinyAssert::same(0, $module->getTwoSurchargeTaxRulesGroupId(), 'negative config must yield 0');
 
-        // Percentage form scales down (normalizeTwoFeeTaxRate convention).
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
-        TinyAssert::same(0.25, $module->getTwoSurchargeTaxRate(), 'stored "25" means 25% → 0.25');
-
-        // Already-fractional input passes through unscaled — the exact
-        // normalizeTwoFeeTaxRate edge behaviour (<= 1.0 is left as-is).
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '0.25');
-        TinyAssert::same(0.25, $module->getTwoSurchargeTaxRate(), 'fractional "0.25" stays 0.25');
-
-        // Garbage and negatives degrade to 0.0, never fatal.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', 'abc');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'non-numeric config must yield 0.0');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '-5');
-        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRate(), 'negative config must yield 0.0');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        TinyAssert::same(400, $module->getTwoSurchargeTaxRulesGroupId(), 'stored group id is returned as int');
     }
 
-    private static function testSurchargeLineItemUsesAdminConfiguredTaxRate(): void
+    private static function testSurchargeTaxRateForCartResolvesDestinationThroughCoreGates(): void
+    {
+        self::reset();
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true]; // ES
+        StubStore::$addresses[901] = ['id_country' => 47, 'loaded' => true]; // NO - group has no rule
+        StubStore::$taxRuleRates[400] = [34 => 21.0];
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        $module = new TwopaymentTestHarness();
+        $cart = new Cart(1);
+        $cart->id_address_invoice = 900;
+        $cart->id_address_delivery = 901;
+
+        // Covered destination resolves the group's rate as a fraction.
+        TinyAssert::same(0.21, $module->getTwoSurchargeTaxRateForCart($cart), 'covered destination resolves the group rate');
+
+        // Destination without a matching rule -> 0 (core zero-rating).
+        $cart->id_address_invoice = 901;
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'no rule for the destination must resolve 0');
+        $cart->id_address_invoice = 900;
+
+        // PS_TAX_ADDRESS_TYPE=delivery: the DELIVERY address is the tax
+        // destination, exactly like core cart pricing.
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_delivery');
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'delivery-address tax destination must be honoured');
+        Configuration::updateValue('PS_TAX_ADDRESS_TYPE', 'id_address_invoice');
+
+        // Shop-wide PS_TAX off zeroes the rate (core Tax::excludeTaxeOption).
+        Configuration::updateValue('PS_TAX', 0);
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'PS_TAX disabled must zero the rate');
+        Configuration::updateValue('PS_TAX', 1);
+
+        // vatnumber-module B2B exemption: foreign VAT number + management on.
+        StubStore::$addresses[900]['vat_number'] = 'NO999999999';
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 1);
+        Configuration::updateValue('VATNUMBER_COUNTRY', 8); // shop country != buyer country
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'VAT-exempt B2B buyer must resolve 0');
+        Configuration::updateValue('VATNUMBER_MANAGEMENT', 0);
+        TinyAssert::same(0.21, $module->getTwoSurchargeTaxRateForCart($cart), 'exemption only applies when the vatnumber module manages it');
+
+        // "No tax" sentinel (id 0) resolves 0 for every destination.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '0');
+        TinyAssert::same(0.0, $module->getTwoSurchargeTaxRateForCart($cart), 'group id 0 must always resolve 0');
+    }
+
+    private static function testSurchargeLineItemUsesSelectedGroupDestinationRate(): void
     {
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 25.0];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
                 // The response carries a WILDLY different total_fee_tax_rate —
-                // it must have zero influence on the line's tax: the admin
-                // config is the only source.
+                // it must have zero influence on the line's tax: the selected
+                // group's destination rate is the only source.
                 return [
                     'http_status' => 200,
                     'buyer_fee_share' => '5.00',
@@ -460,7 +500,7 @@ final class SurchargeSpec
         TinyAssert::same('SERVICE', $line['type']);
         TinyAssert::same('Payment terms fee - 30 days', $line['name']);
         TinyAssert::same('5.00', $line['net_amount']);
-        TinyAssert::same('0.25', $line['tax_rate'], 'tax rate comes from admin config, never the pricing response');
+        TinyAssert::same('0.25', $line['tax_rate'], 'tax rate comes from the selected group, never the pricing response');
         TinyAssert::same('1.25', $line['tax_amount']);
         TinyAssert::same('6.25', $line['gross_amount']);
     }
@@ -475,8 +515,8 @@ final class SurchargeSpec
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
             {
-                // Response has a rate but the admin field is blank: the line
-                // must be untaxed (0), proving the response rate is dead.
+                // Response has a rate but no tax rules group is selected: the
+                // line must be untaxed (0), proving the response rate is dead.
                 return [
                     'http_status' => 200,
                     'buyer_fee_share' => '5.00',
@@ -490,7 +530,7 @@ final class SurchargeSpec
         $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 100.0);
         TinyAssert::same('5.00', $line['net_amount']);
-        TinyAssert::same('0', $line['tax_rate'], 'blank admin config means untaxed line even when the response carries a rate');
+        TinyAssert::same('0', $line['tax_rate'], 'no selected group means untaxed line even when the response carries a rate');
         TinyAssert::same('0.00', $line['tax_amount']);
         TinyAssert::same('5.00', $line['gross_amount']);
     }
@@ -514,7 +554,9 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 25.0];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
@@ -530,6 +572,7 @@ final class SurchargeSpec
         };
         $cart = new Cart(1);
         $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 500.0);
         TinyAssert::same('10.10', $line['net_amount']);
         TinyAssert::same('2.53', $line['tax_amount']);
@@ -543,11 +586,13 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        // Configured rate needing more than TAX_RATE_PRECISION (3dp) decimals
+        // Group rate needing more than TAX_RATE_PRECISION (3dp) decimals
         // as a fraction (21.0098% → 0.210098). Tax must be computed from the
         // SNAPPED rate that is actually sent, else the line fails
         // validateTwoLineItems and is dropped.
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '21.0098');
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [34 => 21.0098];
+        StubStore::$addresses[900] = ['id_country' => 34, 'loaded' => true];
         StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
         $module = new class extends TwopaymentTestHarness {
             public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
@@ -561,6 +606,7 @@ final class SurchargeSpec
         };
         $cart = new Cart(1);
         $cart->id_currency = 978;
+        $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 5000.0);
         TinyAssert::same('0.21', $line['tax_rate'], 'rate is snapped to the sent precision');
         TinyAssert::same('210.00', $line['tax_amount'], 'tax computed from the sent (snapped) rate, not full precision');
@@ -601,7 +647,10 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '5');
-        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_RATE', '25');
+        // Merchant-selected group: FR (country 33, the cart's destination)
+        // at 25%.
+        Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
+        StubStore::$taxRuleRates[400] = [33 => 25.0];
 
         StubStore::$customers[7001] = [
             'email' => 'buyer@example.com',

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit spec for the sole-trader business logic (TWO-24755): the two gates
+ * (registry endpoint + merchant toggle, both riding account-type mode),
+ * registry-only response semantics (empty list = business-only checkout),
+ * fail-soft registry handling, fail-closed token minting, the account_type
+ * gate matrix, and the third option on the address-form selector.
+ */
+
+/**
+ * Harness whose Two API surface returns canned responses keyed by
+ * endpoint prefix, recording every request.
+ */
+final class TwoSoleTraderTestHarness extends TwopaymentTestHarness
+{
+    /** @var array<string, mixed> */
+    public $cannedResponses = [];
+    /** @var string[] */
+    public $requests = [];
+
+    public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+    {
+        $this->requests[] = $endpoint;
+        foreach ($this->cannedResponses as $prefix => $response) {
+            if (strpos($endpoint, $prefix) === 0) {
+                return $response;
+            }
+        }
+        return false;
+    }
+}
+
+final class TwoSoleTraderSpec
+{
+    public static function runAll(): void
+    {
+        $tests = [
+            'testAvailableWhenRegistryAndToggleAgree',
+            'testHiddenWhenToggleOff',
+            'testHiddenWhenAccountTypeModeOff',
+            'testHiddenWhenRegistryOmitsIt',
+            'testRegistryErrorFallsBackToNoSoleTrader',
+            'testRegistryRejectsMalformedCountry',
+            'testRegistryResponseCachedPerRequest',
+            'testAccountTypeAllowedMatrix',
+            'testTokenMintReadsHeaderAndFailsClosed',
+            'testSignupUrlFollowsEnvironment',
+            'testFormatterAddsThirdOptionOnlyWhenAvailable',
+        ];
+        foreach ($tests as $test) {
+            self::reset();
+            self::$test();
+            print("PASS TwoSoleTraderSpec::$test\n");
+        }
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        TwoSoleTrader::resetCache();
+        PrestaShopLogger::reset();
+    }
+
+    private static function harness(array $config, array $responses): TwoSoleTraderTestHarness
+    {
+        foreach ($config as $key => $value) {
+            Configuration::updateValue($key, $value);
+        }
+        $module = new TwoSoleTraderTestHarness();
+        $module->cannedResponses = $responses;
+        StubStore::$moduleInstance = $module;
+        return $module;
+    }
+
+    private static function registryOk(array $types): array
+    {
+        return [
+            'http_status' => 200,
+            'supported_company_types' => $types,
+        ];
+    }
+
+    private static function testAvailableWhenRegistryAndToggleAgree(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
+        // Lowercase input normalises to the same country
+        TwoSoleTrader::resetCache();
+        TinyAssert::true(TwoSoleTrader::isAvailable($module, 'gb'));
+    }
+
+    private static function testHiddenWhenToggleOff(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 0, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
+    }
+
+    private static function testHiddenWhenAccountTypeModeOff(): void
+    {
+        // The option rides the account_type selector; without that mode the
+        // feature cannot surface no matter what the toggle says.
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 0],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
+    }
+
+    private static function testHiddenWhenRegistryOmitsIt(): void
+    {
+        // Registered businesses need no registry enrollment, so the endpoint
+        // deliberately omits them: an empty list means business-only checkout.
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk([])]
+        );
+        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'NO'));
+    }
+
+    private static function testRegistryErrorFallsBackToNoSoleTrader(): void
+    {
+        // Network error (transport returns false)
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+
+        // Non-200
+        TwoSoleTrader::resetCache();
+        StubStore::reset();
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
+        $module->cannedResponses = [
+            '/registry/v1/supported-company-types/' => ['http_status' => 404],
+        ];
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+
+        // 200 with malformed body
+        TwoSoleTrader::resetCache();
+        StubStore::reset();
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
+        $module->cannedResponses = [
+            '/registry/v1/supported-company-types/' => ['http_status' => 200, 'data' => 'junk'],
+        ];
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
+    }
+
+    private static function testRegistryRejectsMalformedCountry(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        // Never hits the API for junk country input
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, ''));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'G'));
+        TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GBR'));
+        TinyAssert::count(0, $module->requests);
+    }
+
+    private static function testRegistryResponseCachedPerRequest(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'gb');
+        TinyAssert::count(1, $module->requests);
+        // A different country is its own cache entry
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'US');
+        TinyAssert::count(2, $module->requests);
+    }
+
+    private static function testAccountTypeAllowedMatrix(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER']),
+             '/registry/v1/supported-company-types/NO' => self::registryOk([])]
+        );
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'NO'));
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'NO'));
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'personal', 'GB'));
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, '', 'GB'));
+
+        // Toggle off: sole_trader rejected even for GB, business still fine
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TwoSoleTrader::resetCache();
+        TinyAssert::false(TwoSoleTrader::isAccountTypeAllowed($module, 'sole_trader', 'GB'));
+        TinyAssert::true(TwoSoleTrader::isAccountTypeAllowed($module, 'business', 'GB'));
+    }
+
+    private static function testTokenMintReadsHeaderAndFailsClosed(): void
+    {
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+
+        // Happy path: both mints return the token header (case handled by
+        // the transport, which lower-cases header names)
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            return [
+                'status' => 200,
+                'headers' => ['two-delegated-authority-token' => $endpoint === '/registry/v1/delegation' ? 'reg-token' : 'autofill-token'],
+            ];
+        };
+        TinyAssert::same(
+            ['delegation_token' => 'reg-token', 'autofill_token' => 'autofill-token'],
+            TwoSoleTrader::mintTokens($module)
+        );
+
+        // Second mint failing voids the pair — never hand the browser half a flow
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            if ($endpoint === '/autofill/v1/delegation') {
+                return ['status' => 500, 'headers' => []];
+            }
+            return ['status' => 200, 'headers' => ['two-delegated-authority-token' => 'reg-token']];
+        };
+        TinyAssert::same(null, TwoSoleTrader::mintTokens($module));
+
+        // Missing header on a 200 also fails closed
+        TwoSoleTrader::$transport = function ($endpoint, $payload) {
+            return ['status' => 200, 'headers' => []];
+        };
+        TinyAssert::same(null, TwoSoleTrader::mintTokens($module));
+    }
+
+    private static function testSignupUrlFollowsEnvironment(): void
+    {
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', 'production');
+        TinyAssert::same('https://checkout.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', 'staging');
+        TinyAssert::same('https://checkout.staging.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+
+        // Anything else (legacy 'development', sandbox, empty) => sandbox,
+        // mirroring Twopayment::ENVIRONMENT_HOSTS semantics
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', 'sandbox');
+        TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+        Configuration::updateValue('PS_TWO_ENVIRONMENT', '');
+        TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup', TwoSoleTrader::getSignupPageUrl());
+    }
+
+    private static function testFormatterAddsThirdOptionOnlyWhenAvailable(): void
+    {
+        $overridePath = dirname(__DIR__) . '/override/classes/form/CustomerAddressFormatter.php';
+        if (!class_exists('CustomerAddressFormatter', false)) {
+            require_once $overridePath;
+        }
+
+        $translator = new class {
+            public function trans($message, array $params = [], $domain = null): string
+            {
+                return (string) $message;
+            }
+        };
+
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+
+        $country = new Country();
+        $country->iso_code = 'GB';
+        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
+        TinyAssert::true(isset($format['account_type']), 'Expected account_type field');
+        TinyAssert::same('Sole trader', $format['account_type']->getAvailableValue('sole_trader'), 'Expected sole_trader option for GB with toggle on');
+
+        // Unsupported country: no third option
+        TwoSoleTrader::resetCache();
+        $module->cannedResponses = ['/registry/v1/supported-company-types/' => self::registryOk([])];
+        $country = new Country();
+        $country->iso_code = 'NO';
+        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
+        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option for NO');
+
+        // Toggle off: no third option even for GB
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TwoSoleTrader::resetCache();
+        $country = new Country();
+        $country->iso_code = 'GB';
+        $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();
+        TinyAssert::same(null, $format['account_type']->getAvailableValue('sole_trader'), 'No sole_trader option when toggle off');
+    }
+}

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -45,6 +45,9 @@ final class TwoSoleTraderSpec
             'testRegistryErrorFallsBackToNoSoleTrader',
             'testRegistryRejectsMalformedCountry',
             'testRegistryResponseCachedPerRequest',
+            'testCookieCacheIsSingleSlotAndOverwritesOnCountryChange',
+            'testCookieCacheExpiresAfterTtl',
+            'testFetchErrorIsNotCached',
             'testAccountTypeAllowedMatrix',
             'testTokenMintReadsHeaderAndFailsClosed',
             'testSignupUrlFollowsEnvironment',
@@ -177,6 +180,80 @@ final class TwoSoleTraderSpec
         // A different country is its own cache entry
         TwoSoleTrader::getSupportedCompanyTypes($module, 'US');
         TinyAssert::count(2, $module->requests);
+    }
+
+    /**
+     * The cookie cache is a single slot (TWO-24755 F3): switching country
+     * overwrites it rather than growing a new key per country, capping the
+     * PrestaShop session cookie's growth regardless of how many countries
+     * a caller requests.
+     */
+    private static function testCookieCacheIsSingleSlotAndOverwritesOnCountryChange(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            [
+                '/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER']),
+                '/registry/v1/supported-company-types/US' => self::registryOk([]),
+            ]
+        );
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        $cookie = Context::getContext()->cookie;
+        TinyAssert::true(isset($cookie->{TwoSoleTrader::COOKIE_KEY}), 'Expected the single cache cookie to be set');
+        $afterGb = json_decode($cookie->{TwoSoleTrader::COOKIE_KEY}, true);
+        TinyAssert::same('GB', $afterGb['country']);
+
+        // Switching country overwrites the same key rather than adding one
+        TwoSoleTrader::resetCache();
+        TwoSoleTrader::getSupportedCompanyTypes($module, 'US');
+        $afterUs = json_decode($cookie->{TwoSoleTrader::COOKIE_KEY}, true);
+        TinyAssert::same('US', $afterUs['country']);
+        TinyAssert::same([], $afterUs['types']);
+    }
+
+    /**
+     * A cached answer for the same country within the TTL is reused
+     * without hitting the registry again; once stale it re-fetches.
+     */
+    private static function testCookieCacheExpiresAfterTtl(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1],
+            ['/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER'])]
+        );
+        $cookie = Context::getContext()->cookie;
+        // Seed a stale cookie entry (older than CACHE_TTL_SECONDS) directly,
+        // bypassing the request-scoped static cache this test doesn't want.
+        $cookie->{TwoSoleTrader::COOKIE_KEY} = json_encode([
+            'country' => 'GB',
+            'types' => ['SOME_STALE_VALUE'],
+            'fetched_at' => time() - TwoSoleTrader::CACHE_TTL_SECONDS - 1,
+        ]);
+        $types = TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TinyAssert::same(['SOLE_TRADER'], $types, 'Stale cookie entry must trigger a re-fetch, not be reused');
+        TinyAssert::count(1, $module->requests);
+    }
+
+    /**
+     * A registry fetch ERROR must not be cached (TWO-24755 Y3) - otherwise
+     * a single transient blip suppresses the sole-trader option for the
+     * rest of the TTL window, indistinguishable from a real business-only
+     * country.
+     */
+    private static function testFetchErrorIsNotCached(): void
+    {
+        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1, 'PS_TWO_USE_ACCOUNT_TYPE' => 1], []);
+        // No canned response for GB => setTwoPaymentRequest returns false => fetch error
+        $types = TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
+        TinyAssert::same([], $types);
+        $cookie = Context::getContext()->cookie;
+        TinyAssert::true(!isset($cookie->{TwoSoleTrader::COOKIE_KEY}) || empty($cookie->{TwoSoleTrader::COOKIE_KEY}), 'A fetch error must not populate the cookie cache');
+
+        // Now the registry recovers - resetCache clears the request-scoped
+        // cache so the recovered answer is actually fetched and used
+        TwoSoleTrader::resetCache();
+        $module->cannedResponses = ['/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER'])];
+        TinyAssert::same(['SOLE_TRADER'], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
     }
 
     private static function testAccountTypeAllowedMatrix(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -73,6 +73,10 @@ namespace {
         public static array $surchargeSyncSeqs = [];
         /** @var array<int,array{id_order:int,product_id:int}> order_detail rows */
         public static array $orderDetails = [];
+        /** @var string[] Every SQL string passed to Db::execute() */
+        public static array $dbExecuted = [];
+        /** @var array<string,string> Existing DB triggers by name => CREATE sql */
+        public static array $dbTriggers = [];
         /** @var int Shared auto-increment for ObjectModel-style stubs */
         public static int $nextId = 90000;
 
@@ -126,6 +130,8 @@ namespace {
             self::$dbLocks = [];
             self::$surchargeSyncSeqs = [];
             self::$orderDetails = [];
+            self::$dbExecuted = [];
+            self::$dbTriggers = [];
             self::$nextId = 90000;
 
             $context = Context::getContext();
@@ -1177,8 +1183,18 @@ namespace {
         public function execute($sql): bool
         {
             $sql = (string) $sql;
+            StubStore::$dbExecuted[] = $sql;
             if (preg_match('/REPLACE INTO `ps_twopayment_surcharge_sync` \(`id_cart`, `seq`, `updated_at`\) VALUES \((\d+), (\d+)/', $sql, $m)) {
                 StubStore::$surchargeSyncSeqs[(int) $m[1]] = (int) $m[2];
+            }
+            // Trigger bookkeeping so specs can assert the DB-enforcement DDL
+            // is issued. The stub CANNOT evaluate trigger semantics (no SQL
+            // engine); rejection behaviour is live-container verified only.
+            if (preg_match('/^\s*CREATE TRIGGER `([^`]+)`/', $sql, $m)) {
+                StubStore::$dbTriggers[$m[1]] = $sql;
+            }
+            if (preg_match('/^\s*DROP TRIGGER IF EXISTS `([^`]+)`/', $sql, $m)) {
+                unset(StubStore::$dbTriggers[$m[1]]);
             }
             return true;
         }
@@ -1215,6 +1231,9 @@ namespace {
             }
             if (preg_match("/SELECT `value` FROM `ps_configuration` WHERE `name` = '([A-Za-z0-9_]+)'/", $sql, $m)) {
                 return StubStore::$configuration[$m[1]] ?? false;
+            }
+            if (preg_match("/FROM information_schema\.TRIGGERS.*TRIGGER_NAME = '([^']+)'/s", $sql, $m)) {
+                return isset(StubStore::$dbTriggers[$m[1]]) ? '1' : '0';
             }
             return false;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -281,6 +281,11 @@ namespace {
             return (string) $message;
         }
 
+        public function displayWarning($message): string
+        {
+            return (string) $message;
+        }
+
         public function display($file, $template): string
         {
             return '';
@@ -406,6 +411,12 @@ namespace {
         public static function updateValue($key, $value): bool
         {
             StubStore::$configuration[$key] = $value;
+            return true;
+        }
+
+        public static function deleteByName($key): bool
+        {
+            unset(StubStore::$configuration[$key]);
             return true;
         }
     }
@@ -1140,7 +1151,13 @@ namespace {
                 ? 'id_address_delivery'
                 : 'id_address_invoice';
             $taxAddress = new Address((int) $this->{$taxAddressField});
-            $rate = Configuration::get('PS_TAX')
+            // vatnumber-module B2B exemption, exactly like core
+            // Product::priceCalculation: VAT number present, buyer country
+            // differs from the module's configured country, management on.
+            $vatExempt = !empty($taxAddress->vat_number)
+                && (int) $taxAddress->id_country !== (int) Configuration::get('VATNUMBER_COUNTRY')
+                && Configuration::get('VATNUMBER_MANAGEMENT');
+            $rate = (Configuration::get('PS_TAX') && !$vatExempt)
                 ? StubStore::resolveTaxRate((int) $product->id_tax_rules_group, (int) $taxAddress->id_country)
                 : 0.0;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -61,6 +61,8 @@ namespace {
         public static array $taxRuleRates = [];
         public static array $dbExecuteSResponses = [];
         public static array $dbLastExecuteS = [];
+        /** @var object|null returned by Module::getInstanceByName in tests */
+        public static $moduleInstance = null;
         public static array $orderCarriers = [];
         public static array $carts = [];
         /** @var array<string,int> Registered admin tab ids by class name */
@@ -164,6 +166,7 @@ namespace {
             self::$taxRuleRates = [];
             self::$dbExecuteSResponses = [];
             self::$dbLastExecuteS = [];
+            self::$moduleInstance = null;
             self::$products = [];
             self::$specificPrices = [];
             self::$stock = [];
@@ -237,6 +240,11 @@ namespace {
     class Module
     {
         public int $id = 1;
+
+        public static function getInstanceByName($name)
+        {
+            return StubStore::$moduleInstance;
+        }
 
         public static function isInstalled($name): bool
         {
@@ -508,6 +516,8 @@ namespace {
 
     class Country
     {
+        public $iso_code = '';
+
         public static function getIsoById($id)
         {
             return StubStore::$countries[(int) $id] ?? false;
@@ -1494,6 +1504,10 @@ namespace {
             }
             return true;
         }
+    }
+
+    if (!defined('_PS_MODULE_DIR_')) {
+        define('_PS_MODULE_DIR_', dirname(__DIR__, 2) . '/');
     }
 
     require_once dirname(__DIR__) . '/twopayment.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,15 @@ namespace {
     if (!defined('_PS_VERSION_')) {
         define('_PS_VERSION_', '8.0.0');
     }
+    if (!defined('_MYSQL_ENGINE_')) {
+        define('_MYSQL_ENGINE_', 'InnoDB');
+    }
+    if (!function_exists('pSQL')) {
+        function pSQL($value, $htmlOK = false)
+        {
+            return addslashes((string) $value);
+        }
+    }
     if (!defined('_PS_CACHE_DIR_')) {
         define('_PS_CACHE_DIR_', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
     }
@@ -58,6 +67,12 @@ namespace {
         public static array $taxRulesGroups = [];
         /** @var array<int,array> Tax rules by id */
         public static array $taxRules = [];
+        /** @var array<string,bool> Held MySQL advisory locks (GET_LOCK stubs) */
+        public static array $dbLocks = [];
+        /** @var array<int,int> Last-applied surcharge sync seq by cart id */
+        public static array $surchargeSyncSeqs = [];
+        /** @var array<int,array{id_order:int,product_id:int}> order_detail rows */
+        public static array $orderDetails = [];
         /** @var int Shared auto-increment for ObjectModel-style stubs */
         public static int $nextId = 90000;
 
@@ -108,6 +123,9 @@ namespace {
             self::$taxes = [];
             self::$taxRulesGroups = [];
             self::$taxRules = [];
+            self::$dbLocks = [];
+            self::$surchargeSyncSeqs = [];
+            self::$orderDetails = [];
             self::$nextId = 90000;
 
             $context = Context::getContext();
@@ -1154,7 +1172,47 @@ namespace {
 
         public function execute($sql): bool
         {
+            $sql = (string) $sql;
+            if (preg_match('/REPLACE INTO `ps_twopayment_surcharge_sync` \(`id_cart`, `seq`, `updated_at`\) VALUES \((\d+), (\d+)/', $sql, $m)) {
+                StubStore::$surchargeSyncSeqs[(int) $m[1]] = (int) $m[2];
+            }
             return true;
+        }
+
+        /**
+         * Recognises exactly the scalar queries the module issues; anything
+         * else answers false (core Db returns false on empty results).
+         */
+        public function getValue($sql)
+        {
+            $sql = (string) $sql;
+            if (preg_match("/GET_LOCK\\('([^']+)'/", $sql, $m)) {
+                if (!empty(StubStore::$dbLocks[$m[1]])) {
+                    return '0'; // held by a simulated concurrent request
+                }
+                StubStore::$dbLocks[$m[1]] = true;
+                return '1';
+            }
+            if (preg_match("/RELEASE_LOCK\\('([^']+)'/", $sql, $m)) {
+                unset(StubStore::$dbLocks[$m[1]]);
+                return '1';
+            }
+            if (preg_match('/SELECT `seq` FROM `ps_twopayment_surcharge_sync` WHERE `id_cart` = (\d+)/', $sql, $m)) {
+                return StubStore::$surchargeSyncSeqs[(int) $m[1]] ?? false;
+            }
+            if (preg_match('/SELECT COUNT\(\*\) FROM `ps_order_detail` WHERE `id_order` = (\d+) AND `product_id` = (\d+)/', $sql, $m)) {
+                $count = 0;
+                foreach (StubStore::$orderDetails as $row) {
+                    if ((int) $row['id_order'] === (int) $m[1] && (int) $row['product_id'] === (int) $m[2]) {
+                        $count++;
+                    }
+                }
+                return (string) $count;
+            }
+            if (preg_match("/SELECT `value` FROM `ps_configuration` WHERE `name` = '([A-Za-z0-9_]+)'/", $sql, $m)) {
+                return StubStore::$configuration[$m[1]] ?? false;
+            }
+            return false;
         }
 
         public function executeS($sql): array

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -150,6 +150,10 @@ namespace {
         }
     }
 
+    class PrestaShopException extends Exception
+    {
+    }
+
     class Module
     {
         public int $id = 1;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,6 +75,8 @@ namespace {
         public static array $orderDetails = [];
         /** @var string[] Every SQL string passed to Db::execute() */
         public static array $dbExecuted = [];
+        /** @var array<int,array> Orders by id (controller specs) */
+        public static array $orders = [];
         /** @var array<string,string> Existing DB triggers by name => CREATE sql */
         public static array $dbTriggers = [];
         /** @var int Shared auto-increment for ObjectModel-style stubs */
@@ -132,6 +134,7 @@ namespace {
             self::$orderDetails = [];
             self::$dbExecuted = [];
             self::$dbTriggers = [];
+            self::$orders = [];
             self::$nextId = 90000;
 
             $context = Context::getContext();
@@ -158,6 +161,36 @@ namespace {
 
     class PrestaShopException extends Exception
     {
+    }
+
+    /**
+     * Thrown by the front-controller stubs wherever real PrestaShop would
+     * redirect-and-exit, so controller specs observe the redirect instead of
+     * falling through code the real flow never reaches.
+     */
+    class StubRedirect extends Exception
+    {
+    }
+
+    class ModuleFrontController
+    {
+        public $module;
+        public $context;
+        public $errors = [];
+
+        public function __construct()
+        {
+            $this->context = Context::getContext();
+        }
+
+        public function postProcess()
+        {
+        }
+
+        public function redirectWithNotifications($url)
+        {
+            throw new StubRedirect((string) $url);
+        }
     }
 
     class Module
@@ -238,6 +271,8 @@ namespace {
         public $link;
         public $controller;
         public $cart;
+        public $customer;
+        public $currency;
         public $language;
         public $smarty;
 
@@ -406,6 +441,11 @@ namespace {
         public static function getToken($page = false): string
         {
             return 'token';
+        }
+
+        public static function redirect($url): void
+        {
+            throw new StubRedirect((string) $url);
         }
 
         public static function strtolower($value): string
@@ -1256,6 +1296,28 @@ namespace {
         public function update($table, $data, $where): bool
         {
             return true;
+        }
+    }
+
+    class Order
+    {
+        public $id = 0;
+        public $id_cart = 0;
+        public $id_customer = 0;
+        public $total_paid = 0.0;
+        public bool $loaded = false;
+
+        public function __construct($id = 0)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$orders[$id])) {
+                $row = StubStore::$orders[$id];
+                $this->id = $id;
+                $this->loaded = true;
+                $this->id_cart = (int) ($row['id_cart'] ?? 0);
+                $this->id_customer = (int) ($row['id_customer'] ?? 0);
+                $this->total_paid = (float) ($row['total_paid'] ?? 0.0);
+            }
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,20 @@ namespace {
         public static array $tabIds = ['AdminTwopaymentInvoice' => 1];
         /** @var string[] Class names passed to Tab::add() */
         public static array $tabAddCalls = [];
+        /** @var array<int,array> Catalog products by id (surcharge cart-line feature) */
+        public static array $products = [];
+        /** @var array<int,array> Specific prices by id */
+        public static array $specificPrices = [];
+        /** @var array<int,array> StockAvailable writes by product id */
+        public static array $stock = [];
+        /** @var array<int,array> Taxes by id */
+        public static array $taxes = [];
+        /** @var array<int,array> Tax rules groups by id */
+        public static array $taxRulesGroups = [];
+        /** @var array<int,array> Tax rules by id */
+        public static array $taxRules = [];
+        /** @var int Shared auto-increment for ObjectModel-style stubs */
+        public static int $nextId = 90000;
 
         public static function reset(): void
         {
@@ -88,6 +102,13 @@ namespace {
             self::$taxRuleRates = [];
             self::$dbExecuteSResponses = [];
             self::$dbLastExecuteS = [];
+            self::$products = [];
+            self::$specificPrices = [];
+            self::$stock = [];
+            self::$taxes = [];
+            self::$taxRulesGroups = [];
+            self::$taxRules = [];
+            self::$nextId = 90000;
 
             $context = Context::getContext();
             $context->cookie = new Cookie();
@@ -383,9 +404,292 @@ namespace {
 
     class Product
     {
+        public bool $loaded = false;
+        public int $id = 0;
+        public $name = [];
+        public $link_rewrite = [];
+        public $reference = '';
+        public $price = 0;
+        public $id_tax_rules_group = 0;
+        public $active = 0;
+        public $available_for_order = 0;
+        public $visibility = 'both';
+        public $indexed = 1;
+        public $is_virtual = 0;
+        public $out_of_stock = 0;
+        public $minimal_quantity = 1;
+        public $id_category_default = 0;
+
+        public function __construct($id = null, $full = false, $idLang = null, $idShop = null)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$products[$id])) {
+                foreach (StubStore::$products[$id] as $property => $value) {
+                    if (property_exists($this, $property)) {
+                        $this->$property = $value;
+                    }
+                }
+                $this->id = $id;
+                $this->loaded = true;
+            }
+        }
+
+        public function add(): bool
+        {
+            $this->id = StubStore::$nextId++;
+            $this->loaded = true;
+            $this->persist();
+            return true;
+        }
+
+        public function update($nullValues = false): bool
+        {
+            $this->persist();
+            return true;
+        }
+
+        public function delete(): bool
+        {
+            unset(StubStore::$products[$this->id]);
+            return true;
+        }
+
+        private function persist(): void
+        {
+            $data = get_object_vars($this);
+            unset($data['loaded']);
+            StubStore::$products[$this->id] = $data;
+        }
+
         public static function getProductCategoriesFull($idProduct, $idLang)
         {
             return StubStore::$productCategories[(int) $idProduct] ?? [];
+        }
+    }
+
+    class SpecificPrice
+    {
+        public bool $loaded = false;
+        public int $id = 0;
+        public $id_product = 0;
+        public $id_product_attribute = 0;
+        public $id_shop = 0;
+        public $id_currency = 0;
+        public $id_country = 0;
+        public $id_group = 0;
+        public $id_customer = 0;
+        public $id_cart = 0;
+        public $price = 0;
+        public $from_quantity = 1;
+        public $reduction = 0;
+        public $reduction_type = 'amount';
+        public $reduction_tax = 1;
+        public $from = '0000-00-00 00:00:00';
+        public $to = '0000-00-00 00:00:00';
+
+        public function __construct($id = null)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$specificPrices[$id])) {
+                foreach (StubStore::$specificPrices[$id] as $property => $value) {
+                    if (property_exists($this, $property)) {
+                        $this->$property = $value;
+                    }
+                }
+                $this->id = $id;
+                $this->loaded = true;
+            }
+        }
+
+        public function add(): bool
+        {
+            $this->id = StubStore::$nextId++;
+            $this->loaded = true;
+            $this->persist();
+            return true;
+        }
+
+        public function update($nullValues = false): bool
+        {
+            $this->persist();
+            return true;
+        }
+
+        private function persist(): void
+        {
+            $data = get_object_vars($this);
+            unset($data['loaded']);
+            StubStore::$specificPrices[$this->id] = $data;
+        }
+
+        /** Core-shape result: rows of ['id_specific_price' => n]. */
+        public static function getIdsByProductId($idProduct, $idProductAttribute = false, $idCart = 0): array
+        {
+            $ids = [];
+            foreach (StubStore::$specificPrices as $id => $row) {
+                if ((int) $row['id_product'] === (int) $idProduct && (int) $row['id_cart'] === (int) $idCart) {
+                    $ids[] = ['id_specific_price' => $id];
+                }
+            }
+            return $ids;
+        }
+
+        public static function deleteByIdCart($idCart, $idProduct = false, $idProductAttribute = false): bool
+        {
+            foreach (StubStore::$specificPrices as $id => $row) {
+                if ((int) $row['id_cart'] !== (int) $idCart) {
+                    continue;
+                }
+                if ($idProduct !== false && (int) $row['id_product'] !== (int) $idProduct) {
+                    continue;
+                }
+                unset(StubStore::$specificPrices[$id]);
+            }
+            return true;
+        }
+
+        /** Net unit price for a cart-scoped row, or null. */
+        public static function getCartUnitPrice(int $idCart, int $idProduct): ?float
+        {
+            foreach (StubStore::$specificPrices as $row) {
+                if ((int) $row['id_cart'] === $idCart && (int) $row['id_product'] === $idProduct) {
+                    return (float) $row['price'];
+                }
+            }
+            return null;
+        }
+    }
+
+    class StockAvailable
+    {
+        public static function setQuantity($idProduct, $idProductAttribute, $quantity, $idShop = null): void
+        {
+            StubStore::$stock[(int) $idProduct]['quantity'] = (int) $quantity;
+        }
+
+        public static function setProductOutOfStock($idProduct, $outOfStock = false, $idShop = null, $idProductAttribute = 0): void
+        {
+            StubStore::$stock[(int) $idProduct]['out_of_stock'] = (int) $outOfStock;
+        }
+    }
+
+    class Tax
+    {
+        public bool $loaded = false;
+        public int $id = 0;
+        public $name = [];
+        public $rate = 0;
+        public $active = 0;
+
+        public function __construct($id = null)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$taxes[$id])) {
+                foreach (StubStore::$taxes[$id] as $property => $value) {
+                    if (property_exists($this, $property)) {
+                        $this->$property = $value;
+                    }
+                }
+                $this->id = $id;
+                $this->loaded = true;
+            }
+        }
+
+        public function add(): bool
+        {
+            $this->id = StubStore::$nextId++;
+            $this->loaded = true;
+            StubStore::$taxes[$this->id] = ['name' => $this->name, 'rate' => $this->rate, 'active' => $this->active];
+            return true;
+        }
+
+        public function update($nullValues = false): bool
+        {
+            StubStore::$taxes[$this->id] = ['name' => $this->name, 'rate' => $this->rate, 'active' => $this->active];
+            return true;
+        }
+    }
+
+    class TaxRulesGroup
+    {
+        public bool $loaded = false;
+        public int $id = 0;
+        public $name = '';
+        public $active = 0;
+
+        public function __construct($id = null)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$taxRulesGroups[$id])) {
+                foreach (StubStore::$taxRulesGroups[$id] as $property => $value) {
+                    if (property_exists($this, $property)) {
+                        $this->$property = $value;
+                    }
+                }
+                $this->id = $id;
+                $this->loaded = true;
+            }
+        }
+
+        public function add(): bool
+        {
+            $this->id = StubStore::$nextId++;
+            $this->loaded = true;
+            StubStore::$taxRulesGroups[$this->id] = ['name' => $this->name, 'active' => $this->active];
+            return true;
+        }
+    }
+
+    class TaxRule
+    {
+        public bool $loaded = false;
+        public int $id = 0;
+        public $id_tax_rules_group = 0;
+        public $id_country = 0;
+        public $id_state = 0;
+        public $zipcode_from = 0;
+        public $zipcode_to = 0;
+        public $id_tax = 0;
+        public $behavior = 0;
+        public $description = '';
+
+        public function __construct($id = null)
+        {
+            $id = (int) $id;
+            if ($id > 0 && isset(StubStore::$taxRules[$id])) {
+                foreach (StubStore::$taxRules[$id] as $property => $value) {
+                    if (property_exists($this, $property)) {
+                        $this->$property = $value;
+                    }
+                }
+                $this->id = $id;
+                $this->loaded = true;
+            }
+        }
+
+        public function add(): bool
+        {
+            $this->id = StubStore::$nextId++;
+            $this->loaded = true;
+            $this->persist();
+            return true;
+        }
+
+        public function update($nullValues = false): bool
+        {
+            $this->persist();
+            return true;
+        }
+
+        private function persist(): void
+        {
+            $data = get_object_vars($this);
+            unset($data['loaded']);
+            StubStore::$taxRules[$this->id] = $data;
+            // Mirror core behavior for the TaxManager stub: the group now
+            // applies the referenced tax's rate.
+            $tax = new Tax((int) $this->id_tax);
+            StubStore::$taxRuleRates[(int) $this->id_tax_rules_group] = (float) $tax->rate;
         }
     }
 
@@ -674,6 +978,120 @@ namespace {
         public function getProducts($refresh = false): array
         {
             return StubStore::$cartProducts[$this->id] ?? [];
+        }
+
+        public function containsProduct($idProduct, $idProductAttribute = 0, $idCustomization = false, $idAddressDelivery = 0)
+        {
+            foreach (StubStore::$cartProducts[$this->id] ?? [] as $row) {
+                if ((int) $row['id_product'] === (int) $idProduct) {
+                    return ['quantity' => (int) $row['cart_quantity']];
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Minimal core-faithful updateQty: prices a NEW line from the
+         * cart-scoped SpecificPrice (net) and the product's tax rules group
+         * rate (gross), mirroring what PS core computes for the hidden
+         * surcharge product. Repeat 'up' calls INCREMENT quantity - exactly
+         * like core - so idempotency must come from the module, not the stub.
+         */
+        public function updateQty($quantity, $idProduct, $idProductAttribute = null, $idCustomization = false, $operator = 'up')
+        {
+            $idProduct = (int) $idProduct;
+            $quantity = (int) $quantity;
+            $rows = StubStore::$cartProducts[$this->id] ?? [];
+
+            $net = SpecificPrice::getCartUnitPrice((int) $this->id, $idProduct);
+            $product = new Product($idProduct);
+            if ($net === null) {
+                $net = $product->loaded ? (float) $product->price : 0.0;
+            }
+            $rate = (float) (StubStore::$taxRuleRates[(int) $product->id_tax_rules_group] ?? 0.0);
+
+            $found = false;
+            foreach ($rows as $i => $row) {
+                if ((int) $row['id_product'] === $idProduct) {
+                    $newQty = (int) $row['cart_quantity'] + ($operator === 'up' ? $quantity : -$quantity);
+                    $this->applyCartTotalsDelta(-(float) $row['total'], -(float) $row['total_wt']);
+                    if ($newQty <= 0) {
+                        unset($rows[$i]);
+                    } else {
+                        $rows[$i]['cart_quantity'] = $newQty;
+                        $rows[$i]['total'] = round($net * $newQty, 2);
+                        $rows[$i]['total_wt'] = round($net * $newQty * (1 + $rate / 100), 2);
+                        $this->applyCartTotalsDelta((float) $rows[$i]['total'], (float) $rows[$i]['total_wt']);
+                    }
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                if ($operator !== 'up') {
+                    return false;
+                }
+                $langId = 1;
+                $name = 'Product ' . $idProduct;
+                if ($product->loaded && is_array($product->name)) {
+                    $name = (string) (reset($product->name) ?: $name);
+                }
+                $rewrite = 'product-' . $idProduct;
+                if ($product->loaded && is_array($product->link_rewrite)) {
+                    $rewrite = (string) (reset($product->link_rewrite) ?: $rewrite);
+                }
+                $row = [
+                    'id_product' => $idProduct,
+                    'link_rewrite' => $rewrite,
+                    'name' => $name,
+                    'description_short' => '',
+                    'manufacturer_name' => '',
+                    'ean13' => '',
+                    'upc' => '',
+                    'cart_quantity' => $quantity,
+                    'price' => $net,
+                    'total' => round($net * $quantity, 2),
+                    'total_wt' => round($net * $quantity * (1 + $rate / 100), 2),
+                    'rate' => $rate,
+                    'reduction' => 0,
+                    'is_virtual' => $product->loaded ? (int) $product->is_virtual : 0,
+                ];
+                $rows[] = $row;
+                $this->applyCartTotalsDelta((float) $row['total'], (float) $row['total_wt']);
+            }
+
+            StubStore::$cartProducts[$this->id] = array_values($rows);
+            return true;
+        }
+
+        public function deleteProduct($idProduct, $idProductAttribute = 0, $idCustomization = 0, $idAddressDelivery = 0)
+        {
+            $rows = StubStore::$cartProducts[$this->id] ?? [];
+            foreach ($rows as $i => $row) {
+                if ((int) $row['id_product'] === (int) $idProduct) {
+                    $this->applyCartTotalsDelta(-(float) $row['total'], -(float) $row['total_wt']);
+                    unset($rows[$i]);
+                }
+            }
+            StubStore::$cartProducts[$this->id] = array_values($rows);
+            return true;
+        }
+
+        private function applyCartTotalsDelta(float $netDelta, float $grossDelta): void
+        {
+            if (isset(StubStore::$cartTotals[$this->id][false][self::BOTH])) {
+                StubStore::$cartTotals[$this->id][false][self::BOTH] = round(
+                    (float) StubStore::$cartTotals[$this->id][false][self::BOTH] + $netDelta,
+                    2
+                );
+            }
+            if (isset(StubStore::$cartTotals[$this->id][true][self::BOTH])) {
+                StubStore::$cartTotals[$this->id][true][self::BOTH] = round(
+                    (float) StubStore::$cartTotals[$this->id][true][self::BOTH] + $grossDelta,
+                    2
+                );
+            }
         }
 
         public function getOrderTotal($withTaxes, $type)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,18 @@ namespace {
         public static array $moduleCurrencies = [];
         public static array $productCategories = [];
         public static array $images = [];
+        /**
+         * Effective tax rates by tax rules group, mirroring core's
+         * TaxManagerFactory resolution (live-container verified on PS 8.2.6):
+         *   - float: flat rate for EVERY destination (legacy shape)
+         *   - array<int,float|float[]>: rate by COUNTRY id; a missing country
+         *     resolves 0 (core: no matching TaxRule -> untaxed destination);
+         *     a float[] value SUMS (core: combined multi-rate rules stack
+         *     additively, e.g. 6% + 2% -> 8%).
+         * Group id 0 always resolves 0 (core "No tax" sentinel).
+         *
+         * @var array<int,float|array<int,float|float[]>>
+         */
         public static array $taxRuleRates = [];
         public static array $dbExecuteSResponses = [];
         public static array $dbLastExecuteS = [];
@@ -55,6 +67,34 @@ namespace {
         public static array $tabIds = ['AdminTwopaymentInvoice' => 1];
         /** @var string[] Class names passed to Tab::add() */
         public static array $tabAddCalls = [];
+
+        /**
+         * Resolve a tax rules group's effective rate for a destination
+         * country - the stub twin of core's
+         * TaxManagerFactory::getManager($address, $groupId)
+         *     ->getTaxCalculator()->getTotalRate().
+         * See $taxRuleRates for the fixture shapes.
+         */
+        public static function resolveTaxRate(int $groupId, int $countryId): float
+        {
+            if ($groupId <= 0 || !isset(self::$taxRuleRates[$groupId])) {
+                return 0.0;
+            }
+            $entry = self::$taxRuleRates[$groupId];
+            if (is_array($entry)) {
+                $entry = $entry[$countryId] ?? 0.0;
+            }
+            if (is_array($entry)) {
+                // Combined multi-rate rules stack additively (core-verified).
+                $sum = 0.0;
+                foreach ($entry as $rate) {
+                    $sum += (float) $rate;
+                }
+                return $sum;
+            }
+
+            return (float) $entry;
+        }
         /** @var array<int,array> Catalog products by id (surcharge cart-line feature) */
         public static array $products = [];
         /** @var array<int,array> Specific prices by id */
@@ -90,6 +130,7 @@ namespace {
                 'PS_TWO_ENVIRONMENT' => 'development',
                 'PS_OS_SHIPPING' => 4,
                 'PS_OS_CANCELED' => 6,
+                'PS_TAX' => 1, // core default: taxes enabled shop-wide
             ];
             self::$countries = [34 => 'ES', 47 => 'NO', 56 => 'BE'];
             self::$states = [
@@ -706,6 +747,23 @@ namespace {
             StubStore::$taxRulesGroups[$this->id] = ['name' => $this->name, 'active' => $this->active];
             return true;
         }
+
+        /** Core-shape rows: id_tax_rules_group / name / active. */
+        public static function getTaxRulesGroups($onlyActive = true): array
+        {
+            $rows = [];
+            foreach (StubStore::$taxRulesGroups as $id => $data) {
+                if ($onlyActive && empty($data['active'])) {
+                    continue;
+                }
+                $rows[] = [
+                    'id_tax_rules_group' => $id,
+                    'name' => (string) ($data['name'] ?? ''),
+                    'active' => (int) ($data['active'] ?? 0),
+                ];
+            }
+            return $rows;
+        }
     }
 
     class TaxRule
@@ -754,10 +812,6 @@ namespace {
             $data = get_object_vars($this);
             unset($data['loaded']);
             StubStore::$taxRules[$this->id] = $data;
-            // Mirror core behavior for the TaxManager stub: the group now
-            // applies the referenced tax's rate.
-            $tax = new Tax((int) $this->id_tax);
-            StubStore::$taxRuleRates[(int) $this->id_tax_rules_group] = (float) $tax->rate;
         }
     }
 
@@ -795,15 +849,17 @@ namespace {
     class TaxManager
     {
         private int $groupId;
+        private int $countryId;
 
-        public function __construct(int $groupId)
+        public function __construct(int $groupId, int $countryId)
         {
             $this->groupId = $groupId;
+            $this->countryId = $countryId;
         }
 
         public function getTaxCalculator(): TaxCalculator
         {
-            return new TaxCalculator((float) (StubStore::$taxRuleRates[$this->groupId] ?? 0.0));
+            return new TaxCalculator(StubStore::resolveTaxRate($this->groupId, $this->countryId));
         }
     }
 
@@ -811,7 +867,8 @@ namespace {
     {
         public static function getManager($address, $taxRulesGroupId): TaxManager
         {
-            return new TaxManager((int) $taxRulesGroupId);
+            $countryId = is_object($address) && isset($address->id_country) ? (int) $address->id_country : 0;
+            return new TaxManager((int) $taxRulesGroupId, $countryId);
         }
     }
 
@@ -1076,7 +1133,16 @@ namespace {
             if ($net === null) {
                 $net = $product->loaded ? (float) $product->price : 0.0;
             }
-            $rate = (float) (StubStore::$taxRuleRates[(int) $product->id_tax_rules_group] ?? 0.0);
+            // Destination-based rate, exactly like core Product::priceCalculation:
+            // the product's tax rules group resolved against the cart's
+            // PS_TAX_ADDRESS_TYPE address (invoice unless configured delivery).
+            $taxAddressField = Configuration::get('PS_TAX_ADDRESS_TYPE') === 'id_address_delivery'
+                ? 'id_address_delivery'
+                : 'id_address_invoice';
+            $taxAddress = new Address((int) $this->{$taxAddressField});
+            $rate = Configuration::get('PS_TAX')
+                ? StubStore::resolveTaxRate((int) $product->id_tax_rules_group, (int) $taxAddress->id_country)
+                : 0.0;
 
             $found = false;
             foreach ($rows as $i => $row) {

--- a/tests/run.php
+++ b/tests/run.php
@@ -5016,6 +5016,7 @@ require __DIR__ . '/MerchantFeeRatesSpec.php';
 require __DIR__ . '/TermSurchargeAmountsSpec.php';
 require __DIR__ . '/SurchargeCartLineSpec.php';
 require __DIR__ . '/ConfirmationLegacyParitySpec.php';
+require __DIR__ . '/TwoSoleTraderSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5030,6 +5031,7 @@ $tests = [
     'TermSurchargeAmountsSpec::runAll' => [TermSurchargeAmountsSpec::class, 'runAll'],
     'SurchargeCartLineSpec::runAll' => [SurchargeCartLineSpec::class, 'runAll'],
     'ConfirmationLegacyParitySpec::runAll' => [ConfirmationLegacyParitySpec::class, 'runAll'],
+    'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -5015,6 +5015,7 @@ require __DIR__ . '/DeployVersionInfoSpec.php';
 require __DIR__ . '/MerchantFeeRatesSpec.php';
 require __DIR__ . '/TermSurchargeAmountsSpec.php';
 require __DIR__ . '/SurchargeCartLineSpec.php';
+require __DIR__ . '/ConfirmationLegacyParitySpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5028,6 +5029,7 @@ $tests = [
     'MerchantFeeRatesSpec::runAll' => [MerchantFeeRatesSpec::class, 'runAll'],
     'TermSurchargeAmountsSpec::runAll' => [TermSurchargeAmountsSpec::class, 'runAll'],
     'SurchargeCartLineSpec::runAll' => [SurchargeCartLineSpec::class, 'runAll'],
+    'ConfirmationLegacyParitySpec::runAll' => [ConfirmationLegacyParitySpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -5014,6 +5014,7 @@ require __DIR__ . '/DefaultPaymentTermSpec.php';
 require __DIR__ . '/DeployVersionInfoSpec.php';
 require __DIR__ . '/MerchantFeeRatesSpec.php';
 require __DIR__ . '/TermSurchargeAmountsSpec.php';
+require __DIR__ . '/SurchargeCartLineSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5026,6 +5027,7 @@ $tests = [
     'DeployVersionInfoSpec::runAll' => [DeployVersionInfoSpec::class, 'runAll'],
     'MerchantFeeRatesSpec::runAll' => [MerchantFeeRatesSpec::class, 'runAll'],
     'TermSurchargeAmountsSpec::runAll' => [TermSurchargeAmountsSpec::class, 'runAll'],
+    'SurchargeCartLineSpec::runAll' => [SurchargeCartLineSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -118,7 +118,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.5.0';
+        $this->version = '2.5.1';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -1327,7 +1327,7 @@ class Twopayment extends PaymentModule
     protected function saveTwoOtherFormValues()
     {
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE'));
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', (int) Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', 0));
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
@@ -2810,10 +2810,15 @@ class Twopayment extends PaymentModule
                 'enable_order_intent' => $this->enable_order_intent,
                 'use_account_type' => (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'),
                 'sole_trader' => array(
+                    // The signup URL and invoice-address country are
+                    // resolved fresh per-request by soleTraderTokens (the
+                    // reliable source for both - see
+                    // classes/TwoSoleTrader.php and controllers/front/
+                    // orderintent.php::ajaxProcessSoleTraderTokens); only
+                    // the feature flag is needed here to decide whether to
+                    // run the flow at all.
                     'enabled' => TwoSoleTrader::isEnabled() ? 1 : 0,
-                    'signup_url' => TwoSoleTrader::getSignupPageUrl(),
                 ),
-                'shop_country' => (string) Context::getContext()->country->iso_code,
                 'order_intent_url' => $this->context->link->getModuleLink($this->name, 'orderintent'),
                 'ajax_token' => Tools::getToken(false),
                 'module_dir' => $this->_path,

--- a/twopayment.php
+++ b/twopayment.php
@@ -6901,11 +6901,7 @@ class Twopayment extends PaymentModule
             return '';
         }
 
-        return $this->l(
-            'Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate,'
-            . ' which has been replaced by a tax rules group. Until you select and save a'
-            . ' "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.'
-        );
+        return $this->l('Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate, which has been replaced by a tax rules group. Until you select and save a "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.');
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -455,6 +455,16 @@ class Twopayment extends PaymentModule
             KEY `idx_attempt_two_order_id` (`two_order_id`),
             KEY `idx_attempt_updated_at` (`updated_at`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+
+        // Per-cart last-applied surcharge sync sequence (buyer AJAX ordering
+        // guard). Also lazily created in ensureTwoSurchargeSyncTable() for
+        // installations upgraded from versions without it.
+        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'twopayment_surcharge_sync` (
+            `id_cart` INT(11) UNSIGNED NOT NULL,
+            `seq` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            `updated_at` DATETIME NOT NULL,
+            PRIMARY KEY (`id_cart`)
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
         // Note: invoice_details (payment info) is NOT stored in DB - fetched from Two API when needed
         // This ensures payment details are always current and avoids stale data issues
 
@@ -536,6 +546,7 @@ class Twopayment extends PaymentModule
     protected function deleteTwoTables()
     {
         $sql = array();
+        $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'twopayment_surcharge_sync`';
         foreach ($sql as $query) {
             if (Db::getInstance()->execute($query) == false) {
                 return false;
@@ -7304,6 +7315,104 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * MySQL advisory lock (GET_LOCK). Used to serialise the surcharge
+     * check-then-create/check-then-act sequences across concurrent requests.
+     * NOTE: paths below may hold two differently-named locks at once; that
+     * requires MySQL >= 5.7.5 or MariaDB >= 10.0.2 (older servers silently
+     * release the first lock on the second GET_LOCK) - both far below any
+     * realistic PrestaShop 8 database floor.
+     *
+     * @param string $name
+     * @param int $timeoutSeconds
+     * @return bool
+     */
+    protected function acquireTwoDbLock($name, $timeoutSeconds = 5)
+    {
+        try {
+            return (string) Db::getInstance()->getValue(
+                "SELECT GET_LOCK('" . pSQL($name) . "', " . (int) $timeoutSeconds . ')'
+            ) === '1';
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: GET_LOCK failed for ' . $name . ' - ' . $e->getMessage(), 3);
+            return false;
+        }
+    }
+
+    /**
+     * Release a lock taken with acquireTwoDbLock. Callers use try/finally so
+     * the lock is released even when the guarded section throws.
+     *
+     * @param string $name
+     */
+    protected function releaseTwoDbLock($name)
+    {
+        try {
+            Db::getInstance()->getValue("SELECT RELEASE_LOCK('" . pSQL($name) . "')");
+        } catch (Exception $e) {
+            // Session teardown releases the lock anyway; log only.
+            PrestaShopLogger::addLog('TwoPayment: RELEASE_LOCK failed for ' . $name . ' - ' . $e->getMessage(), 2);
+        }
+    }
+
+    /**
+     * Lazily create the per-cart surcharge sync-sequence table. Also created
+     * at install; the lazy path covers module upgrades from versions without
+     * it (install() does not re-run on upgrade).
+     */
+    protected function ensureTwoSurchargeSyncTable()
+    {
+        static $ensured = false;
+        if ($ensured) {
+            return;
+        }
+        Db::getInstance()->execute(
+            'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'twopayment_surcharge_sync` (
+                `id_cart` INT(11) UNSIGNED NOT NULL,
+                `seq` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+                `updated_at` DATETIME NOT NULL,
+                PRIMARY KEY (`id_cart`)
+            ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8'
+        );
+        $ensured = true;
+    }
+
+    /**
+     * Last-applied buyer-driven sync sequence for a cart, or null when the
+     * cart has never synced with a sequence number.
+     *
+     * @param int $cartId
+     * @return int|null
+     */
+    protected function getTwoSurchargeSyncLastSeq($cartId)
+    {
+        $this->ensureTwoSurchargeSyncTable();
+        $value = Db::getInstance()->getValue(
+            'SELECT `seq` FROM `' . _DB_PREFIX_ . 'twopayment_surcharge_sync` WHERE `id_cart` = ' . (int) $cartId
+        );
+        if ($value === false || $value === null) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * Persist the last-applied sync sequence for a cart (caller holds the
+     * per-cart advisory lock, so plain REPLACE is race-free here).
+     *
+     * @param int $cartId
+     * @param int $seq
+     */
+    protected function setTwoSurchargeSyncLastSeq($cartId, $seq)
+    {
+        $this->ensureTwoSurchargeSyncTable();
+        Db::getInstance()->execute(
+            'REPLACE INTO `' . _DB_PREFIX_ . 'twopayment_surcharge_sync` (`id_cart`, `seq`, `updated_at`) ' .
+            'VALUES (' . (int) $cartId . ', ' . (int) $seq . ", '" . pSQL(date('Y-m-d H:i:s')) . "')"
+        );
+    }
+
+    /**
      * The surcharge product's line in the given cart, or null when absent.
      * Amounts are PrestaShop's OWN applied totals for the line (the figures
      * the buyer sees), used both for idempotency checks and for the
@@ -7356,11 +7465,74 @@ class Twopayment extends PaymentModule
      * is corrected by delete + re-add. Never throws (fail-soft AJAX
      * contract); 'success' => false tells the caller nothing was reconciled.
      *
+     * ORDERING (buyer-driven AJAX only): two rapid selection changes can have
+     * their requests complete on the server in the wrong order (switch away
+     * from Two, then back - the "back" request may finish first). When the
+     * caller passes a monotonically increasing $syncSeq (the checkout JS
+     * sends one), the last-applied sequence is stored per cart and any
+     * request whose sequence is not strictly greater is a no-op that reports
+     * the current state unchanged. Callers that pass null (the order-create
+     * self-heal in buildTwoOrderPricingData - the final authoritative sync
+     * before charging - and legacy frontends) bypass the guard entirely and
+     * always apply.
+     *
      * @param Cart $cart
      * @param bool $selected Two is the buyer's selected payment option
+     * @param int|null $syncSeq buyer-driven request ordering guard (null = authoritative, always applies)
      * @return array{success:bool,changed:bool,present:bool}
      */
-    public function syncTwoSurchargeCartLine($cart, $selected)
+    public function syncTwoSurchargeCartLine($cart, $selected, $syncSeq = null)
+    {
+        $result = array('success' => false, 'changed' => false, 'present' => false);
+        if ($syncSeq === null) {
+            return $this->applyTwoSurchargeCartLineSync($cart, $selected);
+        }
+
+        try {
+            if (!Validate::isLoadedObject($cart)) {
+                return $result;
+            }
+            // Serialise buyer-driven syncs per cart so the seq check-then-act
+            // and the cart mutation cannot interleave between two requests.
+            $lockName = 'two_surcharge_sync_' . (int) $cart->id;
+            if (!$this->acquireTwoDbLock($lockName)) {
+                PrestaShopLogger::addLog('TwoPayment: Surcharge sync lock not acquired for cart ' . (int) $cart->id, 2);
+                return $result;
+            }
+            try {
+                $lastSeq = $this->getTwoSurchargeSyncLastSeq((int) $cart->id);
+                if ($lastSeq !== null && (int) $syncSeq <= $lastSeq) {
+                    // Stale request (an out-of-order older click): leave the
+                    // cart exactly as the newer request left it.
+                    PrestaShopLogger::addLog(
+                        'TwoPayment: Ignored stale surcharge sync (seq ' . (int) $syncSeq . ' <= ' . $lastSeq . ') for cart ' . (int) $cart->id,
+                        1
+                    );
+                    $result['success'] = true;
+                    $result['present'] = $this->getTwoSurchargeCartLine($cart) !== null;
+                    return $result;
+                }
+                $this->setTwoSurchargeSyncLastSeq((int) $cart->id, (int) $syncSeq);
+                return $this->applyTwoSurchargeCartLineSync($cart, $selected);
+            } finally {
+                $this->releaseTwoDbLock($lockName);
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Surcharge sync ordering guard failed for cart ' . (isset($cart->id) ? (int) $cart->id : 0) . ' - ' . $e->getMessage(), 3);
+            return $result;
+        }
+    }
+
+    /**
+     * The actual reconciliation body of syncTwoSurchargeCartLine (see its
+     * docblock); split out so the buyer-AJAX ordering guard wraps it without
+     * touching the money logic.
+     *
+     * @param Cart $cart
+     * @param bool $selected
+     * @return array{success:bool,changed:bool,present:bool}
+     */
+    protected function applyTwoSurchargeCartLineSync($cart, $selected)
     {
         $result = array('success' => false, 'changed' => false, 'present' => false);
         try {

--- a/twopayment.php
+++ b/twopayment.php
@@ -12,6 +12,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
+require_once dirname(__FILE__) . '/classes/TwoSoleTrader.php';
 
 class Twopayment extends PaymentModule
 {
@@ -299,6 +300,7 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0); // Default: off; merchant opts in (TWO-24755)
         Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 0); // Disabled by default - must be enabled after coordinating with Two
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
@@ -534,6 +536,7 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_ENABLE_TAX_SUBTOTALS');
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
+        Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         $this->deleteTwoSurchargeCartProduct();
         Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
@@ -1136,6 +1139,26 @@ class Twopayment extends PaymentModule
                     ),
                     array(
                         'type' => 'switch',
+                        'label' => $this->l('Enable sole trader checkout'),
+                        'name' => 'PS_TWO_ENABLE_SOLE_TRADER',
+                        'is_bool' => true,
+                        'desc' => $this->l('Adds a Sole Trader option to the Account Type selector for buyers in countries where Two supports sole traders. Requires Account Type selection to be enabled.'),
+                        'required' => true,
+                        'values' => array(
+                            array(
+                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_ON',
+                                'value' => 1,
+                                'label' => $this->l('Yes')
+                            ),
+                            array(
+                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_OFF',
+                                'value' => 0,
+                                'label' => $this->l('No')
+                            ),
+                        ),
+                    ),
+                    array(
+                        'type' => 'switch',
                         'label' => $this->l('Activate company name auto-complete'),
                         'name' => 'PS_TWO_ENABLE_COMPANY_NAME',
                         'is_bool' => true,
@@ -1286,6 +1309,7 @@ class Twopayment extends PaymentModule
     {
         $fields_values = array();
         $fields_values['PS_TWO_USE_ACCOUNT_TYPE'] = Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE', Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'));
+        $fields_values['PS_TWO_ENABLE_SOLE_TRADER'] = Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', Configuration::get('PS_TWO_ENABLE_SOLE_TRADER'));
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
@@ -1303,6 +1327,7 @@ class Twopayment extends PaymentModule
     protected function saveTwoOtherFormValues()
     {
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', Tools::getValue('PS_TWO_USE_ACCOUNT_TYPE'));
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', (int) Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', 0));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
@@ -2784,6 +2809,11 @@ class Twopayment extends PaymentModule
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,
                 'use_account_type' => (int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE'),
+                'sole_trader' => array(
+                    'enabled' => TwoSoleTrader::isEnabled() ? 1 : 0,
+                    'signup_url' => TwoSoleTrader::getSignupPageUrl(),
+                ),
+                'shop_country' => (string) Context::getContext()->country->iso_code,
                 'order_intent_url' => $this->context->link->getModuleLink($this->name, 'orderintent'),
                 'ajax_token' => Tools::getToken(false),
                 'module_dir' => $this->_path,
@@ -2813,6 +2843,7 @@ class Twopayment extends PaymentModule
         // Ensures they load AFTER jQuery
         $this->context->controller->registerJavascript('two-company-search', 'modules/twopayment/views/js/modules/TwoCompanySearch.js', array('priority' => 201, 'async' => false));
         $this->context->controller->registerJavascript('two-order-intent', 'modules/twopayment/views/js/modules/TwoOrderIntent.js', array('priority' => 202, 'async' => false));
+        $this->context->controller->registerJavascript('two-sole-trader', 'modules/twopayment/views/js/modules/TwoSoleTrader.js', array('priority' => 204, 'async' => false));
         $this->context->controller->registerJavascript('two-field-validation', 'modules/twopayment/views/js/modules/TwoFieldValidation.js', array('priority' => 203, 'async' => false));
         // Phone validation removed - Two API handles phone number validation
         $this->context->controller->registerJavascript('two-checkout-manager', 'modules/twopayment/views/js/modules/TwoCheckoutManager.js', array('priority' => 205, 'async' => false));
@@ -2893,11 +2924,12 @@ class Twopayment extends PaymentModule
         // If merchant uses account type selection, gate payment option to business accounts
         if ((int) Configuration::get('PS_TWO_USE_ACCOUNT_TYPE')) {
             $account_type = property_exists($billing_address, 'account_type') ? trim((string) $billing_address->account_type) : '';
-            if ($account_type !== 'business') {
-                PrestaShopLogger::addLog('TwoPayment: Payment option hidden - account type is not business (current: ' . ($account_type ?: 'not set') . ')', 1);
+            $billing_country_iso = (string) Country::getIsoById((int) $billing_address->id_country);
+            if (!TwoSoleTrader::isAccountTypeAllowed($this, $account_type, $billing_country_iso)) {
+                PrestaShopLogger::addLog('TwoPayment: Payment option hidden - account type not eligible (current: ' . ($account_type ?: 'not set') . ')', 1);
                 return [];
             }
-            PrestaShopLogger::addLog('TwoPayment: Payment option shown for business account path', 1);
+            PrestaShopLogger::addLog('TwoPayment: Payment option shown for ' . $account_type . ' account path', 1);
         } else {
             // When account type selection is disabled, allow showing Two option; FE will prompt for company selection as needed
             PrestaShopLogger::addLog('TwoPayment: Payment option shown (account type disabled)', 1);
@@ -9095,7 +9127,7 @@ class Twopayment extends PaymentModule
      * @param resource|CurlHandle $ch cURL handle
      * @return void
      */
-    private function configureSslVerification($ch)
+    public function configureSslVerification($ch)
     {
         // Check if SSL verification is disabled via configuration (for corporate networks)
         $disable_ssl_verify = (bool)Configuration::get('PS_TWO_DISABLE_SSL_VERIFY', false);

--- a/twopayment.php
+++ b/twopayment.php
@@ -78,6 +78,12 @@ class Twopayment extends PaymentModule
     // sentinel. TWO-25071 (replaces the module-managed synthetic
     // Tax/TaxRulesGroup/TaxRule graph + flat PS_TWO_SURCHARGE_TAX_RATE).
     const CONFIG_SURCHARGE_TAX_RULES_GROUP = 'PS_TWO_SURCHARGE_TAX_RULES_GROUP';
+    // Set by upgrade-2.5.0.php when a pre-release flat surcharge tax rate
+    // (PS_TWO_SURCHARGE_TAX_RATE) was configured but no TaxRulesGroup has
+    // been selected yet: on upgrade the fee silently became untaxed, so a
+    // persistent back-office warning nags until the merchant saves a
+    // selection (any explicit save - including "No tax" - clears it).
+    const CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE = 'PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE';
 
     // Constants for delivery dates
     const DEFAULT_DELIVERY_DAYS_OFFSET = 7; // Default expected delivery date offset
@@ -111,7 +117,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.4.0';
+        $this->version = '2.5.0';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -540,6 +546,7 @@ class Twopayment extends PaymentModule
         // are no longer created and no longer cleaned up here.
         Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_RATE');
         Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_SETUP');
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE);
         return true;
     }
 
@@ -617,6 +624,15 @@ class Twopayment extends PaymentModule
         if (((bool) Tools::isSubmit('submitTwoOrderStatusForm')) == true) {
             Configuration::updateValue('PS_TWO_TAB_VALUE', 3);
             $this->saveTwoOrderStatusFormValues();
+        }
+
+        // Post-upgrade nag (upgrade-2.5.0.php): a pre-release flat surcharge
+        // tax rate existed but no TaxRulesGroup is selected - the fee is
+        // untaxed until the merchant re-selects. Rendered on every config
+        // page load until a surcharge-settings save clears the flag.
+        $migrationNotice = $this->getTwoSurchargeTaxMigrationNotice();
+        if ($migrationNotice !== '') {
+            $this->output .= $this->displayWarning($migrationNotice);
         }
 
         $this->context->smarty->assign(
@@ -6864,6 +6880,35 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Post-upgrade "surcharge tax needs re-selection" warning text, or ''
+     * when no warning is due. Due when upgrade-2.5.0.php flagged a shop that
+     * had the pre-release flat rate (PS_TWO_SURCHARGE_TAX_RATE) configured
+     * and no TaxRulesGroup has been saved since: the surcharge is silently
+     * untaxed until the merchant picks a group. Self-retires if a selection
+     * exists (covers saves made outside this module's own form path).
+     *
+     * @return string
+     */
+    public function getTwoSurchargeTaxMigrationNotice()
+    {
+        if (!Configuration::get(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE)) {
+            return '';
+        }
+        $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($stored !== false && $stored !== null && trim((string) $stored) !== '') {
+            Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+
+            return '';
+        }
+
+        return $this->l(
+            'Surcharge tax needs re-selection: this shop previously used a flat surcharge tax rate,'
+            . ' which has been replaced by a tax rules group. Until you select and save a'
+            . ' "Surcharge Tax Rules Group" under Payment settings, the surcharge is NOT taxed.'
+        );
+    }
+
+    /**
      * Effective tax rate (decimal FRACTION, e.g. 0.25) the selected
      * TaxRulesGroup applies to the surcharge for THIS cart's tax destination
      * - resolved through the SAME core machinery PrestaShop's own cart
@@ -8288,7 +8333,11 @@ class Twopayment extends PaymentModule
      * groups - the same list core's own product-edit page offers (its
      * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
      * rate, so the deduplicated getTaxRulesGroups source is used with the
-     * same manual "No tax" prepend).
+     * same manual "No tax" prepend). The currently-configured group is
+     * ALWAYS present even when deactivated (suffixed "(inactive)"): if a
+     * stale selection dropped out of the list, the browser would submit the
+     * first option ("No tax", id 0) on the next unrelated settings save and
+     * silently detax the surcharge.
      *
      * @return array<int,array{id:int,name:string}>
      */
@@ -8298,14 +8347,28 @@ class Twopayment extends PaymentModule
             array('id' => 0, 'name' => $this->l('No tax')),
         );
         $groups = TaxRulesGroup::getTaxRulesGroups(true);
+        $seen = array(0 => true);
         foreach ((array) $groups as $group) {
             if (!isset($group['id_tax_rules_group'])) {
                 continue;
             }
+            $id = (int) $group['id_tax_rules_group'];
             $options[] = array(
-                'id' => (int) $group['id_tax_rules_group'],
+                'id' => $id,
                 'name' => (string) $group['name'],
             );
+            $seen[$id] = true;
+        }
+
+        $configuredId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ($configuredId > 0 && !isset($seen[$configuredId])) {
+            $configured = new TaxRulesGroup($configuredId);
+            if (Validate::isLoadedObject($configured)) {
+                $options[] = array(
+                    'id' => $configuredId,
+                    'name' => (string) $configured->name . ' (' . $this->l('inactive') . ')',
+                );
+            }
         }
 
         return $options;
@@ -8313,12 +8376,12 @@ class Twopayment extends PaymentModule
 
     /**
      * Pre-selection for the surcharge tax rules group dropdown: the stored
-     * selection, else the merchant's "standard" group - the one most of
-     * their catalog uses (Product::getIdTaxRulesGroupMostUsed, the same
-     * default heuristic core's product page uses for new products). Display
-     * default only: runtime behaviour for an UNSAVED config stays "No tax"
-     * (getTwoSurchargeTaxRulesGroupId) - the module never taxes the fee on
-     * a rate the merchant did not confirm by saving.
+     * selection, else "No tax" (0) - the merchant must make an explicit
+     * choice. Deliberately NOT Product::getIdTaxRulesGroupMostUsed(): that
+     * is a full-catalog COUNT/GROUP BY re-run on every unsaved config page
+     * render, and pre-selecting a taxing group the merchant never chose
+     * invites an accidental save. Matches runtime behaviour for an UNSAVED
+     * config (getTwoSurchargeTaxRulesGroupId falls back to "No tax").
      *
      * @return int
      */
@@ -8327,9 +8390,6 @@ class Twopayment extends PaymentModule
         $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
         if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
             return max(0, (int) $stored);
-        }
-        if (method_exists('Product', 'getIdTaxRulesGroupMostUsed')) {
-            return max(0, (int) Product::getIdTaxRulesGroupMostUsed());
         }
 
         return 0;
@@ -8428,6 +8488,9 @@ class Twopayment extends PaymentModule
             $groupId = 0;
         }
         Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
+        // Explicit merchant save (any value, "No tax" included) retires the
+        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php.
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
 
         // Apply the selection to the hidden fee product immediately (the
         // same id_tax_rules_group field every real Product uses); if the

--- a/twopayment.php
+++ b/twopayment.php
@@ -521,9 +521,63 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         $this->deleteTwoSurchargeCartProduct();
+        $this->deleteTwoSurchargeTaxSetup();
         Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
         Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_SETUP);
         return true;
+    }
+
+    /**
+     * Best-effort removal of the module-managed Tax/TaxRulesGroup/TaxRule
+     * graph tracked in CONFIG_SURCHARGE_TAX_SETUP at uninstall. Historical
+     * orders keep their own copied tax rates on order_detail rows, so
+     * deleting the objects does not damage them. Never blocks uninstall.
+     */
+    protected function deleteTwoSurchargeTaxSetup()
+    {
+        try {
+            $setup = json_decode((string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP), true);
+            if (!is_array($setup)) {
+                return;
+            }
+
+            foreach ((array) (isset($setup['rules']) ? $setup['rules'] : array()) as $ruleId) {
+                try {
+                    if ((int) $ruleId > 0 && class_exists('TaxRule')) {
+                        $rule = new TaxRule((int) $ruleId);
+                        if (Validate::isLoadedObject($rule) && method_exists($rule, 'delete')) {
+                            $rule->delete();
+                        }
+                    }
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRule ' . (int) $ruleId . ' at uninstall - ' . $e->getMessage(), 2);
+                }
+            }
+
+            try {
+                if (!empty($setup['id_group']) && class_exists('TaxRulesGroup')) {
+                    $group = new TaxRulesGroup((int) $setup['id_group']);
+                    if (Validate::isLoadedObject($group) && method_exists($group, 'delete')) {
+                        $group->delete();
+                    }
+                }
+            } catch (Exception $e) {
+                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRulesGroup at uninstall - ' . $e->getMessage(), 2);
+            }
+
+            try {
+                if (!empty($setup['id_tax']) && class_exists('Tax')) {
+                    $tax = new Tax((int) $setup['id_tax']);
+                    if (Validate::isLoadedObject($tax) && method_exists($tax, 'delete')) {
+                        $tax->delete();
+                    }
+                }
+            } catch (Exception $e) {
+                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge Tax at uninstall - ' . $e->getMessage(), 2);
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge tax setup at uninstall - ' . $e->getMessage(), 2);
+        }
     }
 
     /**
@@ -7078,6 +7132,26 @@ class Twopayment extends PaymentModule
                 && (string) $product->reference === self::TWO_SURCHARGE_PRODUCT_REFERENCE
             ) {
                 return $productId;
+            }
+            // Stored id no longer points at OUR product. If the object still
+            // exists AND carries our hidden-fee shape (virtual + invisible -
+            // e.g. its reference was edited in the BO), delete it best-effort
+            // so it is not orphaned forever behind its replacement. A
+            // recycled id pointing at a real catalog product will not match
+            // the shape and is never touched.
+            if (
+                Validate::isLoadedObject($product)
+                && (int) $product->is_virtual === 1
+                && (string) $product->visibility === 'none'
+            ) {
+                try {
+                    if (method_exists($product, 'delete')) {
+                        $product->delete();
+                        PrestaShopLogger::addLog('TwoPayment: Deleted stale surcharge product ' . $productId . ' (reference mismatch)', 2);
+                    }
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('TwoPayment: Failed deleting stale surcharge product ' . $productId . ' - ' . $e->getMessage(), 2);
+                }
             }
             $productId = 0;
         }

--- a/twopayment.php
+++ b/twopayment.php
@@ -70,10 +70,14 @@ class Twopayment extends PaymentModule
     // on first use; identified by Configuration id + reference cross-check.
     const TWO_SURCHARGE_PRODUCT_REFERENCE = 'TWO-SURCHARGE-FEE';
     const CONFIG_SURCHARGE_PRODUCT_ID = 'PS_TWO_SURCHARGE_PRODUCT_ID';
-    // JSON snapshot of the Tax/TaxRulesGroup/TaxRule objects backing the
-    // surcharge product's tax, keyed by configured rate + covered countries,
-    // so tax setup is validated/id-driven instead of fuzzy DB lookups.
-    const CONFIG_SURCHARGE_TAX_SETUP = 'PS_TWO_SURCHARGE_TAX_SETUP';
+    // Merchant-selected TaxRulesGroup applied to the hidden surcharge
+    // product - the SAME id_tax_rules_group field every real Product uses,
+    // so the fee line gets PrestaShop's full native tax capability
+    // (per-country/state rules, additive stacking, destination-based
+    // zero-rating when no rule matches). 0 is core's first-class "No tax"
+    // sentinel. TWO-25071 (replaces the module-managed synthetic
+    // Tax/TaxRulesGroup/TaxRule graph + flat PS_TWO_SURCHARGE_TAX_RATE).
+    const CONFIG_SURCHARGE_TAX_RULES_GROUP = 'PS_TWO_SURCHARGE_TAX_RULES_GROUP';
 
     // Constants for delivery dates
     const DEFAULT_DELIVERY_DAYS_OFFSET = 7; // Default expected delivery date offset
@@ -526,63 +530,17 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         $this->deleteTwoSurchargeCartProduct();
-        $this->deleteTwoSurchargeTaxSetup();
         Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
-        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_SETUP);
+        // The merchant's own TaxRulesGroup referenced by this config is NOT
+        // module-owned: delete only the reference, never the group.
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        // Legacy config rows from the retired synthetic-tax implementation
+        // (pre-release builds only; the surcharge feature never shipped with
+        // them). The synthetic Tax/TaxRulesGroup/TaxRule objects themselves
+        // are no longer created and no longer cleaned up here.
+        Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_RATE');
+        Configuration::deleteByName('PS_TWO_SURCHARGE_TAX_SETUP');
         return true;
-    }
-
-    /**
-     * Best-effort removal of the module-managed Tax/TaxRulesGroup/TaxRule
-     * graph tracked in CONFIG_SURCHARGE_TAX_SETUP at uninstall. Historical
-     * orders keep their own copied tax rates on order_detail rows, so
-     * deleting the objects does not damage them. Never blocks uninstall.
-     */
-    protected function deleteTwoSurchargeTaxSetup()
-    {
-        try {
-            $setup = json_decode((string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP), true);
-            if (!is_array($setup)) {
-                return;
-            }
-
-            foreach ((array) (isset($setup['rules']) ? $setup['rules'] : array()) as $ruleId) {
-                try {
-                    if ((int) $ruleId > 0 && class_exists('TaxRule')) {
-                        $rule = new TaxRule((int) $ruleId);
-                        if (Validate::isLoadedObject($rule) && method_exists($rule, 'delete')) {
-                            $rule->delete();
-                        }
-                    }
-                } catch (Exception $e) {
-                    PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRule ' . (int) $ruleId . ' at uninstall - ' . $e->getMessage(), 2);
-                }
-            }
-
-            try {
-                if (!empty($setup['id_group']) && class_exists('TaxRulesGroup')) {
-                    $group = new TaxRulesGroup((int) $setup['id_group']);
-                    if (Validate::isLoadedObject($group) && method_exists($group, 'delete')) {
-                        $group->delete();
-                    }
-                }
-            } catch (Exception $e) {
-                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge TaxRulesGroup at uninstall - ' . $e->getMessage(), 2);
-            }
-
-            try {
-                if (!empty($setup['id_tax']) && class_exists('Tax')) {
-                    $tax = new Tax((int) $setup['id_tax']);
-                    if (Validate::isLoadedObject($tax) && method_exists($tax, 'delete')) {
-                        $tax->delete();
-                    }
-                }
-            } catch (Exception $e) {
-                PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge Tax at uninstall - ' . $e->getMessage(), 2);
-            }
-        } catch (Exception $e) {
-            PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge tax setup at uninstall - ' . $e->getMessage(), 2);
-        }
     }
 
     /**
@@ -6887,42 +6845,83 @@ class Twopayment extends PaymentModule
      * @param mixed $rate
      * @return float
      */
-    private function normalizeTwoFeeTaxRate($rate)
+    /**
+     * Merchant-selected TaxRulesGroup id for the hidden surcharge product
+     * (CONFIG_SURCHARGE_TAX_RULES_GROUP). 0 - also the unset/blank/garbage
+     * fallback - is PrestaShop's first-class "No tax" sentinel: fail-safe is
+     * an untaxed fee, never an invented rate. TWO-25071.
+     *
+     * @return int
+     */
+    public function getTwoSurchargeTaxRulesGroupId()
     {
-        if ($rate === null || $rate === '') {
-            return 0.0;
-        }
-        $rate = (float) $rate;
-        if ($rate <= 0) {
-            return 0.0;
-        }
-        if ($rate > 1.0) {
-            $rate = $rate / 100.0;
+        $raw = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($raw === false || $raw === null || !is_numeric($raw)) {
+            return 0;
         }
 
-        return $rate;
+        return max(0, (int) $raw);
     }
 
     /**
-     * Admin-configured Surcharge Tax Rate for the Two order-creation fee line
-     * (Magento parity: Config\Repository::getSurchargeTaxRate /
-     * XML_PATH_SURCHARGE_TAX_RATE), as a decimal FRACTION (stored "25" →
-     * 0.25) via the same normalizeTwoFeeTaxRate scaling convention the rest
-     * of the file uses. Returns 0.0 when the field is blank/unset/
-     * non-numeric/negative — deliberate deviation from Magento, whose blank
-     * fallback is the store's default product tax class rate: PrestaShop has
-     * no equivalent store-wide default tax rate concept.
+     * Effective tax rate (decimal FRACTION, e.g. 0.25) the selected
+     * TaxRulesGroup applies to the surcharge for THIS cart's tax destination
+     * - resolved through the SAME core machinery PrestaShop's own cart
+     * pricing uses for the hidden fee product (Product::priceCalculation):
+     * TaxManagerFactory over the cart's PS_TAX_ADDRESS_TYPE address, with
+     * the same shop-wide gates (PS_TAX off, vatnumber-module B2B exemption).
+     * Using one resolution for both the PS cart line and the Two payload is
+     * what makes the PR #64 parity gate unable to trip on destination-based
+     * rates. Empirically verified on PS 8.2.6 core: no matching rule for the
+     * destination -> 0 (zero-rating for free), combined multi-rate rules sum
+     * (6%+2% -> 8), group id 0 -> 0 everywhere.
      *
+     * @param Cart $cart
      * @return float
      */
-    public function getTwoSurchargeTaxRate()
+    public function getTwoSurchargeTaxRateForCart($cart)
     {
-        $raw = trim((string) Configuration::get('PS_TWO_SURCHARGE_TAX_RATE'));
-        if ($raw === '' || !is_numeric($raw)) {
+        $groupId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ($groupId <= 0 || !Validate::isLoadedObject($cart)) {
             return 0.0;
         }
 
-        return $this->normalizeTwoFeeTaxRate($raw);
+        // Shop-wide "disable taxes" switch (core: Tax::excludeTaxeOption
+        // inside Product::priceCalculation zeroes every product's tax).
+        if (class_exists('Tax') && method_exists('Tax', 'excludeTaxeOption')) {
+            if (Tax::excludeTaxeOption()) {
+                return 0.0;
+            }
+        } elseif (!Configuration::get('PS_TAX')) {
+            return 0.0;
+        }
+
+        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
+        if ($taxAddressField !== 'id_address_delivery') {
+            $taxAddressField = 'id_address_invoice';
+        }
+        $address = new Address((int) $cart->{$taxAddressField});
+        if (!Validate::isLoadedObject($address)) {
+            // No usable tax destination. Cannot legitimately happen at the
+            // payment step (PS requires addresses first); if it ever does,
+            // the payload carries no tax and the fail-closed parity gate /
+            // post-write sync verification blocks any divergence.
+            return 0.0;
+        }
+
+        // vatnumber-module B2B exemption - the exact condition core's
+        // Product::priceCalculation flips usetax off with.
+        if (
+            !empty($address->vat_number)
+            && (int) $address->id_country !== (int) Configuration::get('VATNUMBER_COUNTRY')
+            && Configuration::get('VATNUMBER_MANAGEMENT')
+        ) {
+            return 0.0;
+        }
+
+        $calculator = TaxManagerFactory::getManager($address, $groupId)->getTaxCalculator();
+
+        return max(0.0, (float) $calculator->getTotalRate()) / 100.0;
     }
 
     /**
@@ -6950,12 +6949,13 @@ class Twopayment extends PaymentModule
     /**
      * Build the buyer-surcharge line item for the Two order payload, or null
      * when no surcharge is configured / the quote fails / the fee is zero.
-     * The line's tax_rate carries the admin-configured Surcharge Tax Rate
-     * (PS_TWO_SURCHARGE_TAX_RATE via getTwoSurchargeTaxRate, Magento parity:
-     * XML_PATH_SURCHARGE_TAX_RATE) — NOT the pricing-preview response's
-     * total_fee_tax_rate, which the plugin never populates in its own
-     * /v1/pricing/order/fee request and is therefore always empty; net/tax/
-     * gross satisfy the Two line-item formulas so validateTwoLineItems
+     * The line's tax_rate is the merchant-selected TaxRulesGroup's effective
+     * rate for THIS cart's tax destination (getTwoSurchargeTaxRateForCart -
+     * the same core resolution PrestaShop applies to the hidden fee cart
+     * line, so the two sides cannot drift) — NOT the pricing-preview
+     * response's total_fee_tax_rate, which the plugin never populates in its
+     * own /v1/pricing/order/fee request and is therefore always empty; net/
+     * tax/gross satisfy the Two line-item formulas so validateTwoLineItems
      * accepts it.
      *
      * @param Cart     $cart
@@ -6993,10 +6993,11 @@ class Twopayment extends PaymentModule
         if ($net <= 0) {
             return null;
         }
-        // The rate comes from the admin-configured Surcharge Tax Rate — the
-        // pricing-preview response's total_fee_tax_rate is never populated
-        // (the plugin sends no tax-rate field in its own fee request), so it
-        // is NOT a usable source. Compute tax from the SAME rate string that
+        // The rate is the selected TaxRulesGroup's destination-resolved rate
+        // (getTwoSurchargeTaxRateForCart) — the pricing-preview response's
+        // total_fee_tax_rate is never populated (the plugin sends no
+        // tax-rate field in its own fee request), so it is NOT a usable
+        // source. Compute tax from the SAME rate string that
         // is sent (formatTwoTaxRate snaps to TAX_RATE_PRECISION dp). Using
         // the full-precision rate to compute tax while sending a rounded rate
         // makes the line fail validateTwoLineItems (tax_amount vs
@@ -7004,7 +7005,7 @@ class Twopayment extends PaymentModule
         // decimals, silently dropping the whole surcharge line. Snapping
         // first mirrors the product-line convention (snapped_product_rate).
         // TWO-24752.
-        $taxRate = $this->getTwoSurchargeTaxRate();
+        $taxRate = $this->getTwoSurchargeTaxRateForCart($cart);
         $taxRateString = $this->formatTwoTaxRate($taxRate);
         $sentRate = (float) $taxRateString;
         $tax = round($net * $sentRate, 2);
@@ -7248,7 +7249,7 @@ class Twopayment extends PaymentModule
         }
         $product->reference = self::TWO_SURCHARGE_PRODUCT_REFERENCE;
         $product->price = 0;
-        $product->id_tax_rules_group = 0;
+        $product->id_tax_rules_group = $this->getTwoSurchargeTaxRulesGroupId();
         $product->active = 1;
         $product->available_for_order = 1;
         $product->visibility = 'none';
@@ -7275,169 +7276,33 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Ensure the surcharge product carries a TaxRulesGroup whose rule for the
-     * cart's tax country applies exactly the admin-configured Surcharge Tax
-     * Rate (getTwoSurchargeTaxRate). Object graph (Tax + group + per-country
-     * rules) is tracked by id in CONFIG_SURCHARGE_TAX_SETUP and validated on
-     * every call, so a merchant deleting objects in the BO self-heals here.
-     * A configured-rate change creates a NEW Tax and re-points the rules
-     * (historical orders keep their order_detail rate copies).
+     * Ensure the hidden surcharge product carries the merchant-selected
+     * TaxRulesGroup (CONFIG_SURCHARGE_TAX_RULES_GROUP) - the exact same
+     * id_tax_rules_group assignment PrestaShop's own product-edit page
+     * makes, so core resolves the fee line's tax natively (per-destination
+     * rules, stacking, "No tax" id 0). Idempotent single-row self-heal: a
+     * merchant re-pointing or clearing the selection is picked up on the
+     * next cart sync. No synthetic Tax/TaxRulesGroup/TaxRule objects are
+     * created any more (TWO-25071); if the merchant deletes the selected
+     * group in the BO, core resolves 0 for every destination on BOTH the
+     * cart line and the Two payload (same resolution path), so parity holds.
      *
-     * @param Cart $cart
      * @param int $productId
-     * @return bool false when the tax setup could not be ensured
+     * @return bool false when the product could not be loaded/updated
      */
-    public function ensureTwoSurchargeTaxSetupForCart($cart, $productId)
+    public function ensureTwoSurchargeProductTaxRulesGroup($productId)
     {
-        $ratePercent = round($this->getTwoSurchargeTaxRate() * 100, 3);
-
         $product = new Product((int) $productId);
         if (!Validate::isLoadedObject($product)) {
             return false;
         }
 
-        if ($ratePercent <= 0) {
-            if ((int) $product->id_tax_rules_group !== 0) {
-                $product->id_tax_rules_group = 0;
-                $product->update();
-                $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
-            }
-            return true;
-        }
-
-        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
-        if ($taxAddressField !== 'id_address_delivery') {
-            $taxAddressField = 'id_address_invoice';
-        }
-        $address = new Address((int) $cart->{$taxAddressField});
-        $countryId = Validate::isLoadedObject($address) ? (int) $address->id_country : 0;
-        if ($countryId <= 0) {
-            return false;
-        }
-
-        // Advisory lock around the whole read-validate-create sequence: two
-        // concurrent first-time carts would otherwise both see an empty
-        // setup and create duplicate Tax/TaxRulesGroup/TaxRule graphs, with
-        // only one surviving in Configuration and the rest orphaned.
-        if (!$this->acquireTwoDbLock('two_surcharge_tax_setup')) {
-            PrestaShopLogger::addLog('TwoPayment: Surcharge tax setup lock not acquired', 2);
-            return false;
-        }
-        try {
-            return $this->ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId);
-        } finally {
-            $this->releaseTwoDbLock('two_surcharge_tax_setup');
-        }
-    }
-
-    /**
-     * Body of ensureTwoSurchargeTaxSetupForCart, executed while holding the
-     * two_surcharge_tax_setup advisory lock.
-     *
-     * @param Product $product
-     * @param float $ratePercent
-     * @param int $countryId
-     * @return bool
-     */
-    protected function ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId)
-    {
-        // Read the tracked setup UNDER the lock, straight from the DB: a
-        // concurrent winner's Configuration write is invisible to this
-        // request's per-request Configuration cache.
-        $setupJson = Db::getInstance()->getValue(
-            'SELECT `value` FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = '" . pSQL(self::CONFIG_SURCHARGE_TAX_SETUP) . "'"
-        );
-        if ($setupJson === false || $setupJson === null || $setupJson === '') {
-            $setupJson = (string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP);
-        }
-        $setup = json_decode((string) $setupJson, true);
-        if (!is_array($setup)) {
-            $setup = array();
-        }
-        $setup += array('rate_percent' => null, 'id_tax' => 0, 'id_group' => 0, 'rules' => array());
-
-        // Group: validate stored id, else create.
-        $group = $setup['id_group'] > 0 ? new TaxRulesGroup((int) $setup['id_group']) : null;
-        if ($group === null || !Validate::isLoadedObject($group)) {
-            $group = new TaxRulesGroup();
-            $group->name = 'Two payment terms fee tax';
-            $group->active = 1;
-            if (!$group->add()) {
+        $groupId = $this->getTwoSurchargeTaxRulesGroupId();
+        if ((int) $product->id_tax_rules_group !== $groupId) {
+            $product->id_tax_rules_group = $groupId;
+            if (!$product->update()) {
                 return false;
             }
-            $setup['id_group'] = (int) $group->id;
-            $setup['rules'] = array(); // stale rules belonged to the lost group
-        }
-
-        // Tax at the configured rate: validate stored id + rate, else create.
-        $tax = $setup['id_tax'] > 0 ? new Tax((int) $setup['id_tax']) : null;
-        $taxValid = $tax !== null && Validate::isLoadedObject($tax)
-            && abs(round((float) $tax->rate, 3) - $ratePercent) < 0.0005;
-        if (!$taxValid) {
-            $tax = new Tax();
-            $tax->name = array();
-            $languageIds = array();
-            foreach ((array) Language::getLanguages(false) as $lang) {
-                if (isset($lang['id_lang'])) {
-                    $languageIds[] = (int) $lang['id_lang'];
-                }
-            }
-            if (empty($languageIds)) {
-                $languageIds[] = isset($this->context->language->id) ? (int) $this->context->language->id : 1;
-            }
-            foreach ($languageIds as $idLang) {
-                $tax->name[$idLang] = 'Two surcharge VAT ' . $this->getTwoRoundAmount($ratePercent) . '%';
-            }
-            $tax->rate = $ratePercent;
-            $tax->active = 1;
-            if (!$tax->add()) {
-                return false;
-            }
-            $setup['id_tax'] = (int) $tax->id;
-
-            // Rate changed: re-point every existing per-country rule at the
-            // new Tax so previously-served countries keep working.
-            foreach ((array) $setup['rules'] as $ruleCountryId => $ruleId) {
-                $rule = new TaxRule((int) $ruleId);
-                if (Validate::isLoadedObject($rule)) {
-                    $rule->id_tax = (int) $tax->id;
-                    $rule->update();
-                } else {
-                    unset($setup['rules'][$ruleCountryId]);
-                }
-            }
-        }
-
-        // Rule for the cart's tax country: validate stored id, else create.
-        $ruleId = isset($setup['rules'][$countryId]) ? (int) $setup['rules'][$countryId] : 0;
-        $rule = $ruleId > 0 ? new TaxRule($ruleId) : null;
-        if ($rule === null || !Validate::isLoadedObject($rule) || (int) $rule->id_tax !== (int) $setup['id_tax']) {
-            if ($rule !== null && Validate::isLoadedObject($rule)) {
-                $rule->id_tax = (int) $setup['id_tax'];
-                $rule->update();
-            } else {
-                $rule = new TaxRule();
-                $rule->id_tax_rules_group = (int) $setup['id_group'];
-                $rule->id_country = $countryId;
-                $rule->id_state = 0;
-                $rule->zipcode_from = 0;
-                $rule->zipcode_to = 0;
-                $rule->id_tax = (int) $setup['id_tax'];
-                $rule->behavior = 0;
-                $rule->description = '';
-                if (!$rule->add()) {
-                    return false;
-                }
-                $setup['rules'][$countryId] = (int) $rule->id;
-            }
-        }
-
-        $setup['rate_percent'] = $ratePercent;
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_SETUP, json_encode($setup));
-
-        if ((int) $product->id_tax_rules_group !== (int) $setup['id_group']) {
-            $product->id_tax_rules_group = (int) $setup['id_group'];
-            $product->update();
             $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
         }
 
@@ -7451,9 +7316,9 @@ class Twopayment extends PaymentModule
      * the product's group via Product::getIdTaxRulesGroupByIdProduct, which
      * memoises 'product_id_tax_rules_group_{id}_{shop}' in Cache. The value
      * gets primed with 0 during product creation, and Product::update does
-     * NOT clean it - so the very first request that creates the tax setup
-     * would price the fee line WITHOUT tax (gross == net) while the Two
-     * payload carries tax, and the stale line would then never self-correct
+     * NOT clean it - so the very first request that re-points the product's
+     * tax rules group would price the fee line WITHOUT tax (gross == net)
+     * while the Two payload carries tax, and the stale line would then never self-correct
      * (the sync no-op check compares net, which matches). Cleaning the exact
      * key here makes the first request price correctly.
      *
@@ -7899,8 +7764,8 @@ class Twopayment extends PaymentModule
                 return $result;
             }
 
-            if (!$this->ensureTwoSurchargeTaxSetupForCart($cart, $productId)) {
-                PrestaShopLogger::addLog('TwoPayment: Surcharge cart line skipped - tax setup could not be ensured for cart ' . (int) $cart->id, 3);
+            if (!$this->ensureTwoSurchargeProductTaxRulesGroup($productId)) {
+                PrestaShopLogger::addLog('TwoPayment: Surcharge cart line skipped - tax rules group could not be applied to product ' . (int) $productId . ' for cart ' . (int) $cart->id, 3);
                 return $result;
             }
 
@@ -7935,7 +7800,7 @@ class Twopayment extends PaymentModule
                     ' - expected (net/gross)=(' . $this->getTwoRoundAmount($expectedNet) . '/' . $this->getTwoRoundAmount($expectedGross) .
                     '), cart applied ' . ($written === null ? 'no line' :
                         '(net/gross)=(' . $this->getTwoRoundAmount($written['net']) . '/' . $this->getTwoRoundAmount($written['gross']) . ')') .
-                    '. Line removed; check the shop tax configuration for the surcharge tax rate.',
+                    '. Line removed; check the selected surcharge tax rules group configuration.',
                     3
                 );
                 $this->removeTwoSurchargeCartLineInternal($cart, $productId);
@@ -8327,11 +8192,15 @@ class Twopayment extends PaymentModule
             'options' => array('query' => $stepQuery, 'id' => 'id', 'name' => 'name'),
         );
         $inputs[] = array(
-            'type' => 'text',
-            'label' => $this->l('Surcharge Tax Rate (%)'),
-            'name' => 'PS_TWO_SURCHARGE_TAX_RATE',
-            'suffix' => '%',
-            'desc' => $this->l('Tax rate applied to the surcharge line sent to Two (e.g. 25 for 25%). Leave blank for no tax on the surcharge line.'),
+            'type' => 'select',
+            'label' => $this->l('Surcharge Tax Rules Group'),
+            'name' => self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
+            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee.'),
+            'options' => array(
+                'query' => $this->getTwoSurchargeTaxRulesGroupOptions(),
+                'id' => 'id',
+                'name' => 'name',
+            ),
         );
         $inputs[] = array(
             'type' => 'html',
@@ -8414,6 +8283,59 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Dropdown options for the surcharge tax rules group: PrestaShop's
+     * "No tax" sentinel (id 0) followed by the merchant's active tax rules
+     * groups - the same list core's own product-edit page offers (its
+     * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
+     * rate, so the deduplicated getTaxRulesGroups source is used with the
+     * same manual "No tax" prepend).
+     *
+     * @return array<int,array{id:int,name:string}>
+     */
+    protected function getTwoSurchargeTaxRulesGroupOptions()
+    {
+        $options = array(
+            array('id' => 0, 'name' => $this->l('No tax')),
+        );
+        $groups = TaxRulesGroup::getTaxRulesGroups(true);
+        foreach ((array) $groups as $group) {
+            if (!isset($group['id_tax_rules_group'])) {
+                continue;
+            }
+            $options[] = array(
+                'id' => (int) $group['id_tax_rules_group'],
+                'name' => (string) $group['name'],
+            );
+        }
+
+        return $options;
+    }
+
+    /**
+     * Pre-selection for the surcharge tax rules group dropdown: the stored
+     * selection, else the merchant's "standard" group - the one most of
+     * their catalog uses (Product::getIdTaxRulesGroupMostUsed, the same
+     * default heuristic core's product page uses for new products). Display
+     * default only: runtime behaviour for an UNSAVED config stays "No tax"
+     * (getTwoSurchargeTaxRulesGroupId) - the module never taxes the fee on
+     * a rate the merchant did not confirm by saving.
+     *
+     * @return int
+     */
+    protected function getTwoSurchargeTaxRulesGroupFormDefault()
+    {
+        $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
+            return max(0, (int) $stored);
+        }
+        if (method_exists('Product', 'getIdTaxRulesGroupMostUsed')) {
+            return max(0, (int) Product::getIdTaxRulesGroupMostUsed());
+        }
+
+        return 0;
+    }
+
+    /**
      * Current values for the surcharge form fields.
      *
      * @return array
@@ -8426,7 +8348,10 @@ class Twopayment extends PaymentModule
             'PS_TWO_SURCHARGE_LINE_DESC' => Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', Configuration::get('PS_TWO_SURCHARGE_LINE_DESC')),
             'PS_TWO_SURCHARGE_ROUNDING_BASIS' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS')),
             'PS_TWO_SURCHARGE_ROUNDING_STEP' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP')),
-            'PS_TWO_SURCHARGE_TAX_RATE' => Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE', Configuration::get('PS_TWO_SURCHARGE_TAX_RATE')),
+            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (int) Tools::getValue(
+                self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
+                $this->getTwoSurchargeTaxRulesGroupFormDefault()
+            ),
         );
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;
@@ -8453,9 +8378,12 @@ class Twopayment extends PaymentModule
         if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
             $this->errors[] = $this->l('Rounding step must be one of the offered values.');
         }
-        $taxRate = Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE');
-        if ($taxRate !== false && $taxRate !== '' && (!is_numeric($taxRate) || (float) $taxRate < 0)) {
-            $this->errors[] = $this->l('Surcharge tax rate must be a non-negative number.');
+        $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
+        if ($groupRaw !== false && $groupRaw !== '') {
+            $groupId = is_numeric($groupRaw) ? (int) $groupRaw : -1;
+            if ($groupId < 0 || ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId)))) {
+                $this->errors[] = $this->l('Surcharge tax rules group must be "No tax" or one of the shop\'s existing tax rules groups.');
+            }
         }
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;
@@ -8491,13 +8419,23 @@ class Twopayment extends PaymentModule
         }
         Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', $step);
 
-        // Same coercion discipline as the grid: invalid input is stored as
-        // blank (→ getTwoSurchargeTaxRate() falls back to 0.0), never fatal.
-        $taxRateRaw = trim((string) Tools::getValue('PS_TWO_SURCHARGE_TAX_RATE', ''));
-        Configuration::updateValue(
-            'PS_TWO_SURCHARGE_TAX_RATE',
-            (is_numeric($taxRateRaw) && (float) $taxRateRaw >= 0) ? (string) (float) $taxRateRaw : ''
-        );
+        // Same coercion discipline as the grid: invalid/unknown input is
+        // stored as 0 ("No tax" - getTwoSurchargeTaxRulesGroupId's fail-safe),
+        // never fatal. A group id is only stored when the group exists.
+        $groupRaw = trim((string) Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, ''));
+        $groupId = (is_numeric($groupRaw) && (int) $groupRaw > 0) ? (int) $groupRaw : 0;
+        if ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
+            $groupId = 0;
+        }
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
+
+        // Apply the selection to the hidden fee product immediately (the
+        // same id_tax_rules_group field every real Product uses); if the
+        // product does not exist yet, lazy creation picks the config up.
+        $productId = (int) Configuration::get(self::CONFIG_SURCHARGE_PRODUCT_ID);
+        if ($productId > 0) {
+            $this->ensureTwoSurchargeProductTaxRulesGroup($productId);
+        }
 
         foreach ($this->getAvailablePaymentTerms() as $days) {
             $days = (int) $days;

--- a/twopayment.php
+++ b/twopayment.php
@@ -8236,7 +8236,7 @@ class Twopayment extends PaymentModule
             'type' => 'select',
             'label' => $this->l('Surcharge Tax Rules Group'),
             'name' => self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
-            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee.'),
+            'desc' => $this->l('Tax rules group applied to the payment terms fee - the same tax rules groups you assign to products. Country and state rules, combined rates and zero-rating apply exactly as they do for any product. Select "No tax" to never tax the fee. A selection is required while surcharges are enabled.'),
             'options' => array(
                 'query' => $this->getTwoSurchargeTaxRulesGroupOptions(),
                 'id' => 'id',
@@ -8324,23 +8324,28 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Dropdown options for the surcharge tax rules group: PrestaShop's
-     * "No tax" sentinel (id 0) followed by the merchant's active tax rules
-     * groups - the same list core's own product-edit page offers (its
+     * Dropdown options for the surcharge tax rules group: an unselected
+     * placeholder (id '' - never a valid selection, save-blocked while
+     * surcharges are enabled, see validTwoSurchargeFormValues), then
+     * PrestaShop's "No tax" sentinel (id 0), then the merchant's active tax
+     * rules groups - the same list core's own product-edit page offers (its
      * TaxRulesGroup::getTaxRulesGroupsForOptions duplicates a group per
      * rate, so the deduplicated getTaxRulesGroups source is used with the
-     * same manual "No tax" prepend). The currently-configured group is
-     * ALWAYS present even when deactivated (suffixed "(inactive)"): if a
-     * stale selection dropped out of the list, the browser would submit the
-     * first option ("No tax", id 0) on the next unrelated settings save and
-     * silently detax the surcharge.
+     * same manual "No tax" prepend). Ids are emitted as STRINGS so the
+     * form template's loose == never conflates the placeholder ('') with
+     * "No tax" ('0') on PHP 7 shops ('' == 0 is true there). The
+     * currently-configured group is ALWAYS present even when deactivated
+     * (suffixed "(inactive)"): if a stale selection dropped out of the
+     * list, the browser would submit the first option (the placeholder) on
+     * the next unrelated settings save and silently unset the treatment.
      *
-     * @return array<int,array{id:int,name:string}>
+     * @return array<int,array{id:string,name:string}>
      */
     protected function getTwoSurchargeTaxRulesGroupOptions()
     {
         $options = array(
-            array('id' => 0, 'name' => $this->l('No tax')),
+            array('id' => '', 'name' => $this->l('-- Select surcharge tax treatment --')),
+            array('id' => '0', 'name' => $this->l('No tax')),
         );
         $groups = TaxRulesGroup::getTaxRulesGroups(true);
         $seen = array(0 => true);
@@ -8350,7 +8355,7 @@ class Twopayment extends PaymentModule
             }
             $id = (int) $group['id_tax_rules_group'];
             $options[] = array(
-                'id' => $id,
+                'id' => (string) $id,
                 'name' => (string) $group['name'],
             );
             $seen[$id] = true;
@@ -8361,7 +8366,7 @@ class Twopayment extends PaymentModule
             $configured = new TaxRulesGroup($configuredId);
             if (Validate::isLoadedObject($configured)) {
                 $options[] = array(
-                    'id' => $configuredId,
+                    'id' => (string) $configuredId,
                     'name' => (string) $configured->name . ' (' . $this->l('inactive') . ')',
                 );
             }
@@ -8372,23 +8377,25 @@ class Twopayment extends PaymentModule
 
     /**
      * Pre-selection for the surcharge tax rules group dropdown: the stored
-     * selection, else "No tax" (0) - the merchant must make an explicit
-     * choice. Deliberately NOT Product::getIdTaxRulesGroupMostUsed(): that
-     * is a full-catalog COUNT/GROUP BY re-run on every unsaved config page
-     * render, and pre-selecting a taxing group the merchant never chose
-     * invites an accidental save. Matches runtime behaviour for an UNSAVED
-     * config (getTwoSurchargeTaxRulesGroupId falls back to "No tax").
+     * selection, else '' - the unselected placeholder. NEVER auto-defaults:
+     * not Product::getIdTaxRulesGroupMostUsed() (a full-catalog COUNT/GROUP
+     * BY re-run on every unsaved config page render, pre-selecting a taxing
+     * group the merchant never chose), and not "No tax" either - untaxed is
+     * a tax treatment, not an absence of one, and pre-selecting it invites
+     * an accidental save. The merchant must pick explicitly; while
+     * surcharges are enabled the save is blocked until they do
+     * (validTwoSurchargeFormValues).
      *
-     * @return int
+     * @return string '' (unselected) or the stored group id ('0' = No tax)
      */
     protected function getTwoSurchargeTaxRulesGroupFormDefault()
     {
         $stored = Configuration::get(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
         if ($stored !== false && $stored !== null && $stored !== '' && is_numeric($stored)) {
-            return max(0, (int) $stored);
+            return (string) max(0, (int) $stored);
         }
 
-        return 0;
+        return '';
     }
 
     /**
@@ -8404,7 +8411,10 @@ class Twopayment extends PaymentModule
             'PS_TWO_SURCHARGE_LINE_DESC' => Tools::getValue('PS_TWO_SURCHARGE_LINE_DESC', Configuration::get('PS_TWO_SURCHARGE_LINE_DESC')),
             'PS_TWO_SURCHARGE_ROUNDING_BASIS' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_BASIS', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_BASIS')),
             'PS_TWO_SURCHARGE_ROUNDING_STEP' => Tools::getValue('PS_TWO_SURCHARGE_ROUNDING_STEP', Configuration::get('PS_TWO_SURCHARGE_ROUNDING_STEP')),
-            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (int) Tools::getValue(
+            // Kept a STRING ('' = unselected placeholder): an (int) cast
+            // would turn the unselected state into 0 and silently
+            // pre-select "No tax".
+            self::CONFIG_SURCHARGE_TAX_RULES_GROUP => (string) Tools::getValue(
                 self::CONFIG_SURCHARGE_TAX_RULES_GROUP,
                 $this->getTwoSurchargeTaxRulesGroupFormDefault()
             ),
@@ -8434,9 +8444,19 @@ class Twopayment extends PaymentModule
         if ($step !== '' && !array_key_exists($step, $this->getTwoRoundingStepOptions())) {
             $this->errors[] = $this->l('Rounding step must be one of the offered values.');
         }
+        // Surcharges are enabled (type !== 'none' - the early return above):
+        // an explicit tax treatment is REQUIRED. The unselected placeholder
+        // ('' / absent) blocks the save server-side - never silently falls
+        // back to "No tax".
         $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP);
-        if ($groupRaw !== false && $groupRaw !== '') {
-            $groupId = is_numeric($groupRaw) ? (int) $groupRaw : -1;
+        $groupTrimmed = is_string($groupRaw) ? trim($groupRaw) : '';
+        if ($groupTrimmed === '') {
+            $this->errors[] = $this->l('Select a surcharge tax treatment: surcharges are enabled, so you must explicitly choose a tax rules group (or "No tax") before saving.');
+        } else {
+            // ctype_digit: a whole non-negative integer only - '0.5', '-5'
+            // and friends are rejected, never truncated into a selection
+            // the merchant did not make.
+            $groupId = ctype_digit($groupTrimmed) ? (int) $groupTrimmed : -1;
             if ($groupId < 0 || ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId)))) {
                 $this->errors[] = $this->l('Surcharge tax rules group must be "No tax" or one of the shop\'s existing tax rules groups.');
             }
@@ -8475,18 +8495,30 @@ class Twopayment extends PaymentModule
         }
         Configuration::updateValue('PS_TWO_SURCHARGE_ROUNDING_STEP', $step);
 
-        // Same coercion discipline as the grid: invalid/unknown input is
-        // stored as 0 ("No tax" - getTwoSurchargeTaxRulesGroupId's fail-safe),
-        // never fatal. A group id is only stored when the group exists.
-        $groupRaw = trim((string) Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, ''));
-        $groupId = (is_numeric($groupRaw) && (int) $groupRaw > 0) ? (int) $groupRaw : 0;
-        if ($groupId > 0 && !Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
-            $groupId = 0;
+        // NEVER silently coerce to "No tax": absent/blank/invalid input is
+        // stored as '' (unselected - the dropdown re-renders on its
+        // placeholder). While surcharges are enabled this path is
+        // unreachable with '' (validTwoSurchargeFormValues blocks the save
+        // first); while disabled, staying unselected is the point - the
+        // merchant must pick explicitly before enabling. '0' ("No tax") is
+        // only ever stored when the merchant submitted it.
+        $groupRaw = Tools::getValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, '');
+        $groupTrimmed = is_string($groupRaw) ? trim($groupRaw) : '';
+        $groupValue = '';
+        if ($groupTrimmed !== '' && ctype_digit($groupTrimmed)) {
+            $groupId = (int) $groupTrimmed;
+            if ($groupId === 0 || Validate::isLoadedObject(new TaxRulesGroup($groupId))) {
+                $groupValue = (string) $groupId;
+            }
         }
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, (string) $groupId);
-        // Explicit merchant save (any value, "No tax" included) retires the
-        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php.
-        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_RULES_GROUP, $groupValue);
+        // An explicit merchant selection ("No tax" included) retires the
+        // post-upgrade "needs re-selection" nag from upgrade-2.5.0.php. A
+        // save that stored '' (still unselected) does NOT - the nag is
+        // accurate until a real choice is made.
+        if ($groupValue !== '') {
+            Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_MIGRATION_NOTICE, '');
+        }
 
         // Apply the selection to the hidden fee product immediately (the
         // same id_tax_rules_group field every real Product uses); if the

--- a/twopayment.php
+++ b/twopayment.php
@@ -63,7 +63,18 @@ class Twopayment extends PaymentModule
     // Two module currency coverage baseline: keep these provider currencies explicitly allowed.
     // Required coverage: NOK, GBP, SEK, USD, DKK, EUR
     const TWO_SUPPORTED_CURRENCY_ISOS = ['NOK', 'GBP', 'SEK', 'USD', 'DKK', 'EUR'];
-    
+
+    // Hidden virtual product that mirrors the Two buyer surcharge as a REAL
+    // PrestaShop cart line, so the fee shows in the order summary, cart,
+    // order and invoice (not only on the Two-side invoice). Lazily created
+    // on first use; identified by Configuration id + reference cross-check.
+    const TWO_SURCHARGE_PRODUCT_REFERENCE = 'TWO-SURCHARGE-FEE';
+    const CONFIG_SURCHARGE_PRODUCT_ID = 'PS_TWO_SURCHARGE_PRODUCT_ID';
+    // JSON snapshot of the Tax/TaxRulesGroup/TaxRule objects backing the
+    // surcharge product's tax, keyed by configured rate + covered countries,
+    // so tax setup is validated/id-driven instead of fuzzy DB lookups.
+    const CONFIG_SURCHARGE_TAX_SETUP = 'PS_TWO_SURCHARGE_TAX_SETUP';
+
     // Constants for delivery dates
     const DEFAULT_DELIVERY_DAYS_OFFSET = 7; // Default expected delivery date offset
     
@@ -157,6 +168,7 @@ class Twopayment extends PaymentModule
 
         $required_hooks = array(
             'actionObjectOrderHistoryAddBefore',
+            'actionFrontControllerInitAfter',
         );
 
         foreach ($required_hooks as $hook_name) {
@@ -248,6 +260,7 @@ class Twopayment extends PaymentModule
             $this->registerHook('actionOrderEdited') &&
             $this->registerHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->registerHook('actionCustomerAddressSave') &&
+            $this->registerHook('actionFrontControllerInitAfter') &&
             $this->installTwoInvoiceAdminTab() &&
             $this->installTwoSettings() &&
             $this->createTwoOrderState() &&
@@ -470,6 +483,7 @@ class Twopayment extends PaymentModule
             $this->unregisterHook('actionOrderEdited') &&
             $this->unregisterHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->unregisterHook('actionCustomerAddressSave') &&
+            $this->unregisterHook('actionFrontControllerInitAfter') &&
             $this->uninstallTwoInvoiceAdminTab() &&
             $this->uninstallTwoSettings() &&
             $this->deleteTwoTables();
@@ -493,7 +507,30 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
+        $this->deleteTwoSurchargeCartProduct();
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
+        Configuration::deleteByName(self::CONFIG_SURCHARGE_TAX_SETUP);
         return true;
+    }
+
+    /**
+     * Best-effort removal of the hidden surcharge product at uninstall.
+     * Order details keep their own copied rows, so deleting the product does
+     * not damage historical orders. Never blocks uninstall on failure.
+     */
+    protected function deleteTwoSurchargeCartProduct()
+    {
+        try {
+            $productId = (int) Configuration::get(self::CONFIG_SURCHARGE_PRODUCT_ID);
+            if ($productId > 0 && class_exists('Product')) {
+                $product = new Product($productId);
+                if (Validate::isLoadedObject($product) && method_exists($product, 'delete')) {
+                    $product->delete();
+                }
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Failed deleting surcharge product at uninstall - ' . $e->getMessage(), 2);
+        }
     }
 
     protected function deleteTwoTables()
@@ -2707,6 +2744,9 @@ class Twopayment extends PaymentModule
                 'countries' => $param_countries,
                 'available_payment_terms' => $this->getAvailablePaymentTerms(),
                 'default_payment_term' => $this->getDefaultPaymentTerm(),
+                // Enables the checkout JS to mirror the buyer surcharge as a
+                // real PrestaShop cart line on payment-option selection.
+                'surcharge_cart_line' => !empty($this->getTwoSurchargeSettings()['enabled']),
                 'payment_term_type' => Configuration::get('PS_TWO_PAYMENT_TERM_TYPE'),
                 'i18n' => $i18n,
                 'phone_i18n' => array(
@@ -2915,8 +2955,19 @@ class Twopayment extends PaymentModule
      * @return array
      * @throws Exception
      */
-    private function buildTwoOrderPricingData($cart, $contextLabel = 'order payload', $strictReconciliation = false, $paymentTermDays = null)
+    private function buildTwoOrderPricingData($cart, $contextLabel = 'order payload', $strictReconciliation = false, $paymentTermDays = null, $syncSurchargeCartLine = false)
     {
+        // Money-critical self-heal (create + strict-submit paths only; never
+        // the update path, whose cart belongs to an already-placed order):
+        // reconcile the cart's surcharge line with the fee this payload will
+        // carry BEFORE totals are read, so a missed/failed frontend sync
+        // (broken theme JS, raced AJAX) cannot ship a PrestaShop total that
+        // diverges from the Two invoice. The parity gate below then verifies
+        // the result and fails closed on any residual mismatch.
+        if ($syncSurchargeCartLine) {
+            $this->syncTwoSurchargeCartLine($cart, true);
+        }
+
         $line_items = $this->getTwoProductItems($cart);
         if (empty($line_items)) {
             PrestaShopLogger::addLog('TwoPayment: Cannot build ' . $contextLabel . ' - no valid line items', 3);
@@ -2979,6 +3030,40 @@ class Twopayment extends PaymentModule
             $line_items[] = $surchargeLine;
             $tax_subtotals = $this->getTwoTaxSubtotals($line_items);
             $subtotalsTotals = $this->calculateOrderTotalsFromTaxSubtotals($tax_subtotals);
+        } else {
+            $surchargeLine = null;
+        }
+
+        // PARITY GATE (the single most important correctness edge of the
+        // surcharge-as-cart-line feature): the fee PrestaShop charges the
+        // buyer (hidden virtual product line) and the fee the Two payload
+        // carries must be the same money. On the create/strict paths a
+        // mismatch beyond ORDER_RECONCILIATION_TOLERANCE throws - checkout
+        // fails with a retryable error instead of ever creating an order
+        // whose PrestaShop total diverges from the Two invoice. The update
+        // path and the non-strict intent precheck log a warning only
+        // (pre-feature orders legitimately have no cart line).
+        $cartSurchargeLine = $this->getTwoSurchargeCartLine($cart);
+        $payloadFeeGrossCents = $surchargeLine !== null ? $this->convertAmountToCents($surchargeLine['gross_amount']) : 0;
+        $payloadFeeNetCents = $surchargeLine !== null ? $this->convertAmountToCents($surchargeLine['net_amount']) : 0;
+        $cartFeeGrossCents = $cartSurchargeLine !== null ? $this->convertAmountToCents($cartSurchargeLine['gross']) : 0;
+        $cartFeeNetCents = $cartSurchargeLine !== null ? $this->convertAmountToCents($cartSurchargeLine['net']) : 0;
+        $surchargeParityDiffCents = max(
+            abs($payloadFeeGrossCents - $cartFeeGrossCents),
+            abs($payloadFeeNetCents - $cartFeeNetCents)
+        );
+        $enforceSurchargeParity = (bool) $syncSurchargeCartLine;
+        if ($surchargeParityDiffCents > $this->convertAmountToCents(self::ORDER_RECONCILIATION_TOLERANCE)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: ' . $contextLabel . ' surcharge parity mismatch - cart line (net/gross)=(' .
+                $this->getTwoRoundAmount($cartFeeNetCents / 100) . '/' . $this->getTwoRoundAmount($cartFeeGrossCents / 100) .
+                ') vs payload fee line (net/gross)=(' .
+                $this->getTwoRoundAmount($payloadFeeNetCents / 100) . '/' . $this->getTwoRoundAmount($payloadFeeGrossCents / 100) . ')',
+                $enforceSurchargeParity ? 3 : 2
+            );
+            if ($enforceSurchargeParity) {
+                throw new Exception('Surcharge line mismatch between cart and Two payload');
+            }
         }
 
         return [
@@ -3043,6 +3128,14 @@ class Twopayment extends PaymentModule
 
         $cartGross = round((float)$cart->getOrderTotal(true, Cart::BOTH), 2);
         $cartNet = round((float)$cart->getOrderTotal(false, Cart::BOTH), 2);
+        // The hidden surcharge line is excluded from the product line items
+        // (its payload counterpart is appended AFTER this gate), so subtract
+        // its cart-side totals to compare like with like.
+        $surchargeCartLine = $this->getTwoSurchargeCartLine($cart);
+        if ($surchargeCartLine !== null && ($cartGross != 0.0 || $cartNet != 0.0)) {
+            $cartGross = round($cartGross - $surchargeCartLine['gross'], 2);
+            $cartNet = round($cartNet - $surchargeCartLine['net'], 2);
+        }
         if ($cart->nbProducts() > 0 && $cartGross == 0.0 && $cartNet == 0.0) {
             PrestaShopLogger::addLog(
                 'TwoPayment: Cart totals unavailable for ' . $contextLabel . '; skipping strict reconciliation gate.',
@@ -3167,7 +3260,9 @@ class Twopayment extends PaymentModule
         $contextLabel = (bool)$strictReconciliation ? 'order intent strict submit' : 'order intent';
         // Order intent pre-check remains permissive for UX refresh checks.
         // Payment-submit authoritative intent checks must be strict.
-        $pricingData = $this->buildTwoOrderPricingData($cart, $contextLabel, (bool)$strictReconciliation);
+        // Strict submit is the authoritative pre-create check: self-heal the
+        // cart's surcharge line and enforce cart-vs-payload fee parity.
+        $pricingData = $this->buildTwoOrderPricingData($cart, $contextLabel, (bool)$strictReconciliation, null, (bool)$strictReconciliation);
         $line_items = $pricingData['line_items'];
         $tax_subtotals = $pricingData['tax_subtotals'];
         $final_net = $pricingData['net_amount'];
@@ -3517,7 +3612,7 @@ class Twopayment extends PaymentModule
             }
         }
 
-        $pricingData = $this->buildTwoOrderPricingData($cart, 'order data (merchant_order_id=' . $merchant_order_id . ')');
+        $pricingData = $this->buildTwoOrderPricingData($cart, 'order data (merchant_order_id=' . $merchant_order_id . ')', false, null, true);
         $line_items = $pricingData['line_items'];
         $tax_subtotals = $pricingData['tax_subtotals'];
         $final_net = $pricingData['net_amount'];
@@ -3759,8 +3854,17 @@ class Twopayment extends PaymentModule
             return $items; // Return empty array (caller should handle empty cart)
         }
         $known_product_rate_candidates = $this->collectTwoKnownTaxRatesFromConfiguredProductRates($line_items);
-        
+        $surchargeProductId = $this->getTwoSurchargeCartProductId(false);
+
         foreach ($line_items as $line_item) {
+            // The hidden surcharge product is NOT merchandise: the Two payload
+            // carries the fee as its own appended SERVICE line
+            // (buildTwoSurchargeLineItemForCart), and the fee basis must never
+            // include the fee itself. Skip it here; reconciliation subtracts
+            // its cart totals symmetrically.
+            if ($surchargeProductId > 0 && (int) $line_item['id_product'] === $surchargeProductId) {
+                continue;
+            }
             $categories = Product::getProductCategoriesFull($line_item['id_product'], $cart->id_lang);
             $image = Image::getCover($line_item['id_product']);
             $imagePath = $this->context->link->getImageLink($line_item['link_rewrite'], $image['id_image'], ImageType::getFormattedName('home'));
@@ -6882,6 +6986,12 @@ class Twopayment extends PaymentModule
             // gross (getTwoNewOrderData) — NOT the full line-item pipeline,
             // which is far too heavy for a render-time preview call.
             $gross_basis = round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
+            // The hidden surcharge line must never feed its own basis: quote
+            // every term against the merchandise+shipping total only.
+            $surchargeCartLine = $this->getTwoSurchargeCartLine($cart);
+            if ($surchargeCartLine !== null) {
+                $gross_basis = round($gross_basis - $surchargeCartLine['gross'], 2);
+            }
             if ($gross_basis <= 0) {
                 // Empty cart / anonymous probe: nothing to quote against —
                 // the JS clears the chips' loading indicators to blank.
@@ -6914,6 +7024,615 @@ class Twopayment extends PaymentModule
         } catch (\Throwable $e) {
             // Checkout render must never break on a preview quote.
             return array('success' => false);
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Surcharge as a REAL PrestaShop cart line (hidden virtual product)  *
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Id of the hidden virtual product mirroring the Two buyer surcharge in
+     * the PrestaShop cart. Lazily created on first use (more robust than
+     * install-time creation: survives DB restores, module upgrades from
+     * versions without the product, and accidental catalog deletion). The
+     * stored id is cross-checked against the product reference so a recycled
+     * id can never silently point at a different catalog product.
+     *
+     * @param bool $createIfMissing
+     * @return int 0 when missing and creation was not requested / failed
+     */
+    public function getTwoSurchargeCartProductId($createIfMissing = false)
+    {
+        $productId = (int) Configuration::get(self::CONFIG_SURCHARGE_PRODUCT_ID);
+        if ($productId > 0) {
+            $product = new Product($productId);
+            if (
+                Validate::isLoadedObject($product)
+                && isset($product->reference)
+                && (string) $product->reference === self::TWO_SURCHARGE_PRODUCT_REFERENCE
+            ) {
+                return $productId;
+            }
+            $productId = 0;
+        }
+
+        if (!$createIfMissing) {
+            return 0;
+        }
+
+        try {
+            $productId = $this->createTwoSurchargeCartProduct();
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Failed creating surcharge cart product - ' . $e->getMessage(), 3);
+            return 0;
+        }
+        if ($productId > 0) {
+            Configuration::updateValue(self::CONFIG_SURCHARGE_PRODUCT_ID, $productId);
+        }
+
+        return $productId;
+    }
+
+    /**
+     * Create the hidden virtual surcharge product. Empirically verified
+     * pattern on PS8 core: visibility 'none' keeps it out of catalog, search
+     * and listings; indexed=0 keeps it out of the search index; is_virtual=1
+     * bypasses all shipping/carrier logic; active=1 + available_for_order=1
+     * + out_of_stock=1 (+ large stock) are REQUIRED for Cart::updateQty and
+     * Cart::checkQuantities to accept it at order time.
+     *
+     * The catalog product name is term-agnostic (a shared catalog object
+     * cannot carry per-buyer term days; concurrent carts may hold different
+     * terms). The Two-side payload line keeps the term-specific label from
+     * getTwoSurchargeLineLabel; amounts - not labels - are the parity
+     * contract between the two lines.
+     *
+     * @return int new product id (0 on failure)
+     */
+    protected function createTwoSurchargeCartProduct()
+    {
+        $label = $this->getTwoBrandConfig('fee_line_label');
+        $label = !empty($label) ? $this->l((string) $label) : $this->l('Payment terms fee');
+
+        $languageIds = array();
+        foreach ((array) Language::getLanguages(false) as $lang) {
+            if (isset($lang['id_lang'])) {
+                $languageIds[] = (int) $lang['id_lang'];
+            }
+        }
+        if (empty($languageIds)) {
+            $languageIds[] = isset($this->context->language->id) ? (int) $this->context->language->id : 1;
+        }
+
+        $product = new Product();
+        $product->name = array();
+        $product->link_rewrite = array();
+        foreach ($languageIds as $idLang) {
+            $product->name[$idLang] = $label;
+            $product->link_rewrite[$idLang] = 'two-payment-terms-fee';
+        }
+        $product->reference = self::TWO_SURCHARGE_PRODUCT_REFERENCE;
+        $product->price = 0;
+        $product->id_tax_rules_group = 0;
+        $product->active = 1;
+        $product->available_for_order = 1;
+        $product->visibility = 'none';
+        $product->indexed = 0;
+        $product->is_virtual = 1;
+        $product->out_of_stock = 1; // allow orders regardless of stock
+        $product->minimal_quantity = 1;
+        $product->id_category_default = (int) Configuration::get('PS_HOME_CATEGORY');
+
+        if (!$product->add()) {
+            return 0;
+        }
+
+        if (class_exists('StockAvailable')) {
+            StockAvailable::setQuantity((int) $product->id, 0, 1000000);
+            if (method_exists('StockAvailable', 'setProductOutOfStock')) {
+                StockAvailable::setProductOutOfStock((int) $product->id, 1);
+            }
+        }
+
+        PrestaShopLogger::addLog('TwoPayment: Created hidden surcharge cart product ' . (int) $product->id, 1);
+
+        return (int) $product->id;
+    }
+
+    /**
+     * Ensure the surcharge product carries a TaxRulesGroup whose rule for the
+     * cart's tax country applies exactly the admin-configured Surcharge Tax
+     * Rate (getTwoSurchargeTaxRate). Object graph (Tax + group + per-country
+     * rules) is tracked by id in CONFIG_SURCHARGE_TAX_SETUP and validated on
+     * every call, so a merchant deleting objects in the BO self-heals here.
+     * A configured-rate change creates a NEW Tax and re-points the rules
+     * (historical orders keep their order_detail rate copies).
+     *
+     * @param Cart $cart
+     * @param int $productId
+     * @return bool false when the tax setup could not be ensured
+     */
+    public function ensureTwoSurchargeTaxSetupForCart($cart, $productId)
+    {
+        $ratePercent = round($this->getTwoSurchargeTaxRate() * 100, 3);
+
+        $product = new Product((int) $productId);
+        if (!Validate::isLoadedObject($product)) {
+            return false;
+        }
+
+        if ($ratePercent <= 0) {
+            if ((int) $product->id_tax_rules_group !== 0) {
+                $product->id_tax_rules_group = 0;
+                $product->update();
+                $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
+            }
+            return true;
+        }
+
+        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
+        if ($taxAddressField !== 'id_address_delivery') {
+            $taxAddressField = 'id_address_invoice';
+        }
+        $address = new Address((int) $cart->{$taxAddressField});
+        $countryId = Validate::isLoadedObject($address) ? (int) $address->id_country : 0;
+        if ($countryId <= 0) {
+            return false;
+        }
+
+        $setup = json_decode((string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP), true);
+        if (!is_array($setup)) {
+            $setup = array();
+        }
+        $setup += array('rate_percent' => null, 'id_tax' => 0, 'id_group' => 0, 'rules' => array());
+
+        // Group: validate stored id, else create.
+        $group = $setup['id_group'] > 0 ? new TaxRulesGroup((int) $setup['id_group']) : null;
+        if ($group === null || !Validate::isLoadedObject($group)) {
+            $group = new TaxRulesGroup();
+            $group->name = 'Two payment terms fee tax';
+            $group->active = 1;
+            if (!$group->add()) {
+                return false;
+            }
+            $setup['id_group'] = (int) $group->id;
+            $setup['rules'] = array(); // stale rules belonged to the lost group
+        }
+
+        // Tax at the configured rate: validate stored id + rate, else create.
+        $tax = $setup['id_tax'] > 0 ? new Tax((int) $setup['id_tax']) : null;
+        $taxValid = $tax !== null && Validate::isLoadedObject($tax)
+            && abs(round((float) $tax->rate, 3) - $ratePercent) < 0.0005;
+        if (!$taxValid) {
+            $tax = new Tax();
+            $tax->name = array();
+            $languageIds = array();
+            foreach ((array) Language::getLanguages(false) as $lang) {
+                if (isset($lang['id_lang'])) {
+                    $languageIds[] = (int) $lang['id_lang'];
+                }
+            }
+            if (empty($languageIds)) {
+                $languageIds[] = isset($this->context->language->id) ? (int) $this->context->language->id : 1;
+            }
+            foreach ($languageIds as $idLang) {
+                $tax->name[$idLang] = 'Two surcharge VAT ' . $this->getTwoRoundAmount($ratePercent) . '%';
+            }
+            $tax->rate = $ratePercent;
+            $tax->active = 1;
+            if (!$tax->add()) {
+                return false;
+            }
+            $setup['id_tax'] = (int) $tax->id;
+
+            // Rate changed: re-point every existing per-country rule at the
+            // new Tax so previously-served countries keep working.
+            foreach ((array) $setup['rules'] as $ruleCountryId => $ruleId) {
+                $rule = new TaxRule((int) $ruleId);
+                if (Validate::isLoadedObject($rule)) {
+                    $rule->id_tax = (int) $tax->id;
+                    $rule->update();
+                } else {
+                    unset($setup['rules'][$ruleCountryId]);
+                }
+            }
+        }
+
+        // Rule for the cart's tax country: validate stored id, else create.
+        $ruleId = isset($setup['rules'][$countryId]) ? (int) $setup['rules'][$countryId] : 0;
+        $rule = $ruleId > 0 ? new TaxRule($ruleId) : null;
+        if ($rule === null || !Validate::isLoadedObject($rule) || (int) $rule->id_tax !== (int) $setup['id_tax']) {
+            if ($rule !== null && Validate::isLoadedObject($rule)) {
+                $rule->id_tax = (int) $setup['id_tax'];
+                $rule->update();
+            } else {
+                $rule = new TaxRule();
+                $rule->id_tax_rules_group = (int) $setup['id_group'];
+                $rule->id_country = $countryId;
+                $rule->id_state = 0;
+                $rule->zipcode_from = 0;
+                $rule->zipcode_to = 0;
+                $rule->id_tax = (int) $setup['id_tax'];
+                $rule->behavior = 0;
+                $rule->description = '';
+                if (!$rule->add()) {
+                    return false;
+                }
+                $setup['rules'][$countryId] = (int) $rule->id;
+            }
+        }
+
+        $setup['rate_percent'] = $ratePercent;
+        Configuration::updateValue(self::CONFIG_SURCHARGE_TAX_SETUP, json_encode($setup));
+
+        if ((int) $product->id_tax_rules_group !== (int) $setup['id_group']) {
+            $product->id_tax_rules_group = (int) $setup['id_group'];
+            $product->update();
+            $this->flushTwoProductTaxRulesGroupCache((int) $product->id);
+        }
+
+        return true;
+    }
+
+    /**
+     * Invalidate core's per-request tax-rules-group cache for one product.
+     *
+     * EMPIRICALLY REQUIRED (verified live on PS8 core): cart pricing resolves
+     * the product's group via Product::getIdTaxRulesGroupByIdProduct, which
+     * memoises 'product_id_tax_rules_group_{id}_{shop}' in Cache. The value
+     * gets primed with 0 during product creation, and Product::update does
+     * NOT clean it - so the very first request that creates the tax setup
+     * would price the fee line WITHOUT tax (gross == net) while the Two
+     * payload carries tax, and the stale line would then never self-correct
+     * (the sync no-op check compares net, which matches). Cleaning the exact
+     * key here makes the first request price correctly.
+     *
+     * @param int $productId
+     */
+    protected function flushTwoProductTaxRulesGroupCache($productId)
+    {
+        if (!class_exists('Cache') || !method_exists('Cache', 'clean')) {
+            return;
+        }
+        $shopId = isset($this->context->shop->id) ? (int) $this->context->shop->id : 0;
+        Cache::clean('product_id_tax_rules_group_' . (int) $productId . '_' . $shopId);
+        if ($shopId !== 0) {
+            // Defensive: some call paths resolve with a null/default shop.
+            Cache::clean('product_id_tax_rules_group_' . (int) $productId . '_0');
+        }
+    }
+
+    /**
+     * The surcharge product's line in the given cart, or null when absent.
+     * Amounts are PrestaShop's OWN applied totals for the line (the figures
+     * the buyer sees), used both for idempotency checks and for the
+     * cart-vs-payload parity gate.
+     *
+     * @param Cart $cart
+     * @return array{quantity:int,net:float,gross:float}|null
+     */
+    public function getTwoSurchargeCartLine($cart)
+    {
+        if (!Validate::isLoadedObject($cart)) {
+            return null;
+        }
+        $productId = $this->getTwoSurchargeCartProductId(false);
+        if ($productId <= 0) {
+            return null;
+        }
+        foreach ((array) $cart->getProducts(true) as $row) {
+            if ((int) $row['id_product'] === $productId) {
+                return array(
+                    'quantity' => (int) $row['cart_quantity'],
+                    'net' => round((float) $row['total'], 2),
+                    'gross' => round((float) $row['total_wt'], 2),
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reconcile the cart's surcharge line with the buyer's Two selection:
+     * upsert exactly one unit priced at the CURRENT quoted net fee when Two
+     * is selected, remove it otherwise. This is the single writer for the
+     * line - AJAX selection changes, term changes, and the order-create
+     * self-heal all converge through here.
+     *
+     * AMOUNT SOURCE (requirement: zero drift vs the Two payload): the net is
+     * taken from buildTwoSurchargeLineItemForCart() - the exact function
+     * that builds the Two order payload's fee line - fed with the SAME basis
+     * derivation the payload builder uses (calculateTwoLineItemTotals over
+     * getTwoProductItems, which excludes this very product), so the quote
+     * cache key (days|gross|country|currency) is byte-identical and both
+     * sides read the same cached quote. There is no second computation that
+     * could drift.
+     *
+     * IDEMPOTENCY: add-if-absent / remove-if-present keyed on the product id
+     * via getTwoSurchargeCartLine; repeated calls with the same selection are
+     * no-ops ('changed' => false). A quantity other than 1 or a stale amount
+     * is corrected by delete + re-add. Never throws (fail-soft AJAX
+     * contract); 'success' => false tells the caller nothing was reconciled.
+     *
+     * @param Cart $cart
+     * @param bool $selected Two is the buyer's selected payment option
+     * @return array{success:bool,changed:bool,present:bool}
+     */
+    public function syncTwoSurchargeCartLine($cart, $selected)
+    {
+        $result = array('success' => false, 'changed' => false, 'present' => false);
+        try {
+            if (!Validate::isLoadedObject($cart)) {
+                return $result;
+            }
+
+            // Only materialise the product when actually adding a line.
+            $productId = $this->getTwoSurchargeCartProductId((bool) $selected);
+            if ($productId <= 0) {
+                // Nothing ever created and nothing to remove -> vacuous success.
+                $result['success'] = !$selected || empty($this->getTwoSurchargeSettings()['enabled']);
+                return $result;
+            }
+
+            $existing = $this->getTwoSurchargeCartLine($cart);
+
+            $expectedNet = null;
+            $expectedGross = null;
+            if ($selected) {
+                $settings = $this->getTwoSurchargeSettings();
+                if (!empty($settings['enabled'])) {
+                    // Same basis derivation as buildTwoOrderPricingData:
+                    // product+shipping line items, surcharge product excluded.
+                    $basisTotals = $this->calculateTwoLineItemTotals($this->getTwoProductItems($cart));
+                    $basis = round((float) $basisTotals['gross'], 2);
+                    if ($basis > 0) {
+                        $line = $this->buildTwoSurchargeLineItemForCart($cart, $basis);
+                        if ($line !== null) {
+                            $expectedNet = round((float) $line['net_amount'], 2);
+                            $expectedGross = round((float) $line['gross_amount'], 2);
+                        }
+                    }
+                }
+            }
+
+            if ($expectedNet === null || $expectedNet <= 0) {
+                // Deselected / disabled / quote unavailable / empty basis:
+                // the Two payload will carry no fee line either (same quote
+                // source), so removing keeps both sides consistent.
+                if ($existing !== null) {
+                    $this->removeTwoSurchargeCartLineInternal($cart, $productId);
+                    $result['changed'] = true;
+                }
+                $this->clearTwoSurchargeCartCookie();
+                $result['success'] = true;
+                return $result;
+            }
+
+            if (
+                $existing !== null
+                && (int) $existing['quantity'] === 1
+                && $this->convertAmountToCents($existing['net']) === $this->convertAmountToCents($expectedNet)
+                // Gross must match too: a net-only check would let a stale
+                // tax application (rate change, primed tax-group cache)
+                // persist forever, since net comes from the SpecificPrice
+                // and never drifts on its own.
+                && abs($this->convertAmountToCents($existing['gross']) - $this->convertAmountToCents($expectedGross))
+                    <= $this->convertAmountToCents(self::ORDER_RECONCILIATION_TOLERANCE)
+            ) {
+                // Already exactly one unit at the current quote: no-op.
+                $this->setTwoSurchargeCartCookie($cart);
+                $result['success'] = true;
+                $result['present'] = true;
+                return $result;
+            }
+
+            if (!$this->ensureTwoSurchargeTaxSetupForCart($cart, $productId)) {
+                PrestaShopLogger::addLog('TwoPayment: Surcharge cart line skipped - tax setup could not be ensured for cart ' . (int) $cart->id, 3);
+                return $result;
+            }
+
+            $this->upsertTwoSurchargeSpecificPrice($cart, $productId, $expectedNet);
+            if ($existing !== null) {
+                // Wrong quantity or stale amount: rebuild the line cleanly.
+                $cart->deleteProduct($productId);
+            }
+            if (!$cart->updateQty(1, $productId)) {
+                PrestaShopLogger::addLog('TwoPayment: Failed adding surcharge line to cart ' . (int) $cart->id, 3);
+                SpecificPrice::deleteByIdCart((int) $cart->id, $productId);
+                return $result;
+            }
+
+            // Post-write verification: PrestaShop's own applied amounts must
+            // match what the Two payload will carry. If they don't (broken
+            // tax config the ensure step could not represent), REMOVE the
+            // line and report success=false with changed=false - reporting a
+            // change here would let the frontend refresh/restore cycle retry
+            // forever. With no cart line and a fee-bearing payload, the
+            // order-create parity gate blocks Two checkout loudly instead of
+            // ever mischarging.
+            $written = $this->getTwoSurchargeCartLine($cart);
+            $toleranceCents = $this->convertAmountToCents(self::ORDER_RECONCILIATION_TOLERANCE);
+            if (
+                $written === null
+                || $this->convertAmountToCents($written['net']) !== $this->convertAmountToCents($expectedNet)
+                || abs($this->convertAmountToCents($written['gross']) - $this->convertAmountToCents($expectedGross)) > $toleranceCents
+            ) {
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Surcharge line verification failed for cart ' . (int) $cart->id .
+                    ' - expected (net/gross)=(' . $this->getTwoRoundAmount($expectedNet) . '/' . $this->getTwoRoundAmount($expectedGross) .
+                    '), cart applied ' . ($written === null ? 'no line' :
+                        '(net/gross)=(' . $this->getTwoRoundAmount($written['net']) . '/' . $this->getTwoRoundAmount($written['gross']) . ')') .
+                    '. Line removed; check the shop tax configuration for the surcharge tax rate.',
+                    3
+                );
+                $this->removeTwoSurchargeCartLineInternal($cart, $productId);
+                return $result;
+            }
+
+            $this->setTwoSurchargeCartCookie($cart);
+            $result['success'] = true;
+            $result['changed'] = true;
+            $result['present'] = true;
+            return $result;
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Surcharge cart line sync failed for cart ' . (isset($cart->id) ? (int) $cart->id : 0) . ' - ' . $e->getMessage(), 3);
+            return $result;
+        }
+    }
+
+    /**
+     * Cart-scoped, currency-pinned SpecificPrice carrying the quoted net fee.
+     * id_cart scopes the price to THIS cart only (concurrent buyers hold
+     * their own rows); id_currency pins the amount so core never applies FX
+     * conversion (empirically verified: Product::priceCalculation skips
+     * Tools::convertPrice when the specific price's currency matches).
+     *
+     * @param Cart $cart
+     * @param int $productId
+     * @param float $net tax-excluded fee amount in the cart currency
+     */
+    protected function upsertTwoSurchargeSpecificPrice($cart, $productId, $net)
+    {
+        $existingIds = SpecificPrice::getIdsByProductId((int) $productId, false, (int) $cart->id);
+        $row = is_array($existingIds) && !empty($existingIds) ? $existingIds[0] : null;
+        $specificPriceId = is_array($row) ? (int) reset($row) : (int) $row;
+
+        $sp = $specificPriceId > 0 ? new SpecificPrice($specificPriceId) : new SpecificPrice();
+        $sp->id_product = (int) $productId;
+        $sp->id_product_attribute = 0;
+        $sp->id_shop = 0;
+        $sp->id_currency = (int) $cart->id_currency;
+        $sp->id_country = 0;
+        $sp->id_group = 0;
+        $sp->id_customer = 0;
+        $sp->id_cart = (int) $cart->id;
+        $sp->price = (float) $net;
+        $sp->from_quantity = 1;
+        $sp->reduction = 0;
+        $sp->reduction_type = 'amount';
+        $sp->reduction_tax = 1;
+        $sp->from = '0000-00-00 00:00:00';
+        $sp->to = '0000-00-00 00:00:00';
+        if ($specificPriceId > 0 && Validate::isLoadedObject($sp)) {
+            $sp->update();
+        } else {
+            $sp->add();
+        }
+
+        // Same-request price caches would otherwise serve the pre-update
+        // figure to the parity gate right after a self-heal resync.
+        if (method_exists('SpecificPrice', 'flushCache')) {
+            SpecificPrice::flushCache();
+        }
+        if (method_exists('Product', 'flushPriceCache')) {
+            Product::flushPriceCache((int) $productId);
+        }
+    }
+
+    /**
+     * Remove the surcharge line and its cart-scoped price row.
+     *
+     * @param Cart $cart
+     * @param int $productId
+     */
+    protected function removeTwoSurchargeCartLineInternal($cart, $productId)
+    {
+        $cart->deleteProduct((int) $productId);
+        SpecificPrice::deleteByIdCart((int) $cart->id, (int) $productId);
+        $this->clearTwoSurchargeCartCookie();
+    }
+
+    /**
+     * Session marker legitimising the surcharge line for THIS cart. Absent
+     * marker + present line = stale (abandoned/resumed cart in a fresh
+     * session) and the stale-guard removes the line.
+     *
+     * @param Cart $cart
+     */
+    protected function setTwoSurchargeCartCookie($cart)
+    {
+        if (isset($this->context->cookie)) {
+            $this->context->cookie->two_surcharge_cart_id = (string) (int) $cart->id;
+            // Force an immediate write: the sync AJAX request ends via
+            // ajaxDie()/exit, which does not guarantee Cookie::__destruct in
+            // every PHP/webserver configuration (same precedent as
+            // storeTwoFeeQuoteInSession). A lost marker would make the
+            // stale-guard strip the line on the very next request.
+            if (method_exists($this->context->cookie, 'write')) {
+                $this->context->cookie->write();
+            }
+        }
+    }
+
+    protected function clearTwoSurchargeCartCookie()
+    {
+        if (isset($this->context->cookie) && isset($this->context->cookie->two_surcharge_cart_id)) {
+            unset($this->context->cookie->two_surcharge_cart_id);
+            if (method_exists($this->context->cookie, 'write')) {
+                $this->context->cookie->write();
+            }
+        }
+    }
+
+    /**
+     * Stale-line guard (runs on every front request, cheap early-outs).
+     *
+     * Two removal rules, both money-protective:
+     * 1. ANOTHER payment module's front controller is executing (its order
+     *    validation POST included): the buyer is not paying with Two, so the
+     *    Two fee must never be charged - remove before that module computes
+     *    totals. False positives (non-payment module controllers) only cost
+     *    a re-add on the next Two selection / order-create self-heal.
+     * 2. The session marker does not match the cart (abandoned cart resumed
+     *    in a fresh session, cookie expired): the selection that justified
+     *    the line is gone - remove so the buyer never sees a fee line
+     *    without having selected Two.
+     *
+     * Own-module controllers are exempt so the payment/confirmation flow and
+     * the sync endpoint itself never race their own line.
+     *
+     * @param array $params
+     */
+    public function hookActionFrontControllerInitAfter($params)
+    {
+        try {
+            $cart = isset($this->context->cart) ? $this->context->cart : null;
+            if (!Validate::isLoadedObject($cart)) {
+                return;
+            }
+            $productId = $this->getTwoSurchargeCartProductId(false);
+            if ($productId <= 0) {
+                return;
+            }
+            if ($this->getTwoSurchargeCartLine($cart) === null) {
+                return;
+            }
+
+            $controller = isset($params['controller']) ? $params['controller'] : (isset($this->context->controller) ? $this->context->controller : null);
+            $controllerModuleName = '';
+            if (is_object($controller) && isset($controller->module) && is_object($controller->module) && isset($controller->module->name)) {
+                $controllerModuleName = (string) $controller->module->name;
+            }
+            if ($controllerModuleName === $this->name) {
+                return;
+            }
+
+            $isOtherModuleController = $controllerModuleName !== '';
+            $cookieCartId = isset($this->context->cookie->two_surcharge_cart_id) ? (int) $this->context->cookie->two_surcharge_cart_id : 0;
+            $markerValid = $cookieCartId === (int) $cart->id;
+
+            if ($isOtherModuleController || !$markerValid) {
+                $this->removeTwoSurchargeCartLineInternal($cart, $productId);
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Removed stale surcharge line from cart ' . (int) $cart->id .
+                    ($isOtherModuleController ? ' (other module controller: ' . $controllerModuleName . ')' : ' (session marker mismatch)'),
+                    1
+                );
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Surcharge stale-guard failed - ' . $e->getMessage(), 2);
         }
     }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -7083,17 +7083,46 @@ class Twopayment extends PaymentModule
             return 0;
         }
 
-        try {
-            $productId = $this->createTwoSurchargeCartProduct();
-        } catch (Exception $e) {
-            PrestaShopLogger::addLog('TwoPayment: Failed creating surcharge cart product - ' . $e->getMessage(), 3);
+        // Advisory lock: two concurrent FIRST-EVER requests (fresh install,
+        // two buyers selecting Two near-simultaneously) would otherwise each
+        // pass the read-check above and create a duplicate hidden product,
+        // orphaning the loser's copy forever.
+        if (!$this->acquireTwoDbLock('two_surcharge_product_create')) {
+            PrestaShopLogger::addLog('TwoPayment: Surcharge product creation lock not acquired', 2);
             return 0;
         }
-        if ($productId > 0) {
-            Configuration::updateValue(self::CONFIG_SURCHARGE_PRODUCT_ID, $productId);
-        }
+        try {
+            // Double-check UNDER the lock, straight from the DB: the winner
+            // of the race wrote Configuration in ITS request, which this
+            // request's per-request Configuration cache cannot see.
+            $storedId = (int) Db::getInstance()->getValue(
+                'SELECT `value` FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = '" . pSQL(self::CONFIG_SURCHARGE_PRODUCT_ID) . "'"
+            );
+            if ($storedId > 0) {
+                $product = new Product($storedId);
+                if (
+                    Validate::isLoadedObject($product)
+                    && isset($product->reference)
+                    && (string) $product->reference === self::TWO_SURCHARGE_PRODUCT_REFERENCE
+                ) {
+                    return $storedId;
+                }
+            }
 
-        return $productId;
+            try {
+                $productId = $this->createTwoSurchargeCartProduct();
+            } catch (Exception $e) {
+                PrestaShopLogger::addLog('TwoPayment: Failed creating surcharge cart product - ' . $e->getMessage(), 3);
+                return 0;
+            }
+            if ($productId > 0) {
+                Configuration::updateValue(self::CONFIG_SURCHARGE_PRODUCT_ID, $productId);
+            }
+
+            return $productId;
+        } finally {
+            $this->releaseTwoDbLock('two_surcharge_product_create');
+        }
     }
 
     /**
@@ -7203,7 +7232,42 @@ class Twopayment extends PaymentModule
             return false;
         }
 
-        $setup = json_decode((string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP), true);
+        // Advisory lock around the whole read-validate-create sequence: two
+        // concurrent first-time carts would otherwise both see an empty
+        // setup and create duplicate Tax/TaxRulesGroup/TaxRule graphs, with
+        // only one surviving in Configuration and the rest orphaned.
+        if (!$this->acquireTwoDbLock('two_surcharge_tax_setup')) {
+            PrestaShopLogger::addLog('TwoPayment: Surcharge tax setup lock not acquired', 2);
+            return false;
+        }
+        try {
+            return $this->ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId);
+        } finally {
+            $this->releaseTwoDbLock('two_surcharge_tax_setup');
+        }
+    }
+
+    /**
+     * Body of ensureTwoSurchargeTaxSetupForCart, executed while holding the
+     * two_surcharge_tax_setup advisory lock.
+     *
+     * @param Product $product
+     * @param float $ratePercent
+     * @param int $countryId
+     * @return bool
+     */
+    protected function ensureTwoSurchargeTaxSetupForCartLocked($product, $ratePercent, $countryId)
+    {
+        // Read the tracked setup UNDER the lock, straight from the DB: a
+        // concurrent winner's Configuration write is invisible to this
+        // request's per-request Configuration cache.
+        $setupJson = Db::getInstance()->getValue(
+            'SELECT `value` FROM `' . _DB_PREFIX_ . "configuration` WHERE `name` = '" . pSQL(self::CONFIG_SURCHARGE_TAX_SETUP) . "'"
+        );
+        if ($setupJson === false || $setupJson === null || $setupJson === '') {
+            $setupJson = (string) Configuration::get(self::CONFIG_SURCHARGE_TAX_SETUP);
+        }
+        $setup = json_decode((string) $setupJson, true);
         if (!is_array($setup)) {
             $setup = array();
         }

--- a/twopayment.php
+++ b/twopayment.php
@@ -3595,7 +3595,18 @@ class Twopayment extends PaymentModule
         return round($gross_amount, 2);
     }
 
-    public function getTwoNewOrderData($merchant_order_id, $cart, $merchant_urls = null)
+    /**
+     * @param string $merchant_order_id
+     * @param Cart $cart
+     * @param array|null $merchant_urls
+     * @param bool $syncSurchargeCartLine when true (default, order-create
+     *        paths) the cart's surcharge line is self-healed and fee parity
+     *        is ENFORCED before totals are read; pass false for pure
+     *        comparison/snapshot builds that must not mutate the cart.
+     * @return array
+     * @throws Exception
+     */
+    public function getTwoNewOrderData($merchant_order_id, $cart, $merchant_urls = null, $syncSurchargeCartLine = true)
     {
         // Validate cart has products before building order data
         if (!Validate::isLoadedObject($cart) || $cart->nbProducts() <= 0) {
@@ -3623,7 +3634,7 @@ class Twopayment extends PaymentModule
             }
         }
 
-        $pricingData = $this->buildTwoOrderPricingData($cart, 'order data (merchant_order_id=' . $merchant_order_id . ')', false, null, true);
+        $pricingData = $this->buildTwoOrderPricingData($cart, 'order data (merchant_order_id=' . $merchant_order_id . ')', false, null, (bool) $syncSurchargeCartLine);
         $line_items = $pricingData['line_items'];
         $tax_subtotals = $pricingData['tax_subtotals'];
         $final_net = $pricingData['net_amount'];

--- a/twopayment.php
+++ b/twopayment.php
@@ -475,6 +475,11 @@ class Twopayment extends PaymentModule
                 return false;
             }
         }
+
+        // DB-level guard against manual/duplicate fee-product order rows.
+        // Best-effort (logs loudly on failure) - must not break install.
+        $this->installTwoOrderDetailFeeGuardTrigger();
+
         return true;
     }
 
@@ -602,6 +607,7 @@ class Twopayment extends PaymentModule
 
     protected function deleteTwoTables()
     {
+        $this->dropTwoOrderDetailFeeGuardTrigger();
         $sql = array();
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'twopayment_surcharge_sync`';
         foreach ($sql as $query) {
@@ -7529,6 +7535,143 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Name of the order_detail fee-guard trigger (prefixed like the module's
+     * tables so several shops sharing one database never collide).
+     *
+     * @return string
+     */
+    protected function getTwoFeeGuardTriggerName()
+    {
+        return _DB_PREFIX_ . 'twopayment_fee_guard';
+    }
+
+    /**
+     * DDL for the DB-level fee-row guard. This trigger - not the
+     * actionObjectOrderDetailAddBefore hook - is the actual enforcement
+     * layer: Hook::callHookOn() swallows module exceptions unless the shop
+     * runs in debug mode (verified against PS8 core), so a thrown
+     * PrestaShopException protects nothing in a production shop. A BEFORE
+     * INSERT trigger holds on EVERY insertion path (front order creation,
+     * back-office AddProductToOrderHandler, webservice order_details
+     * resource, direct SQL).
+     *
+     * Rules enforced for the hidden fee product (looked up LIVE from the
+     * configuration table, so recreating the product never requires
+     * recreating the trigger):
+     *  1. at most ONE fee row per order, ever - the single legitimate row
+     *     is written by PaymentModule::validateOrder at order creation
+     *     (Order::add() precedes OrderDetail::createList(), verified against
+     *     PS8 core), and a fee line is never edited or re-added afterwards;
+     *  2. a fee row is only accepted for an order whose originating CART
+     *     actually carries the fee line - which is true for every genuine
+     *     Two order at creation time and false for a webservice/back-office
+     *     caller grafting the fee onto an arbitrary existing order.
+     *
+     * Empirically verified on the live PS8 container (MariaDB 10.11):
+     * legitimate first insert passes, duplicate insert and fee-less-cart
+     * insert are rejected with SIGNAL 45000, ordinary products unaffected.
+     * SIGNAL requires MySQL >= 5.5 / MariaDB >= 5.5 - far below any PS8
+     * platform floor.
+     *
+     * @return string
+     */
+    protected function buildTwoFeeGuardTriggerSql()
+    {
+        return 'CREATE TRIGGER `' . $this->getTwoFeeGuardTriggerName() . '`
+            BEFORE INSERT ON `' . _DB_PREFIX_ . 'order_detail`
+            FOR EACH ROW
+            BEGIN
+                IF NEW.product_id > 0
+                    AND EXISTS (
+                        SELECT 1 FROM `' . _DB_PREFIX_ . 'configuration`
+                        WHERE `name` = \'' . pSQL(self::CONFIG_SURCHARGE_PRODUCT_ID) . '\'
+                          AND CAST(`value` AS UNSIGNED) = NEW.product_id
+                    )
+                THEN
+                    IF EXISTS (
+                        SELECT 1 FROM `' . _DB_PREFIX_ . 'order_detail`
+                        WHERE `id_order` = NEW.id_order
+                          AND `product_id` = NEW.product_id
+                    ) THEN
+                        SIGNAL SQLSTATE \'45000\'
+                            SET MESSAGE_TEXT = \'TwoPayment: rejected duplicate payment terms fee row (fee is added once, at order creation only)\';
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1
+                        FROM `' . _DB_PREFIX_ . 'orders` o
+                        INNER JOIN `' . _DB_PREFIX_ . 'cart_product` cp
+                            ON cp.`id_cart` = o.`id_cart`
+                           AND cp.`id_product` = NEW.product_id
+                        WHERE o.`id_order` = NEW.id_order
+                    ) THEN
+                        SIGNAL SQLSTATE \'45000\'
+                            SET MESSAGE_TEXT = \'TwoPayment: rejected payment terms fee row for an order whose cart does not carry the fee line\';
+                    END IF;
+                END IF;
+            END';
+    }
+
+    /**
+     * Create the fee-guard trigger if absent. Best-effort by design: a DB
+     * user without the TRIGGER privilege (or a pathologically old server)
+     * must not break install or checkout - the failure is logged loudly and
+     * the hook-based guard remains as the (debug-mode-only) fallback.
+     *
+     * @return bool trigger present after the call
+     */
+    public function installTwoOrderDetailFeeGuardTrigger()
+    {
+        try {
+            $exists = (int) Db::getInstance()->getValue(
+                'SELECT COUNT(*) FROM information_schema.TRIGGERS' .
+                " WHERE TRIGGER_SCHEMA = DATABASE() AND TRIGGER_NAME = '" . pSQL($this->getTwoFeeGuardTriggerName()) . "'"
+            );
+            if ($exists > 0) {
+                return true;
+            }
+            if (Db::getInstance()->execute($this->buildTwoFeeGuardTriggerSql())) {
+                PrestaShopLogger::addLog('TwoPayment: Installed order_detail fee-guard trigger ' . $this->getTwoFeeGuardTriggerName(), 1);
+                return true;
+            }
+            PrestaShopLogger::addLog('TwoPayment: Could not create fee-guard trigger ' . $this->getTwoFeeGuardTriggerName() . ' - duplicate fee rows are NOT DB-enforced (TRIGGER privilege missing?)', 3);
+            return false;
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Fee-guard trigger creation failed - duplicate fee rows are NOT DB-enforced. ' . $e->getMessage(), 3);
+            return false;
+        }
+    }
+
+    /**
+     * Lazily (re)install the fee-guard trigger once per request. Covers
+     * module upgrades from versions without it (install() does not re-run on
+     * upgrade), DB restores that dropped triggers, and manual drops -
+     * self-healing on the next checkout instead of trusting a stale flag.
+     */
+    protected function ensureTwoOrderDetailFeeGuardTrigger()
+    {
+        if ($this->twoFeeGuardTriggerEnsured) {
+            return;
+        }
+        $this->twoFeeGuardTriggerEnsured = true;
+        $this->installTwoOrderDetailFeeGuardTrigger();
+    }
+
+    /** @var bool once-per-request memo for ensureTwoOrderDetailFeeGuardTrigger */
+    protected $twoFeeGuardTriggerEnsured = false;
+
+    /**
+     * Best-effort trigger drop at uninstall - never blocks uninstall.
+     */
+    protected function dropTwoOrderDetailFeeGuardTrigger()
+    {
+        try {
+            Db::getInstance()->execute('DROP TRIGGER IF EXISTS `' . $this->getTwoFeeGuardTriggerName() . '`');
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog('TwoPayment: Failed dropping fee-guard trigger at uninstall - ' . $e->getMessage(), 2);
+        }
+    }
+
+    /**
      * Last-applied buyer-driven sync sequence for a cart, or null when the
      * cart has never synced with a sequence number.
      *
@@ -7635,6 +7778,10 @@ class Twopayment extends PaymentModule
      */
     public function syncTwoSurchargeCartLine($cart, $selected, $syncSeq = null)
     {
+        // Upgrades from versions without the fee-guard trigger (and DB
+        // restores that dropped it) get it back on the next checkout.
+        $this->ensureTwoOrderDetailFeeGuardTrigger();
+
         $result = array('success' => false, 'changed' => false, 'present' => false);
         if ($syncSeq === null) {
             return $this->applyTwoSurchargeCartLineSync($cart, $selected);
@@ -7974,9 +8121,18 @@ class Twopayment extends PaymentModule
      *
      * Fires on ObjectModel::add for every OrderDetail (verified against PS8
      * core: OrderDetail::create() -> save() -> add() -> this hook, both at
-     * order creation and in the BO AddProductToOrderHandler). Throwing here
-     * aborts the insert; the BO controller catches the exception and shows
-     * it as an admin-visible error.
+     * order creation and in the BO AddProductToOrderHandler).
+     *
+     * IMPORTANT - this hook is dev-environment UX ONLY, not the enforcement
+     * layer. Hook::callHookOn() (PS8 core, verified) catches every module
+     * exception and only re-throws when Environment::isDebug() is true
+     * (_PS_MODE_DEV_, false in production) - in a production shop a throw
+     * here is silently swallowed and the insert proceeds. The ACTUAL
+     * enforcement is the database BEFORE INSERT trigger installed by
+     * installTwoOrderDetailFeeGuardTrigger(), which rejects illegitimate fee
+     * rows on every insertion path regardless of PHP context. This hook is
+     * kept because in debug/dev shops it produces a friendlier,
+     * properly-surfaced admin error before the SQL layer is ever reached.
      *
      * @param array $params ['object' => OrderDetail]
      * @throws PrestaShopException when the add must be blocked

--- a/twopayment.php
+++ b/twopayment.php
@@ -169,6 +169,7 @@ class Twopayment extends PaymentModule
         $required_hooks = array(
             'actionObjectOrderHistoryAddBefore',
             'actionFrontControllerInitAfter',
+            'actionObjectOrderDetailAddBefore',
         );
 
         foreach ($required_hooks as $hook_name) {
@@ -261,6 +262,7 @@ class Twopayment extends PaymentModule
             $this->registerHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->registerHook('actionCustomerAddressSave') &&
             $this->registerHook('actionFrontControllerInitAfter') &&
+            $this->registerHook('actionObjectOrderDetailAddBefore') &&
             $this->installTwoInvoiceAdminTab() &&
             $this->installTwoSettings() &&
             $this->createTwoOrderState() &&
@@ -494,6 +496,7 @@ class Twopayment extends PaymentModule
             $this->unregisterHook('actionAdminOrdersTrackingNumberUpdate') &&
             $this->unregisterHook('actionCustomerAddressSave') &&
             $this->unregisterHook('actionFrontControllerInitAfter') &&
+            $this->unregisterHook('actionObjectOrderDetailAddBefore') &&
             $this->uninstallTwoInvoiceAdminTab() &&
             $this->uninstallTwoSettings() &&
             $this->deleteTwoTables();
@@ -7881,6 +7884,81 @@ class Twopayment extends PaymentModule
         } catch (Exception $e) {
             PrestaShopLogger::addLog('TwoPayment: Surcharge stale-guard failed - ' . $e->getMessage(), 2);
         }
+    }
+
+    /**
+     * Guard the ORDER (post-creation) against ever gaining an illegitimate
+     * surcharge fee row. All the idempotency logic in this feature protects
+     * the CART before order creation; nothing in core stops a back-office
+     * employee from using the AdminOrders "Add product" search to add the
+     * hidden "Payment terms fee" product to an already-placed, already-
+     * invoiced Two order - a real duplicate financial line. OrderDetail rows
+     * are only ever legitimately created for this product by PrestaShop's
+     * own order-creation pipeline (validateOrder over a cart this module
+     * synced), which runs in a FRONT context and always as the product's
+     * FIRST row on the order.
+     *
+     * Fires on ObjectModel::add for every OrderDetail (verified against PS8
+     * core: OrderDetail::create() -> save() -> add() -> this hook, both at
+     * order creation and in the BO AddProductToOrderHandler). Throwing here
+     * aborts the insert; the BO controller catches the exception and shows
+     * it as an admin-visible error.
+     *
+     * @param array $params ['object' => OrderDetail]
+     * @throws PrestaShopException when the add must be blocked
+     */
+    public function hookActionObjectOrderDetailAddBefore($params)
+    {
+        $orderDetail = isset($params['object']) ? $params['object'] : null;
+        if (!is_object($orderDetail) || !isset($orderDetail->product_id)) {
+            return;
+        }
+
+        $surchargeProductId = $this->getTwoSurchargeCartProductId(false);
+        if ($surchargeProductId <= 0 || (int) $orderDetail->product_id !== $surchargeProductId) {
+            return;
+        }
+
+        // Manual back-office adds are NEVER legitimate for this product:
+        // only the module's own automated cart-sync + order creation may
+        // materialise it.
+        if ($this->isTwoAdminContext()) {
+            throw new PrestaShopException(
+                'The payment terms fee product is managed automatically by the Two payment module and cannot be added to an order manually.'
+            );
+        }
+
+        // Belt-and-braces for any other path: a SECOND fee row on the same
+        // order is always a duplicate charge - fail loudly, never silently.
+        $idOrder = isset($orderDetail->id_order) ? (int) $orderDetail->id_order : 0;
+        if ($idOrder > 0) {
+            $existingRows = (int) Db::getInstance()->getValue(
+                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_detail` WHERE `id_order` = ' . $idOrder .
+                ' AND `product_id` = ' . $surchargeProductId
+            );
+            if ($existingRows >= 1) {
+                throw new PrestaShopException(
+                    'Order ' . $idOrder . ' already carries the payment terms fee line; refusing to add a duplicate fee row.'
+                );
+            }
+        }
+    }
+
+    /**
+     * Whether the current request executes in a back-office context.
+     * Primary signal is the controller_type PrestaShop stamps on every
+     * controller; _PS_ADMIN_DIR_ is the fallback for early/legacy paths.
+     *
+     * @return bool
+     */
+    protected function isTwoAdminContext()
+    {
+        $controller = isset($this->context->controller) ? $this->context->controller : null;
+        if (is_object($controller) && isset($controller->controller_type)) {
+            return in_array((string) $controller->controller_type, array('admin', 'moduleadmin'), true);
+        }
+
+        return defined('_PS_ADMIN_DIR_');
     }
 
     /**

--- a/upgrade/upgrade-2.5.0.php
+++ b/upgrade/upgrade-2.5.0.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.5.0
+ *
+ * Surcharge tax migration visibility (TWO-25071):
+ * The flat "Surcharge Tax Rate (%)" (PS_TWO_SURCHARGE_TAX_RATE, pre-release
+ * builds only) is replaced by a merchant-selected TaxRulesGroup
+ * (PS_TWO_SURCHARGE_TAX_RULES_GROUP). No automatic conversion is attempted:
+ * inventing a TaxRulesGroup to match a bare percentage is destination-blind
+ * and risks taxing orders wrongly. Instead, when a shop upgrades with the
+ * flat rate configured and no group selected yet, this script:
+ * - logs a warning via PrestaShopLogger, and
+ * - sets a persistent flag (PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE) that the
+ *   module config page renders as a visible "surcharge tax needs
+ *   re-selection" warning until the merchant saves a selection.
+ *
+ * Created: 2026-07-11
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_5_0($module)
+{
+    $flatRate = Configuration::get('PS_TWO_SURCHARGE_TAX_RATE');
+    $group = Configuration::get('PS_TWO_SURCHARGE_TAX_RULES_GROUP');
+
+    $flatRateWasConfigured = ($flatRate !== false && $flatRate !== null && trim((string) $flatRate) !== '');
+    $groupIsConfigured = ($group !== false && $group !== null && trim((string) $group) !== '');
+
+    if ($flatRateWasConfigured && !$groupIsConfigured) {
+        PrestaShopLogger::addLog(
+            'TwoPayment Upgrade 2.5.0: A flat surcharge tax rate (PS_TWO_SURCHARGE_TAX_RATE='
+            . trim((string) $flatRate)
+            . ') was configured but is no longer used. The surcharge is UNTAXED until a'
+            . ' Surcharge Tax Rules Group is selected and saved in the module Payment settings.',
+            2,
+            null,
+            'Module',
+            $module->id
+        );
+        Configuration::updateValue('PS_TWO_SURCHARGE_TAX_MIGRATION_NOTICE', '1');
+    }
+
+    return true;
+}

--- a/upgrade/upgrade-2.5.1.php
+++ b/upgrade/upgrade-2.5.1.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.5.1
+ *
+ * Sole trader checkout (TWO-24755): new PS_TWO_ENABLE_SOLE_TRADER admin
+ * toggle. install() sets an explicit default of 0 for fresh installs; this
+ * script does the same for shops that already ran install() before this
+ * feature existed, so the config key is an explicit stored 0 rather than
+ * an unset/false read, matching this module's convention for new config
+ * keys (see upgrade-2.3.0.php, upgrade-2.5.0.php). Guarded by hasKey() so
+ * it never clobbers a value a later release may have already set.
+ *
+ * Created: 2026-07-15
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_5_1($module)
+{
+    if (!Configuration::hasKey('PS_TWO_ENABLE_SOLE_TRADER')) {
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+    }
+
+    return true;
+}

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1185,3 +1185,24 @@
 .payment-option.two-loading::after {
     display: none !important;
 }
+
+/* Sole trader flow (TWO-24755) */
+.two-sole-trader {
+    margin: 0 0 12px;
+}
+
+.two-sole-trader__prompt {
+    display: inline-block;
+    font-size: 13px;
+    text-decoration: underline;
+}
+
+.two-sole-trader__status {
+    font-size: 13px;
+    color: #027a48;
+}
+
+.two-sole-trader__error {
+    font-size: 13px;
+    color: #b42318;
+}

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -249,6 +249,36 @@ class TwoCheckoutManager {
             prestashop.on('checkout', (event) => {
                 this.handleCheckoutEvent(event);
             });
+
+            // Cart-content changes while Two is selected (quantity spinners /
+            // remove links on the checkout order-summary widget): core emits
+            // 'updatedCart' AFTER it re-renders the summary (verified against
+            // classic theme theme.js - distinct from the 'updateCart' event
+            // this module itself emits to REQUEST a refresh). The fee is a
+            // percentage of the cart basis, so re-quote and resync the line.
+            // No loop risk: the server endpoint is idempotent - when nothing
+            // changed it reports changed=false and no further refresh fires.
+            //
+            // ACCEPTED LIMITATION - admin mid-session tax-rate change: there
+            // is no push channel from the back office into an open buyer
+            // session, so a live payment step can display the old rate until
+            // any of these triggers fires. The order-create self-heal always
+            // reprices authoritatively and the server-side parity gate fails
+            // closed, so the buyer can never be CHARGED off a stale rate.
+            prestashop.on('updatedCart', () => {
+                if (this.isTwoPaymentSelected()) {
+                    this.syncSurchargeCartLine(true);
+                }
+            });
+        }
+
+        // Page-load resync: currency switching is a plain link in core (full
+        // page reload - verified against ps_currencyselector), so if the
+        // theme restores the Two selection after the reload the existing
+        // line still carries the OLD currency's amount until resynced.
+        // Idempotent no-op in the common case where nothing changed.
+        if (this.isTwoPaymentSelected()) {
+            this.syncSurchargeCartLine(true);
         }
         
         // CRITICAL: Listen for payment option selection (theme-independent)

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -148,7 +148,9 @@ class TwoCheckoutManager {
         if (!this.isBusinessAccount) {
             const accountTypeField = document.querySelector("select[name='account_type']");
             if (accountTypeField) {
-                this.isBusinessAccount = accountTypeField.value === 'business';
+                // Sole trader counts as a company-bearing flow (TWO-24755):
+                // the order-intent machinery must run for it too.
+                this.isBusinessAccount = accountTypeField.value === 'business' || accountTypeField.value === 'sole_trader';
             }
         }
         
@@ -298,7 +300,7 @@ class TwoCheckoutManager {
         this._accountTypeListenerAdded = true;
         accountTypeField.addEventListener('change', () => {
             const value = accountTypeField.value;
-            this.isBusinessAccount = (value === 'business');
+            this.isBusinessAccount = (value === 'business' || value === 'sole_trader');
             try { sessionStorage.setItem('two_account_type', value); } catch (e) {}
             // Keep company search available on address forms for reliable company selection.
             if (this.config.companySearchEnabled && !this.companySearch) {
@@ -1797,7 +1799,7 @@ class TwoCheckoutManager {
                 if (saved && accountTypeField && accountTypeField.value !== saved) {
                     accountTypeField.value = saved;
                     accountTypeField.dispatchEvent(new Event('change', { bubbles: true }));
-                    this.isBusinessAccount = (saved === 'business');
+                    this.isBusinessAccount = (saved === 'business' || saved === 'sole_trader');
                 }
             } catch (e) {}
 

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -28,8 +28,12 @@ class TwoCheckoutManager {
         this._initialIntentTriggered = false;
         // Monotonic sequence for surcharge cart-line syncs: only the LATEST
         // selection's response may drive the UI (last-wins against re-ordered
-        // AJAX responses when the buyer clicks between options quickly).
-        this._surchargeSyncSeq = 0;
+        // AJAX responses when the buyer clicks between options quickly), and
+        // the same value is sent to the server so a slower OLDER request can
+        // never overwrite a newer one there either. Seeded with Date.now()
+        // (not 0) so the sequence stays monotonic across page reloads - the
+        // server persists the last-applied value per cart.
+        this._surchargeSyncSeq = Date.now();
         this._surchargeRestoreKey = 'two_restore_payment_selection';
 
         this.init();
@@ -427,7 +431,10 @@ class TwoCheckoutManager {
                     ajax: 1,
                     action: 'syncSurchargeLine',
                     token: window.twopayment.ajax_token,
-                    selected: selected ? 1 : 0
+                    selected: selected ? 1 : 0,
+                    // Server-side ordering guard: requests carrying a lower
+                    // seq than the last applied one are ignored server-side.
+                    seq: seq
                 }
             }).done(resolve).fail(reject);
         });

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -26,7 +26,12 @@ class TwoCheckoutManager {
         this._intentCooldownMs = 800;
         this._lastIntentRunAt = 0;
         this._initialIntentTriggered = false;
-        
+        // Monotonic sequence for surcharge cart-line syncs: only the LATEST
+        // selection's response may drive the UI (last-wins against re-ordered
+        // AJAX responses when the buyer clicks between options quickly).
+        this._surchargeSyncSeq = 0;
+        this._surchargeRestoreKey = 'two_restore_payment_selection';
+
         this.init();
     }
 
@@ -59,7 +64,12 @@ class TwoCheckoutManager {
         
         // Setup PrestaShop-native event listeners
         this.setupPrestaShopEventListeners();
-        
+
+        // If the native cart refresh (full payment-step reload) was triggered
+        // by a surcharge line sync, restore the payment option the buyer had
+        // clicked - the reload wipes radio state.
+        this.restorePaymentSelectionAfterCartRefresh();
+
         this.isInitialized = true;
     }
     
@@ -352,7 +362,12 @@ class TwoCheckoutManager {
     handlePaymentOptionChange(radioButton) {
         // Check if Two payment is selected using various patterns
         const isTwoSelected = this.isTwoPaymentSelected(radioButton);
-        
+
+        // Mirror the buyer surcharge as a real PrestaShop cart line (add on
+        // Two selection, remove on any other selection). Server-side endpoint
+        // is idempotent, so repeated change events are harmless.
+        this.syncSurchargeCartLine(isTwoSelected);
+
         if (isTwoSelected && this.config.orderIntentEnabled) {
             // Ensure orderIntent is initialized even after dynamic DOM changes
             if (!this.orderIntent && window.TwoOrderIntent) {
@@ -374,6 +389,122 @@ class TwoCheckoutManager {
         }
     }
     
+    /**
+     * Reconcile the cart's hidden surcharge line with the current payment
+     * selection via the syncSurchargeLine AJAX action, then - only when the
+     * server reports an actual cart change - trigger PrestaShop's NATIVE
+     * cart-refresh plumbing so the order summary re-renders itself.
+     *
+     * FAILURE HANDLING (documented decision): the call is fail-soft in the
+     * UI - one silent retry, then a console warning; checkout is never
+     * blocked and the Place-order button is never touched from here. The
+     * HARD guarantee that a buyer can never complete a Two order whose
+     * PrestaShop total diverges from the Two invoice lives server-side: the
+     * order-create path self-heals the cart line and fails closed on any
+     * residual mismatch (Twopayment::buildTwoOrderPricingData parity gate).
+     * A lost remove-sync for OTHER payment methods is likewise covered
+     * server-side (actionFrontControllerInitAfter stale-guard strips the
+     * line before any other payment module computes totals).
+     *
+     * @param {boolean} selected Two is the buyer's selected payment option
+     * @returns {Promise<object>} the endpoint's {success, changed, present}
+     */
+    syncSurchargeCartLine(selected) {
+        if (!window.twopayment || !window.twopayment.surcharge_cart_line ||
+            !window.twopayment.order_intent_url || !window.twopayment.ajax_token ||
+            typeof jQuery === 'undefined') {
+            return Promise.resolve({ success: true, changed: false, present: false });
+        }
+
+        const seq = ++this._surchargeSyncSeq;
+        const requestOnce = () => new Promise((resolve, reject) => {
+            jQuery.ajax({
+                url: window.twopayment.order_intent_url,
+                type: 'POST',
+                dataType: 'json',
+                timeout: 10000,
+                data: {
+                    ajax: 1,
+                    action: 'syncSurchargeLine',
+                    token: window.twopayment.ajax_token,
+                    selected: selected ? 1 : 0
+                }
+            }).done(resolve).fail(reject);
+        });
+
+        return requestOnce()
+            .catch(() => requestOnce()) // one silent retry on transport failure
+            .catch(() => ({ success: false, changed: false, present: false }))
+            .then((response) => {
+                if (seq !== this._surchargeSyncSeq) {
+                    // A newer selection superseded this sync; let it drive the UI.
+                    return response;
+                }
+                if (response && response.success && response.changed) {
+                    this.triggerNativeCartRefresh();
+                } else if (!response || !response.success) {
+                    console.warn('Two Payment: surcharge cart line sync failed; server-side order-create gate remains authoritative.');
+                }
+                return response;
+            });
+    }
+
+    /**
+     * Trigger PrestaShop core's own cart-refresh pipeline (no hand-rolled
+     * summary re-render). Empirically verified against PS8 themes/core.js:
+     * core listens on the 'updateCart' event, POSTs the .js-cart
+     * data-refresh-url, replaces the summary partials, and - because the
+     * payment step carries the .js-cart-payment-step-refresh marker - fully
+     * reloads the checkout page (then emits 'updatedCart' post-render). The
+     * handler dereferences event.resp.cart unconditionally, so a cart object
+     * (prestashop.cart or {}) must always be passed.
+     */
+    triggerNativeCartRefresh() {
+        try {
+            const checkedRadio = document.querySelector('input[name="payment-option"]:checked, .payment-options input[type="radio"]:checked');
+            if (checkedRadio && checkedRadio.id) {
+                sessionStorage.setItem(this._surchargeRestoreKey, checkedRadio.id);
+            }
+        } catch (e) {
+            // sessionStorage unavailable: reload still happens, buyer re-picks manually.
+        }
+
+        if (window.prestashop && typeof window.prestashop.emit === 'function') {
+            window.prestashop.emit('updateCart', {
+                reason: { linkAction: 'twoSurchargeSync' },
+                resp: { cart: (window.prestashop && window.prestashop.cart) || {} }
+            });
+        }
+    }
+
+    /**
+     * After the native payment-step reload, re-check the payment option the
+     * buyer had clicked and re-fire its change event so all listeners
+     * (PrestaShop core's option toggling, our own handler) rebuild their
+     * state. The server-side sync endpoint is idempotent, so the re-fired
+     * change cannot loop: it reports changed=false and no refresh is
+     * triggered again.
+     */
+    restorePaymentSelectionAfterCartRefresh() {
+        let radioId = null;
+        try {
+            radioId = sessionStorage.getItem(this._surchargeRestoreKey);
+            if (radioId !== null) {
+                sessionStorage.removeItem(this._surchargeRestoreKey);
+            }
+        } catch (e) {
+            return;
+        }
+        if (!radioId) {
+            return;
+        }
+        const radio = document.getElementById(radioId);
+        if (radio && !radio.checked) {
+            radio.checked = true;
+            radio.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+    }
+
     /**
      * ENHANCED: Check if Two payment is selected (theme-independent with better detection)
      */
@@ -1339,6 +1470,14 @@ class TwoCheckoutManager {
                             dataType: 'json',
                             data: { ajax: 1, action: 'savePaymentTerm', token: window.twopayment.ajax_token, days: days },
                             timeout: 10000
+                        }).done(() => {
+                            // The surcharge amount is term-dependent: with Two
+                            // selected, re-quote and update the cart line for
+                            // the newly persisted term (idempotent server-side;
+                            // no-op when the amount is unchanged).
+                            if (this.isTwoPaymentSelected()) {
+                                this.syncSurchargeCartLine(true);
+                            }
                         }).fail((xhr, statusText) => {
                             if (statusText !== 'abort') {
                                 console.error('Two Payment: Error saving term:', statusText);

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -1,0 +1,320 @@
+/**
+ * Two Sole Trader - presentation layer for the sole-trader checkout flow
+ * (TWO-24755).
+ *
+ * All decisioning lives server-side in classes/TwoSoleTrader.php (whether
+ * the option shows for a country, token minting); this module only reacts
+ * to the buyer's account_type, opens Two's hosted signup popup, autofills
+ * the company data from GET /autofill/v1/buyer/current, and persists it
+ * through the existing saveCompany action so the regular order-intent and
+ * payment paths run unchanged. Mirrors the WooCommerce/Magento plugins'
+ * flow: enrolment happens in the hosted popup, which posts 'ACCEPTED'
+ * back to this window; the enrolled buyer's TWO:ST organization number
+ * carries the sole-trader semantics.
+ */
+class TwoSoleTrader {
+    constructor(config) {
+        this.config = {
+            enabled: false,
+            checkoutHost: '',
+            orderIntentUrl: '',
+            ajaxToken: '',
+            signupUrl: '',
+            ...config
+        };
+        this.tokens = null;
+        this.flowStarted = false;
+        this.messageListenerBound = false;
+
+        if (this.config.enabled) {
+            this.init();
+        }
+    }
+
+    init() {
+        const self = this;
+        // The account_type select lives on the address step; the payment
+        // box renders later. Watch both: select changes and DOM arrival of
+        // the payment container (checkout step transitions re-render).
+        document.addEventListener('change', function (event) {
+            if (event.target && event.target.matches("select[name='account_type']")) {
+                self.evaluate();
+            }
+        });
+        const observer = new MutationObserver(function () {
+            self.evaluate();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        this.evaluate();
+    }
+
+    accountType() {
+        const field = document.querySelector("select[name='account_type']");
+        if (field && field.value) {
+            return field.value;
+        }
+        // The address form is gone at the payment step; TwoCheckoutManager
+        // mirrors the selection into sessionStorage on every change.
+        try {
+            return sessionStorage.getItem('two_account_type') || '';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    container() {
+        return document.querySelector('.two-sole-trader');
+    }
+
+    /**
+     * Show/hide the sole-trader block and kick the flow off exactly once
+     * per page when the buyer is in sole-trader mode at the payment step.
+     */
+    evaluate() {
+        const container = this.container();
+        if (!container) {
+            return;
+        }
+        if (this.accountType() === 'sole_trader') {
+            container.style.display = 'block';
+            if (!this.flowStarted) {
+                this.flowStarted = true;
+                this.fetchTokens();
+            }
+        } else {
+            container.style.display = 'none';
+        }
+    }
+
+    moduleUrl(action) {
+        const url = new URL(this.config.orderIntentUrl, window.location.origin);
+        url.searchParams.set('ajax', '1');
+        url.searchParams.set('action', action);
+        url.searchParams.set('token', this.config.ajaxToken);
+        return url.toString();
+    }
+
+    fetchTokens() {
+        const self = this;
+        fetch(this.moduleUrl('soleTraderTokens'), { method: 'POST' })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                if (json && json.success && json.autofill_token) {
+                    self.tokens = json;
+                    self.bindPopupMessageListener();
+                    self.getCurrentBuyer();
+                } else {
+                    self.showError();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    /**
+     * The buyer's email as entered in the checkout, for matching against
+     * the Two registration. Sourced from PrestaShop's customer object
+     * (present once the personal-information step is done) with the email
+     * form field as fallback.
+     */
+    checkoutEmail() {
+        const ps = window.prestashop;
+        if (ps && ps.customer && ps.customer.email) {
+            return String(ps.customer.email);
+        }
+        const field = document.querySelector("input[name='email'], #email");
+        return field ? String(field.value || '') : '';
+    }
+
+    /**
+     * Autofill from the buyer's current Two sole-trader business. A 404,
+     * a missing checkout email or an email mismatch means no usable
+     * registration yet - show the signup prompt instead. The email match
+     * is case-insensitive and required, the same contract the WooCommerce
+     * and Magento plugins apply.
+     */
+    getCurrentBuyer() {
+        const self = this;
+        fetch(this.config.checkoutHost + '/autofill/v1/buyer/current', {
+            credentials: 'include',
+            headers: { 'two-delegated-authority-token': this.tokens.autofill_token }
+        })
+            .then(function (response) {
+                if (response.ok) {
+                    return response.json();
+                }
+                if (response.status === 404) {
+                    return null;
+                }
+                throw new Error('autofill/v1/buyer/current failed');
+            })
+            .then(function (buyer) {
+                const entered = self.checkoutEmail().trim().toLowerCase();
+                const matches = !!(buyer && buyer.email && entered
+                    && String(buyer.email).toLowerCase() === entered);
+                if (matches) {
+                    self.applyBuyer(buyer);
+                } else {
+                    self.showPrompt();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    /**
+     * Persist the enrolled sole trader's company data through the existing
+     * saveCompany cookie action; the order-intent and payment paths then
+     * pick it up via the regular company-data fallback chain.
+     */
+    applyBuyer(buyer) {
+        const self = this;
+        const country = this.billingCountry();
+        const body = new URLSearchParams({
+            company: buyer.company_name || '',
+            companyid: buyer.organization_number || '',
+            country: country
+        });
+        fetch(this.moduleUrl('saveCompany'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+        })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                if (json && json.success) {
+                    self.showStatus(buyer.company_name || buyer.organization_number);
+                    self.hidePrompt();
+                    document.dispatchEvent(new CustomEvent('two:sole-trader-ready'));
+                } else {
+                    self.showError();
+                }
+            })
+            .catch(function () {
+                self.showError();
+            });
+    }
+
+    billingCountry() {
+        const field = document.querySelector("select[name='id_country'], select[name='country']");
+        if (field && field.selectedOptions && field.selectedOptions.length) {
+            const iso = field.selectedOptions[0].getAttribute('data-iso-code');
+            if (iso) {
+                return iso;
+            }
+        }
+        return (window.twopayment && window.twopayment.shop_country) || '';
+    }
+
+    /**
+     * Base64 for the signup page's autofillData parameter. UTF-8-safe:
+     * a bare btoa() throws on any character outside Latin-1 (e.g. å/ø/æ
+     * in names), so encode to UTF-8 bytes first - same as the WooCommerce
+     * plugin; the signup page decodes base64-of-UTF-8 either way.
+     */
+    encodeAutofillData(data) {
+        return btoa(unescape(encodeURIComponent(JSON.stringify(data))));
+    }
+
+    openPopup() {
+        if (!this.tokens) {
+            return null;
+        }
+        const ps = window.prestashop;
+        const customer = (ps && ps.customer) || {};
+        const firstName = document.querySelector("input[name='firstname']");
+        const lastName = document.querySelector("input[name='lastname']");
+        const phone = document.querySelector("input[name='phone']");
+        const prefill = {
+            email: this.checkoutEmail(),
+            first_name: (firstName && firstName.value) || customer.firstname || '',
+            last_name: (lastName && lastName.value) || customer.lastname || '',
+            phone_number: phone ? phone.value : ''
+        };
+        const url =
+            this.tokens.signup_url +
+            '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
+            '&autofillToken=' + encodeURIComponent(this.tokens.autofill_token) +
+            '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill));
+        const popup = window.open(
+            url,
+            '_blank',
+            'location=yes,resizable=yes,scrollbars=yes,status=yes,height=805,width=610'
+        );
+        if (!popup) {
+            // Popup blocked despite opening from a click - surface it
+            // rather than failing silently.
+            this.showError();
+        }
+        return popup;
+    }
+
+    /**
+     * The hosted signup posts 'ACCEPTED' back to the opener when the buyer
+     * completes registration; re-fetch the buyer to autofill. Origin must
+     * be the signup page's own; anything else from that origin is a
+     * failure signal.
+     */
+    bindPopupMessageListener() {
+        if (this.messageListenerBound) {
+            return;
+        }
+        this.messageListenerBound = true;
+        const self = this;
+        window.addEventListener('message', function (event) {
+            if (self.accountType() !== 'sole_trader' || !self.tokens) {
+                return;
+            }
+            if (event.origin !== new URL(self.tokens.signup_url).origin) {
+                return;
+            }
+            if (event.data === 'ACCEPTED') {
+                self.getCurrentBuyer();
+            } else {
+                self.showError();
+            }
+        });
+    }
+
+    showPrompt() {
+        const self = this;
+        const prompt = this.container() && this.container().querySelector('.two-sole-trader__prompt');
+        if (!prompt) {
+            return;
+        }
+        prompt.style.display = 'inline';
+        if (!prompt.dataset.twoBound) {
+            prompt.dataset.twoBound = '1';
+            prompt.addEventListener('click', function (event) {
+                event.preventDefault();
+                self.openPopup();
+            });
+        }
+    }
+
+    hidePrompt() {
+        const prompt = this.container() && this.container().querySelector('.two-sole-trader__prompt');
+        if (prompt) {
+            prompt.style.display = 'none';
+        }
+    }
+
+    showStatus(label) {
+        const status = this.container() && this.container().querySelector('.two-sole-trader__status');
+        if (status) {
+            status.textContent = label;
+            status.style.display = 'inline';
+        }
+    }
+
+    showError() {
+        const error = this.container() && this.container().querySelector('.two-sole-trader__error');
+        if (error) {
+            error.style.display = 'inline';
+        }
+    }
+}
+
+window.TwoSoleTrader = TwoSoleTrader;

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -19,12 +19,12 @@ class TwoSoleTrader {
             checkoutHost: '',
             orderIntentUrl: '',
             ajaxToken: '',
-            signupUrl: '',
             ...config
         };
         this.tokens = null;
         this.flowStarted = false;
         this.messageListenerBound = false;
+        this.observer = null;
 
         if (this.config.enabled) {
             this.init();
@@ -41,11 +41,23 @@ class TwoSoleTrader {
                 self.evaluate();
             }
         });
-        const observer = new MutationObserver(function () {
+        this.observer = new MutationObserver(function () {
             self.evaluate();
         });
-        observer.observe(document.body, { childList: true, subtree: true });
+        this.observer.observe(document.body, { childList: true, subtree: true });
         this.evaluate();
+    }
+
+    /**
+     * Once the flow has resolved (enrolled company saved) there is nothing
+     * left for this instance to react to; stop observing rather than
+     * running a body-wide observer for the rest of checkout.
+     */
+    stopObserving() {
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
     }
 
     accountType() {
@@ -67,8 +79,12 @@ class TwoSoleTrader {
     }
 
     /**
-     * Show/hide the sole-trader block and kick the flow off exactly once
-     * per page when the buyer is in sole-trader mode at the payment step.
+     * Show/hide the sole-trader block and kick the flow off when the buyer
+     * is in sole-trader mode at the payment step. Retries on re-evaluation
+     * (e.g. address step -> payment step transition, or the buyer leaving
+     * and re-entering sole-trader mode) whenever the previous attempt
+     * didn't leave us with usable tokens - a transient failure must not
+     * strand the buyer until a full page reload.
      */
     evaluate() {
         const container = this.container();
@@ -77,7 +93,7 @@ class TwoSoleTrader {
         }
         if (this.accountType() === 'sole_trader') {
             container.style.display = 'block';
-            if (!this.flowStarted) {
+            if (!this.flowStarted || !this.tokens) {
                 this.flowStarted = true;
                 this.fetchTokens();
             }
@@ -104,10 +120,12 @@ class TwoSoleTrader {
                     self.bindPopupMessageListener();
                     self.getCurrentBuyer();
                 } else {
+                    self.tokens = null;
                     self.showError();
                 }
             })
             .catch(function () {
+                self.tokens = null;
                 self.showError();
             });
     }
@@ -168,14 +186,26 @@ class TwoSoleTrader {
      * Persist the enrolled sole trader's company data through the existing
      * saveCompany cookie action; the order-intent and payment paths then
      * pick it up via the regular company-data fallback chain.
+     *
+     * Two things a naive implementation gets wrong here:
+     *  - company_name may be BLANK for a sole trader (they often trade
+     *    under their own name, not a company name); saveCompany rejects an
+     *    empty company, so fall back to the organization number - the
+     *    order-intent payload only needs a non-empty, non-blank pair, and
+     *    the org-number prefix is what carries the sole-trader semantics
+     *    server-side anyway (TWO-24749).
+     *  - the country MUST be the token response's server-resolved invoice
+     *    country, not a DOM guess: getTwoValidatedSessionCompanyData()
+     *    wipes the whole session company the moment the saved country
+     *    disagrees with the cart's actual invoice-address country.
      */
     applyBuyer(buyer) {
         const self = this;
-        const country = this.billingCountry();
+        const companyLabel = buyer.company_name || buyer.organization_number || '';
         const body = new URLSearchParams({
-            company: buyer.company_name || '',
+            company: companyLabel,
             companyid: buyer.organization_number || '',
-            country: country
+            country: (this.tokens && this.tokens.country) || ''
         });
         fetch(this.moduleUrl('saveCompany'), {
             method: 'POST',
@@ -185,8 +215,9 @@ class TwoSoleTrader {
             .then(function (response) { return response.json(); })
             .then(function (json) {
                 if (json && json.success) {
-                    self.showStatus(buyer.company_name || buyer.organization_number);
+                    self.showStatus(companyLabel);
                     self.hidePrompt();
+                    self.stopObserving();
                     document.dispatchEvent(new CustomEvent('two:sole-trader-ready'));
                 } else {
                     self.showError();
@@ -195,17 +226,6 @@ class TwoSoleTrader {
             .catch(function () {
                 self.showError();
             });
-    }
-
-    billingCountry() {
-        const field = document.querySelector("select[name='id_country'], select[name='country']");
-        if (field && field.selectedOptions && field.selectedOptions.length) {
-            const iso = field.selectedOptions[0].getAttribute('data-iso-code');
-            if (iso) {
-                return iso;
-            }
-        }
-        return (window.twopayment && window.twopayment.shop_country) || '';
     }
 
     /**
@@ -233,6 +253,12 @@ class TwoSoleTrader {
             last_name: (lastName && lastName.value) || customer.lastname || '',
             phone_number: phone ? phone.value : ''
         };
+        // Tokens travel in the popup URL's query string (browser history,
+        // Referer to third-party assets on the signup page) - the same
+        // trade-off the WooCommerce plugin makes. Acceptable here because
+        // both tokens are scoped to this buyer and short-lived; a
+        // meaningfully more private delivery (postMessage/fragment) would
+        // require the hosted signup page to support it first.
         const url =
             this.tokens.signup_url +
             '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
@@ -254,8 +280,10 @@ class TwoSoleTrader {
     /**
      * The hosted signup posts 'ACCEPTED' back to the opener when the buyer
      * completes registration; re-fetch the buyer to autofill. Origin must
-     * be the signup page's own; anything else from that origin is a
-     * failure signal.
+     * be the signup page's own. Any other message from that origin is
+     * ignored rather than treated as a failure - the signup page may emit
+     * unrelated messages (resize/analytics) that are none of our business,
+     * and only an explicit ACCEPTED is a signal we act on.
      */
     bindPopupMessageListener() {
         if (this.messageListenerBound) {
@@ -272,8 +300,6 @@ class TwoSoleTrader {
             }
             if (event.data === 'ACCEPTED') {
                 self.getCurrentBuyer();
-            } else {
-                self.showError();
             }
         });
     }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -25,6 +25,17 @@ class TwoSoleTrader {
         this.flowStarted = false;
         this.messageListenerBound = false;
         this.observer = null;
+        // In-flight guard + cooldown: the MutationObserver below fires on
+        // essentially any DOM change during checkout (spinners, unrelated
+        // widget re-renders). Without these, a persistent token-mint
+        // failure (no invoice address yet, registry down, rate-limited...)
+        // would re-invoke fetchTokens() - two upstream Two API calls - on
+        // every single mutation, with overlapping in-flight requests and
+        // no backoff. isFetchingTokens blocks re-entry while a request is
+        // outstanding; nextRetryAt enforces a minimum gap between attempts.
+        this.isFetchingTokens = false;
+        this.nextRetryAt = 0;
+        this.retryCooldownMs = 5000;
 
         if (this.config.enabled) {
             this.init();
@@ -84,7 +95,10 @@ class TwoSoleTrader {
      * (e.g. address step -> payment step transition, or the buyer leaving
      * and re-entering sole-trader mode) whenever the previous attempt
      * didn't leave us with usable tokens - a transient failure must not
-     * strand the buyer until a full page reload.
+     * strand the buyer until a full page reload. fetchTokens() itself
+     * guards against overlapping requests and enforces a cooldown, so this
+     * can be called as often as the (body-wide) MutationObserver fires
+     * without risking a request storm.
      */
     evaluate() {
         const container = this.container();
@@ -110,7 +124,17 @@ class TwoSoleTrader {
         return url.toString();
     }
 
+    /**
+     * Mint tokens, guarded against the retry-on-every-mutation path above
+     * turning into a request storm: refuses re-entry while a request is
+     * already outstanding (isFetchingTokens) and enforces a minimum gap
+     * between attempts after a failure (nextRetryAt/retryCooldownMs).
+     */
     fetchTokens() {
+        if (this.isFetchingTokens || Date.now() < this.nextRetryAt) {
+            return;
+        }
+        this.isFetchingTokens = true;
         const self = this;
         fetch(this.moduleUrl('soleTraderTokens'), { method: 'POST' })
             .then(function (response) { return response.json(); })
@@ -121,12 +145,17 @@ class TwoSoleTrader {
                     self.getCurrentBuyer();
                 } else {
                     self.tokens = null;
+                    self.nextRetryAt = Date.now() + self.retryCooldownMs;
                     self.showError();
                 }
             })
             .catch(function () {
                 self.tokens = null;
+                self.nextRetryAt = Date.now() + self.retryCooldownMs;
                 self.showError();
+            })
+            .finally(function () {
+                self.isFetchingTokens = false;
             });
     }
 

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -132,8 +132,7 @@
                     enabled: true,
                     checkoutHost: twopayment.checkout_host,
                     orderIntentUrl: twopayment.order_intent_url,
-                    ajaxToken: twopayment.ajax_token,
-                    signupUrl: twopayment.sole_trader.signup_url
+                    ajaxToken: twopayment.ajax_token
                 });
             }
 

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -119,7 +119,24 @@
             
             // Store global reference for modules
             window.TwoCheckoutManager_Instance = checkoutManager;
-            
+
+            // Sole trader flow (TWO-24755) - separate presentation module,
+            // active only when the merchant enabled it.
+            if (
+                typeof TwoSoleTrader !== 'undefined' &&
+                twopayment.sole_trader &&
+                String(twopayment.sole_trader.enabled) === '1' &&
+                !window.TwoSoleTrader_Instance
+            ) {
+                window.TwoSoleTrader_Instance = new TwoSoleTrader({
+                    enabled: true,
+                    checkoutHost: twopayment.checkout_host,
+                    orderIntentUrl: twopayment.order_intent_url,
+                    ajaxToken: twopayment.ajax_token,
+                    signupUrl: twopayment.sole_trader.signup_url
+                });
+            }
+
         } catch (error) {
             console.error('Two Payment: Initialization failed:', error);
             

--- a/views/templates/hook/paymentinfo.tpl
+++ b/views/templates/hook/paymentinfo.tpl
@@ -11,6 +11,14 @@
         <span class="two-result-icon"></span>
         <span class="two-result-text"></span>
     </div>
+
+    {* Sole trader flow (TWO-24755) - shown by TwoSoleTrader.js when the
+       buyer's account type is sole_trader *}
+    <div class="two-sole-trader" style="display: none;">
+        <a href="#" class="two-sole-trader__prompt" style="display: none;">{l s='Click here to log in or sign up as a sole trader with Two.' mod='twopayment'}</a>
+        <span class="two-sole-trader__status" style="display: none;"></span>
+        <span class="two-sole-trader__error" style="display: none;">{l s='Something went wrong setting up sole trader checkout. Please try again.' mod='twopayment'}</span>
+    </div>
     
     {* Header Section *}
     <div class="two-header">


### PR DESCRIPTION
## Summary

Resurrects TWO-24755 (previously "Review needed" in Linear, never resolved). Supersedes the abandoned, closed **PR #35** on branch `doug/TWO-24755-sole-trader` — that branch was based on old `doug/TWO-24752-terms-chips` and conflicts significantly against current `staging` (surcharge rework, tax-treatment explicit-selection, terms chips, admin fee grid all landed since). This PR reimplements the same design fresh off current `staging`; the old branch/PR are left untouched for reference and can be cleaned up once this merges.

- Buyers in countries where Two's registry supports sole traders (`GET /registry/v1/supported-company-types/<ISO>`) get a **Sole Trader** option added to the existing Personal/Business `account_type` selector on the address form — gated server-side by the registry answer AND a new **"Enable sole trader checkout"** admin toggle (default **off**, requires Account Type selection mode to be on).
- At the payment step, choosing Sole Trader mints delegation + autofill delegated-authority tokens server-side (merchant API key never reaches the browser; fail-closed pair — either token missing voids both), opens Two's hosted signup popup, and on completion (`postMessage` `'ACCEPTED'` from the signup page's own origin) autofills the buyer's company data from `GET /autofill/v1/buyer/current` (case-insensitive email match required) and persists it through the existing `saveCompany` cookie path — order-intent and payment run unchanged.
- Matches the WooCommerce/Magento plugins' actual current flow (verified against their real code, not assumed): registry gate + admin toggle default off, fail-closed token pair, `ACCEPTED` postMessage with origin check, UTF-8-safe `btoa` encoding for the popup prefill data.

## Review process (self-review lane, no second human reviewer required)

Two rounds of adversarial review (4 lenses: reliability/edge-cases, input-boundary prosecution, PrestaShop-idiom correctness, maintainability) plus a verification pass, all as separate commits:

**Round 1** found and fixed 12 issues, including two blockers in the popup→autofill persistence chain (the exact kind of gap the old abandoned PR #35 reportedly left unfinished):
- Sole traders with no distinct company name (common — they trade under their own name) could never complete checkout: `saveCompany` rejects an empty company, so the flow now falls back to the organization number as the persisted label.
- The JS guessed the billing country from the DOM at the payment step (where the address form is gone) and fell back to the shop's context country; any mismatch against the cart's real invoice country made the existing session-company validator silently wipe the just-saved company on the next order-intent call. The token-mint endpoint now returns its server-resolved invoice-address country, and the JS uses that instead of guessing.
- Plus: token endpoint now fails closed (no client-country fallback) when the cart has no invoice address yet; the registry-answer cache is a single cookie slot instead of one key per requested country (was an unbounded session-cookie growth vector); fetch errors are no longer cached as if they were a real "not supported" answer; missing `_PS_VERSION_` direct-access guard added; upgrade script + version bump added for the new config key; CHANGELOG entry added; dead config fields removed; JS retries after a failure instead of latching permanently; the body-wide `MutationObserver` disconnects once the flow resolves.

**Round 2 (verification)** confirmed all round-1 fixes hold up under direct code read, and caught one regression the retry fix introduced: the retry-on-mutation logic had no in-flight guard or backoff, so a persistently failing token mint could re-invoke the mint endpoint (2 upstream Two API calls) on every DOM mutation during checkout. Fixed with an in-flight guard + 5s cooldown (separate commit).

Both known open items from the old PR #35's review are addressed here: the SSL-verify fix is carried over and applies to the token-mint curl call; the `btoa`/UTF-8 handling was verified against actual current WooCommerce behavior (UTF-8-safe encoding, not Magento's bare `btoa()` which throws on non-Latin-1 characters) rather than assumed; the popup handler is now traced end-to-end and the two breaks found in that chain are fixed.

## Test plan

- [x] `tests/run.php` full suite green locally and in `php:8.2-cli` Docker (matches CI's `make test`)
- [x] New `TwoSoleTraderSpec` covers: both gates (registry + toggle + account-type mode dependency), registry-only response semantics (empty list = business-only), fail-soft vs fail-closed distinction, cookie cache single-slot/overwrite/TTL-expiry/error-not-cached, account-type allow matrix, token-mint fail-closed pairing, signup URL per environment, and the address-form third option
- [x] PHP lint clean on every touched file; JS syntax-checked
- [ ] CI checks (pending — will monitor and fix any failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— posted by Claude