### PR TITLE
TWO-25105: real FX layer on GET /refdata/v1/fx-rates (replace core conversion + currency pinning)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
           php -l tests/TrackingNumberSpec.php
           php -l tests/DefaultPaymentTermSpec.php
           php -l tests/MinimumOrderGateSpec.php
+          php -l tests/FxRatesSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Merchants who had the toggle enabled were server-side whitelisted, and all previously-whitelisted merchants already carry `invoice_distributed_by_merchant = true` (TWO-24761), so no merchant loses the feature on upgrade
 
 ### Added
+- **Real FX layer on Two's own spot rates** (TWO-25105)
+  - Every Two-side currency conversion (platform/merchant minimum-order gate, minimum-order decline hint, admin floor display and save validation, fixed-surcharge/cap re-denomination) now uses the rates from `GET /refdata/v1/fx-rates` - the same EUR-pivot table checkout-api enforces server-side - instead of PrestaShop core's own conversion rates
+  - The full rate table is fetched server-side with the merchant API key (never from browser JS), cached in module configuration with a 6h TTL refreshed from the checkout media hook, and fetched on demand when a not-yet-cached currency reaches a conversion; the response's `as_of` staleness floor is retained alongside the rates
+  - Failure posture: a failed refresh serves the last-known-good table and retries after a short backoff; gate conversions fail closed only when no table was ever fetched, display conversions fail soft
+  - Fixed surcharge amounts and caps (configured in the shop default currency) are converted into the quote currency before the pricing call, replacing the previous single-currency pinning; an unconvertible figure omits the fee quote instead of sending a wrong-currency amount
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice
   - The line's net amount comes from the same live fee quote as the Two order payload (single computation path); its tax applies the merchant-selected tax rules group (see TWO-25071 below)

--- a/classes/TwoSurchargeCalculator.php
+++ b/classes/TwoSurchargeCalculator.php
@@ -84,9 +84,11 @@ class TwoSurchargeCalculator
             'surcharge_basis' => 'buyer_pays',
         );
 
-        // Fixed amounts and caps are sent in the store currency as configured.
-        // The plugin does no FX conversion (single-currency stores only for
-        // fixed surcharge); percentage surcharge is currency-agnostic.
+        // Fixed amounts and caps are emitted here in the store currency they
+        // are configured in; the module re-denominates them into the quote
+        // currency via Two's FX rates before the wire call
+        // (Twopayment::convertTwoBuyerFeeShareCurrency, TWO-25105).
+        // Percentage surcharge is currency-agnostic.
         if ($hasFixed && isset($row['fixed']) && (float) $row['fixed'] > 0) {
             $buyer_fee_share['surcharge'] = (float) $row['fixed'];
         }

--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -248,7 +248,7 @@ final class FxRatesSpec
         TinyAssert::true($module->refreshTwoFxRates());
         // Fresh values win; the dropped currency keeps its last-known-good
         // rate instead of failing its gate closed for a whole TTL.
-        TinyAssert::same(90.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same(111.11, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'), 'fresh NOK rate (0.09 EUR/NOK) must replace the cached 0.1');
         TinyAssert::same(12.5, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'));
         TinyAssert::same(1, $module->fxFetchCount);
     }

--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -249,7 +249,7 @@ final class FxRatesSpec
         // Fresh values win; the dropped currency keeps its last-known-good
         // rate instead of failing its gate closed for a whole TTL.
         TinyAssert::same(111.11, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'), 'fresh NOK rate (0.09 EUR/NOK) must replace the cached 0.1');
-        TinyAssert::same(12.5, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'));
+        TinyAssert::same(8.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'), 'dropped GBP keeps its last-known-good rate (1.25 EUR/GBP)');
         TinyAssert::same(1, $module->fxFetchCount);
     }
 

--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -32,6 +32,7 @@ final class FxRatesSpec
         self::testRefreshHonoursTtl();
         self::testFailedRefreshServesLastKnownGoodAndBacksOff();
         self::testPartialResponseMergesOverLastKnownGood();
+        self::testAllJunkResponseIsAFailedFetch();
         self::testNeverFetchedFailsGateClosedAndDisplaySoft();
         self::testMissingApiKeyNeverFetches();
         self::testGateJudgesCrossCurrencyBasketOnEndpointRate();
@@ -231,25 +232,53 @@ final class FxRatesSpec
     private static function testPartialResponseMergesOverLastKnownGood(): void
     {
         self::reset();
-        // The refetch succeeds but transiently DROPS GBP and moves NOK.
+        // The refetch succeeds but moves NOK, DROPS SEK entirely, and
+        // carries a malformed (zero) GBP rate.
         $module = self::fxModule([
             'http_status' => 200,
             'base' => 'EUR',
             'as_of' => '2026-07-15',
-            'rates' => ['EUR' => 1.0, 'NOK' => 0.09],
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.09, 'GBP' => 0],
         ]);
         Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
             'base' => 'EUR',
             'as_of' => '2026-07-01',
-            'rates' => ['EUR' => 1.0, 'NOK' => 0.1, 'GBP' => 1.25],
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1, 'GBP' => 1.25, 'SEK' => 0.09],
         ]));
         Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
 
         TinyAssert::true($module->refreshTwoFxRates());
-        // Fresh values win; the dropped currency keeps its last-known-good
-        // rate instead of failing its gate closed for a whole TTL.
+        // Fresh validated values win; dropped and malformed currencies keep
+        // their last-known-good rates instead of failing their gates closed
+        // for a whole TTL.
         TinyAssert::same(111.11, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'), 'fresh NOK rate (0.09 EUR/NOK) must replace the cached 0.1');
-        TinyAssert::same(8.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'), 'dropped GBP keeps its last-known-good rate (1.25 EUR/GBP)');
+        TinyAssert::same(8.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'), 'malformed (zero) GBP rate must not displace the cached 1.25');
+        TinyAssert::same(111.11, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'SEK'), 'dropped SEK keeps its last-known-good rate');
+        TinyAssert::same(1, $module->fxFetchCount);
+    }
+
+    private static function testAllJunkResponseIsAFailedFetch(): void
+    {
+        self::reset();
+        // A 200 whose rates are entirely unusable must take the FAILURE path
+        // (backoff + serve-stale), not wipe the validated table.
+        $module = self::fxModule([
+            'http_status' => 200,
+            'base' => 'EUR',
+            'as_of' => '2026-07-15',
+            'rates' => ['EUR' => 0, 'NOK' => 'junk'],
+        ]);
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-01',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
+
+        TinyAssert::false($module->refreshTwoFxRates());
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'), 'last-known-good table survives an all-junk 200');
+        // Failure backoff engaged: no immediate retry.
+        TinyAssert::false($module->refreshTwoFxRates());
         TinyAssert::same(1, $module->fxFetchCount);
     }
 

--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-25105 - the real FX layer on GET /refdata/v1/fx-rates, replacing
+ * PrestaShop core's own conversion rates and the currency-pinning
+ * workaround. Contract under test:
+ *
+ *  - convertTwoAmountBetweenCurrencies converts via the endpoint's
+ *    EUR-pivot table (rates[CCY] = 1 CCY in EUR), NEVER via PS core
+ *    conversion_rate (poisoned in every fixture to prove it).
+ *  - Cache: one wire fetch fills the full table; every later conversion
+ *    (any pair, any module instance) is served from Configuration without
+ *    refetching until the 6h TTL expires; `as_of` rides along.
+ *  - Failure: a failed fetch serves the last-known-good table (gate
+ *    conversions keep working) and backs off FX_RATES_RETRY_BACKOFF before
+ *    retrying; with NO table ever fetched, conversions resolve null - the
+ *    platform-minimum gate fails closed, display conversions fail soft.
+ *  - Fixed surcharge / cap re-denomination: fetchTwoTermFee converts the
+ *    shop-default-currency figures into the quote currency through the
+ *    endpoint rate (pinning removed); an unconvertible figure omits the
+ *    quote instead of sending a wrong-currency amount.
+ */
+final class FxRatesSpec
+{
+    public static function runAll(): void
+    {
+        self::testConvertFetchesOnDemandAndUsesEndpointRates();
+        self::testConversionsAreServedFromCacheWithoutRefetch();
+        self::testSameCurrencyConversionNeedsNoRates();
+        self::testRefreshHonoursTtl();
+        self::testFailedRefreshServesLastKnownGoodAndBacksOff();
+        self::testNeverFetchedFailsGateClosedAndDisplaySoft();
+        self::testMissingApiKeyNeverFetches();
+        self::testGateJudgesCrossCurrencyBasketOnEndpointRate();
+        self::testFixedSurchargeAndCapConvertedIntoQuoteCurrency();
+        self::testUnconvertibleFixedSurchargeOmitsQuote();
+    }
+
+    /**
+     * Common fixture. Shop currencies 1=EUR (default), 2=NOK, 3=GBP with
+     * POISONED PS-core conversion rates: any figure derived from 999.0
+     * proves core conversion leaked back in.
+     */
+    private static function reset(): void
+    {
+        StubStore::reset();
+        Tools::resetTestValues();
+        PrestaShopLogger::reset();
+        Context::getContext()->cookie = new Cookie();
+        StubStore::$currencies = [
+            1 => ['iso_code' => 'EUR', 'conversion_rate' => 999.0],
+            2 => ['iso_code' => 'NOK', 'conversion_rate' => 999.0],
+            3 => ['iso_code' => 'GBP', 'conversion_rate' => 999.0],
+        ];
+        Configuration::updateValue('PS_CURRENCY_DEFAULT', 1);
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'm-123');
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', 'test-api-key');
+    }
+
+    /**
+     * Round-number EUR-pivot table: 10 NOK/EUR, 0.8 GBP/EUR.
+     */
+    private static function ratesResponse(string $asOf = '2026-07-14'): array
+    {
+        return [
+            'http_status' => 200,
+            'base' => 'EUR',
+            'as_of' => $asOf,
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1, 'GBP' => 1.25],
+        ];
+    }
+
+    /**
+     * Harness whose wire calls are stubbed per endpoint and counted.
+     *
+     * @param array<string,mixed> $responsesByEndpoint endpoint => response
+     *        (or a callable receiving the payload)
+     */
+    private static function moduleWithResponses(array $responsesByEndpoint): object
+    {
+        return new class ($responsesByEndpoint) extends TwopaymentTestHarness {
+            public int $fxFetchCount = 0;
+            /** @var array<int,array{endpoint:string,method:string,payload:array,timeout:mixed}> */
+            public array $requests = [];
+            private array $responsesByEndpoint;
+
+            public function __construct(array $responsesByEndpoint)
+            {
+                parent::__construct();
+                $this->responsesByEndpoint = $responsesByEndpoint;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                $this->requests[] = [
+                    'endpoint' => $endpoint,
+                    'method' => $method,
+                    'payload' => $payload,
+                    'timeout' => $timeout,
+                ];
+                if ($endpoint === '/refdata/v1/fx-rates') {
+                    $this->fxFetchCount++;
+                }
+                $response = $this->responsesByEndpoint[$endpoint] ?? ['http_status' => 500];
+                return is_callable($response) ? $response($payload) : $response;
+            }
+        };
+    }
+
+    private static function fxModule($fxResponse): object
+    {
+        return self::moduleWithResponses(['/refdata/v1/fx-rates' => $fxResponse]);
+    }
+
+    /** @param float $gross @param float $net */
+    private static function cart(int $idCurrency, float $gross, float $net): Cart
+    {
+        $cart = new Cart();
+        $cart->id = 42;
+        $cart->id_currency = $idCurrency;
+        StubStore::$cartTotals[42][true][Cart::BOTH] = $gross;
+        StubStore::$cartTotals[42][false][Cart::BOTH] = $net;
+        return $cart;
+    }
+
+    private static function testConvertFetchesOnDemandAndUsesEndpointRates(): void
+    {
+        self::reset();
+        $module = self::fxModule(self::ratesResponse());
+
+        // GBP -> NOK crosses through the EUR pivot: 100 * 1.25 / 0.1.
+        TinyAssert::same(1250.0, $module->convertTwoAmountBetweenCurrencies(100.0, 'GBP', 'NOK'));
+        TinyAssert::same(1, $module->fxFetchCount, 'a cold cache is filled by exactly one on-demand fetch');
+
+        // The fetch is a GET on the refdata endpoint with the tight
+        // render-path timeout - never the long default.
+        TinyAssert::same('/refdata/v1/fx-rates', $module->requests[0]['endpoint']);
+        TinyAssert::same('GET', $module->requests[0]['method']);
+        TinyAssert::same(Twopayment::API_TIMEOUT_STATE_CHECK, $module->requests[0]['timeout']);
+
+        // The response's as_of staleness floor is retained in the cache.
+        $table = $module->getTwoFxRatesTable();
+        TinyAssert::same('2026-07-14', $table['as_of']);
+        TinyAssert::same('EUR', $table['base']);
+    }
+
+    private static function testConversionsAreServedFromCacheWithoutRefetch(): void
+    {
+        self::reset();
+        $module = self::fxModule(self::ratesResponse());
+
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        // Different pairs, both directions: still the one original fetch.
+        TinyAssert::same(8.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'));
+        TinyAssert::same(80.0, $module->convertTwoAmountBetweenCurrencies(1000.0, 'NOK', 'GBP'));
+        TinyAssert::same(1, $module->fxFetchCount, 'a fresh table must not be refetched per conversion');
+
+        // A brand-new module instance (fresh request) reads the shared
+        // Configuration cache - no wire call at all.
+        $second = self::fxModule(self::ratesResponse('2099-01-01'));
+        TinyAssert::same(100.0, $second->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same(0, $second->fxFetchCount, 'cross-request cache must serve without refetching');
+        TinyAssert::same('2026-07-14', $second->getTwoFxRatesTable()['as_of'], 'cached as_of served, not a new fetch');
+    }
+
+    private static function testSameCurrencyConversionNeedsNoRates(): void
+    {
+        self::reset();
+        $module = self::fxModule(self::ratesResponse());
+        TinyAssert::same(10.55, $module->convertTwoAmountBetweenCurrencies(10.554, 'EUR', 'EUR'));
+        TinyAssert::same(0, $module->fxFetchCount, 'same-currency conversion must not touch the wire');
+    }
+
+    private static function testRefreshHonoursTtl(): void
+    {
+        self::reset();
+        $module = self::fxModule(self::ratesResponse('2026-07-15'));
+
+        // Fresh clock: the sanctioned-refresh-point call is a no-op.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-10',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.2],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time());
+        TinyAssert::false($module->refreshTwoFxRates(), 'within TTL the refresh must not fetch');
+        TinyAssert::same(0, $module->fxFetchCount);
+
+        // Expired clock: one fetch renews the table AND its as_of.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
+        TinyAssert::true($module->refreshTwoFxRates());
+        TinyAssert::same(1, $module->fxFetchCount);
+        TinyAssert::same('2026-07-15', $module->getTwoFxRatesTable()['as_of']);
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'), 'renewed rate (0.1) must replace the stale one (0.2)');
+    }
+
+    private static function testFailedRefreshServesLastKnownGoodAndBacksOff(): void
+    {
+        self::reset();
+        $module = self::fxModule(['http_status' => 500]);
+
+        // Last-known-good table, expired TTL.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-01',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
+
+        TinyAssert::false($module->refreshTwoFxRates(), 'failed fetch reports failure');
+        TinyAssert::same(1, $module->fxFetchCount);
+        // Serve-stale: the gate keeps converting on the last-known-good rate.
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same('2026-07-01', $module->getTwoFxRatesTable()['as_of']);
+
+        // Within the retry backoff no second fetch fires - not from the
+        // refresh point, not from conversions.
+        TinyAssert::false($module->refreshTwoFxRates());
+        $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK');
+        TinyAssert::same(1, $module->fxFetchCount, 'failure backoff must absorb repeat refresh attempts');
+
+        // Once the backoff has elapsed the retry happens.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
+        TinyAssert::false($module->refreshTwoFxRates());
+        TinyAssert::same(2, $module->fxFetchCount, 'after the backoff a retry must fire');
+    }
+
+    private static function testNeverFetchedFailsGateClosedAndDisplaySoft(): void
+    {
+        self::reset();
+        $module = self::fxModule(['http_status' => 500]);
+        Configuration::updateValue(
+            Twopayment::CONFIG_PLATFORM_MIN_ORDER,
+            json_encode(['amount' => 100.0, 'currency' => 'EUR', 'basis' => 'gross'])
+        );
+
+        // No table was EVER fetched and the API is down: the cross-currency
+        // basket cannot be judged - the platform-minimum gate fails CLOSED.
+        TinyAssert::false($module->isTwoMinimumOrderSatisfied(self::cart(2, 1000000.0, 999999.0)));
+        TinyAssert::same(1, $module->fxFetchCount, 'the gate miss attempts exactly one on-demand fetch');
+
+        // Display conversion fails SOFT: no hint rather than a wrong figure,
+        // and the failure backoff absorbs the extra conversion attempts.
+        TinyAssert::same(
+            '',
+            $module->getTwoMinimumOrderDeclineHint(
+                ['decline_reason' => 'ORDER_BELOW_MIN_INVOICE_AMOUNT'],
+                self::cart(2, 50.0, 40.0)
+            )
+        );
+        TinyAssert::same(1, $module->fxFetchCount);
+    }
+
+    private static function testMissingApiKeyNeverFetches(): void
+    {
+        self::reset();
+        Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', '');
+        $module = self::fxModule(self::ratesResponse());
+
+        TinyAssert::same(null, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same(0, $module->fxFetchCount, 'the merchant-key-authenticated endpoint must not be called without a key');
+    }
+
+    private static function testGateJudgesCrossCurrencyBasketOnEndpointRate(): void
+    {
+        self::reset();
+        $module = self::fxModule(self::ratesResponse());
+        Configuration::updateValue(
+            Twopayment::CONFIG_PLATFORM_MIN_ORDER,
+            json_encode(['amount' => 100.0, 'currency' => 'EUR', 'basis' => 'gross'])
+        );
+
+        // NOK basket vs 100 EUR minimum on the ENDPOINT rate (10 NOK/EUR):
+        // 1200 NOK = 120 EUR passes, 900 NOK = 90 EUR fails. The poisoned
+        // PS-core rate (999) would have judged both identically.
+        TinyAssert::true($module->isTwoMinimumOrderSatisfied(self::cart(2, 1200.0, 1000.0)));
+        TinyAssert::false($module->isTwoMinimumOrderSatisfied(self::cart(2, 900.0, 750.0)));
+        TinyAssert::same(1, $module->fxFetchCount, 'both judgements share the one cached table');
+    }
+
+    private static function surchargeFixtures(): void
+    {
+        Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'fixed_and_percentage');
+        Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '1.5');
+        Configuration::updateValue('PS_TWO_SURCHARGE_FIXED_30', '10');
+        Configuration::updateValue('PS_TWO_SURCHARGE_CAP_30', '20');
+        Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1);
+    }
+
+    private static function testFixedSurchargeAndCapConvertedIntoQuoteCurrency(): void
+    {
+        self::reset();
+        self::surchargeFixtures();
+
+        $module = self::moduleWithResponses([
+            '/refdata/v1/fx-rates' => self::ratesResponse(),
+            '/v1/pricing/order/fee' => [
+                'http_status' => 200,
+                'buyer_fee_share' => '115.00',
+                'total_fee_tax_rate' => '0.25',
+                'currency' => 'NOK',
+            ],
+        ]);
+
+        // Shop default is EUR; the buyer checks out in NOK. The configured
+        // 10 EUR fixed fee / 20 EUR cap must reach the pricing API as
+        // 100 / 200 NOK (endpoint rate 10 NOK/EUR) - NOT as the raw
+        // shop-currency figures the old pinning sent.
+        $quote = $module->fetchTwoTermFee(30, 1000.0, 'NO', 'NOK');
+        TinyAssert::same('115.00', $quote['buyer_fee_share']);
+
+        $pricing = null;
+        foreach ($module->requests as $request) {
+            if ($request['endpoint'] === '/v1/pricing/order/fee') {
+                $pricing = $request['payload'];
+            }
+        }
+        TinyAssert::true(is_array($pricing), 'pricing quote must have been requested');
+        TinyAssert::same(100.0, $pricing['buyer_fee_share']['surcharge']);
+        TinyAssert::same(200.0, $pricing['buyer_fee_share']['cap']);
+        TinyAssert::same(1.5, $pricing['buyer_fee_share']['percentage'], 'percentage is currency-agnostic and passes through');
+        TinyAssert::same('NOK', $pricing['currency']);
+    }
+
+    private static function testUnconvertibleFixedSurchargeOmitsQuote(): void
+    {
+        self::reset();
+        self::surchargeFixtures();
+
+        // Fresh table WITHOUT the quote currency: USD cannot be converted
+        // and (fresh TTL) no refetch is due.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-14',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time());
+
+        $module = self::moduleWithResponses([
+            '/v1/pricing/order/fee' => [
+                'http_status' => 200,
+                'buyer_fee_share' => '12.00',
+                'currency' => 'USD',
+            ],
+        ]);
+
+        // Fail-soft: the quote is omitted entirely (fee line skipped,
+        // checkout never blocked) instead of quoting 10 "USD" that are
+        // really EUR - the wrong-currency figure the old pinning produced.
+        TinyAssert::same(null, $module->fetchTwoTermFee(30, 1000.0, 'US', 'USD'));
+        foreach ($module->requests as $request) {
+            TinyAssert::notSame('/v1/pricing/order/fee', $request['endpoint'], 'no pricing call may carry an unconverted fixed fee');
+        }
+    }
+}

--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -31,6 +31,7 @@ final class FxRatesSpec
         self::testSameCurrencyConversionNeedsNoRates();
         self::testRefreshHonoursTtl();
         self::testFailedRefreshServesLastKnownGoodAndBacksOff();
+        self::testPartialResponseMergesOverLastKnownGood();
         self::testNeverFetchedFailsGateClosedAndDisplaySoft();
         self::testMissingApiKeyNeverFetches();
         self::testGateJudgesCrossCurrencyBasketOnEndpointRate();
@@ -225,6 +226,31 @@ final class FxRatesSpec
         Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
         TinyAssert::false($module->refreshTwoFxRates());
         TinyAssert::same(2, $module->fxFetchCount, 'after the backoff a retry must fire');
+    }
+
+    private static function testPartialResponseMergesOverLastKnownGood(): void
+    {
+        self::reset();
+        // The refetch succeeds but transiently DROPS GBP and moves NOK.
+        $module = self::fxModule([
+            'http_status' => 200,
+            'base' => 'EUR',
+            'as_of' => '2026-07-15',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.09],
+        ]);
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-01',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.1, 'GBP' => 1.25],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time() - Twopayment::FX_RATES_TTL - 1);
+
+        TinyAssert::true($module->refreshTwoFxRates());
+        // Fresh values win; the dropped currency keeps its last-known-good
+        // rate instead of failing its gate closed for a whole TTL.
+        TinyAssert::same(90.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same(12.5, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'GBP'));
+        TinyAssert::same(1, $module->fxFetchCount);
     }
 
     private static function testNeverFetchedFailsGateClosedAndDisplaySoft(): void

--- a/tests/MinimumOrderGateSpec.php
+++ b/tests/MinimumOrderGateSpec.php
@@ -56,14 +56,24 @@ final class MinimumOrderGateSpec
         StubStore::reset();
         Tools::resetTestValues();
         PrestaShopLogger::reset();
-        // Shop currencies: 1=EUR (default), 2=NOK, 3=GBP.
-        // conversion_rate is expressed against the shop default currency.
+        // Shop currencies: 1=EUR (default), 2=NOK, 3=GBP. PS core
+        // conversion_rate values are deliberately POISONED: since TWO-25105
+        // every Two-side conversion must come from the cached
+        // /refdata/v1/fx-rates table, never from PS core's own rates.
         StubStore::$currencies = [
-            1 => ['iso_code' => 'EUR', 'conversion_rate' => 1.0, 'symbol' => "\u{20AC}"],
-            2 => ['iso_code' => 'NOK', 'conversion_rate' => 11.5, 'symbol' => 'kr'],
-            3 => ['iso_code' => 'GBP', 'conversion_rate' => 0.85, 'symbol' => "\u{A3}"],
+            1 => ['iso_code' => 'EUR', 'conversion_rate' => 999.0, 'symbol' => "\u{20AC}"],
+            2 => ['iso_code' => 'NOK', 'conversion_rate' => 999.0, 'symbol' => 'kr'],
+            3 => ['iso_code' => 'GBP', 'conversion_rate' => 999.0, 'symbol' => "\u{A3}"],
         ];
         Configuration::updateValue('PS_CURRENCY_DEFAULT', 1);
+        // Cached FX table (EUR pivot: rates[CCY] = 1 CCY in EUR), matching
+        // the historical fixture rates 11.5 NOK/EUR and 0.85 GBP/EUR.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-15',
+            'rates' => ['EUR' => 1.0, 'NOK' => 1 / 11.5, 'GBP' => 1 / 0.85],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time());
         return new TwopaymentTestHarness();
     }
 
@@ -234,8 +244,9 @@ final class MinimumOrderGateSpec
     private static function testGateFailsClosedWithoutFxRate(): void
     {
         $module = self::freshModule();
-        // USD is not an installed shop currency - the basket cannot be proven
-        // to satisfy the funding partner's minimum: fail closed.
+        // USD carries no rate in the cached FX table (and no API key is
+        // configured, so no on-demand refetch happens) - the basket cannot be
+        // proven to satisfy the funding partner's minimum: fail closed.
         self::cachePlatformMinimum(['amount' => 100.0, 'currency' => 'USD', 'basis' => 'gross']);
         TinyAssert::false($module->isTwoMinimumOrderSatisfied(self::cart(1, 1000000.0, 999999.0)));
     }

--- a/tests/run.php
+++ b/tests/run.php
@@ -5018,6 +5018,7 @@ require __DIR__ . '/SurchargeCartLineSpec.php';
 require __DIR__ . '/ConfirmationLegacyParitySpec.php';
 require __DIR__ . '/MinimumOrderGateSpec.php';
 require __DIR__ . '/InvoiceUploadGateSpec.php';
+require __DIR__ . '/FxRatesSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5034,6 +5035,7 @@ $tests = [
     'ConfirmationLegacyParitySpec::runAll' => [ConfirmationLegacyParitySpec::class, 'runAll'],
     'MinimumOrderGateSpec::runAll' => [MinimumOrderGateSpec::class, 'runAll'],
     'InvoiceUploadGateSpec::runAll' => [InvoiceUploadGateSpec::class, 'runAll'],
+    'FxRatesSpec::runAll' => [FxRatesSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -65,6 +65,23 @@ class Twopayment extends PaymentModule
     const CONFIG_MERCHANT_MIN_ORDER = 'PS_TWO_MERCHANT_MIN_ORDER';
     const CONFIG_MERCHANT_MIN_ORDER_BASIS = 'PS_TWO_MERCHANT_MIN_ORDER_BASIS';
 
+    // Cached FX spot-rate table from GET /refdata/v1/fx-rates (TWO-25105):
+    // JSON {base:'EUR', as_of:'YYYY-MM-DD', rates:{ISO: value of 1 ISO in
+    // EUR}}. Replaces PrestaShop core's own conversion rates for every
+    // Two-side conversion (minimum-order gate, decline hint, admin floor,
+    // fixed-surcharge/cap re-denomination) so the plugin converts with the
+    // SAME rates checkout-api enforces server-side. Refreshed TTL-gated (6h)
+    // from the checkout media hook and on-demand on a cache miss; a fetch
+    // failure serves the last-known-good table (gate conversions fail closed
+    // ONLY when no table was ever fetched - ticket fail semantics).
+    const CONFIG_FX_RATES = 'PS_TWO_FX_RATES';
+    const CONFIG_FX_RATES_TS = 'PS_TWO_FX_RATES_TS';
+    const FX_RATES_TTL = 21600; // 6 hours
+    // On a FAILED fx-rates fetch, retry after this short backoff instead of
+    // waiting the full TTL (same serve-stale + backoff discipline as the
+    // merchant-record cache).
+    const FX_RATES_RETRY_BACKOFF = 300; // 5 minutes
+
     // Constants for API timeouts (seconds)
     const API_TIMEOUT_SHORT = 30; // Standard API timeout
     const API_TIMEOUT_LONG = 60; // Extended timeout for file uploads
@@ -1141,7 +1158,8 @@ class Twopayment extends PaymentModule
      * default currency when a conversion rate is available (with the native
      * figure alongside when the currencies differ). Mirrors
      * woocommerce-plugin's get_merchant_minimum_order_description() with
-     * PrestaShop's own FX rates filling the gap WooCommerce has (TWO-24776).
+     * Two's own FX rates (/refdata/v1/fx-rates, TWO-25105) filling the gap
+     * WooCommerce has (TWO-24776).
      *
      * @return string
      */
@@ -2934,6 +2952,10 @@ class Twopayment extends PaymentModule
         // term list (TWO-24813); prime the cache before the cache-only reads
         // in getAvailablePaymentTerms / getDefaultPaymentTerm below.
         $this->getMerchantAvailableTerms(true);
+        // Same sanctioned refresh point keeps the FX table warm (TTL-gated
+        // 6h, TWO-25105) so cross-currency conversions on the checkout hot
+        // path hit the cache instead of fetching inline.
+        $this->refreshTwoFxRates();
 
         Media::addJsDef(array('twopayment' => array(
                 'search_empty_text' => $this->l('No result found'),
@@ -6809,13 +6831,18 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Convert an amount between two installed currencies via PrestaShop's own
-     * conversion rates (each Currency's conversion_rate is expressed against
-     * the shop default currency). Returns null when either currency is not
-     * installed or carries no usable rate - the CALLER decides the failure
-     * posture (the checkout gate fails closed on the platform minimum, the
-     * decline hint fails soft). Mirrors magento-plugin's
-     * CurrencyRatesProviderInterface contract (TWO-24775).
+     * Convert an amount between two currencies via Two's own FX spot rates
+     * (GET /refdata/v1/fx-rates, TWO-25105) - NOT PrestaShop core's
+     * conversion rates, so the plugin reasons with the same rates
+     * checkout-api enforces server-side. Returns null when no rate table has
+     * ever been fetched or either currency is absent from it - the CALLER
+     * decides the failure posture (the checkout gate fails closed on the
+     * platform minimum, the decline hint and admin descriptions fail soft).
+     *
+     * A stale table is still served (last-known-good, ticket fail
+     * semantics); a cache miss triggers ONE TTL/backoff-gated on-demand
+     * fetch so a checkout in a not-yet-cached currency resolves within the
+     * same request and lands in the shared cache for the next render.
      *
      * @param float $amount
      * @param string $from_iso
@@ -6832,25 +6859,145 @@ class Twopayment extends PaymentModule
         if ($from_iso === $to_iso) {
             return round((float) $amount, 2);
         }
-        $from_id = (int) Currency::getIdByIsoCode($from_iso);
-        $to_id = (int) Currency::getIdByIsoCode($to_iso);
-        if ($from_id <= 0 || $to_id <= 0) {
+
+        $rates = $this->getTwoFxRatesForPair($from_iso, $to_iso);
+        if ($rates === null) {
             return null;
         }
-        $from = new Currency($from_id);
-        $to = new Currency($to_id);
-        if (!Validate::isLoadedObject($from) || !Validate::isLoadedObject($to)) {
-            return null;
+        // rates[CCY] = value of 1 CCY in EUR (the endpoint's EUR pivot):
+        // FROM -> EUR -> TO. Full-precision arithmetic, rounded once at the
+        // boundary.
+        return round((float) $amount * $rates[$from_iso] / $rates[$to_iso], 2);
+    }
+
+    /**
+     * Usable EUR-pivot rates for a currency pair, or null. Serves the cached
+     * table (stale included - serve-stale is the gate's last-known-good
+     * contract); when the table is missing or lacks either currency, allows
+     * one TTL/backoff-gated refresh before giving up, so a first-ever
+     * checkout in an uncached currency is fetched on demand and cached.
+     *
+     * @param string $from_iso normalised ISO code
+     * @param string $to_iso normalised ISO code
+     * @return array<string,float>|null
+     */
+    private function getTwoFxRatesForPair($from_iso, $to_iso)
+    {
+        foreach (array(false, true) as $refreshed) {
+            if ($refreshed) {
+                if (!$this->refreshTwoFxRates()) {
+                    return null;
+                }
+            }
+            $table = $this->getTwoFxRatesTable();
+            if ($table !== null) {
+                $from_rate = isset($table['rates'][$from_iso]) ? (float) $table['rates'][$from_iso] : 0.0;
+                $to_rate = isset($table['rates'][$to_iso]) ? (float) $table['rates'][$to_iso] : 0.0;
+                if ($from_rate > 0 && $to_rate > 0) {
+                    return array($from_iso => $from_rate, $to_iso => $to_rate);
+                }
+            }
         }
-        $from_rate = isset($from->conversion_rate) ? (float) $from->conversion_rate : 0.0;
-        $to_rate = isset($to->conversion_rate) ? (float) $to->conversion_rate : 0.0;
-        if ($from_rate <= 0 || $to_rate <= 0) {
-            return null;
+        return null;
+    }
+
+    /**
+     * The cached FX spot-rate table (TWO-25105), or null when none was ever
+     * stored. CACHE-ONLY - never blocks on HTTP; staleness is deliberately
+     * NOT checked here (a stale table is the last-known-good the gate must
+     * keep using; only refreshTwoFxRates consults the clock). Re-validated
+     * on read: Configuration is shared mutable state.
+     *
+     * @return array{base:string,as_of:string,rates:array<string,float>}|null
+     */
+    public function getTwoFxRatesTable()
+    {
+        if ($this->twoFxRatesMemo !== false) {
+            return $this->twoFxRatesMemo;
         }
-        // conversion_rate = units of the currency per 1 unit of the shop
-        // default currency; route through the default to cross-convert.
-        // Full-precision arithmetic, rounded once at the boundary.
-        return round((float) $amount / $from_rate * $to_rate, 2);
+        $this->twoFxRatesMemo = null;
+        $cached = Configuration::get(self::CONFIG_FX_RATES);
+        if (!Tools::isEmpty($cached)) {
+            $decoded = json_decode((string) $cached, true);
+            if (is_array($decoded) && isset($decoded['rates']) && is_array($decoded['rates'])) {
+                $rates = array();
+                foreach ($decoded['rates'] as $iso => $rate) {
+                    if (is_string($iso) && $iso !== '' && is_numeric($rate) && (float) $rate > 0) {
+                        $rates[Tools::strtoupper($iso)] = (float) $rate;
+                    }
+                }
+                if (!empty($rates)) {
+                    $this->twoFxRatesMemo = array(
+                        'base' => isset($decoded['base']) ? (string) $decoded['base'] : 'EUR',
+                        'as_of' => isset($decoded['as_of']) ? (string) $decoded['as_of'] : '',
+                        'rates' => $rates,
+                    );
+                }
+            }
+        }
+        return $this->twoFxRatesMemo;
+    }
+
+    /**
+     * TTL-gated fetch of GET /refdata/v1/fx-rates (TWO-25105). Called from
+     * the checkout media hook (the same sanctioned refresh point as the
+     * merchant record - the "6h background refresh") and on-demand from a
+     * conversion cache miss. Same discipline as getMerchantAvailableTerms:
+     * the clock is bumped BEFORE the wire call (anti-stampede), a failure
+     * rolls it back to the short retry backoff and keeps serving the
+     * last-known-good table, and the whole thing is skipped without an API
+     * key (the endpoint is merchant-API-key authenticated; also keeps unit
+     * specs off the wire). The stored `as_of` is the endpoint's staleness
+     * floor for the rates and rides along for logging/QA; freshness gating
+     * uses the local fetch clock, so an unchanged `as_of` on refetch simply
+     * renews the TTL rather than forcing extra fetches.
+     *
+     * @return bool Whether a wire fetch was attempted AND succeeded.
+     */
+    public function refreshTwoFxRates()
+    {
+        $checked_on = (int) Configuration::get(self::CONFIG_FX_RATES_TS);
+        if ($checked_on > 0 && ($checked_on + self::FX_RATES_TTL) > time()) {
+            return false;
+        }
+        $api_key = Configuration::get('PS_TWO_MERCHANT_API_KEY');
+        if (Tools::isEmpty($api_key)) {
+            return false;
+        }
+        Configuration::updateValue(self::CONFIG_FX_RATES_TS, time());
+        // Refreshes run on render/checkout paths - cap tight, never stall.
+        $response = $this->setTwoPaymentRequest(
+            '/refdata/v1/fx-rates',
+            array(),
+            'GET',
+            array(),
+            self::API_TIMEOUT_STATE_CHECK
+        );
+        $http_status = isset($response['http_status']) ? (int) $response['http_status'] : 0;
+        $rates = (is_array($response) && isset($response['rates']) && is_array($response['rates']))
+            ? $response['rates']
+            : null;
+        if ($http_status !== self::HTTP_STATUS_OK || empty($rates)) {
+            // Failed fetch: roll the pre-bumped clock back so retry happens
+            // after the short backoff, not a whole TTL; the last-known-good
+            // table keeps being served meanwhile (serve-stale).
+            Configuration::updateValue(
+                self::CONFIG_FX_RATES_TS,
+                time() - self::FX_RATES_TTL + self::FX_RATES_RETRY_BACKOFF
+            );
+            PrestaShopLogger::addLog(
+                'TwoPayment: FX rates fetch failed (HTTP ' . $http_status . ') - serving last-known-good rates',
+                2
+            );
+            return false;
+        }
+        Configuration::updateValue(self::CONFIG_FX_RATES, json_encode(array(
+            'base' => isset($response['base']) ? (string) $response['base'] : 'EUR',
+            'as_of' => isset($response['as_of']) ? (string) $response['as_of'] : '',
+            'rates' => $rates,
+        )));
+        $this->twoFxRatesMemo = false; // drop the request-scoped memo
+        return true;
     }
 
     /**
@@ -7197,6 +7344,15 @@ class Twopayment extends PaymentModule
     protected $twoFeeCache = array();
 
     /**
+     * Request-scoped memo of the FX table read (false = not yet resolved this
+     * request; null = unresolvable; array = the table). Configuration is
+     * cheap but the JSON decode + validation is not free on hot render paths.
+     *
+     * @var false|null|array{base:string,as_of:string,rates:array<string,float>}
+     */
+    protected $twoFxRatesMemo = false;
+
+    /**
      * Read a brand-config value (brands/two.php), cached per request. Returns
      * null for unknown keys. A minimal seam pending the full brand-config
      * foundation (TWO-24746); mirrors the WooCommerce plugin's WC_Twoinc_Brand.
@@ -7265,6 +7421,45 @@ class Twopayment extends PaymentModule
     }
 
     /**
+     * Re-denominate the currency-carrying members of a buyer_fee_share block
+     * (fixed `surcharge`, `cap`) from the shop default currency they are
+     * configured in into the quote currency, via Two's FX rates (TWO-25105).
+     * Percentage members are currency-agnostic and pass through untouched.
+     *
+     * Returns null when a conversion is needed but no rate is available -
+     * the caller omits the quote entirely (fee line skipped, checkout never
+     * blocked) instead of quoting a fixed fee denominated in the wrong
+     * currency, which is what the old currency pinning silently did on
+     * multi-currency stores.
+     *
+     * @param array $share buyer_fee_share block from TwoSurchargeCalculator
+     * @param string $quote_currency_iso the currency the fee is quoted in
+     * @return array|null
+     */
+    public function convertTwoBuyerFeeShareCurrency(array $share, $quote_currency_iso)
+    {
+        if (!isset($share['surcharge']) && !isset($share['cap'])) {
+            return $share;
+        }
+        $quote_iso = Tools::strtoupper(trim((string) $quote_currency_iso));
+        $shop_iso = $this->getTwoShopDefaultCurrencyIso();
+        if ($quote_iso === '' || $shop_iso === '' || $quote_iso === $shop_iso) {
+            return $share;
+        }
+        foreach (array('surcharge', 'cap') as $member) {
+            if (!isset($share[$member])) {
+                continue;
+            }
+            $converted = $this->convertTwoAmountBetweenCurrencies((float) $share[$member], $shop_iso, $quote_iso);
+            if ($converted === null) {
+                return null;
+            }
+            $share[$member] = $converted;
+        }
+        return $share;
+    }
+
+    /**
      * Quote the buyer's fee share for one term via POST /v1/pricing/order/fee.
      * Fail-soft: returns null on any error (the fee line is simply omitted and
      * checkout is never blocked on a quote, TWO-24752). Request-scoped cache.
@@ -7291,6 +7486,16 @@ class Twopayment extends PaymentModule
 
         $share = $this->buildTwoBuyerFeeShare($days);
         if ($share === null || $gross_amount <= 0) {
+            return $this->twoFeeCache[$cacheKey] = null;
+        }
+        // Fixed amounts and caps are configured in the shop default currency;
+        // re-denominate them into the quote currency via Two's FX rates
+        // (TWO-25105 - replaces the previous single-currency-stores-only
+        // pinning). An unconvertible amount omits the quote (fail-soft, the
+        // TWO-24752 contract) rather than sending a figure in the wrong
+        // currency.
+        $share = $this->convertTwoBuyerFeeShareCurrency($share, (string) $currency_iso);
+        if ($share === null) {
             return $this->twoFeeCache[$cacheKey] = null;
         }
 
@@ -7320,8 +7525,11 @@ class Twopayment extends PaymentModule
             return $this->twoFeeCache[$cacheKey] = null;
         }
 
-        // Guard against a reinterpreted currency — applying a figure quoted in
-        // a different currency would need FX the plugin does not do.
+        // Guard against a reinterpreted currency — the quote must be
+        // denominated in the currency it was requested in; a mismatch is an
+        // API contract violation, not something to paper over with a second
+        // conversion (the request's fixed figures were already FX-converted
+        // into the quote currency, TWO-25105).
         $respCurrency = isset($response['currency']) ? (string) $response['currency'] : (string) $currency_iso;
         if ($currency_iso !== '' && $respCurrency !== (string) $currency_iso) {
             return $this->twoFeeCache[$cacheKey] = null;
@@ -8426,11 +8634,14 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Cart-scoped, currency-pinned SpecificPrice carrying the quoted net fee.
-     * id_cart scopes the price to THIS cart only (concurrent buyers hold
-     * their own rows); id_currency pins the amount so core never applies FX
-     * conversion (empirically verified: Product::priceCalculation skips
-     * Tools::convertPrice when the specific price's currency matches).
+     * Cart-scoped, currency-denominated SpecificPrice carrying the quoted
+     * net fee. id_cart scopes the price to THIS cart only (concurrent buyers
+     * hold their own rows); id_currency makes core take the amount as
+     * already denominated in the cart currency, so a Two-side converted
+     * figure enters the basket at the conversion output with no PS
+     * re-conversion on top (TWO-25105 requirement; empirically verified:
+     * Product::priceCalculation skips Tools::convertPrice when the specific
+     * price's currency matches).
      *
      * @param Cart $cart
      * @param int $productId

--- a/twopayment.php
+++ b/twopayment.php
@@ -85,7 +85,7 @@ class Twopayment extends PaymentModule
     // Constants for API timeouts (seconds)
     const API_TIMEOUT_SHORT = 30; // Standard API timeout
     const API_TIMEOUT_LONG = 60; // Extended timeout for file uploads
-    const API_TIMEOUT_STATE_CHECK = 10; // Tight timeout for the invoice-download order state check
+    const API_TIMEOUT_STATE_CHECK = 10; // Tight timeout for render-path fetches (invoice-download state check, merchant-record and FX-rate refreshes, fee quotes)
     const API_TIMEOUT_PDF_FETCH = 10; // Tight timeout for synchronous invoice PDF fetches (buyer + admin download clicks)
     const API_CONNECT_TIMEOUT = 5; // Connection-establishment timeout for all Two API calls
     
@@ -6990,6 +6990,16 @@ class Twopayment extends PaymentModule
                 2
             );
             return false;
+        }
+        // Merge the fresh rates OVER the cached table rather than replacing
+        // it: a 200 that transiently drops a previously-known currency must
+        // not erode that currency's last-known-good rate (which would fail
+        // its gate closed for a full TTL). Fresh values always win; retained
+        // stragglers may predate the stored as_of, which is the freshness
+        // floor of the NEW response.
+        $previous = $this->getTwoFxRatesTable();
+        if ($previous !== null) {
+            $rates = array_merge($previous['rates'], $rates);
         }
         Configuration::updateValue(self::CONFIG_FX_RATES, json_encode(array(
             'base' => isset($response['base']) ? (string) $response['base'] : 'EUR',

--- a/twopayment.php
+++ b/twopayment.php
@@ -6974,9 +6974,18 @@ class Twopayment extends PaymentModule
             self::API_TIMEOUT_STATE_CHECK
         );
         $http_status = isset($response['http_status']) ? (int) $response['http_status'] : 0;
-        $rates = (is_array($response) && isset($response['rates']) && is_array($response['rates']))
-            ? $response['rates']
-            : null;
+        // Validate BEFORE merging/storing: only positive-numeric rates may
+        // displace cached last-known-good values, otherwise a 200 carrying
+        // zero/junk rates would erode (or wholesale destroy) the validated
+        // table the serve-stale contract depends on.
+        $rates = array();
+        if (is_array($response) && isset($response['rates']) && is_array($response['rates'])) {
+            foreach ($response['rates'] as $iso => $rate) {
+                if (is_string($iso) && $iso !== '' && is_numeric($rate) && (float) $rate > 0) {
+                    $rates[Tools::strtoupper($iso)] = (float) $rate;
+                }
+            }
+        }
         if ($http_status !== self::HTTP_STATUS_OK || empty($rates)) {
             // Failed fetch: roll the pre-bumped clock back so retry happens
             // after the short backoff, not a whole TTL; the last-known-good


### PR DESCRIPTION
## Summary

Builds the real FX layer on checkout-api's live `GET /refdata/v1/fx-rates` endpoint (TWO-24776), replacing PS-core's own conversion rates and the currency-pinning workaround.

- **FX client + cache**: the full EUR-pivot spot table is fetched server-side with the merchant API key (never browser JS), cached in module Configuration with a 6h TTL refreshed from the checkout media hook (the same sanctioned refresh point as the merchant record), and fetched on demand when a not-yet-cached currency reaches a conversion. The response's `as_of` staleness floor is retained. Anti-stampede pre-bumped clock, 5-min retry backoff on failure, serve-stale meanwhile — the same discipline as the merchant-record cache.
- **Conversion cutover**: `convertTwoAmountBetweenCurrencies` (minimum-order gate, decline hint, admin floor display + save validation) now crosses through the endpoint's EUR pivot instead of PS core `conversion_rate`. Caller contract unchanged: gate conversions use last-known-good and fail CLOSED only when no table was ever fetched; display conversions fail SOFT.
- **Pinning removed**: fixed surcharge amounts and caps (configured in the shop default currency) are re-denominated into the quote currency before the pricing call — previously they were sent raw ("single-currency stores only"). An unconvertible figure omits the fee quote (fail-soft per TWO-24752) rather than sending a wrong-currency amount. The cart-scoped SpecificPrice keeps `id_currency` deliberately: it is the mechanism that makes a converted fee enter the basket at the conversion output with no PS re-conversion on top.

## Validation

- New `tests/FxRatesSpec.php` (10 tests): endpoint-rate lookup incl. cross rates, cache/TTL/no-over-fetch (incl. cross-request), `as_of` retention, failure → last-known-good + backoff, never-fetched → gate fails closed / display soft, no-API-key → no wire call, fixed-fee/cap re-denomination, unconvertible → quote omitted.
- `MinimumOrderGateSpec` fixtures now POISON PS-core conversion rates (999.0) and seed the FX table instead — proving the endpoint table is the only conversion source.
- Suite is executed by CI (`php tests/run.php`, tests.yml, PHP 8.2/8.3) — verified green locally on PHP 8.2 (docker, same as `make test`) and 8.5.
- Manual QA on the PS staging shop (display currency ≠ merchant base currency, live endpoint rate reflected in surcharge/min-order) still owed — tracked on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)