### PR TITLE
TWO-25111: gate invoice upload on invoice_distributed_by_merchant, retire PS_TWO_USE_OWN_INVOICES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Invoice upload is now gated on the merchant record, not an admin toggle** (TWO-25111, per decision TWO-25106 Option A)
+  - The plugin-side invoice upload (own-invoice merchants) now triggers only when the `invoice_distributed_by_merchant` flag on the Two merchant record (`GET /v1/merchant`) is true - the same signal checkout-api itself enforces (TWO-24761), and the same gating model Magento (TWO-24758) and WooCommerce (TWO-24757) use
+  - The flag is cached by the existing TTL-gated merchant-record fetch (shared with `available_terms`/`due_in_days`); absent-from-response is treated as false, a failed fetch serves the last known value, and a merchant identity change fails closed
+  - Module version bumped to `2.6.0`
+
+### Removed
+- **`PS_TWO_USE_OWN_INVOICES` admin setting retired** (TWO-25111)
+  - The "Upload Own Invoices to Two" switch is removed from the module configuration page; the upgrade script deletes the configuration row and any leftover value has zero effect (covered by unit test)
+  - Merchants who had the toggle enabled were server-side whitelisted, and all previously-whitelisted merchants already carry `invoice_distributed_by_merchant = true` (TWO-24761), so no merchant loses the feature on upgrade
+
 ### Added
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.5.0]]></version>
+    <version><![CDATA[2.6.0]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/tests/InvoiceUploadGateSpec.php
+++ b/tests/InvoiceUploadGateSpec.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-25111 - the plugin-side invoice upload is gated SOLELY on the merchant's
+ * server-side `invoice_distributed_by_merchant` flag, sourced from the same
+ * GET /v1/merchant fetch/cache seam as available_terms (TWO-24813) and
+ * due_in_days (TWO-24859). The manual PS_TWO_USE_OWN_INVOICES admin toggle is
+ * retired (TWO-25106, Option A): leftover configuration rows from upgraded
+ * shops must have ZERO effect on behaviour.
+ */
+final class InvoiceUploadGateSpec
+{
+    public static function runAll(): void
+    {
+        // Flag semantics (null-safe, absent = false, strict boolean).
+        self::testFlagTrueEnablesGate();
+        self::testFlagFalseDisablesGate();
+        self::testFlagAbsentFromResponseDisablesGate();
+        self::testAbsentFlagOverwritesPreviouslyCachedTrue();
+        self::testNonBooleanTruthyFlagValueDisablesGate();
+        self::testUnresolvedCacheDefaultsToFalse();
+
+        // Cache lifecycle shared with the merchant-record seam.
+        self::testFailedFetchServesLastKnownFlag();
+        self::testInvalidateFailsClosed();
+
+        // Toggle retirement: remnants of PS_TWO_USE_OWN_INVOICES are inert.
+        self::testLeftoverToggleEnabledHasNoEffectWhenFlagUnresolved();
+        self::testLeftoverToggleDisabledDoesNotSuppressFlag();
+        self::testSourceNeverReadsRetiredToggle();
+    }
+
+    /** Set the identity config the merchant-record fetch guards on. */
+    private static function configureMerchantIdentity(): void
+    {
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'm-123');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'test-api-key');
+    }
+
+    /**
+     * Harness whose GET /v1/merchant fetch (setTwoPaymentRequest) is stubbed,
+     * so the flag caching can be asserted offline.
+     */
+    private static function moduleWithMerchantResponse($response): object
+    {
+        return new class ($response) extends TwopaymentTestHarness {
+            public int $fetchCount = 0;
+            private $response;
+
+            public function __construct($response)
+            {
+                parent::__construct();
+                $this->response = $response;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->fetchCount++;
+                return $this->response;
+            }
+        };
+    }
+
+    /** A 200 merchant record; $flag === null omits the field entirely. */
+    private static function okResponse($flag): array
+    {
+        $body = array('http_status' => Twopayment::HTTP_STATUS_OK, 'available_terms' => array(30));
+        if ($flag !== null) {
+            $body['invoice_distributed_by_merchant'] = $flag;
+        }
+        return $body;
+    }
+
+    private static function refreshedModule($response): object
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        $module = self::moduleWithMerchantResponse($response);
+        $module->getMerchantAvailableTerms(true); // sanctioned refresh point
+        return $module;
+    }
+
+    // ---- Flag semantics ---------------------------------------------------
+
+    private static function testFlagTrueEnablesGate(): void
+    {
+        $module = self::refreshedModule(self::okResponse(true));
+
+        TinyAssert::same(1, $module->fetchCount);
+        TinyAssert::true($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testFlagFalseDisablesGate(): void
+    {
+        $module = self::refreshedModule(self::okResponse(false));
+
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testFlagAbsentFromResponseDisablesGate(): void
+    {
+        $module = self::refreshedModule(self::okResponse(null));
+
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testAbsentFlagOverwritesPreviouslyCachedTrue(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_INVOICE_DISTRIBUTED, 1);
+
+        $module = self::moduleWithMerchantResponse(self::okResponse(null));
+        $module->getMerchantAvailableTerms(true);
+
+        // Unlike the term list (serve-stale on omission), an absent flag is a
+        // definitive "not enabled" and must overwrite the stale entitlement.
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testNonBooleanTruthyFlagValueDisablesGate(): void
+    {
+        // Defensive: the API contract is a JSON boolean; anything else must
+        // not open the gate ("true"/1 strings fail the strict === true check).
+        $module = self::refreshedModule(self::okResponse('true'));
+
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testUnresolvedCacheDefaultsToFalse(): void
+    {
+        StubStore::reset();
+        $module = new TwopaymentTestHarness();
+
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    // ---- Cache lifecycle --------------------------------------------------
+
+    private static function testFailedFetchServesLastKnownFlag(): void
+    {
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_INVOICE_DISTRIBUTED, 1);
+
+        $module = self::moduleWithMerchantResponse(array('http_status' => 500));
+        $module->getMerchantAvailableTerms(true);
+
+        // A network blip must not flap the gate off mid-entitlement; only a
+        // successful response (with the field absent or false) revokes it.
+        TinyAssert::same(1, $module->fetchCount);
+        TinyAssert::true($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testInvalidateFailsClosed(): void
+    {
+        StubStore::reset();
+        Configuration::updateValue(Twopayment::CONFIG_MERCHANT_INVOICE_DISTRIBUTED, 1);
+
+        $module = new TwopaymentTestHarness();
+        $module->invalidateMerchantAvailableTerms();
+
+        // Identity change: the old merchant's upload entitlement must never
+        // carry over to the new identity.
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    // ---- Retired toggle is inert -------------------------------------------
+
+    private static function testLeftoverToggleEnabledHasNoEffectWhenFlagUnresolved(): void
+    {
+        StubStore::reset();
+        // Upgraded shop with a leftover enabled toggle row and no resolved flag.
+        Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 1);
+
+        $module = new TwopaymentTestHarness();
+
+        TinyAssert::false($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testLeftoverToggleDisabledDoesNotSuppressFlag(): void
+    {
+        // The inverse remnant: a shop that had the toggle explicitly OFF but
+        // whose merchant record now carries the flag - the flag wins.
+        StubStore::reset();
+        self::configureMerchantIdentity();
+        Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 0);
+
+        $module = self::moduleWithMerchantResponse(self::okResponse(true));
+        $module->getMerchantAvailableTerms(true);
+
+        TinyAssert::true($module->isMerchantInvoiceDistributed());
+    }
+
+    private static function testSourceNeverReadsRetiredToggle(): void
+    {
+        // Belt-and-braces for "old config remnants must have zero effect"
+        // (TWO-25111 validation): the runtime module source must not READ
+        // PS_TWO_USE_OWN_INVOICES anywhere. The only sanctioned mentions are
+        // deletions (uninstall cleanup in twopayment.php, upgrade-2.6.0.php)
+        // and the historical upgrade-2.2.0.php that introduced it.
+        $root = dirname(__DIR__);
+        $sources = array_merge(
+            array($root . '/twopayment.php'),
+            glob($root . '/classes/*.php') ?: array(),
+            glob($root . '/controllers/*/*.php') ?: array()
+        );
+
+        foreach ($sources as $file) {
+            $lines = file($file);
+            TinyAssert::true(is_array($lines), 'Unreadable source file ' . $file);
+            foreach ($lines as $number => $line) {
+                if (strpos($line, 'PS_TWO_USE_OWN_INVOICES') === false) {
+                    continue;
+                }
+                $isDeletion = strpos($line, "Configuration::deleteByName('PS_TWO_USE_OWN_INVOICES')") !== false;
+                $isComment = preg_match('#^\s*(//|\*|/\*)#', $line) === 1;
+                TinyAssert::true(
+                    $isDeletion || $isComment,
+                    'Retired toggle PS_TWO_USE_OWN_INVOICES referenced (non-deletion) at '
+                    . $file . ':' . ($number + 1) . ' - ' . trim($line)
+                );
+            }
+        }
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -5017,6 +5017,7 @@ require __DIR__ . '/TermSurchargeAmountsSpec.php';
 require __DIR__ . '/SurchargeCartLineSpec.php';
 require __DIR__ . '/ConfirmationLegacyParitySpec.php';
 require __DIR__ . '/MinimumOrderGateSpec.php';
+require __DIR__ . '/InvoiceUploadGateSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5032,6 +5033,7 @@ $tests = [
     'SurchargeCartLineSpec::runAll' => [SurchargeCartLineSpec::class, 'runAll'],
     'ConfirmationLegacyParitySpec::runAll' => [ConfirmationLegacyParitySpec::class, 'runAll'],
     'MinimumOrderGateSpec::runAll' => [MinimumOrderGateSpec::class, 'runAll'],
+    'InvoiceUploadGateSpec::runAll' => [InvoiceUploadGateSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -2263,7 +2263,14 @@ class Twopayment extends PaymentModule
                             }
                             
                             // Invoice Upload: upload the PrestaShop invoice to Two when the
-                            // merchant's invoice_distributed_by_merchant flag is set (TWO-25111)
+                            // merchant's invoice_distributed_by_merchant flag is set (TWO-25111).
+                            // Prime the merchant-record cache first (TTL-gated, a no-op while
+                            // fresh): fulfilment may be the first merchant-record touch since
+                            // deploy/upgrade, and the gate must not read an unresolved flag and
+                            // silently skip the upload for a one-shot fulfilment transition.
+                            // This path already makes synchronous Two calls, so one more
+                            // capped GET (at most once per TTL) is acceptable here.
+                            $this->getMerchantAvailableTerms(true);
                             $use_own_invoices = $this->isMerchantInvoiceDistributed();
                             PrestaShopLogger::addLog(
                                 'TwoPayment: Invoice upload check - invoice_distributed_by_merchant=' . ($use_own_invoices ? 'YES' : 'NO') . ', Order ID=' . $id_order,
@@ -6540,8 +6547,8 @@ class Twopayment extends PaymentModule
                         $due = isset($response['due_in_days']) ? $response['due_in_days'] : null;
                         $due_days = (is_numeric($due) && (int) $due > 0) ? (int) $due : 0;
                         Configuration::updateValue(self::CONFIG_MERCHANT_DUE_IN_DAYS, $due_days);
-                        // Third cache fed by this fetch: the invoice-upload
-                        // gate (TWO-25111). Unlike the term list, an absent
+                        // The invoice-upload gate is fed by this same fetch
+                        // (TWO-25111). Unlike the term list, an absent
                         // field IS an answer here - the backend omitting the
                         // flag means uploads are not enabled for this
                         // merchant, so cache 0 rather than serving stale
@@ -11277,7 +11284,12 @@ class Twopayment extends PaymentModule
                 'twopaymentdata' => $twopaymentdata,
                 'two_portal_url' => $this->getTwoPortalUrl(), // Dynamic portal URL based on environment
                 'two_pdf_url' => $pdf_url, // PDF invoice URL if available
-                'use_own_invoices' => $this->isMerchantInvoiceDistributed(),
+                // Show the upload-status section when the merchant currently
+                // has the feature OR this order already carries upload history
+                // (an order uploaded under a past entitlement must keep showing
+                // what happened to it even if the flag is later revoked).
+                'use_own_invoices' => $this->isMerchantInvoiceDistributed()
+                    || !empty($twopaymentdata['two_invoice_upload_status']),
                 'two_invoice_actions_available' => $invoice_actions_available,
                 'two_invoice_notice' => $this->getTwoInvoiceNoticeFromRequest(),
             ));

--- a/twopayment.php
+++ b/twopayment.php
@@ -41,6 +41,14 @@ class Twopayment extends PaymentModule
     // term). Populated by the SAME fetch as CONFIG_MERCHANT_AVAILABLE_TERMS and
     // gated by the shared CONFIG_MERCHANT_AVAILABLE_TERMS_TS (TWO-24859).
     const CONFIG_MERCHANT_DUE_IN_DAYS = 'PS_TWO_MERCHANT_DUE_IN_DAYS';
+    // Cached GET /v1/merchant `invoice_distributed_by_merchant` flag (TWO-25111).
+    // Gates the plugin-side invoice upload (TwoInvoiceUploadService) - the
+    // merchant-controlled admin toggle PS_TWO_USE_OWN_INVOICES it replaces is
+    // retired (TWO-25106, Option A: flag-driven only, no admin toggle).
+    // Populated by the SAME fetch as CONFIG_MERCHANT_AVAILABLE_TERMS and gated
+    // by the shared CONFIG_MERCHANT_AVAILABLE_TERMS_TS. Null-safe: a response
+    // without the field caches `0` (absent = false).
+    const CONFIG_MERCHANT_INVOICE_DISTRIBUTED = 'PS_TWO_MERCHANT_INVOICE_DISTRIBUTED';
     // Cached GET /v1/merchant minimum-order tuple (min_order_amount /
     // min_order_currency / min_order_basis - the funding-partner default with
     // any merchant override, resolved server-side, the same value checkout-api
@@ -132,7 +140,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.5.0';
+        $this->version = '2.6.0';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -314,7 +322,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
         Configuration::updateValue('PS_TWO_USE_ACCOUNT_TYPE', 0);
-        Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', 0); // Disabled by default - must be enabled after coordinating with Two
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1); // Enabled by default; can be disabled for compatibility
@@ -553,6 +560,11 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         Configuration::deleteByName('PS_TWO_USE_ACCOUNT_TYPE');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
+        Configuration::deleteByName(self::CONFIG_MERCHANT_INVOICE_DISTRIBUTED);
+        // Retired admin toggle (TWO-25111) - shops upgraded from <=2.5.0 may
+        // still carry the row; the upgrade script deletes it, this covers
+        // uninstall-without-upgrade.
+        Configuration::deleteByName('PS_TWO_USE_OWN_INVOICES');
         $this->deleteTwoSurchargeCartProduct();
         Configuration::deleteByName(self::CONFIG_SURCHARGE_PRODUCT_ID);
         // The merchant's own TaxRulesGroup referenced by this config is NOT
@@ -1345,44 +1357,6 @@ class Twopayment extends PaymentModule
                     ),
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Upload Own Invoices to Two'),
-                        'name' => 'PS_TWO_USE_OWN_INVOICES',
-                        'is_bool' => true,
-                        'desc' => $this->l('Enable this ONLY if you are using your own invoices instead of Two\'s generated invoices. This must be coordinated with Two before enabling.') . '<br><br>' .
-                                  '<strong>' . $this->l('When enabled:') . '</strong><br>' .
-                                  '• ' . $this->l('Your PrestaShop invoices will be uploaded to Two when orders are fulfilled') . '<br>' .
-                                  '• ' . $this->l('Two will NOT generate invoices - your invoice is used instead') . '<br><br>' .
-                                  '<strong style="color: #d63031;">' . $this->l('REQUIRED: You must customize your invoice template') . '</strong><br>' .
-                                  $this->l('Edit your invoice template to include Two\'s payment details FOR TWO ORDERS ONLY.') . '<br>' .
-                                  $this->l('Template location:') . ' <code>/themes/YOUR_THEME/pdf/invoice.tpl</code> ' . $this->l('or') . ' <code>/pdf/invoice.tpl</code><br><br>' .
-                                  '<strong>' . $this->l('Add this code to your invoice template:') . '</strong>' .
-                                  '<pre style="background:#f5f5f5; padding:10px; margin:10px 0; border-radius:4px; font-size:11px; overflow-x:auto;">' .
-                                  '{if $order->module == \'twopayment\'}<br>' .
-                                  '&lt;div style="margin-top:20px; padding:15px; border:1px solid #333;"&gt;<br>' .
-                                  '  &lt;strong&gt;Payment Instructions&lt;/strong&gt;&lt;br&gt;<br>' .
-                                  '  The debt represented by this invoice has been assigned to Two.<br>' .
-                                  '  Please pay to Two\'s bank account (details provided by Two).<br>' .
-                                  '  Include your payment reference when paying.<br>' .
-                                  '&lt;/div&gt;<br>' .
-                                  '{/if}</pre>' .
-                                  $this->l('Two will provide you with the specific bank details and payment reference format to include.') . '<br><br>' .
-                                  '<strong style="color: #d63031;">' . $this->l('Important: Contact Two support before enabling this feature.') . '</strong>',
-                        'required' => true,
-                        'values' => array(
-                            array(
-                                'id' => 'PS_TWO_USE_OWN_INVOICES_ON',
-                                'value' => 1,
-                                'label' => $this->l('Yes')
-                            ),
-                            array(
-                                'id' => 'PS_TWO_USE_OWN_INVOICES_OFF',
-                                'value' => 0,
-                                'label' => $this->l('No')
-                            ),
-                        ),
-                    ),
-                    array(
-                        'type' => 'switch',
                         'label' => $this->l('Send tax subtotals in request payloads'),
                         'name' => 'PS_TWO_ENABLE_TAX_SUBTOTALS',
                         'is_bool' => true,
@@ -1438,7 +1412,6 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
-        $fields_values['PS_TWO_USE_OWN_INVOICES'] = Tools::getValue('PS_TWO_USE_OWN_INVOICES', Configuration::get('PS_TWO_USE_OWN_INVOICES'));
         $fields_values['PS_TWO_ENABLE_B2B_B2C'] = Tools::getValue('PS_TWO_ENABLE_B2B_B2C', Configuration::get('PS_TWO_ENABLE_B2B_B2C'));
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
@@ -1455,7 +1428,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
-        Configuration::updateValue('PS_TWO_USE_OWN_INVOICES', Tools::getValue('PS_TWO_USE_OWN_INVOICES'));
         Configuration::updateValue('PS_TWO_ENABLE_B2B_B2C', Tools::getValue('PS_TWO_ENABLE_B2B_B2C'));
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
@@ -2290,10 +2262,11 @@ class Twopayment extends PaymentModule
                                 $this->setTwoOrderPaymentData($id_order, $payment_data);
                             }
                             
-                            // Invoice Upload: Upload PrestaShop invoice to Two when using own invoices
-                            $use_own_invoices = Configuration::get('PS_TWO_USE_OWN_INVOICES');
+                            // Invoice Upload: upload the PrestaShop invoice to Two when the
+                            // merchant's invoice_distributed_by_merchant flag is set (TWO-25111)
+                            $use_own_invoices = $this->isMerchantInvoiceDistributed();
                             PrestaShopLogger::addLog(
-                                'TwoPayment: Invoice upload check - PS_TWO_USE_OWN_INVOICES=' . ($use_own_invoices ? 'YES' : 'NO') . ', Order ID=' . $id_order,
+                                'TwoPayment: Invoice upload check - invoice_distributed_by_merchant=' . ($use_own_invoices ? 'YES' : 'NO') . ', Order ID=' . $id_order,
                                 1,
                                 null,
                                 'Order',
@@ -6567,6 +6540,16 @@ class Twopayment extends PaymentModule
                         $due = isset($response['due_in_days']) ? $response['due_in_days'] : null;
                         $due_days = (is_numeric($due) && (int) $due > 0) ? (int) $due : 0;
                         Configuration::updateValue(self::CONFIG_MERCHANT_DUE_IN_DAYS, $due_days);
+                        // Third cache fed by this fetch: the invoice-upload
+                        // gate (TWO-25111). Unlike the term list, an absent
+                        // field IS an answer here - the backend omitting the
+                        // flag means uploads are not enabled for this
+                        // merchant, so cache 0 rather than serving stale
+                        // (null-safe absent-is-false, per TWO-25106).
+                        Configuration::updateValue(
+                            self::CONFIG_MERCHANT_INVOICE_DISTRIBUTED,
+                            (isset($response['invoice_distributed_by_merchant']) && $response['invoice_distributed_by_merchant'] === true) ? 1 : 0
+                        );
                         // Third cache fed by the same fetch: the platform
                         // minimum-order tuple (TWO-24775). Unlike the term
                         // list, an absent or malformed tuple IS the answer
@@ -6648,7 +6631,32 @@ class Twopayment extends PaymentModule
         // "no minimum" - the correct fail-open posture until the re-fetch
         // (the API still enforces the real minimum at order create).
         Configuration::updateValue(self::CONFIG_PLATFORM_MIN_ORDER, '');
+        // The invoice-upload gate is sourced from the same merchant record:
+        // an identity change must never leave the OLD merchant's upload
+        // entitlement in force for the new one (TWO-25111). Fail closed.
+        Configuration::updateValue(self::CONFIG_MERCHANT_INVOICE_DISTRIBUTED, 0);
         Configuration::updateValue(self::CONFIG_MERCHANT_AVAILABLE_TERMS_TS, 0);
+    }
+
+    /**
+     * Whether the merchant distributes their own invoices - the server-side
+     * `invoice_distributed_by_merchant` flag from the cached GET /v1/merchant
+     * record. This is the ONLY gate for the plugin-side invoice upload
+     * (TwoInvoiceUploadService): the manual PS_TWO_USE_OWN_INVOICES admin
+     * toggle is retired (TWO-25111 / TWO-25106 Option A) and any leftover
+     * value of it in the configuration table has zero effect. checkout-api
+     * enforces the same flag server-side (403 when false, TWO-24761), so this
+     * plugin-side gate only avoids doomed upload attempts; it is not a
+     * security boundary.
+     *
+     * Cache-only (never fetches): refreshed by the same TTL-gated fetch as
+     * the available-terms cache. Null-safe: unresolved/absent caches as 0.
+     *
+     * @return bool
+     */
+    public function isMerchantInvoiceDistributed()
+    {
+        return (bool) Configuration::get(self::CONFIG_MERCHANT_INVOICE_DISTRIBUTED);
     }
 
     /**
@@ -11269,7 +11277,7 @@ class Twopayment extends PaymentModule
                 'twopaymentdata' => $twopaymentdata,
                 'two_portal_url' => $this->getTwoPortalUrl(), // Dynamic portal URL based on environment
                 'two_pdf_url' => $pdf_url, // PDF invoice URL if available
-                'use_own_invoices' => (bool)Configuration::get('PS_TWO_USE_OWN_INVOICES'),
+                'use_own_invoices' => $this->isMerchantInvoiceDistributed(),
                 'two_invoice_actions_available' => $invoice_actions_available,
                 'two_invoice_notice' => $this->getTwoInvoiceNoticeFromRequest(),
             ));

--- a/upgrade/upgrade-2.6.0.php
+++ b/upgrade/upgrade-2.6.0.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.0
+ *
+ * Retire the PS_TWO_USE_OWN_INVOICES admin toggle (TWO-25111 / TWO-25106
+ * Option A): the plugin-side invoice upload is now gated solely on the
+ * merchant's server-side `invoice_distributed_by_merchant` flag, read from
+ * the cached GET /v1/merchant record. The configuration row is deleted so no
+ * remnant can be mistaken for a live setting; the code never reads it again
+ * either way.
+ *
+ * Migration safety: merchants who had the toggle enabled were whitelisted
+ * server-side, and TWO-24761 (checkout-api whitelist retirement) set
+ * invoice_distributed_by_merchant=true for all previously-whitelisted
+ * merchants - so deleting the toggle does not remove the feature from any
+ * merchant that legitimately had it.
+ *
+ * Created: 2026-07-15
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_0($module)
+{
+    if (Configuration::hasKey('PS_TWO_USE_OWN_INVOICES')) {
+        $was_enabled = (bool) Configuration::get('PS_TWO_USE_OWN_INVOICES');
+        Configuration::deleteByName('PS_TWO_USE_OWN_INVOICES');
+        PrestaShopLogger::addLog(
+            'TwoPayment Upgrade 2.6.0: Removed retired PS_TWO_USE_OWN_INVOICES toggle (was '
+            . ($was_enabled ? 'ENABLED' : 'disabled')
+            . '). Invoice upload is now gated on the invoice_distributed_by_merchant flag from the Two merchant record (TWO-25111).',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Why

[TWO-25106](https://linear.app/two-inc/issue/TWO-25106) resolved the invoice-upload gating model as **Option A — flag-driven, no admin toggle**. PrestaShop was the one live implementation doing the opposite. This brings PS in line so all three plugins (Magento TWO-24758, WooCommerce TWO-24757) gate identically on the server-side signal.

Ticket: [TWO-25111](https://linear.app/two-inc/issue/TWO-25111)

## What

- **Gate**: `TwoInvoiceUploadService` invocation (fulfilment path) now triggers only when `invoice_distributed_by_merchant` is true on the cached `GET /v1/merchant` record. Null-safe: absent = false; strict boolean check.
- **Cache seam**: the flag is a third cache fed by the existing TTL-gated merchant-record fetch (`getMerchantAvailableTerms`), alongside `available_terms` and `due_in_days`. A failed fetch serves the last known value (no gate-flap on a network blip); a merchant identity change fails closed.
- **Toggle retired**: `PS_TWO_USE_OWN_INVOICES` admin switch removed (form field, read, save, install default). Upgrade script `2.6.0` deletes the config row; uninstall covers the remnant for shops that never run the upgrade. No backward-compat shim — leftover rows have zero effect.
- **Admin order tab**: the "Invoice Upload Status" section visibility now follows the flag too.
- Version bump 2.5.0 → 2.6.0, CHANGELOG entry.

## Migration safety

Merchants with the toggle enabled were server-side whitelisted, and TWO-24761 (merged) set `invoice_distributed_by_merchant = true` for all previously-whitelisted merchants — checkout-api already gates solely on the flag (403 when false). No merchant silently loses the feature.

## Validation

- New `tests/InvoiceUploadGateSpec.php` (11 cases): flag true/false/absent/non-boolean, unresolved cache default, serve-stale on failed fetch, fail-closed invalidation, leftover-toggle inertness both ways, and a source scan asserting no runtime read of the retired key remains.
- Full suite green: `php tests/run.php` — 15/15 specs pass.