### PR TITLE
TWO-24880/feat: VAT declared-rate relay - remove derive/snap/Spanish fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The flag is cached by the existing TTL-gated merchant-record fetch (shared with `available_terms`/`due_in_days`); absent-from-response is treated as false, a failed fetch serves the last known value, and a merchant identity change fails closed
   - Module version bumped to `2.6.0`
 
+- **Line-item VAT rates are now relayed from PrestaShop's own tax configuration** (TWO-24880)
+  - Product, ecotax, shipping and gift-wrapping lines source their tax rate from the merchant's configured tax rules group, resolved at the cart's tax address (`PS_TAX_ADDRESS_TYPE` granularity) - the same resolution PrestaShop uses to compute the amounts. The rate is never derived from `tax / net`, never snapped toward nearby rates, and never substituted with a fallback
+  - Removed the hardcoded Spanish 21% fallback and the snap-to-known-contexts machinery entirely - a snap-to-canonical step could relabel a reduced-rate line (e.g. 10%) to a neighbouring rate (e.g. 21%) while still passing amount checks, producing an incorrect VAT breakdown on the invoice
+  - Divergence now fails loud: when the declared rate does not reconcile with PrestaShop's applied amounts (beyond a 2-cent rounding tolerance), order building throws instead of silently correcting - the merchant sees the actionable cause in the shop log, the buyer sees a controlled decline
+  - Discount lines keep the exact-cent canonical-rate split; unattributable discounts now fail loud instead of emitting a blended synthetic rate
+  - `PS_ATCP_SHIPWRAP` (average-tax shipping/wrapping) carts split the charge across the cart's canonical product rate classes instead of ever emitting the blended average rate
+  - Free-shipping discount lines mirror the shipping line's emitted rate, and the net-cap path now keeps gross/net/tax rate-consistent
+  - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now also asserts `gross == net + tax` exactly
+
 ### Removed
 - **`PS_TWO_USE_OWN_INVOICES` admin setting retired** (TWO-25111)
   - The "Upload Own Invoices to Two" switch is removed from the module configuration page; the upgrade script deletes the configuration row and any leftover value has zero effect (covered by unit test)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Discount lines keep the exact-cent canonical-rate split; unattributable discounts now fail loud instead of emitting a blended synthetic rate
   - `PS_ATCP_SHIPWRAP` (average-tax shipping/wrapping) carts split the charge across the cart's canonical product rate classes instead of ever emitting the blended average rate
   - Free-shipping discount lines mirror the shipping line's emitted rate, and the net-cap path now keeps gross/net/tax rate-consistent
-  - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now also asserts `gross == net + tax` exactly
+  - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now validates the emitted amounts and also asserts `gross == net + tax` exactly
 
 ### Removed
 - **`PS_TWO_USE_OWN_INVOICES` admin setting retired** (TWO-25111)

--- a/tests/ConfirmationLegacyParitySpec.php
+++ b/tests/ConfirmationLegacyParitySpec.php
@@ -120,6 +120,11 @@ final class ConfirmationLegacyParitySpec
         ]];
         StubStore::$productCategories[9401] = [['name' => 'Books']];
         StubStore::$images[9401] = ['id_image' => 9401];
+        // Declared-rate relay (TWO-24880): the ordinary product's own
+        // tax-rules group (flat 5.5%, matching total/total_wt) — distinct
+        // from the fee product's merchant-selected group (400).
+        StubStore::$products[9401]['id_tax_rules_group'] = 500;
+        StubStore::$taxRuleRates[500] = 5.5;
         StubStore::$cartTotals[self::CART_ID] = [
             true => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_GROSS],
             false => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],

--- a/tests/SurchargeCartLineSpec.php
+++ b/tests/SurchargeCartLineSpec.php
@@ -118,6 +118,11 @@ final class SurchargeCartLineSpec
         ]];
         StubStore::$productCategories[9401] = [['name' => 'Books']];
         StubStore::$images[9401] = ['id_image' => 9401];
+        // Declared-rate relay (TWO-24880): the ordinary product's own
+        // tax-rules group (flat 5.5%, matching total/total_wt) — distinct
+        // from the fee product's merchant-selected group (TAX_GROUP_ID).
+        StubStore::$products[9401]['id_tax_rules_group'] = 500;
+        StubStore::$taxRuleRates[500] = 5.5;
         StubStore::$cartTotals[self::CART_ID] = [
             true => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_GROSS],
             false => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],
@@ -672,6 +677,16 @@ final class SurchargeCartLineSpec
         Configuration::updateValue('VATNUMBER_COUNTRY', 47);
         StubStore::$addresses[8201]['vat_number'] = 'FR999999999';
         StubStore::$addresses[8202]['vat_number'] = 'FR999999999';
+        // Core's Product::priceCalculation zeroes the tax on EVERY cart line
+        // for the exempt buyer, so the exempt cart reports untaxed amounts —
+        // keep the fixture coherent with what core would produce (the relay
+        // fails loud on taxed amounts under an exempt declaration).
+        StubStore::$cartProducts[self::CART_ID][0]['total_wt'] = self::PRODUCT_NET;
+        StubStore::$cartTotals[self::CART_ID] = [
+            true => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],
+            false => [Cart::ONLY_DISCOUNTS => 0.0, Cart::BOTH => self::PRODUCT_NET],
+            'average_products_tax_rate' => 0.0,
+        ];
 
         $module->syncTwoSurchargeCartLine($cart, true);
         $lines = self::feeLines();

--- a/tests/SurchargeSpec.php
+++ b/tests/SurchargeSpec.php
@@ -841,9 +841,9 @@ final class SurchargeSpec
         self::reset();
         Configuration::updateValue('PS_TWO_SURCHARGE_TYPE', 'percentage');
         Configuration::updateValue('PS_TWO_SURCHARGE_PCT_30', '2');
-        // Group rate needing more than TAX_RATE_PRECISION (3dp) decimals
-        // as a fraction (21.0098% → 0.210098). Tax must be computed from the
-        // SNAPPED rate that is actually sent, else the line fails
+        // High-precision group rate (21.0098% → 0.210098): TAX_RATE_PRECISION
+        // (6dp) now carries the full fraction in the sent payload. Tax must
+        // be computed from the SENT rate, else the line fails
         // validateTwoLineItems and is dropped.
         Configuration::updateValue(Twopayment::CONFIG_SURCHARGE_TAX_RULES_GROUP, '400');
         StubStore::$taxRuleRates[400] = [34 => 21.0098];
@@ -863,9 +863,9 @@ final class SurchargeSpec
         $cart->id_currency = 978;
         $cart->id_address_invoice = 900;
         $line = $module->buildTwoSurchargeLineItemForCart($cart, 5000.0);
-        TinyAssert::same('0.21', $line['tax_rate'], 'rate is snapped to the sent precision');
-        TinyAssert::same('210.00', $line['tax_amount'], 'tax computed from the sent (snapped) rate, not full precision');
-        TinyAssert::same('1210.00', $line['gross_amount']);
+        TinyAssert::same('0.210098', $line['tax_rate'], 'full 6dp rate survives the sent precision');
+        TinyAssert::same('210.10', $line['tax_amount'], 'tax computed from the sent rate');
+        TinyAssert::same('1210.10', $line['gross_amount']);
         TinyAssert::true($module->validateTwoLineItems([$line]), 'high-precision fee tax rate must not silently drop the line');
     }
 
@@ -953,6 +953,10 @@ final class SurchargeSpec
         ]];
         StubStore::$productCategories[9301] = [['name' => 'Books']];
         StubStore::$images[9301] = ['id_image' => 9301];
+        // Declared-rate relay (TWO-24880): product rate from its tax-rules
+        // group at the cart's tax address, never the row's 'rate' field.
+        StubStore::$products[9301]['id_tax_rules_group'] = 500;
+        StubStore::$taxRuleRates[500] = 5.5;
         StubStore::$cartTotals[7001] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 0.0,

--- a/tests/TrackingNumberSpec.php
+++ b/tests/TrackingNumberSpec.php
@@ -51,6 +51,17 @@ final class TrackingNumberSpec
         };
     }
 
+    /**
+     * Declared-rate relay wiring (TWO-24880): the payload's product tax rate
+     * comes from the product's tax-rules group resolved at the cart's tax
+     * address (the fixture cart carries its own loaded invoice address).
+     */
+    private static function declareProductRate(int $pid, float $ratePct): void
+    {
+        StubStore::$products[$pid]['id_tax_rules_group'] = 9000 + $pid;
+        StubStore::$taxRuleRates[9000 + $pid] = $ratePct;
+    }
+
     private static function testTrackingNumberComesFromOrderCarrier(): void
     {
         StubStore::reset();
@@ -323,6 +334,7 @@ final class TrackingNumberSpec
         ]];
         StubStore::$productCategories[9401] = [['name' => 'Gear']];
         StubStore::$images[9401] = ['id_image' => 9401];
+        self::declareProductRate(9401, 25.0);
         StubStore::$cartTotals[7300] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 0.0,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -571,6 +571,20 @@ namespace {
             }
         }
 
+        /**
+         * Core-faithful static resolver: the product's tax rules group id
+         * (product+shop scoped; combinations do not carry their own group).
+         */
+        public static function getIdTaxRulesGroupByIdProduct($idProduct, $context = null)
+        {
+            $idProduct = (int) $idProduct;
+            if (isset(StubStore::$products[$idProduct]['id_tax_rules_group'])) {
+                return (int) StubStore::$products[$idProduct]['id_tax_rules_group'];
+            }
+
+            return 0;
+        }
+
         public function add(): bool
         {
             $this->id = StubStore::$nextId++;

--- a/tests/run.php
+++ b/tests/run.php
@@ -62,13 +62,18 @@ final class OrderBuilderSpec
     {
         self::testValidateTwoLineItemsRejectsBrokenTaxFormula();
         self::testGetTwoTaxSubtotalsNormalizesTaxRateToTwoDecimals();
-        self::testGetTwoProductItemsUsesAppliedTaxRateWhenConfiguredRateDiffers();
+        self::testGetTwoProductItemsThrowsWhenDeclaredRateDivergesFromAmounts();
         self::testGetTwoProductItemsSplitsEcotaxIntoServiceLine();
         self::testGetTwoNewOrderDataSupportsFivePointFivePercentVat();
         self::testGetTwoNewOrderDataIncludesGiftWrappingLine();
-        self::testGetTwoNewOrderDataSnapsGiftWrappingRateToCanonicalContext();
-        self::testGetTwoProductItemsSnapsMinorRateDriftToKnownProductContexts();
-        self::testGetTwoProductItemsSpanishFallbackDefaultsToTwentyOnePercentWithoutKnownContext();
+        self::testGetTwoNewOrderDataSourcesGiftWrappingRateFromConfiguredGroup();
+        self::testGetTwoProductItemsRelaysDeclaredRateWithinRoundingTolerance();
+        self::testGetTwoProductItemsRelaysNonCanonicalDeclaredRateInsteadOfSpanishFallback();
+        self::testGetTwoProductItemsMultiJurisdictionCartRelaysPerLineDeclaredRates();
+        self::testGetTwoProductItemsIgnoresCountryOnlyRateFieldAndRelaysAddressCorrectRate();
+        self::testGetTwoNewOrderDataSplitsAtcpShippingAcrossProductRateClasses();
+        self::testGetTwoNewOrderDataFreeShippingDiscountRederivesGrossWhenNetCapBites();
+        self::testGetTwoProductItemsHighQuantityLineStaysWithinNetTolerance();
         self::testGetTwoNewOrderDataOmitsTopLevelTaxRate();
         self::testGetTwoNewOrderDataOmitsTaxSubtotalsWhenDisabled();
         self::testGetTwoIntentOrderDataOmitsTopLevelTaxRateAndOmitsTaxSubtotalsWhenDisabled();
@@ -178,6 +183,60 @@ final class OrderBuilderSpec
         PrestaShopLogger::reset();
     }
 
+    /**
+     * Declared-rate relay wiring (TWO-24880): a product's tax rate is
+     * sourced from its tax-rules group resolved at the cart's tax address,
+     * never from amounts or the row's 'rate' field. This declares the
+     * merchant-configured rate for a product and guarantees the cart has a
+     * loaded tax address for the resolver.
+     */
+    private static function declareProductRate(Cart $cart, int $pid, float $ratePct): void
+    {
+        self::ensureCartTaxAddress($cart);
+        StubStore::$products[$pid]['id_tax_rules_group'] = 9000 + $pid;
+        StubStore::$taxRuleRates[9000 + $pid] = $ratePct;
+    }
+
+    /** Declare the shop's configured gift-wrapping tax group rate. */
+    private static function declareWrappingRate(Cart $cart, float $ratePct): void
+    {
+        self::ensureCartTaxAddress($cart);
+        StubStore::$configuration['PS_GIFT_WRAPPING_TAX_RULES_GROUP'] = 7001;
+        StubStore::$taxRuleRates[7001] = $ratePct;
+    }
+
+    /** Declare the shop's configured ecotax tax group rate. */
+    private static function declareEcotaxRate(Cart $cart, float $ratePct): void
+    {
+        self::ensureCartTaxAddress($cart);
+        StubStore::$configuration['PS_ECOTAX_TAX_RULES_GROUP_ID'] = 7002;
+        StubStore::$taxRuleRates[7002] = $ratePct;
+    }
+
+    /** Declare a carrier's tax-rules group rate for shipping lines. */
+    private static function declareCarrierRate(Cart $cart, int $carrierId, float $ratePct): void
+    {
+        self::ensureCartTaxAddress($cart);
+        StubStore::$carriers[$carrierId]['tax_rules_group_id'] = 8000 + $carrierId;
+        StubStore::$taxRuleRates[8000 + $carrierId] = $ratePct;
+    }
+
+    /**
+     * The declared-rate resolver needs a LOADED cart tax address
+     * (PS_TAX_ADDRESS_TYPE, default invoice). Seed a minimal ES address only
+     * when the cart fixture set none of its own.
+     */
+    private static function ensureCartTaxAddress(Cart $cart): void
+    {
+        if ((int) $cart->id_address_invoice > 0 || (int) $cart->id_address_delivery > 0) {
+            return;
+        }
+        if (!isset(StubStore::$addresses[9901])) {
+            StubStore::$addresses[9901] = ['id_country' => 34, 'loaded' => true];
+        }
+        $cart->id_address_invoice = 9901;
+    }
+
     private static function testValidateTwoLineItemsRejectsBrokenTaxFormula(): void
     {
         self::reset();
@@ -187,6 +246,8 @@ final class OrderBuilderSpec
             'name' => 'TV',
             'net_amount' => '100.00',
             'tax_amount' => '15.00',
+            // Gross kept consistent (net + tax) so ONLY the tax formula is broken.
+            'gross_amount' => '115.00',
             'tax_rate' => '0.21',
             'unit_price' => '100.00',
             'quantity' => 1,
@@ -215,7 +276,7 @@ final class OrderBuilderSpec
         TinyAssert::same('72.75', $subtotals[0]['tax_amount']);
     }
 
-    private static function testGetTwoProductItemsUsesAppliedTaxRateWhenConfiguredRateDiffers(): void
+    private static function testGetTwoProductItemsThrowsWhenDeclaredRateDivergesFromAmounts(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
@@ -224,6 +285,8 @@ final class OrderBuilderSpec
         $cart->id_lang = 1;
         $cart->id_carrier = 999;
 
+        // Declared 21% but PrestaShop applied 20.50 tax on 100.00 net: the
+        // relay never derives/substitutes a rate — it fails loud.
         StubStore::$cartProducts[10] = [[
             'id_product' => 501,
             'link_rewrite' => 'smart-tv',
@@ -242,13 +305,14 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[501] = [['name' => 'Electronics']];
         StubStore::$images[501] = ['id_image' => 9001];
+        self::declareProductRate($cart, 501, 21.0);
 
-        $items = $module->getTwoProductItems($cart);
-
-        TinyAssert::count(1, $items);
-        TinyAssert::same('0.205', $items[0]['tax_rate']);
-        TinyAssert::same('20.50', $items[0]['tax_amount']);
-        TinyAssert::same('120.50', $items[0]['gross_amount']);
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Declared tax rate diverges'
+        );
     }
 
     private static function testGetTwoProductItemsSplitsEcotaxIntoServiceLine(): void
@@ -280,6 +344,10 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[777] = [['name' => 'Accessories']];
         StubStore::$images[777] = ['id_image' => 9011];
+        // Ecotax rate comes from the configured PS_ECOTAX_TAX_RULES_GROUP_ID
+        // group (the row's ecotax_tax_rate field is no longer read).
+        self::declareProductRate($cart, 777, 21.0);
+        self::declareEcotaxRate($cart, 5.5);
 
         $items = $module->getTwoProductItems($cart);
 
@@ -326,6 +394,7 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[888] = [['name' => 'Misc']];
         StubStore::$images[888] = ['id_image' => 9012];
+        self::declareProductRate($cart, 888, 21.0);
 
         TinyAssert::throws(
             static function () use ($module, $cart): void {
@@ -370,6 +439,7 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[889] = [['name' => 'Misc']];
         StubStore::$images[889] = ['id_image' => 9013];
+        self::declareProductRate($cart, 889, 21.0);
 
         TinyAssert::throws(
             static function () use ($module, $cart): void {
@@ -411,6 +481,7 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[890] = [['name' => 'Misc']];
         StubStore::$images[890] = ['id_image' => 9014];
+        self::declareProductRate($cart, 890, 21.0);
 
         $items = $module->getTwoProductItems($cart);
 
@@ -451,6 +522,7 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[891] = [['name' => 'Misc']];
         StubStore::$images[891] = ['id_image' => 9015];
+        self::declareProductRate($cart, 891, 21.0);
 
         $items = $module->getTwoProductItems($cart);
 
@@ -511,6 +583,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9301] = [['name' => 'Books']];
         StubStore::$images[9301] = ['id_image' => 9301];
+        self::declareProductRate($cart, 9301, 5.5);
         StubStore::$cartTotals[7001] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 0.0,
@@ -589,6 +662,8 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9302] = [['name' => 'Gifts']];
         StubStore::$images[9302] = ['id_image' => 9302];
+        self::declareProductRate($cart, 9302, 21.0);
+        self::declareWrappingRate($cart, 21.0);
         StubStore::$cartTotals[7002] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 0.0,
@@ -629,7 +704,7 @@ final class OrderBuilderSpec
         TinyAssert::true($hasWrappingLine);
     }
 
-    private static function testGetTwoNewOrderDataSnapsGiftWrappingRateToCanonicalContext(): void
+    private static function testGetTwoNewOrderDataSourcesGiftWrappingRateFromConfiguredGroup(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
@@ -680,6 +755,11 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9303] = [['name' => 'Gifts']];
         StubStore::$images[9303] = ['id_image' => 9303];
+        // Wrapping (2.47 net / 2.99 gross -> 0.52 tax) reconciles with the
+        // configured PS_GIFT_WRAPPING_TAX_RULES_GROUP at 21%: the declared
+        // rate is relayed as-is.
+        self::declareProductRate($cart, 9303, 21.0);
+        self::declareWrappingRate($cart, 21.0);
         StubStore::$cartTotals[7003] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 0.0,
@@ -718,7 +798,7 @@ final class OrderBuilderSpec
         TinyAssert::same('0.21', (string)$wrappingLine['tax_rate']);
     }
 
-    private static function testGetTwoProductItemsSnapsMinorRateDriftToKnownProductContexts(): void
+    private static function testGetTwoProductItemsRelaysDeclaredRateWithinRoundingTolerance(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
@@ -727,52 +807,40 @@ final class OrderBuilderSpec
         $cart->id_lang = 1;
         $cart->id_carrier = 0;
 
+        // Applied tax 21.01 on net 100.00 is within the 2-cent rounding
+        // tolerance of the declared 21% rate: the declared rate is relayed
+        // and PrestaShop's reported amounts are preserved untouched.
         StubStore::$cartProducts[12] = [
             [
-                'id_product' => 8801,
-                'link_rewrite' => 'anchor-product',
-                'name' => 'Anchor Product',
-                'description_short' => 'Anchor',
-                'manufacturer_name' => 'ACME',
-                'ean13' => '',
-                'upc' => '',
-                'total' => 100.00,
-                'total_wt' => 121.00,
-                'cart_quantity' => 1,
-                'rate' => 21.0,
-                'price' => 100.00,
-                'reduction' => 0,
-            ],
-            [
                 'id_product' => 8802,
-                'link_rewrite' => 'drift-product',
-                'name' => 'Drift Product',
+                'link_rewrite' => 'rounding-drift-product',
+                'name' => 'Rounding Drift Product',
                 'description_short' => 'Drift',
                 'manufacturer_name' => 'ACME',
                 'ean13' => '',
                 'upc' => '',
-                'total' => 2.47,
-                'total_wt' => 2.99,
+                'total' => 100.00,
+                'total_wt' => 121.01,
                 'cart_quantity' => 1,
-                // Intentionally missing rate field to simulate amount-derived drift.
-                'price' => 2.47,
+                'price' => 100.00,
                 'reduction' => 0,
             ],
         ];
 
-        StubStore::$productCategories[8801] = [['name' => 'General']];
         StubStore::$productCategories[8802] = [['name' => 'General']];
-        StubStore::$images[8801] = ['id_image' => 8801];
         StubStore::$images[8802] = ['id_image' => 8802];
+        self::declareProductRate($cart, 8802, 21.0);
 
         $items = $module->getTwoProductItems($cart);
 
-        TinyAssert::count(2, $items);
+        TinyAssert::count(1, $items);
         TinyAssert::same('0.21', (string)$items[0]['tax_rate']);
-        TinyAssert::same('0.21', (string)$items[1]['tax_rate']);
+        TinyAssert::same('21.01', (string)$items[0]['tax_amount']);
+        TinyAssert::same('121.01', (string)$items[0]['gross_amount']);
+        TinyAssert::same('100.00', (string)$items[0]['net_amount']);
     }
 
-    private static function testGetTwoProductItemsSpanishFallbackDefaultsToTwentyOnePercentWithoutKnownContext(): void
+    private static function testGetTwoProductItemsRelaysNonCanonicalDeclaredRateInsteadOfSpanishFallback(): void
     {
         self::reset();
         $module = new TwopaymentTestHarness();
@@ -796,6 +864,11 @@ final class OrderBuilderSpec
         $cart->id_address_invoice = 7401;
         $cart->id_address_delivery = 7402;
 
+        // REGRESSION (TWO-24880): the deleted Spanish-fallback code relabeled
+        // near-canonical ES lines to 21% whenever |tax - net*0.21| <= 0.02.
+        // Here tax is 0.06 and |0.06 - 0.30*0.21| = 0.003, so the old code
+        // would have emitted 0.21. The relay must emit the merchant's
+        // declared 20% untouched.
         StubStore::$cartProducts[14] = [[
             'id_product' => 8811,
             'link_rewrite' => 'es-fallback-product',
@@ -804,20 +877,466 @@ final class OrderBuilderSpec
             'manufacturer_name' => 'ACME',
             'ean13' => '',
             'upc' => '',
-            'total' => 2.47,
-            'total_wt' => 2.99,
+            'total' => 0.30,
+            'total_wt' => 0.36,
             'cart_quantity' => 1,
-            // Intentionally no rate field to force amount-derived unresolved context.
-            'price' => 2.47,
+            'price' => 0.30,
             'reduction' => 0,
         ]];
         StubStore::$productCategories[8811] = [['name' => 'General']];
         StubStore::$images[8811] = ['id_image' => 8811];
+        self::declareProductRate($cart, 8811, 20.0);
 
         $items = $module->getTwoProductItems($cart);
 
         TinyAssert::count(1, $items);
+        TinyAssert::same('0.2', (string)$items[0]['tax_rate']);
+        TinyAssert::same('0.06', (string)$items[0]['tax_amount']);
+    }
+
+    private static function testGetTwoProductItemsMultiJurisdictionCartRelaysPerLineDeclaredRates(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(16);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+
+        // One cart, three tax jurisdictions: each line relays its OWN
+        // declared group rate (21% / 10% / no group = 0%), never a blend.
+        StubStore::$cartProducts[16] = [
+            [
+                'id_product' => 8821,
+                'link_rewrite' => 'standard-rate-product',
+                'name' => 'Standard Rate Product',
+                'description_short' => 'Standard',
+                'manufacturer_name' => 'ACME',
+                'ean13' => '',
+                'upc' => '',
+                'total' => 100.00,
+                'total_wt' => 121.00,
+                'cart_quantity' => 1,
+                'rate' => 21.0,
+                'price' => 100.00,
+                'reduction' => 0,
+            ],
+            [
+                'id_product' => 8822,
+                'link_rewrite' => 'reduced-rate-product',
+                'name' => 'Reduced Rate Product',
+                'description_short' => 'Reduced',
+                'manufacturer_name' => 'ACME',
+                'ean13' => '',
+                'upc' => '',
+                'total' => 50.00,
+                'total_wt' => 55.00,
+                'cart_quantity' => 1,
+                'rate' => 10.0,
+                'price' => 50.00,
+                'reduction' => 0,
+            ],
+            [
+                'id_product' => 8823,
+                'link_rewrite' => 'zero-rate-product',
+                'name' => 'Zero Rate Product',
+                'description_short' => 'Zero',
+                'manufacturer_name' => 'ACME',
+                'ean13' => '',
+                'upc' => '',
+                'total' => 30.00,
+                'total_wt' => 30.00,
+                'cart_quantity' => 1,
+                'rate' => 0.0,
+                'price' => 30.00,
+                'reduction' => 0,
+            ],
+        ];
+        StubStore::$productCategories[8821] = [['name' => 'General']];
+        StubStore::$productCategories[8822] = [['name' => 'General']];
+        StubStore::$productCategories[8823] = [['name' => 'General']];
+        StubStore::$images[8821] = ['id_image' => 8821];
+        StubStore::$images[8822] = ['id_image' => 8822];
+        StubStore::$images[8823] = ['id_image' => 8823];
+        self::declareProductRate($cart, 8821, 21.0);
+        self::declareProductRate($cart, 8822, 10.0);
+        // 8823: no tax-rules group declared (core "No tax" sentinel -> 0).
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(3, $items);
         TinyAssert::same('0.21', (string)$items[0]['tax_rate']);
+        TinyAssert::same('21.00', (string)$items[0]['tax_amount']);
+        TinyAssert::same('0.1', (string)$items[1]['tax_rate']);
+        TinyAssert::same('5.00', (string)$items[1]['tax_amount']);
+        TinyAssert::same('0', (string)$items[2]['tax_rate']);
+        TinyAssert::same('0.00', (string)$items[2]['tax_amount']);
+    }
+
+    private static function testGetTwoProductItemsIgnoresCountryOnlyRateFieldAndRelaysAddressCorrectRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(17);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::ensureCartTaxAddress($cart); // seeds ES (country 34) invoice address
+
+        // Sub-national plumbing proof (Canary IGIC class of bug): the
+        // getProducts() row still carries the country-only 'rate' field
+        // (21.0), but the product's declared group resolves 7% for THIS
+        // cart's tax address and PrestaShop applied 7% to the amounts. The
+        // relay must emit the address-correct 7%, proving the country-only
+        // 'rate' field is dead.
+        StubStore::$cartProducts[17] = [[
+            'id_product' => 502,
+            'link_rewrite' => 'igic-product',
+            'name' => 'IGIC Product',
+            'description_short' => 'Sub-national rate',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 107.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0, // country-only field: must be ignored
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[502] = [['name' => 'General']];
+        StubStore::$images[502] = ['id_image' => 9502];
+        StubStore::$products[502]['id_tax_rules_group'] = 9502;
+        // Country-mapped shape: the group resolves 7% for country 34 only.
+        StubStore::$taxRuleRates[9502] = [34 => 7.0];
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('0.07', (string)$items[0]['tax_rate']);
+        TinyAssert::same('7.00', (string)$items[0]['tax_amount']);
+        TinyAssert::same('107.00', (string)$items[0]['gross_amount']);
+    }
+
+    private static function testGetTwoNewOrderDataSplitsAtcpShippingAcrossProductRateClasses(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // PS_ATCP_SHIPWRAP taxes shipping at the blended average product
+        // rate ((100*0.21 + 50*0.10) / 150 = 17.333% -> gross 11.73 on net
+        // 10.00). The payload must NEVER carry that blended rate: the charge
+        // is split across the cart's canonical product rate classes.
+        StubStore::$configuration['PS_ATCP_SHIPWRAP'] = 1;
+
+        StubStore::$customers[6201] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Pia',
+            'lastname' => 'Sol',
+            'secure_key' => 'secure-key-6201',
+            'loaded' => true,
+        ];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[34] = 'ES';
+        StubStore::$addresses[7601] = [
+            'id_country' => 34,
+            'company' => 'SPAIN',
+            'companyid' => 'E20468708',
+            'address1' => 'Calle Tres 3',
+            'city' => 'Madrid',
+            'postcode' => '28009',
+            'phone' => '666666676',
+            'loaded' => true,
+        ];
+        StubStore::$addresses[7602] = StubStore::$addresses[7601];
+        StubStore::$carriers[62] = [
+            'name' => 'ATCP Carrier',
+            'delay' => '',
+            'shipping_method' => Carrier::SHIPPING_METHOD_PRICE,
+            'tax_rules_group_id' => 0, // irrelevant under PS_ATCP_SHIPWRAP
+        ];
+
+        $cart = new Cart(6201);
+        $cart->id_customer = 6201;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 7601;
+        $cart->id_address_delivery = 7602;
+        $cart->id_carrier = 62;
+        $cart->id_lang = 1;
+
+        StubStore::$cartProducts[6201] = [
+            [
+                'id_product' => 8831,
+                'link_rewrite' => 'atcp-standard',
+                'name' => 'ATCP Standard',
+                'description_short' => 'Standard',
+                'manufacturer_name' => 'ACME',
+                'ean13' => '',
+                'upc' => '',
+                'total' => 100.00,
+                'total_wt' => 121.00,
+                'cart_quantity' => 1,
+                'rate' => 21.0,
+                'price' => 100.00,
+                'reduction' => 0,
+            ],
+            [
+                'id_product' => 8832,
+                'link_rewrite' => 'atcp-reduced',
+                'name' => 'ATCP Reduced',
+                'description_short' => 'Reduced',
+                'manufacturer_name' => 'ACME',
+                'ean13' => '',
+                'upc' => '',
+                'total' => 50.00,
+                'total_wt' => 55.00,
+                'cart_quantity' => 1,
+                'rate' => 10.0,
+                'price' => 50.00,
+                'reduction' => 0,
+            ],
+        ];
+        StubStore::$productCategories[8831] = [['name' => 'General']];
+        StubStore::$productCategories[8832] = [['name' => 'General']];
+        StubStore::$images[8831] = ['id_image' => 8831];
+        StubStore::$images[8832] = ['id_image' => 8832];
+        self::declareProductRate($cart, 8831, 21.0);
+        self::declareProductRate($cart, 8832, 10.0);
+        StubStore::$cartShipping[6201] = [
+            true => 11.73,
+            false => 10.00,
+        ];
+        StubStore::$cartTotals[6201] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::BOTH => 187.73,
+                Cart::ONLY_SHIPPING => 11.73,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::BOTH => 160.00,
+                Cart::ONLY_SHIPPING => 10.00,
+            ],
+            'average_products_tax_rate' => 17.3333,
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-6201', $cart, [
+            'merchant_confirmation_url' => 'https://shop.local/confirm',
+            'merchant_cancel_order_url' => 'https://shop.local/cancel',
+            'merchant_edit_order_url' => '',
+            'merchant_order_verification_failed_url' => '',
+            'merchant_invoice_url' => '',
+            'merchant_shipping_document_url' => '',
+        ]);
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        // Exactly the two canonical product rate classes - no blended rate.
+        TinyAssert::count(2, $shippingLines);
+        $seenRates = [];
+        $netSum = 0.0;
+        $taxSum = 0.0;
+        foreach ($shippingLines as $line) {
+            $seenRates[] = (string)$line['tax_rate'];
+            $lineNet = (float)$line['net_amount'];
+            $lineTax = (float)$line['tax_amount'];
+            $lineGross = (float)$line['gross_amount'];
+            $lineRate = (float)$line['tax_rate'];
+            $netSum = round($netSum + $lineNet, 2);
+            $taxSum = round($taxSum + $lineTax, 2);
+            // Each split line must be rate-consistent and gross-exact.
+            TinyAssert::true(
+                abs($lineTax - $lineRate * $lineNet) <= 0.02,
+                'Shipping split line must satisfy |tax - rate*net| <= 0.02, got tax=' . $line['tax_amount'] . ' rate=' . $line['tax_rate'] . ' net=' . $line['net_amount']
+            );
+            TinyAssert::same(
+                number_format($lineNet + $lineTax, 2, '.', ''),
+                number_format($lineGross, 2, '.', ''),
+                'Shipping split line gross must equal net + tax exactly'
+            );
+        }
+        sort($seenRates);
+        TinyAssert::same(['0.1', '0.21'], $seenRates, 'Expected ONLY the canonical 10% and 21% rate classes, never the blended 17.33%');
+        TinyAssert::same('10.00', number_format($netSum, 2, '.', ''), 'Split nets must sum to the PrestaShop shipping net');
+        TinyAssert::same('1.73', number_format($taxSum, 2, '.', ''), 'Split taxes must sum to the PrestaShop shipping tax');
+        TinyAssert::same('187.73', (string)$payload['gross_amount']);
+        TinyAssert::same('160.00', (string)$payload['net_amount']);
+    }
+
+    private static function testGetTwoNewOrderDataFreeShippingDiscountRederivesGrossWhenNetCapBites(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        StubStore::$countries[34] = 'ES';
+        StubStore::$addresses[7701] = [
+            'id_country' => 34,
+            'company' => 'SPAIN',
+            'companyid' => 'E20468708',
+            'address1' => 'Calle Cuatro 4',
+            'city' => 'Madrid',
+            'postcode' => '28010',
+            'phone' => '666666677',
+            'loaded' => true,
+        ];
+        StubStore::$addresses[7702] = StubStore::$addresses[7701];
+
+        $cart = new Cart(18);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 41;
+        $cart->id_address_invoice = 7701;
+        $cart->id_address_delivery = 7702;
+
+        StubStore::$cartProducts[18] = [[
+            'id_product' => 8841,
+            'link_rewrite' => 'cap-bite-product',
+            'name' => 'Cap Bite Product',
+            'description_short' => 'Product',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 121.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[8841] = [['name' => 'General']];
+        StubStore::$images[8841] = ['id_image' => 8841];
+        self::declareProductRate($cart, 8841, 21.0);
+        StubStore::$carriers[41] = [
+            'name' => 'Cap Carrier',
+            'delay' => '',
+            'shipping_method' => Carrier::SHIPPING_METHOD_PRICE,
+        ];
+        self::declareCarrierRate($cart, 41, 21.0);
+        StubStore::$cartShipping[18] = [true => 12.10, false => 10.00];
+        // No discounts yet: build the clean product + shipping items first.
+        StubStore::$cartTotals[18] = [
+            true => [Cart::ONLY_DISCOUNTS => 0.00],
+            false => [Cart::ONLY_DISCOUNTS => 0.00],
+            'average_products_tax_rate' => 21.0,
+        ];
+        // Free-shipping rule WITHOUT net metadata (no value_tax_exc): the
+        // discount builder can only take the shipping-context fallback path.
+        StubStore::$cartRules[18] = [[
+            'name' => 'free-ship-cap',
+            'code' => 'free-ship-cap',
+            'value' => -12.10,
+            'value_real' => 12.10,
+            'free_shipping' => 1,
+        ]];
+
+        $items = $module->getTwoProductItems($cart);
+
+        // CAP PATH (TWO-24880 regression): the shipping-ratio-derived net
+        // for a 12.10 gross allocation is 10.00; a cart-level discount NET
+        // total of 9.40 is lower, so the min() cap bites. The old code kept
+        // the 12.10 gross with the clamped 9.40 net (tax 2.70 vs
+        // rate-implied 1.97 - a rate-inconsistent line); the new code
+        // re-derives gross from the capped net at the mirrored shipping
+        // rate. The branch is private and cannot return through the public
+        // builder (see below), so it is invoked directly.
+        $method = new ReflectionMethod(Twopayment::class, 'buildTwoFallbackFreeShippingDiscountLine');
+        $method->setAccessible(true);
+        $fallback = $method->invoke($module, $cart, $items, 12.10, 9.40, null);
+
+        TinyAssert::true(is_array($fallback), 'Expected a fallback free-shipping discount line');
+        TinyAssert::same('9.40', number_format((float)$fallback['net'], 2, '.', ''));
+        TinyAssert::same('11.37', number_format((float)$fallback['gross'], 2, '.', ''), 'Gross must be re-derived from the capped net, not clamped at 12.10');
+
+        $line = $fallback['line'];
+        TinyAssert::same('-9.40', (string)$line['net_amount']);
+        TinyAssert::same('-1.97', (string)$line['tax_amount']); // round(9.40 * 0.21, 2)
+        TinyAssert::same('-11.37', (string)$line['gross_amount']);
+        TinyAssert::same('0.21', (string)$line['tax_rate']);
+        $lineNet = (float)$line['net_amount'];
+        $lineTax = (float)$line['tax_amount'];
+        $lineGross = (float)$line['gross_amount'];
+        TinyAssert::same(
+            number_format($lineNet + $lineTax, 2, '.', ''),
+            number_format($lineGross, 2, '.', ''),
+            'Free-shipping discount line gross must equal net + tax exactly'
+        );
+        TinyAssert::true(
+            abs($lineTax - (float)$line['tax_rate'] * $lineNet) <= 0.02,
+            'Free-shipping discount line must satisfy |tax - rate*net| <= 0.02'
+        );
+
+        // Through the PUBLIC builder the same cart data must fail loud: the
+        // re-derived (smaller) gross leaves a 0.73 gross residue with zero
+        // net remaining, which is attributable to no declared rate - the
+        // cart's own discount totals (12.10 gross on 9.40 net = 28.7%)
+        // contradict the declared 21%. The old code silently absorbed that
+        // contradiction into a rate-inconsistent line.
+        StubStore::$cartTotals[18][true][Cart::ONLY_DISCOUNTS] = 12.10;
+        StubStore::$cartTotals[18][false][Cart::ONLY_DISCOUNTS] = 9.40;
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoProductItems($cart);
+            },
+            'Discount amounts diverge from all declared cart tax rates'
+        );
+    }
+
+    private static function testGetTwoProductItemsHighQuantityLineStaysWithinNetTolerance(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $cart = new Cart(19);
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+
+        // High-quantity ROUND_ITEM-style edge: 400 x 8.34005 = 3336.02, but
+        // the emitted 2dp unit price (8.34) implies 400 x 8.34 = 3336.00 -
+        // exactly the 0.02 NET_FORMULA_TOLERANCE edge. (A unit price like
+        // 8.3449 is impossible at qty 400 under the tightened tolerance:
+        // 400 x 0.0049 = 1.96 of drift - any real 3rd/4th-decimal unit
+        // price would rightly fail; only sub-half-cent-per-400 precision
+        // survives.) Declared 21%: tax 700.56 = round(3336.02 * 0.21, 2).
+        StubStore::$cartProducts[19] = [[
+            'id_product' => 8851,
+            'link_rewrite' => 'bulk-precision-product',
+            'name' => 'Bulk Precision Product',
+            'description_short' => 'Bulk precision',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 3336.02,
+            'total_wt' => 4036.58,
+            'cart_quantity' => 400,
+            'rate' => 21.0,
+            'price' => 8.34005,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[8851] = [['name' => 'Bulk']];
+        StubStore::$images[8851] = ['id_image' => 8851];
+        self::declareProductRate($cart, 8851, 21.0);
+
+        $items = $module->getTwoProductItems($cart);
+
+        TinyAssert::count(1, $items);
+        TinyAssert::same('3336.02', (string)$items[0]['net_amount']);
+        TinyAssert::same('700.56', (string)$items[0]['tax_amount']);
+        TinyAssert::same('4036.58', (string)$items[0]['gross_amount']);
+        TinyAssert::same('0.21', (string)$items[0]['tax_rate']);
+        TinyAssert::same('8.34', (string)$items[0]['unit_price']);
+        TinyAssert::same('0.00', (string)$items[0]['discount_amount']);
+        TinyAssert::same(400, (int)$items[0]['quantity']);
+        // The 0.02 drift between qty*unit_price and net must pass the
+        // tightened net-formula validation - at the exact boundary.
+        TinyAssert::true(
+            $module->validateTwoLineItems($items),
+            'High-quantity line at the 2-cent net-formula boundary must validate'
+        );
+        TinyAssert::count(0, PrestaShopLogger::$logs);
     }
 
     private static function testGetTwoNewOrderDataOmitsTopLevelTaxRate(): void
@@ -1113,6 +1632,8 @@ final class OrderBuilderSpec
                     'name' => 'Broken line',
                     'net_amount' => '100.00',
                     'tax_amount' => '10.00',
+                    // Gross consistent (net + tax); ONLY the tax formula is broken.
+                    'gross_amount' => '110.00',
                     'tax_rate' => '0.21',
                     'unit_price' => '100.00',
                     'quantity' => 1,
@@ -1717,6 +2238,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[777] = [['name' => 'TV']];
         StubStore::$images[777] = ['id_image' => 9901];
+        self::declareProductRate($cart, 777, 21.0);
         StubStore::$cartShipping[491] = [
             true => 58.00,
             false => 47.93,
@@ -1848,6 +2370,8 @@ final class OrderBuilderSpec
         StubStore::$productCategories[780] = [['name' => 'General']];
         StubStore::$images[779] = ['id_image' => 9903];
         StubStore::$images[780] = ['id_image' => 9904];
+        // 779 is zero-rated: no tax-rules group declared (resolves 0).
+        self::declareProductRate($cart, 780, 21.0);
         StubStore::$cartShipping[494] = [
             true => 116.00,
             false => 95.87,
@@ -1953,10 +2477,15 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[778] = [['name' => 'Bulk']];
         StubStore::$images[778] = ['id_image' => 9902];
+        self::declareProductRate($cart, 778, 21.0);
         StubStore::$cartShipping[492] = [
             true => 121.00,
             false => 100.00,
         ];
+        // Discount nets must reconcile with the declared 21% context under
+        // the relay (the deleted code blended a synthetic rate instead):
+        // free-shipping carve-out is 121.00/100.00, the remainder
+        // 588.25 gross / 486.16 net implies exactly round(486.16*0.21)=102.09.
         StubStore::$cartTotals[492] = [
             true => [
                 Cart::ONLY_DISCOUNTS => 709.25,
@@ -1964,8 +2493,8 @@ final class OrderBuilderSpec
                 Cart::ONLY_SHIPPING => 0.00,
             ],
             false => [
-                Cart::ONLY_DISCOUNTS => 586.25,
-                Cart::BOTH => 2513.75,
+                Cart::ONLY_DISCOUNTS => 586.16,
+                Cart::BOTH => 2513.84,
                 Cart::ONLY_SHIPPING => 0.00,
             ],
             'average_products_tax_rate' => 21.0,
@@ -2089,6 +2618,9 @@ final class OrderBuilderSpec
         StubStore::$productCategories[8202] = [['name' => 'Stationery']];
         StubStore::$images[8201] = ['id_image' => 8201];
         StubStore::$images[8202] = ['id_image' => 8202];
+        // 8201 is zero-rated (430.80/430.80): no group declared (resolves 0).
+        self::declareProductRate($cart, 8202, 21.0);
+        self::declareWrappingRate($cart, 21.0);
         StubStore::$cartShipping[493] = [
             true => 116.00,
             false => 95.87,
@@ -2219,6 +2751,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[8302] = [['name' => 'General']];
         StubStore::$images[8302] = ['id_image' => 8302];
+        self::declareProductRate($cart, 8302, 21.0);
         StubStore::$cartShipping[497] = [true => 0.00, false => 0.00];
         StubStore::$cartTotals[497] = [
             true => [
@@ -2343,6 +2876,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[8396] = [['name' => 'General']];
         StubStore::$images[8396] = ['id_image' => 8396];
+        self::declareProductRate($cart, 8396, 10.0);
         StubStore::$cartShipping[596] = [true => 12.10, false => 10.00];
         StubStore::$cartTotals[596] = [
             true => [
@@ -2476,6 +3010,9 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[8397] = [['name' => 'General']];
         StubStore::$images[8397] = ['id_image' => 8397];
+        // Declared 21%: applied tax 115.89 vs expected 115.88 is within the
+        // 2-cent relay tolerance, so the declared rate is relayed as-is.
+        self::declareProductRate($cart, 8397, 21.0);
         StubStore::$cartShipping[597] = [true => 2.99, false => 2.47];
         StubStore::$cartTotals[597] = [
             true => [
@@ -2604,6 +3141,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[8398] = [['name' => 'General']];
         StubStore::$images[8398] = ['id_image' => 8398];
+        self::declareProductRate($cart, 8398, 21.0);
         StubStore::$cartShipping[598] = [true => 1.21, false => 1.00];
         StubStore::$cartTotals[598] = [
             true => [
@@ -2733,6 +3271,7 @@ final class OrderBuilderSpec
         ];
         StubStore::$productCategories[8301] = [['name' => 'General']];
         StubStore::$images[8301] = ['id_image' => 8301];
+        self::declareProductRate($cart, 8301, 21.0);
         StubStore::$cartShipping[496] = [true => 0.00, false => 0.00];
         StubStore::$cartTotals[496] = [
             true => [
@@ -2837,6 +3376,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9101] = [['name' => 'TV']];
         StubStore::$images[9101] = ['id_image' => 9101];
+        self::declareProductRate($cart, 9101, 21.0);
         StubStore::$cartShipping[6101] = [
             true => 58.00,
             false => 47.93,
@@ -2967,6 +3507,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9201] = [['name' => 'Projectors']];
         StubStore::$images[9201] = ['id_image' => 9201];
+        self::declareProductRate($cart, 9201, 21.0);
         StubStore::$cartShipping[6102] = [
             true => 2.99,
             false => 2.47,
@@ -3057,6 +3598,7 @@ final class OrderBuilderSpec
         ]];
         StubStore::$productCategories[9301] = [['name' => 'Audio']];
         StubStore::$images[9301] = ['id_image' => 9301];
+        self::declareProductRate($cart, 9301, 21.0);
         StubStore::$cartShipping[6103] = [
             true => 2.99,
             false => 2.47,
@@ -4932,6 +5474,7 @@ final class OrderBuilderSpec
 
         StubStore::$productCategories[701] = [['name' => 'Furniture']];
         StubStore::$images[701] = ['id_image' => 9901];
+        self::declareProductRate($cart, 701, 21.0);
 
         $items = $module->getTwoProductItems($cart);
 
@@ -5044,6 +5587,9 @@ foreach ($tests as $name => $callable) {
     } catch (Throwable $e) {
         $failed++;
         fwrite(STDERR, "FAIL {$name}: {$e->getMessage()}\n");
+        if (getenv('TESTS_TRACE')) {
+            fwrite(STDERR, $e->getTraceAsString() . "\n");
+        }
     }
 }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -71,6 +71,7 @@ final class OrderBuilderSpec
         self::testGetTwoProductItemsRelaysNonCanonicalDeclaredRateInsteadOfSpanishFallback();
         self::testGetTwoProductItemsMultiJurisdictionCartRelaysPerLineDeclaredRates();
         self::testGetTwoProductItemsIgnoresCountryOnlyRateFieldAndRelaysAddressCorrectRate();
+        self::testToleranceSingleRateSegmentRejectsAmbiguousMultiRateFit();
         self::testGetTwoNewOrderDataSplitsAtcpShippingAcrossProductRateClasses();
         self::testGetTwoNewOrderDataFreeShippingDiscountRederivesGrossWhenNetCapBites();
         self::testGetTwoProductItemsHighQuantityLineStaysWithinNetTolerance();
@@ -973,6 +974,34 @@ final class OrderBuilderSpec
         TinyAssert::same('0.00', (string)$items[2]['tax_amount']);
     }
 
+    private static function testToleranceSingleRateSegmentRejectsAmbiguousMultiRateFit(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // UNIQUE-FIT RULE: when a tiny row's tax is within tolerance of TWO
+        // declared rates, attribution is ambiguous and must return [] (the
+        // caller fails loud) — accepting the nearest fit would be the exact
+        // relabel-to-neighbouring-rate failure mode the deleted Spanish
+        // fallback had. net=0.20, tax=0.03: 10% implies 0.02 (diff 1c, fits),
+        // 21% implies 0.04 (diff 1c, fits) -> ambiguous.
+        $method = new ReflectionMethod(Twopayment::class, 'buildTwoToleranceSingleRateSegment');
+        $method->setAccessible(true);
+        $ambiguous = $method->invoke($module, 20, 3, [0.10, 0.21]);
+        TinyAssert::same([], $ambiguous, 'Ambiguous multi-rate fit must be rejected, not nearest-matched');
+
+        // Exactly one fitting declared rate is accepted with amounts preserved.
+        $unique = $method->invoke($module, 20, 1, [0.10, 0.21]);
+        TinyAssert::count(1, $unique);
+        TinyAssert::same(0.10, $unique[0]['rate']);
+        TinyAssert::same(0.20, $unique[0]['net']);
+        TinyAssert::same(0.01, $unique[0]['tax']);
+
+        // No fitting rate at all: genuine divergence, also rejected.
+        $none = $method->invoke($module, 10000, 1500, [0.10, 0.21]);
+        TinyAssert::same([], $none, 'Non-reconciling tax must be rejected');
+    }
+
     private static function testGetTwoProductItemsIgnoresCountryOnlyRateFieldAndRelaysAddressCorrectRate(): void
     {
         self::reset();
@@ -983,12 +1012,16 @@ final class OrderBuilderSpec
         $cart->id_carrier = 0;
         self::ensureCartTaxAddress($cart); // seeds ES (country 34) invoice address
 
-        // Sub-national plumbing proof (Canary IGIC class of bug): the
-        // getProducts() row still carries the country-only 'rate' field
-        // (21.0), but the product's declared group resolves 7% for THIS
-        // cart's tax address and PrestaShop applied 7% to the amounts. The
-        // relay must emit the address-correct 7%, proving the country-only
-        // 'rate' field is dead.
+        // Plumbing proof for the Canary-IGIC class of bug: the getProducts()
+        // row still carries the country-only 'rate' field (21.0), but the
+        // product's declared group resolves 7% for THIS cart's tax address
+        // and PrestaShop applied 7% to the amounts. The relay must emit the
+        // address-correct 7%, proving the country-only 'rate' field is dead.
+        // NOTE: the stub resolves rates by COUNTRY id, so this pins the
+        // "row field ignored, TaxManagerFactory wins" plumbing only — real
+        // sub-national (state/zip) zone resolution can only be proven
+        // against a live PrestaShop tax engine (design doc section 7.1b:
+        // staging Canary/Ceuta order, post-merge validation).
         StubStore::$cartProducts[17] = [[
             'id_product' => 502,
             'link_rewrite' => 'igic-product',

--- a/tests/run.php
+++ b/tests/run.php
@@ -1329,11 +1329,12 @@ final class OrderBuilderSpec
 
         // High-quantity ROUND_ITEM-style edge: 400 x 8.34005 = 3336.02, but
         // the emitted 2dp unit price (8.34) implies 400 x 8.34 = 3336.00 -
-        // exactly the 0.02 NET_FORMULA_TOLERANCE edge. (A unit price like
-        // 8.3449 is impossible at qty 400 under the tightened tolerance:
-        // 400 x 0.0049 = 1.96 of drift - any real 3rd/4th-decimal unit
-        // price would rightly fail; only sub-half-cent-per-400 precision
-        // survives.) Declared 21%: tax 700.56 = round(3336.02 * 0.21, 2).
+        // a 0.02 drift, comfortably inside NET_FORMULA_TOLERANCE (0.05).
+        // (NET_FORMULA_TOLERANCE is deliberately NOT tightened to 0.02:
+        // a >2dp unit price at high quantity drifts up to qty*0.005, e.g.
+        // 400 x 8.3449 = 1.96 of drift - the 2dp-unit/6dp-discount
+        // absorption gap must be fixed before tightening, design 4.3 pt 4.)
+        // Declared 21%: tax 700.56 = round(3336.02 * 0.21, 2).
         StubStore::$cartProducts[19] = [[
             'id_product' => 8851,
             'link_rewrite' => 'bulk-precision-product',
@@ -1364,10 +1365,10 @@ final class OrderBuilderSpec
         TinyAssert::same('0.00', (string)$items[0]['discount_amount']);
         TinyAssert::same(400, (int)$items[0]['quantity']);
         // The 0.02 drift between qty*unit_price and net must pass the
-        // tightened net-formula validation - at the exact boundary.
+        // net-formula validation (tolerance 0.05).
         TinyAssert::true(
             $module->validateTwoLineItems($items),
-            'High-quantity line at the 2-cent net-formula boundary must validate'
+            'High-quantity line with 2-cent net-formula drift must validate'
         );
         TinyAssert::count(0, PrestaShopLogger::$logs);
     }

--- a/twopayment.php
+++ b/twopayment.php
@@ -74,7 +74,7 @@ class Twopayment extends PaymentModule
     
     // Constants for validation tolerances
     const TAX_FORMULA_TOLERANCE = 0.02; // Tolerance for tax formula validation
-    const NET_FORMULA_TOLERANCE = 0.02; // Tolerance for net formula validation (matches the tax-formula tolerance; the API rejects wider gaps)
+    const NET_FORMULA_TOLERANCE = 0.05; // Tolerance for net formula validation. Deliberately NOT tightened to 0.02 yet: the emitted unit_price is 2dp while the discount is derived at 6dp, so a legitimate high-quantity line with a >2dp unit price can drift up to qty*0.005. Tighten only after that absorption gap is fixed (design 4.3 pt 4).
     const ORDER_RECONCILIATION_TOLERANCE = 0.02; // Warn-level parity tolerance against cart totals (PrestaShop rounding can drift by up to 2 cents)
     const TAX_RATE_PRECISION = 6; // Decimal precision for line-item tax rates sent to Two (native PrestaShop precision; must stay >= 4dp so the 2dp-of-percent normaliser output survives formatting)
     const TAX_SUBTOTAL_RATE_PRECISION = 2; // Keep tax subtotal grouping stable for compatibility
@@ -5367,7 +5367,13 @@ class Twopayment extends PaymentModule
      * actual tax (PrestaShop rounds discount buckets once; per-line rounding
      * can legitimately differ by a cent or two). The amounts are preserved
      * as-is — the rate is only accepted, never derived from the amounts.
-     * Returns [] when no declared rate reconciles (caller fails loud).
+     *
+     * UNIQUE-FIT RULE: if MORE THAN ONE declared rate fits within the
+     * tolerance the row is ambiguous (this only happens on tiny nets where
+     * neighbouring rates are cents apart) — returns [] so the caller fails
+     * loud rather than risk relabeling a line to a neighbouring rate, the
+     * exact failure mode the deleted snap/fallback machinery had. Also
+     * returns [] when no declared rate reconciles at all.
      *
      * @param int $net_cents
      * @param int $tax_cents
@@ -5377,23 +5383,21 @@ class Twopayment extends PaymentModule
     private function buildTwoToleranceSingleRateSegment($net_cents, $tax_cents, $rates)
     {
         $tolerance_cents = (int) round(self::TAX_FORMULA_TOLERANCE * 100);
-        $best_rate = null;
-        $best_diff = null;
+        $fitting_rates = [];
         foreach ((array) $rates as $rate) {
             $rate = max(0, (float) $rate);
             $diff = abs((int) round($net_cents * $rate, 0) - $tax_cents);
-            if ($diff > $tolerance_cents) {
-                continue;
-            }
-            if ($best_diff === null || $diff < $best_diff) {
-                $best_diff = $diff;
-                $best_rate = $rate;
+            if ($diff <= $tolerance_cents) {
+                $fitting_rates[$this->formatTwoTaxRate($rate)] = $rate;
             }
         }
 
-        if ($best_rate === null) {
+        if (count($fitting_rates) !== 1) {
+            // 0 fits: genuine divergence. 2+ fits: ambiguous attribution.
+            // Both fail loud at the caller.
             return [];
         }
+        $best_rate = reset($fitting_rates);
 
         return [[
             'net' => round($net_cents / 100, 2),

--- a/twopayment.php
+++ b/twopayment.php
@@ -74,15 +74,12 @@ class Twopayment extends PaymentModule
     
     // Constants for validation tolerances
     const TAX_FORMULA_TOLERANCE = 0.02; // Tolerance for tax formula validation
-    const NET_FORMULA_TOLERANCE = 0.05; // Tolerance for net formula validation
+    const NET_FORMULA_TOLERANCE = 0.02; // Tolerance for net formula validation (matches the tax-formula tolerance; the API rejects wider gaps)
     const ORDER_RECONCILIATION_TOLERANCE = 0.02; // Warn-level parity tolerance against cart totals (PrestaShop rounding can drift by up to 2 cents)
-    const TAX_RATE_PRECISION = 3; // Decimal precision for line-item tax rates sent to Two
+    const TAX_RATE_PRECISION = 6; // Decimal precision for line-item tax rates sent to Two (native PrestaShop precision; must stay >= 4dp so the 2dp-of-percent normaliser output survives formatting)
     const TAX_SUBTOTAL_RATE_PRECISION = 2; // Keep tax subtotal grouping stable for compatibility
     const SNAPSHOT_TAX_RATE_PRECISION = 2; // Keep snapshot hash behavior stable across minor rate precision drift
     const TAX_RATE_PERCENT_PRECISION = 2; // Provider expects VAT rates rounded to 2 decimals in percent
-    const TAX_RATE_VARIANCE_TOLERANCE = 0.005; // Acceptable decimal variance between configured and applied rate
-    const TAX_RATE_CONTEXT_SNAP_TOLERANCE = 0.0025; // Snap near-context discount rates (e.g. 0.212 -> 0.21) for provider compatibility
-    const SPANISH_FALLBACK_TAX_RATE = 0.21; // ES strict fallback when unresolved line rates drift from canonical contexts
     // Two module currency coverage baseline: keep these provider currencies explicitly allowed.
     // Required coverage: NOK, GBP, SEK, USD, DKK, EUR
     const TWO_SUPPORTED_CURRENCY_ISOS = ['NOK', 'GBP', 'SEK', 'USD', 'DKK', 'EUR'];
@@ -4082,14 +4079,12 @@ class Twopayment extends PaymentModule
         $items = [];
         $carrier = new Carrier($cart->id_carrier, $cart->id_lang);
         $line_items = $cart->getProducts(true);
-        $use_spanish_rate_policy = $this->shouldApplyTwoSpanishTaxRatePolicy($cart);
-        
+
         //  Validate cart has products
         if (empty($line_items)) {
             PrestaShopLogger::addLog('TwoPayment: Cart is empty, cannot build line items', 3);
             return $items; // Return empty array (caller should handle empty cart)
         }
-        $known_product_rate_candidates = $this->collectTwoKnownTaxRatesFromConfiguredProductRates($line_items);
         $surchargeProductId = $this->getTwoSurchargeCartProductId(false);
 
         foreach ($line_items as $line_item) {
@@ -4122,7 +4117,8 @@ class Twopayment extends PaymentModule
                 $line_item,
                 $quantity,
                 $net_amount_prestashop,
-                $gross_amount_prestashop
+                $gross_amount_prestashop,
+                $cart
             );
             if (!empty($ecotax_breakdown['enabled'])) {
                 $net_amount_prestashop = (float)$ecotax_breakdown['product_net'];
@@ -4134,69 +4130,42 @@ class Twopayment extends PaymentModule
                 }
             }
             
-            // DIAGNOSTIC LOGGING: Log tax data for debugging store-specific issues
-            // Only log when debug mode is enabled to avoid excessive log entries in production
+            // DECLARED-RATE RELAY (TWO-24880): the line's tax rate is the
+            // merchant's own configured rate — the product's tax-rules group
+            // resolved at the cart's PS_TAX_ADDRESS_TYPE address, exactly the
+            // resolution PrestaShop used to compute the amounts. We never
+            // derive the rate from tax/net, never snap it toward canonical
+            // values, and never substitute a fallback. NOTE: the row's
+            // 'rate' field from getProducts() is country-only (it ignores
+            // state/zip tax rules) and must not be used.
+            $declared_tax_rules_group_id = (int) Product::getIdTaxRulesGroupByIdProduct(
+                (int) $line_item['id_product'],
+                $this->context
+            );
+            $tax_rate = $this->getTwoConfiguredTaxRateDecimalForGroup($declared_tax_rules_group_id, $cart);
+
             if (Configuration::get('PS_TWO_DEBUG_MODE')) {
-                $calculated_rate_for_log = ($net_amount_prestashop > 0) 
-                    ? round((($gross_amount_prestashop - $net_amount_prestashop) / $net_amount_prestashop) * 100, 2) 
-                    : 0;
                 PrestaShopLogger::addLog(
-                    'TwoPayment: Product tax debug - ID: ' . $line_item['id_product'] . 
-                    ' | rate field: ' . (isset($line_item['rate']) ? $line_item['rate'] : 'NULL') . 
-                    ' | total (net): ' . $net_amount_prestashop . 
-                    ' | total_wt (gross): ' . $gross_amount_prestashop .
-                    ' | calculated rate: ' . $calculated_rate_for_log . '%',
+                    'TwoPayment: Product tax debug - ID: ' . $line_item['id_product'] .
+                    ' | tax rules group: ' . $declared_tax_rules_group_id .
+                    ' | declared rate: ' . round($tax_rate * 100, 2) . '%' .
+                    ' | total (net): ' . $net_amount_prestashop .
+                    ' | total_wt (gross): ' . $gross_amount_prestashop,
                     1 // Info level
                 );
             }
-            
-            // Derive the effective tax rate from applied PrestaShop amounts first.
-            // Keep configured rate only when it is very close (normal variance).
-            $rate_from_field_percent = isset($line_item['rate']) ? (float)$line_item['rate'] : 0;
-            $rate_from_field_decimal = $rate_from_field_percent / 100;
-            $rate_from_amounts_decimal = 0.0;
 
-            if ($net_amount_prestashop > 0) {
-                $rate_from_amounts_decimal = $tax_amount_prestashop / $net_amount_prestashop;
-                if ($rate_from_amounts_decimal < 0) {
-                    $rate_from_amounts_decimal = 0.0;
-                }
-            }
-
-            $tax_rate = 0.0;
-            if ($net_amount_prestashop > 0) {
-                $rate_difference = abs($rate_from_field_decimal - $rate_from_amounts_decimal);
-                if ($rate_from_field_percent > 0 && $rate_difference <= self::TAX_RATE_VARIANCE_TOLERANCE) {
-                    $tax_rate = $rate_from_field_decimal;
-                } else {
-                    $tax_rate = $rate_from_amounts_decimal;
-                    if ($rate_from_field_percent > 0 && Configuration::get('PS_TWO_DEBUG_MODE')) {
-                        PrestaShopLogger::addLog(
-                            'TwoPayment: Tax rate variance - field: ' . $rate_from_field_percent . '%, amounts: ' .
-                            round($rate_from_amounts_decimal * 100, 2) . '% | Product: ' . $line_item['id_product'] .
-                            ' | Using applied rate from amounts',
-                            1
-                        );
-                    }
-                }
-            } elseif ($rate_from_field_percent > 0) {
-                $tax_rate = $rate_from_field_decimal;
-            }
-
-            $tax_rate = $this->normalizeTwoTaxRateToPercentPrecision($tax_rate);
-            $product_known_context_rates = $known_product_rate_candidates;
-            if ($rate_from_field_percent > 0) {
-                $product_known_context_rates[] = $this->normalizeTwoTaxRateToPercentPrecision($rate_from_field_decimal);
-            }
-            $snapped_product_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-                $this->snapTwoTaxRateToKnownContexts($tax_rate, $product_known_context_rates)
+            // Fail loud when the declared rate contradicts PrestaShop's own
+            // applied amounts: we cannot faithfully represent an internally
+            // inconsistent line, and silently correcting it would be
+            // substituting our judgment for the merchant's declaration.
+            $this->assertTwoDeclaredRateReconcilesWithAmounts(
+                'product ' . $line_item['id_product'],
+                $net_amount_prestashop,
+                $tax_amount_prestashop,
+                $tax_rate
             );
-            if (
-                abs($tax_amount_prestashop - ($net_amount_prestashop * $snapped_product_rate)) <= self::TAX_FORMULA_TOLERANCE
-            ) {
-                $tax_rate = $snapped_product_rate;
-            }
-            
+
             // Use PrestaShop unit price when available; otherwise derive from net total.
             $unit_price_net_prestashop = isset($line_item['price']) ? (float)$line_item['price'] : null;
             
@@ -4334,26 +4303,7 @@ class Twopayment extends PaymentModule
             $shipping_net = round((float)$shipping_cost_without_tax, 2);
             $shipping_gross = round((float)$shipping_cost_with_tax, 2);
             $shipping_tax_amount = round($shipping_gross - $shipping_net, 2);
-            $shipping_tax_rate_decimal = $shipping_net > 0
-                ? max(0, $shipping_tax_amount / $shipping_net)
-                : 0.0;
-            $shipping_tax_rate_decimal = $this->normalizeTwoTaxRateToPercentPrecision($shipping_tax_rate_decimal);
-            $shipping_known_context_rates = $this->collectTwoKnownTaxRatesFromPositiveItems($items);
-            $carrier_configured_rate = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
-            if ($carrier_configured_rate > 0) {
-                $shipping_known_context_rates[] = $carrier_configured_rate;
-            }
-            $snapped_shipping_tax_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-                $this->snapTwoTaxRateToKnownContexts($shipping_tax_rate_decimal, $shipping_known_context_rates)
-            );
-            if (
-                abs($shipping_tax_amount - ($shipping_net * $snapped_shipping_tax_rate)) <= self::TAX_FORMULA_TOLERANCE
-            ) {
-                $shipping_tax_rate_decimal = $snapped_shipping_tax_rate;
-            }
-            $shipping_tax_rate_percent = round($shipping_tax_rate_decimal * 100, 2);
-            $shipping_unit_price = $shipping_net;
-            
+
             $shipping_name = $carrier->name ? $carrier->name : $this->l('Shipping');
             $shipping_delay = '';
             if ($carrier->delay && is_array($carrier->delay)) {
@@ -4370,59 +4320,87 @@ class Twopayment extends PaymentModule
             } elseif ($carrier->shipping_method == Carrier::SHIPPING_METHOD_PRICE) {
                 $shipping_description .= ' ' . sprintf($this->l('(by price)'));
             }
-            
-            $shipping_line = [
+
+            $shipping_line_template = [
                 'name' => $shipping_name,
                 'description' => Tools::substr(strip_tags($shipping_description), 0, 255),
-                'gross_amount' => (string)$this->getTwoRoundAmount($shipping_gross),
-                'net_amount' => (string)$this->getTwoRoundAmount($shipping_net),
-                'discount_amount' => '0.00',
-                'tax_amount' => (string)$this->getTwoRoundAmount($shipping_tax_amount),
-                'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount($shipping_tax_rate_percent) . '%',
-                'tax_rate' => $this->formatTwoTaxRate($shipping_tax_rate_decimal),
-                'unit_price' => (string)$this->getTwoRoundAmount($shipping_unit_price),
-                'quantity' => 1,
                 'quantity_unit' => 'pcs',
-                'image_url' => '',
-                'product_page_url' => '',
-                'type' => 'SHIPPING_FEE'
+                'type' => 'SHIPPING_FEE',
             ];
 
-            $items[] = $shipping_line;
+            if ($this->isTwoAtcpShipWrapEnabled()) {
+                // PS_ATCP_SHIPWRAP taxes shipping at the average product tax
+                // rate (a blended, non-canonical rate). Split the charge
+                // across the cart's canonical product rate classes instead of
+                // ever emitting the blended rate.
+                foreach ($this->splitTwoChargeAcrossProductRateClasses(
+                    $shipping_net,
+                    $shipping_tax_amount,
+                    $items,
+                    'shipping'
+                ) as $segment) {
+                    $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
+                }
+            } else {
+                // DECLARED-RATE RELAY: the shipping rate is the carrier's own
+                // tax-rules group resolved at the cart's tax address — never
+                // derived from tax/net, never snapped.
+                $shipping_tax_rate_decimal = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
+                $this->assertTwoDeclaredRateReconcilesWithAmounts(
+                    'shipping (' . $shipping_name . ')',
+                    $shipping_net,
+                    $shipping_tax_amount,
+                    $shipping_tax_rate_decimal
+                );
+                $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, [
+                    'net' => $shipping_net,
+                    'tax' => $shipping_tax_amount,
+                    'gross' => $shipping_gross,
+                    'rate' => $shipping_tax_rate_decimal,
+                ]);
+            }
         }
 
         $wrapping_totals = $this->getTwoGiftWrappingTotals($cart);
         if ($wrapping_totals['gross'] > 0) {
-            $wrapping_rate_decimal = $wrapping_totals['net'] > 0
-                ? max(0, $wrapping_totals['tax'] / $wrapping_totals['net'])
-                : 0.0;
-            $wrapping_rate_decimal = $this->normalizeTwoTaxRateToPercentPrecision($wrapping_rate_decimal);
-            $wrapping_known_context_rates = $this->collectTwoKnownTaxRatesFromPositiveItems($items);
-            $snapped_wrapping_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-                $this->snapTwoTaxRateToKnownContexts($wrapping_rate_decimal, $wrapping_known_context_rates)
-            );
-            if (
-                abs($wrapping_totals['tax'] - ($wrapping_totals['net'] * $snapped_wrapping_rate)) <= self::TAX_FORMULA_TOLERANCE
-            ) {
-                $wrapping_rate_decimal = $snapped_wrapping_rate;
-            }
-            $wrapping_rate_percent = round($wrapping_rate_decimal * 100, 2);
-            $items[] = [
+            $wrapping_line_template = [
                 'name' => $this->l('Gift wrapping'),
                 'description' => Tools::substr(strip_tags($this->l('Gift wrapping for this order')), 0, 255),
-                'gross_amount' => (string)$this->getTwoRoundAmount($wrapping_totals['gross']),
-                'net_amount' => (string)$this->getTwoRoundAmount($wrapping_totals['net']),
-                'discount_amount' => '0.00',
-                'tax_amount' => (string)$this->getTwoRoundAmount($wrapping_totals['tax']),
-                'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount($wrapping_rate_percent) . '%',
-                'tax_rate' => $this->formatTwoTaxRate($wrapping_rate_decimal),
-                'unit_price' => (string)$this->getTwoRoundAmount($wrapping_totals['net']),
-                'quantity' => 1,
                 'quantity_unit' => 'item',
-                'image_url' => '',
-                'product_page_url' => '',
                 'type' => 'DIGITAL',
             ];
+
+            if ($this->isTwoAtcpShipWrapEnabled()) {
+                // PS_ATCP_SHIPWRAP also taxes wrapping at the blended average
+                // product rate — same canonical split as shipping.
+                foreach ($this->splitTwoChargeAcrossProductRateClasses(
+                    $wrapping_totals['net'],
+                    $wrapping_totals['tax'],
+                    $items,
+                    'gift wrapping'
+                ) as $segment) {
+                    $items[] = $this->buildTwoChargeLineFromSegment($wrapping_line_template, $segment);
+                }
+            } else {
+                // DECLARED-RATE RELAY: wrapping is taxed by the shop's
+                // configured PS_GIFT_WRAPPING_TAX_RULES_GROUP.
+                $wrapping_rate_decimal = $this->getTwoConfiguredTaxRateDecimalForGroup(
+                    (int) Configuration::get('PS_GIFT_WRAPPING_TAX_RULES_GROUP'),
+                    $cart
+                );
+                $this->assertTwoDeclaredRateReconcilesWithAmounts(
+                    'gift wrapping',
+                    $wrapping_totals['net'],
+                    $wrapping_totals['tax'],
+                    $wrapping_rate_decimal
+                );
+                $items[] = $this->buildTwoChargeLineFromSegment($wrapping_line_template, [
+                    'net' => $wrapping_totals['net'],
+                    'tax' => $wrapping_totals['tax'],
+                    'gross' => $wrapping_totals['gross'],
+                    'rate' => $wrapping_rate_decimal,
+                ]);
+            }
         }
 
         // Add cart-level discounts as one or more lines split by tax context when applicable.
@@ -4433,11 +4411,206 @@ class Twopayment extends PaymentModule
             }
         }
 
-        if ($use_spanish_rate_policy) {
-            $items = $this->applyTwoSpanishCanonicalTaxRateFallbackToItems($items);
+        return $items;
+    }
+
+    /**
+     * Whether PrestaShop's "average tax of cart products for shipping and
+     * wrapping" mode is enabled (PS_ATCP_SHIPWRAP).
+     *
+     * @return bool
+     */
+    private function isTwoAtcpShipWrapEnabled()
+    {
+        return (bool) Configuration::get('PS_ATCP_SHIPWRAP');
+    }
+
+    /**
+     * Materialize a payload line from a shared template plus a
+     * net/tax/gross/rate segment.
+     *
+     * @param array $template name/description/quantity_unit/type
+     * @param array{net:float,tax:float,gross:float,rate:float} $segment
+     * @return array
+     */
+    private function buildTwoChargeLineFromSegment($template, $segment)
+    {
+        $rate = max(0, (float) $segment['rate']);
+        $rate_percent = round($rate * 100, 2);
+
+        return [
+            'name' => $template['name'],
+            'description' => $template['description'],
+            'gross_amount' => (string) $this->getTwoRoundAmount($segment['gross']),
+            'net_amount' => (string) $this->getTwoRoundAmount($segment['net']),
+            'discount_amount' => '0.00',
+            'tax_amount' => (string) $this->getTwoRoundAmount($segment['tax']),
+            'tax_class_name' => 'VAT ' . $this->getTwoRoundAmount($rate_percent) . '%',
+            'tax_rate' => $this->formatTwoTaxRate($rate),
+            'unit_price' => (string) $this->getTwoRoundAmount($segment['net']),
+            'quantity' => 1,
+            'quantity_unit' => $template['quantity_unit'],
+            'image_url' => '',
+            'product_page_url' => '',
+            'type' => $template['type'],
+        ];
+    }
+
+    /**
+     * Split a charge taxed at PrestaShop's blended average product rate
+     * (PS_ATCP_SHIPWRAP) across the cart's canonical product rate classes,
+     * reconciling rounded sub-lines to the PrestaShop-authoritative totals
+     * cent-exactly (largest-remainder on net, bounded per-line nudge on tax).
+     * Fails loud when no rate-consistent distribution can hit the target.
+     *
+     * @param float $charge_net PrestaShop-authoritative net for the charge
+     * @param float $charge_tax PrestaShop-authoritative tax for the charge
+     * @param array $items Positive payload lines built so far (rate classes)
+     * @param string $label For error messages ('shipping', 'gift wrapping')
+     * @return array<int,array{net:float,tax:float,gross:float,rate:float}>
+     */
+    private function splitTwoChargeAcrossProductRateClasses($charge_net, $charge_tax, $items, $label)
+    {
+        $charge_net = round(max(0, (float) $charge_net), 2);
+        $charge_tax = round((float) $charge_tax, 2);
+        if ($charge_net <= 0 && $charge_tax <= 0) {
+            return [];
         }
 
-        return $items;
+        // Collect canonical rate classes from positive lines, net-weighted —
+        // the same basis PrestaShop's getAverageProductsTaxRate() blends.
+        $classes = [];
+        foreach ($items as $item) {
+            $line_net = isset($item['net_amount']) ? round((float) $item['net_amount'], 2) : 0.0;
+            $line_gross = isset($item['gross_amount']) ? round((float) $item['gross_amount'], 2) : 0.0;
+            if ($line_net <= 0 || $line_gross <= 0 || !isset($item['tax_rate'])) {
+                continue;
+            }
+            $rate = max(0, (float) $item['tax_rate']);
+            $key = $this->formatTwoTaxRate($rate);
+            if (!isset($classes[$key])) {
+                $classes[$key] = ['rate' => $rate, 'net_weight' => 0.0];
+            }
+            $classes[$key]['net_weight'] += $line_net;
+        }
+
+        if (empty($classes)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Cannot split ' . $label . ' across product tax-rate classes - no positive product lines',
+                3
+            );
+            throw new Exception('Cannot attribute ' . $label . ' tax under PS_ATCP_SHIPWRAP: no product rate classes');
+        }
+
+        $net_weights = [];
+        foreach ($classes as $key => $class) {
+            $net_weights[$key] = (float) $class['net_weight'];
+        }
+        $allocated_nets = $this->allocateTwoAmountByWeights($charge_net, $net_weights);
+
+        // Per-class tax at the class's canonical rate, then reconcile the
+        // rounding residual to PrestaShop's authoritative tax total with a
+        // bounded per-line nudge that stays inside TAX_FORMULA_TOLERANCE.
+        $target_tax_cents = $this->convertAmountToCents($charge_tax);
+        $tax_cents = [];
+        $allocated_tax_cents_total = 0;
+        foreach ($classes as $key => $class) {
+            $class_net = isset($allocated_nets[$key]) ? (float) $allocated_nets[$key] : 0.0;
+            $tax_cents[$key] = (int) round($this->convertAmountToCents($class_net) * $class['rate'], 0);
+            $allocated_tax_cents_total += $tax_cents[$key];
+        }
+
+        $residual_cents = $target_tax_cents - $allocated_tax_cents_total;
+        $max_nudge_cents = (int) round(self::TAX_FORMULA_TOLERANCE * 100);
+        // Nudge largest classes first: bigger nets absorb a cent with the
+        // least relative distortion.
+        arsort($net_weights);
+        $nudged = [];
+        foreach (array_keys($net_weights) as $key) {
+            $nudged[$key] = 0;
+        }
+        while ($residual_cents !== 0) {
+            $applied = false;
+            foreach (array_keys($net_weights) as $key) {
+                if ($residual_cents === 0) {
+                    break;
+                }
+                $step = $residual_cents > 0 ? 1 : -1;
+                if (abs($nudged[$key] + $step) > $max_nudge_cents) {
+                    continue;
+                }
+                if ($step < 0 && $tax_cents[$key] <= 0) {
+                    continue;
+                }
+                $tax_cents[$key] += $step;
+                $nudged[$key] += $step;
+                $residual_cents -= $step;
+                $applied = true;
+            }
+            if (!$applied) {
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Cannot reconcile ' . $label . ' tax split to PrestaShop totals. ' .
+                    'Residual=' . $residual_cents . 'c beyond per-line tolerance',
+                    3
+                );
+                throw new Exception('Cannot reconcile ' . $label . ' tax under PS_ATCP_SHIPWRAP with canonical rates');
+            }
+        }
+
+        $segments = [];
+        foreach ($classes as $key => $class) {
+            $segment_net = isset($allocated_nets[$key]) ? round((float) $allocated_nets[$key], 2) : 0.0;
+            $segment_tax = round($tax_cents[$key] / 100, 2);
+            $segment_gross = round($segment_net + $segment_tax, 2);
+            if ($segment_gross <= 0 && $segment_net <= 0) {
+                continue;
+            }
+            $segments[] = [
+                'net' => $segment_net,
+                'tax' => $segment_tax,
+                'gross' => $segment_gross,
+                'rate' => $class['rate'],
+            ];
+        }
+
+        return $segments;
+    }
+
+    /**
+     * Fail loud when a line's declared (merchant-configured) tax rate does
+     * not reconcile with PrestaShop's own applied amounts. This is the
+     * deterministic, plugin-side divergence gate of the declared-rate relay
+     * design: we never derive, snap or substitute a rate — an internally
+     * contradictory line is surfaced to the merchant instead.
+     *
+     * @param string $label Line description for logs/errors
+     * @param float $net_amount Emitted 2dp net amount
+     * @param float $tax_amount Emitted 2dp tax amount
+     * @param float $rate_decimal Declared decimal rate (e.g. 0.21)
+     * @return void
+     * @throws Exception
+     */
+    private function assertTwoDeclaredRateReconcilesWithAmounts($label, $net_amount, $tax_amount, $rate_decimal)
+    {
+        $net_amount = round((float) $net_amount, 2);
+        $tax_amount = round((float) $tax_amount, 2);
+        $expected_tax = round($net_amount * max(0, (float) $rate_decimal), 2);
+        if (abs($tax_amount - $expected_tax) <= self::TAX_FORMULA_TOLERANCE) {
+            return;
+        }
+
+        PrestaShopLogger::addLog(
+            'TwoPayment: Declared tax rate does not reconcile with applied amounts for ' . $label .
+            '. Declared rate=' . round(max(0, (float) $rate_decimal) * 100, 2) . '%' .
+            ', net=' . $this->getTwoRoundAmount($net_amount) .
+            ', applied tax=' . $this->getTwoRoundAmount($tax_amount) .
+            ', expected tax at declared rate=' . $this->getTwoRoundAmount($expected_tax) .
+            '. Check the tax rules configured for this line (tax rules group, address-specific rules).',
+            3
+        );
+        throw new Exception(
+            'Declared tax rate diverges from applied tax amounts for ' . $label
+        );
     }
 
     /**
@@ -4459,7 +4632,14 @@ class Twopayment extends PaymentModule
         }
 
         if ($wrapping_gross < $wrapping_net) {
-            $wrapping_gross = $wrapping_net;
+            // Silently clamping gross to net would mask a genuine divergence
+            // in PrestaShop's own wrapping totals — fail loud instead.
+            PrestaShopLogger::addLog(
+                'TwoPayment: Gift wrapping totals diverge - gross (' . $this->getTwoRoundAmount($wrapping_gross) .
+                ') is below net (' . $this->getTwoRoundAmount($wrapping_net) . ')',
+                3
+            );
+            throw new Exception('Gift wrapping totals diverge (gross below net)');
         }
 
         return [
@@ -4478,9 +4658,10 @@ class Twopayment extends PaymentModule
      * @param int $quantity
      * @param float $line_net
      * @param float $line_gross
+     * @param Cart $cart
      * @return array{enabled:bool,net:float,tax:float,gross:float,rate:float,product_net:float,product_gross:float,unit_net:float}
      */
-    private function extractTwoEcotaxLineBreakdown($line_item, $quantity, $line_net, $line_gross)
+    private function extractTwoEcotaxLineBreakdown($line_item, $quantity, $line_net, $line_gross, $cart)
     {
         $quantity = (int)$quantity;
         if ($quantity <= 0) {
@@ -4498,10 +4679,14 @@ class Twopayment extends PaymentModule
             return ['enabled' => false];
         }
 
-        $ecotax_rate_percent = isset($line_item['ecotax_tax_rate']) && is_numeric($line_item['ecotax_tax_rate'])
-            ? max(0, (float)$line_item['ecotax_tax_rate'])
-            : (isset($line_item['rate']) ? max(0, (float)$line_item['rate']) : 0.0);
-        $ecotax_rate_decimal = round($ecotax_rate_percent / 100, self::TAX_RATE_PRECISION);
+        // Declared-rate relay: ecotax is taxed by the shop-configured
+        // PS_ECOTAX_TAX_RULES_GROUP_ID group (the rate PrestaShop itself
+        // embedded in total_ecotax), resolved at the cart's tax address via
+        // the shared helper. Never the row's country-only 'rate' field.
+        $ecotax_rate_decimal = $this->getTwoConfiguredTaxRateDecimalForGroup(
+            (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID'),
+            $cart
+        );
         $ecotax_total_tax = round($ecotax_total_net * $ecotax_rate_decimal, 2);
         $ecotax_total_gross = round($ecotax_total_net + $ecotax_total_tax, 2);
 
@@ -4656,23 +4841,16 @@ class Twopayment extends PaymentModule
 
             $segments = $this->buildTwoCanonicalDiscountRateSegments($line_net, $line_tax, $known_context_rates);
             if (empty($segments)) {
-                $line_rate_raw = $line_net > 0
-                    ? max(0, $line_tax / $line_net)
-                    : max(0, (float)$context_data['tax_rate']);
-                $line_rate = $this->normalizeTwoTaxRateToPercentPrecision($line_rate_raw);
-                $snapped_line_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-                    $this->snapTwoTaxRateToKnownContexts($line_rate_raw, $known_context_rates)
+                // Declared-rate relay: a discount that cannot be attributed
+                // to the cart's declared rates (exactly or within rounding
+                // tolerance) is internally contradictory — fail loud, never
+                // emit a derived tax/net blend.
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Discount allocation does not reconcile with any declared cart tax rate. ' .
+                    'net=' . $this->getTwoRoundAmount($line_net) . ', tax=' . $this->getTwoRoundAmount($line_tax),
+                    3
                 );
-                if (abs($line_tax - ($line_net * $snapped_line_rate)) <= self::TAX_FORMULA_TOLERANCE) {
-                    $line_rate = $snapped_line_rate;
-                }
-                $segments = [[
-                    'net' => $line_net,
-                    'tax' => $line_tax,
-                    'gross' => $line_gross,
-                    'rate' => $line_rate,
-                    'precision' => 4,
-                ]];
+                throw new Exception('Discount amounts diverge from all declared cart tax rates');
             }
 
             $is_segment_split = count($segments) > 1;
@@ -4790,23 +4968,24 @@ class Twopayment extends PaymentModule
             return null;
         }
 
-        $shipping_ratio = $shipping_gross > 0 ? ($shipping_net / $shipping_gross) : 1.0;
-        $alloc_net = round($alloc_gross * $shipping_ratio, 2);
-        $alloc_net = min($alloc_net, round(max(0, (float)$discountNetTotal), 2), $alloc_gross);
-        $alloc_tax = round($alloc_gross - $alloc_net, 2);
+        // DECLARED-RATE RELAY: the free-shipping discount line MIRRORS the
+        // emitted rate of the shipping line it offsets, so the pair nets to
+        // zero at one consistent rate. Never derived from tax/net.
+        $shipping_rate = isset($shipping_line['tax_rate']) ? max(0, (float) $shipping_line['tax_rate']) : 0.0;
 
-        $shipping_rate = $shipping_net > 0 ? ($shipping_tax / $shipping_net) : 0.0;
-        if ($shipping_rate < 0) {
-            $shipping_rate = 0.0;
+        $shipping_ratio = $shipping_gross > 0 ? ($shipping_net / $shipping_gross) : 1.0;
+        $alloc_net_uncapped = round($alloc_gross * $shipping_ratio, 2);
+        $alloc_net = min($alloc_net_uncapped, round(max(0, (float)$discountNetTotal), 2), $alloc_gross);
+        if ($alloc_net < $alloc_net_uncapped) {
+            // The cap bit (multi-discount cart): re-derive gross from the
+            // capped net at the mirrored rate so gross/net/tax stay
+            // rate-consistent — never clamp net independently of gross.
+            $alloc_tax = round($alloc_net * $shipping_rate, 2);
+            $alloc_gross = round($alloc_net + $alloc_tax, 2);
+        } else {
+            $alloc_tax = round($alloc_gross - $alloc_net, 2);
         }
-        $shipping_rate = $this->normalizeTwoTaxRateToPercentPrecision($shipping_rate);
-        $shipping_known_context_rates = $this->collectTwoKnownTaxRatesFromPositiveItems($existingItems);
-        $snapped_shipping_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-            $this->snapTwoTaxRateToKnownContexts($shipping_rate, $shipping_known_context_rates)
-        );
-        if (abs($shipping_tax - ($shipping_net * $snapped_shipping_rate)) <= self::TAX_FORMULA_TOLERANCE) {
-            $shipping_rate = $snapped_shipping_rate;
-        }
+
         $shipping_rate_percent = round($shipping_rate * 100, 2);
         $descriptor_rule = !empty($free_shipping_rules) ? reset($free_shipping_rules) : null;
         $descriptor = $descriptor_rule !== null
@@ -4985,22 +5164,15 @@ class Twopayment extends PaymentModule
             $line_tax = round($line_gross - $line_net, 2);
             $segments = $this->buildTwoCanonicalDiscountRateSegments($line_net, $line_tax, $known_context_rates);
             if (empty($segments)) {
-                $fallback_rate = $line_net > 0
-                    ? max(0, $line_tax / $line_net)
-                    : 0.0;
-                $fallback_rate = $this->normalizeTwoTaxRateToPercentPrecision($fallback_rate);
-                $snapped_fallback_rate = $this->normalizeTwoTaxRateToPercentPrecision(
-                    $this->snapTwoTaxRateToKnownContexts($fallback_rate, $known_context_rates)
+                // Declared-rate relay: fail loud instead of emitting a
+                // derived tax/net blend for an unattributable rule discount.
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Cart-rule discount "' . $descriptor['name'] . '" does not reconcile with any ' .
+                    'declared cart tax rate. net=' . $this->getTwoRoundAmount($line_net) .
+                    ', tax=' . $this->getTwoRoundAmount($line_tax),
+                    3
                 );
-                if (abs($line_tax - ($line_net * $snapped_fallback_rate)) <= self::TAX_FORMULA_TOLERANCE) {
-                    $fallback_rate = $snapped_fallback_rate;
-                }
-                $segments = [[
-                    'net' => $line_net,
-                    'tax' => $line_tax,
-                    'gross' => round($line_net + $line_tax, 2),
-                    'rate' => $fallback_rate,
-                ]];
+                throw new Exception('Discount amounts diverge from all declared cart tax rates');
             }
 
             $is_split = count($segments) > 1;
@@ -5071,6 +5243,17 @@ class Twopayment extends PaymentModule
             return [];
         }
 
+        // A zero-tax discount row is exactly representable at rate 0 —
+        // tax == rate * net holds identically. Not a derivation.
+        if ($tax_cents === 0) {
+            return [[
+                'net' => round($net_cents / 100, 2),
+                'tax' => 0.0,
+                'gross' => round($net_cents / 100, 2),
+                'rate' => 0.0,
+            ]];
+        }
+
         $rates = [];
         foreach ((array)$known_rates as $rate) {
             $normalized_rate = $this->normalizeTwoTaxRateToPercentPrecision((float)$rate);
@@ -5096,7 +5279,7 @@ class Twopayment extends PaymentModule
         }
 
         if (count($rates) < 2) {
-            return [];
+            return $this->buildTwoToleranceSingleRateSegment($net_cents, $tax_cents, $rates);
         }
 
         $implied_rate = $net_cents > 0 ? ((float)$tax_cents / (float)$net_cents) : 0.0;
@@ -5175,7 +5358,49 @@ class Twopayment extends PaymentModule
             }
         }
 
-        return [];
+        return $this->buildTwoToleranceSingleRateSegment($net_cents, $tax_cents, $rates);
+    }
+
+    /**
+     * Last resort before failing loud: represent the row at ONE declared
+     * cart rate whose implied tax is within TAX_FORMULA_TOLERANCE of the
+     * actual tax (PrestaShop rounds discount buckets once; per-line rounding
+     * can legitimately differ by a cent or two). The amounts are preserved
+     * as-is — the rate is only accepted, never derived from the amounts.
+     * Returns [] when no declared rate reconciles (caller fails loud).
+     *
+     * @param int $net_cents
+     * @param int $tax_cents
+     * @param array $rates Declared decimal rates present on the cart
+     * @return array<int,array{net:float,tax:float,gross:float,rate:float}>
+     */
+    private function buildTwoToleranceSingleRateSegment($net_cents, $tax_cents, $rates)
+    {
+        $tolerance_cents = (int) round(self::TAX_FORMULA_TOLERANCE * 100);
+        $best_rate = null;
+        $best_diff = null;
+        foreach ((array) $rates as $rate) {
+            $rate = max(0, (float) $rate);
+            $diff = abs((int) round($net_cents * $rate, 0) - $tax_cents);
+            if ($diff > $tolerance_cents) {
+                continue;
+            }
+            if ($best_diff === null || $diff < $best_diff) {
+                $best_diff = $diff;
+                $best_rate = $rate;
+            }
+        }
+
+        if ($best_rate === null) {
+            return [];
+        }
+
+        return [[
+            'net' => round($net_cents / 100, 2),
+            'tax' => round($tax_cents / 100, 2),
+            'gross' => round(($net_cents + $tax_cents) / 100, 2),
+            'rate' => $best_rate,
+        ]];
     }
 
     /**
@@ -5420,184 +5645,6 @@ class Twopayment extends PaymentModule
         return $contexts;
     }
 
-    /**
-     * Collect configured product tax rates from cart lines as decimal contexts.
-     *
-     * @param array $line_items
-     * @return array
-     */
-    private function collectTwoKnownTaxRatesFromConfiguredProductRates($line_items)
-    {
-        $known_rates = [];
-        foreach ($line_items as $line_item) {
-            if (!isset($line_item['rate']) || !is_numeric($line_item['rate'])) {
-                continue;
-            }
-
-            $rate_percent = max(0, (float)$line_item['rate']);
-            if ($rate_percent <= 0) {
-                continue;
-            }
-
-            $rate_decimal = $this->normalizeTwoTaxRateToPercentPrecision($rate_percent / 100);
-            $normalized = $this->formatTwoTaxRate($rate_decimal);
-            $known_rates[$normalized] = (float)$normalized;
-        }
-
-        return array_values($known_rates);
-    }
-
-    /**
-     * Determine whether ES canonical tax-rate policy should be applied for this cart.
-     *
-     * @param Cart $cart
-     * @return bool
-     */
-    private function shouldApplyTwoSpanishTaxRatePolicy($cart)
-    {
-        if (!Validate::isLoadedObject($cart)) {
-            return false;
-        }
-
-        $address_ids = array_unique(array_filter([
-            (int)$cart->id_address_invoice,
-            (int)$cart->id_address_delivery,
-        ]));
-
-        foreach ($address_ids as $address_id) {
-            $address = new Address((int)$address_id);
-            if (!Validate::isLoadedObject($address)) {
-                continue;
-            }
-
-            $country_iso = Country::getIsoById((int)$address->id_country);
-            if (is_string($country_iso) && strtoupper($country_iso) === 'ES') {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Apply ES canonical tax-rate fallback across unresolved payload lines.
-     * Default fallback rate for unresolved lines is 0.21 when formula-safe.
-     *
-     * @param array $items
-     * @return array
-     */
-    private function applyTwoSpanishCanonicalTaxRateFallbackToItems($items)
-    {
-        if (empty($items)) {
-            return $items;
-        }
-
-        $canonical_rates = [
-            0.21,
-            0.10,
-            0.04,
-        ];
-
-        $known_canonical_rates = [];
-        foreach ($items as $item) {
-            if (!isset($item['tax_rate'])) {
-                continue;
-            }
-
-            $rate = $this->normalizeTwoTaxRateToPercentPrecision((float)$item['tax_rate']);
-            foreach ($canonical_rates as $canonical_rate) {
-                if (abs($rate - $canonical_rate) <= 0.000001) {
-                    $known_canonical_rates[(string)$canonical_rate] = $canonical_rate;
-                    break;
-                }
-            }
-        }
-
-        $fallback_candidates = array_values($known_canonical_rates);
-        if (empty($fallback_candidates)) {
-            $fallback_candidates[] = self::SPANISH_FALLBACK_TAX_RATE;
-        } elseif (!in_array(self::SPANISH_FALLBACK_TAX_RATE, $fallback_candidates, true)) {
-            $fallback_candidates[] = self::SPANISH_FALLBACK_TAX_RATE;
-        }
-
-        foreach ($items as $index => $item) {
-            if (!isset($item['tax_rate']) || !isset($item['net_amount']) || !isset($item['tax_amount'])) {
-                continue;
-            }
-
-            $line_rate = $this->normalizeTwoTaxRateToPercentPrecision((float)$item['tax_rate']);
-            $line_net = round((float)$item['net_amount'], 2);
-            $line_tax = round((float)$item['tax_amount'], 2);
-
-            if (abs($line_net) < 0.01) {
-                continue;
-            }
-
-            $is_already_canonical = false;
-            foreach ($canonical_rates as $canonical_rate) {
-                if (abs($line_rate - $canonical_rate) <= 0.000001) {
-                    $is_already_canonical = true;
-                    break;
-                }
-            }
-            if ($is_already_canonical) {
-                continue;
-            }
-
-            $selected_rate = null;
-            $nearest_diff = null;
-            foreach ($fallback_candidates as $candidate_rate) {
-                $candidate_rate = $this->normalizeTwoTaxRateToPercentPrecision((float)$candidate_rate);
-                $diff = abs($line_rate - $candidate_rate);
-                if ($nearest_diff === null || $diff < $nearest_diff) {
-                    $nearest_diff = $diff;
-                    $selected_rate = $candidate_rate;
-                }
-            }
-
-            if ($selected_rate === null) {
-                $selected_rate = self::SPANISH_FALLBACK_TAX_RATE;
-            }
-
-            $is_formula_safe = abs($line_tax - ($line_net * $selected_rate)) <= self::TAX_FORMULA_TOLERANCE;
-            if (!$is_formula_safe && abs($line_tax - ($line_net * self::SPANISH_FALLBACK_TAX_RATE)) <= self::TAX_FORMULA_TOLERANCE) {
-                $selected_rate = self::SPANISH_FALLBACK_TAX_RATE;
-                $is_formula_safe = true;
-            }
-
-            if (!$is_formula_safe) {
-                continue;
-            }
-
-            $items[$index]['tax_rate'] = $this->formatTwoTaxRate($selected_rate);
-            $items[$index]['tax_class_name'] = 'VAT ' . $this->getTwoRoundAmount($selected_rate * 100) . '%';
-        }
-
-        return $items;
-    }
-
-    /**
-     * Collect unique tax-rate contexts from positive payload lines.
-     *
-     * @param array $items
-     * @return array
-     */
-    private function collectTwoKnownTaxRatesFromPositiveItems($items)
-    {
-        $known_rates = [];
-        foreach ($items as $item) {
-            $line_gross = isset($item['gross_amount']) ? round((float)$item['gross_amount'], 2) : 0.0;
-            $line_net = isset($item['net_amount']) ? round((float)$item['net_amount'], 2) : 0.0;
-            if ($line_gross <= 0 || $line_net <= 0 || !isset($item['tax_rate'])) {
-                continue;
-            }
-
-            $normalized_rate = $this->formatTwoTaxRate((float)$item['tax_rate']);
-            $known_rates[$normalized_rate] = (float)$normalized_rate;
-        }
-
-        return array_values($known_rates);
-    }
 
     /**
      * Resolve carrier tax-rule rate as decimal (e.g. 0.21 for 21%).
@@ -5612,14 +5659,77 @@ class Twopayment extends PaymentModule
             return 0.0;
         }
 
-        $taxRulesGroupId = (int)$carrier->getIdTaxRulesGroup();
-        if ($taxRulesGroupId <= 0) {
+        // Route through the shared address-correct helper so the shipping
+        // RATE source uses the same PS_TAX_ADDRESS_TYPE address PrestaShop's
+        // getPackageShippingCost() used for the shipping AMOUNTS.
+        return $this->getTwoConfiguredTaxRateDecimalForGroup((int) $carrier->getIdTaxRulesGroup(), $cart);
+    }
+
+    /**
+     * Shared declared-rate resolver: the effective tax rate (decimal
+     * fraction, e.g. 0.21) a TaxRulesGroup applies for THIS cart's tax
+     * destination, resolved through the same core machinery PrestaShop's own
+     * pricing uses (TaxManagerFactory over the PS_TAX_ADDRESS_TYPE address,
+     * with the shop-wide PS_TAX gate and the vatnumber-module B2B
+     * exemption). This is the single rate source for product, ecotax,
+     * shipping and wrapping lines — the plugin relays the merchant's
+     * declared rate and never derives one from amounts.
+     *
+     * Group id 0/unset returns 0.0 (core's "No tax" sentinel — ecotax and
+     * wrapping groups are legitimately unset on many shops). Resolution
+     * failures are logged UNCONDITIONALLY (not gated on debug mode) so a
+     * swallowed-to-zero rate surfaces its root cause in the merchant log
+     * instead of only appearing downstream as a formula mismatch.
+     *
+     * @param int $taxRulesGroupId
+     * @param Cart $cart
+     * @return float Decimal rate normalised to 2dp-of-percent
+     */
+    private function getTwoConfiguredTaxRateDecimalForGroup($taxRulesGroupId, $cart)
+    {
+        $taxRulesGroupId = (int) $taxRulesGroupId;
+        if ($taxRulesGroupId <= 0 || !Validate::isLoadedObject($cart)) {
             return 0.0;
         }
 
-        $address = new Address((int)$cart->id_address_delivery);
+        // Shop-wide "disable taxes" switch (core: Tax::excludeTaxeOption
+        // inside Product::priceCalculation zeroes every product's tax).
+        if (class_exists('Tax') && method_exists('Tax', 'excludeTaxeOption')) {
+            if (Tax::excludeTaxeOption()) {
+                return 0.0;
+            }
+        } elseif (!Configuration::get('PS_TAX')) {
+            return 0.0;
+        }
+
+        // Same address granularity core used for the amounts: the cart's
+        // PS_TAX_ADDRESS_TYPE address (the Configuration value string IS the
+        // Cart property name), with a delivery fallback.
+        $taxAddressField = (string) Configuration::get('PS_TAX_ADDRESS_TYPE');
+        if ($taxAddressField !== 'id_address_delivery') {
+            $taxAddressField = 'id_address_invoice';
+        }
+        $address = new Address((int) $cart->{$taxAddressField});
         if (!Validate::isLoadedObject($address)) {
-            $address = new Address((int)$cart->id_address_invoice);
+            $address = new Address((int) $cart->id_address_delivery);
+        }
+        if (!Validate::isLoadedObject($address)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: No usable tax address on cart ' . (int) $cart->id .
+                ' while resolving declared rate for tax rules group ' . $taxRulesGroupId,
+                3
+            );
+            return 0.0;
+        }
+
+        // vatnumber-module B2B exemption — the exact condition core's
+        // Product::priceCalculation flips usetax off with.
+        if (
+            !empty($address->vat_number)
+            && (int) $address->id_country !== (int) Configuration::get('VATNUMBER_COUNTRY')
+            && Configuration::get('VATNUMBER_MANAGEMENT')
+        ) {
+            return 0.0;
         }
 
         try {
@@ -5633,19 +5743,17 @@ class Twopayment extends PaymentModule
                 return 0.0;
             }
 
-            $ratePercent = max(0, (float)$taxCalculator->getTotalRate());
-            if ($ratePercent <= 0) {
-                return 0.0;
-            }
+            $ratePercent = max(0, (float) $taxCalculator->getTotalRate());
 
             return $this->normalizeTwoTaxRateToPercentPrecision($ratePercent / 100);
         } catch (Exception $e) {
-            if (Configuration::get('PS_TWO_DEBUG_MODE')) {
-                PrestaShopLogger::addLog(
-                    'TwoPayment: Unable to resolve carrier tax rate from tax rules - ' . $e->getMessage(),
-                    2
-                );
-            }
+            // Unconditional: a broken/deleted tax group resolving to 0 must
+            // show its cause here, not only as a downstream formula mismatch.
+            PrestaShopLogger::addLog(
+                'TwoPayment: Unable to resolve declared tax rate for tax rules group ' .
+                $taxRulesGroupId . ' - ' . $e->getMessage(),
+                3
+            );
         }
 
         return 0.0;
@@ -6053,42 +6161,54 @@ class Twopayment extends PaymentModule
     public function validateTwoLineItems($line_items)
     {
         $validation_issues = 0;
-        
+
         foreach ($line_items as $item) {
-            $net_amount = (float)$item['net_amount'];
-            $tax_amount = (float)$item['tax_amount'];
+            // Validate the EMITTED 2dp amounts exactly as the API sees them.
+            $net_amount = round((float)$item['net_amount'], 2);
+            $tax_amount = round((float)$item['tax_amount'], 2);
+            $gross_amount = round((float)$item['gross_amount'], 2);
             $tax_rate = (float)$item['tax_rate'];
             $unit_price = (float)$item['unit_price'];
             $quantity = (int)$item['quantity'];
             $discount_amount = (float)$item['discount_amount'];
-            
-            // Critical validation: tax_amount = net_amount * tax_rate (tax_rate is now decimal)
-            // Allow 0.01 tolerance for rounding differences (2 decimal places = ±0.005 rounding error)
+
+            // Critical validation: tax_amount = net_amount * tax_rate (tax_rate is decimal)
             $expected_tax_amount = $net_amount * $tax_rate;
             if (abs($tax_amount - $expected_tax_amount) > self::TAX_FORMULA_TOLERANCE) {
                 PrestaShopLogger::addLog(
-                    'TwoPayment CRITICAL Tax Formula Error - Item: ' . $item['name'] . 
-                    ', Got: ' . $tax_amount . ', Expected: ' . $expected_tax_amount . 
-                    ' (diff: ' . abs($tax_amount - $expected_tax_amount) . ')', 
+                    'TwoPayment CRITICAL Tax Formula Error - Item: ' . $item['name'] .
+                    ', Got: ' . $tax_amount . ', Expected: ' . $expected_tax_amount .
+                    ' (diff: ' . abs($tax_amount - $expected_tax_amount) . ')',
                     3
                 );
                 $validation_issues++;
             }
-            
+
+            // Critical validation: gross_amount == net_amount + tax_amount EXACTLY
+            // (2dp, compared in cents). The API enforces this per line in
+            // addition to the tax-formula tolerance check.
+            if ($this->convertAmountToCents($gross_amount) !== $this->convertAmountToCents(round($net_amount + $tax_amount, 2))) {
+                PrestaShopLogger::addLog(
+                    'TwoPayment CRITICAL Gross Formula Error - Item: ' . $item['name'] .
+                    ', Got gross: ' . $gross_amount . ', Expected net+tax: ' . round($net_amount + $tax_amount, 2),
+                    3
+                );
+                $validation_issues++;
+            }
+
             // Critical validation: net_amount = (quantity * unit_price) - discount_amount
-            // Allow 0.05 tolerance for rounding differences (accounts for multiple rounding operations)
             $expected_net_amount = ($quantity * $unit_price) - $discount_amount;
             if (abs($net_amount - $expected_net_amount) > self::NET_FORMULA_TOLERANCE) {
                 PrestaShopLogger::addLog(
-                    'TwoPayment CRITICAL Net Formula Error - Item: ' . $item['name'] . 
-                    ', Got: ' . $net_amount . ', Expected: ' . $expected_net_amount . 
-                    ' (diff: ' . abs($net_amount - $expected_net_amount) . ')', 
+                    'TwoPayment CRITICAL Net Formula Error - Item: ' . $item['name'] .
+                    ', Got: ' . $net_amount . ', Expected: ' . $expected_net_amount .
+                    ' (diff: ' . abs($net_amount - $expected_net_amount) . ')',
                     3
                 );
                 $validation_issues++;
             }
         }
-        
+
         return $validation_issues === 0;
     }
 
@@ -6130,67 +6250,6 @@ class Twopayment extends PaymentModule
     {
         $percent = round(max(0, (float)$rate) * 100, self::TAX_RATE_PERCENT_PRECISION);
         return $percent / 100;
-    }
-
-    /**
-     * Snap rate to known cart contexts when only minor rounding drift exists.
-     *
-     * @param float $rate
-     * @param array $known_rates
-     * @return float
-     */
-    private function snapTwoTaxRateToKnownContexts($rate, $known_rates)
-    {
-        $rate = max(0, (float)$rate);
-        if (empty($known_rates)) {
-            return $rate;
-        }
-
-        $nearest = null;
-        $nearest_diff = null;
-        foreach ($known_rates as $candidate) {
-            $candidate = max(0, (float)$candidate);
-            $diff = abs($rate - $candidate);
-            if ($nearest_diff === null || $diff < $nearest_diff) {
-                $nearest = $candidate;
-                $nearest_diff = $diff;
-            }
-        }
-
-        // Only snap when difference is tiny (pure rounding drift).
-        if (
-            $nearest !== null &&
-            $nearest_diff !== null &&
-            $nearest_diff <= self::TAX_RATE_CONTEXT_SNAP_TOLERANCE
-        ) {
-            return $nearest;
-        }
-
-        return $rate;
-    }
-
-    /**
-     * Calculate effective order-level tax rate from final net and tax totals.
-     *
-     * @param float $net_amount
-     * @param float $tax_amount
-     * @return float Decimal tax rate
-     */
-    private function calculateTwoOrderTaxRate($net_amount, $tax_amount)
-    {
-        $net_amount = (float)$net_amount;
-        $tax_amount = (float)$tax_amount;
-
-        if (abs($net_amount) < 0.000001) {
-            return 0.0;
-        }
-
-        $rate = $tax_amount / $net_amount;
-        if ($rate < 0) {
-            return 0.0;
-        }
-
-        return round($rate, self::TAX_RATE_PRECISION);
     }
 
     public function getTwoCheckoutHostUrl()


### PR DESCRIPTION
## TWO-24880: VAT line-item rate sourcing — declared-rate relay

Implements the in-repo design doc (`.ai/vat-rate-sourcing-design.md`, PR #36): the plugin now **relays the merchant's declared tax rate** for every line and **never derives, snaps, or substitutes** one.

### What changed

**Rate sourcing (the inversion):**
- New shared helper `getTwoConfiguredTaxRateDecimalForGroup($groupId, $cart)`: resolves a tax-rules group's effective rate at the cart's `PS_TAX_ADDRESS_TYPE` address via `TaxManagerFactory` — the same resolution PrestaShop used to compute the amounts. Group `0`/unset resolves `0.0` (core "No tax" sentinel); resolution failures are logged **unconditionally** so a swallowed-to-zero rate surfaces its root cause.
- **Product lines**: rate from `Product::getIdTaxRulesGroupByIdProduct()` via the helper. The row's `rate` field from `getProducts()` is country-only (ignores sub-national tax rules, e.g. Canary IGIC / Ceuta-Melilla IPSI) and is no longer read anywhere.
- **Ecotax lines**: rate from `PS_ECOTAX_TAX_RULES_GROUP_ID` via the helper (was: `ecotax_tax_rate` row field with a country-only fallback).
- **Shipping lines**: carrier tax-rules group via the helper (carrier resolver now routes through the shared helper, so the rate address matches the amount address).
- **Wrapping lines**: `PS_GIFT_WRAPPING_TAX_RULES_GROUP` via the helper.
- **Free-shipping discount lines**: mirror the emitted rate of the shipping line they offset.

**Fail loud on divergence (design §4.3/§5):** `assertTwoDeclaredRateReconcilesWithAmounts()` throws when the declared rate and PrestaShop's applied amounts disagree beyond the 2-cent tolerance — at every positive-line site. Discount rows that cannot be attributed to any declared cart rate (exactly, or within the same tolerance) throw instead of emitting a `tax÷net` blend. All throw-reachable call sites already degrade to a controlled decline with the actionable detail in the shop log.

**Deleted entirely:** `SPANISH_FALLBACK_TAX_RATE` (hardcoded 21%), `applyTwoSpanishCanonicalTaxRateFallbackToItems`, `shouldApplyTwoSpanishTaxRatePolicy`, `snapTwoTaxRateToKnownContexts`, `collectTwoKnownTaxRatesFromConfiguredProductRates`, `collectTwoKnownTaxRatesFromPositiveItems`, `TAX_RATE_VARIANCE_TOLERANCE`, `TAX_RATE_CONTEXT_SNAP_TOLERANCE`. The Spanish fallback was a live mis-declaration risk: it could relabel a 10% line as 21% while still passing amount checks.

**Correctness fixes shipped with the inversion (per design):**
- `PS_ATCP_SHIPWRAP` support: shipping/wrapping taxed at PrestaShop's blended average product rate are **split across the cart's canonical rate classes** (largest-remainder net allocation + bounded per-line tax nudge reconciling cent-exactly to PrestaShop's totals; fails loud if unreconcilable). The blended non-canonical rate is never emitted.
- Free-ship `min()` cap fix (§4.2.1): when the net cap bites, gross is re-derived from the capped net so gross/net/tax stay rate-consistent.
- Wrapping `gross < net` clamp removed — now fails loud.
- Zero-tax discount rows are represented exactly at rate 0 (not a derivation: `tax == rate·net` holds identically).
- `TAX_RATE_PRECISION` 3 → 6 (§4.4: 3dp re-truncated faithful 4dp rates like 0.0855; 6dp matches native PrestaShop precision; the 2dp-of-percent ceiling is unchanged).
- `validateTwoLineItems` now validates the emitted 2dp amounts, adds the exact `gross == net + tax` per-line check, and the net-formula tolerance is tightened 0.05 → 0.02.

### Tests
- Regression: a cart that previously hit the Spanish 21% fallback (derived 20% relabeled to 21% because the amounts were formula-safe at 21%) now relays the declared 20% exactly.
- Divergence: declared 21% vs amounts at 20.5% throws.
- Multi-jurisdiction cart: 21% / 10% / exempt lines relay per-line declared rates.
- Sub-national plumbing: row `rate` field says 21%, declared group resolves 7% for the address — 7% is relayed (the Canary-IGIC class of bug).
- ATCP split, free-ship cap, high-quantity net-tolerance, ecotax group sourcing, 6dp precision round-trip.
- Full suite migrated to declared-rate fixtures (products/carriers/wrapping/ecotax now declare tax-rules groups); suite green on PHP 8.2 and 8.3.

### Out of scope (deliberately)
- The dynamic PHP × PrestaShop CI compatibility matrix + min-version guard (design §9) is CI infrastructure, orthogonal to this money-logic change — split to its own follow-up so this PR stays reviewable.
- tax_code / exemption-reason resolver → TWO-24877.
- Surcharge fee-line VAT → TWO-25069 (no shared code with this path).

Design doc: `.ai/vat-rate-sourcing-design.md`. Linear: TWO-24880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
