### PR TITLE
TWO-25107: add phpstan static analysis gate to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,28 @@ jobs:
 
       - name: Run offline test suite
         run: php tests/run.php
+
+  phpstan:
+    name: phpstan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          coverage: none
+
+      - name: Download phpstan (pinned + checksum-verified)
+        env:
+          PHPSTAN_VERSION: "2.2.5"
+          PHPSTAN_SHA256: "1b2f03384ebcfd67053b06b69cbc0b9f62bf239349f69eaf723649409789e2e6"
+        run: |
+          curl -sL -o /tmp/phpstan.phar "https://github.com/phpstan/phpstan/releases/download/${PHPSTAN_VERSION}/phpstan.phar"
+          echo "${PHPSTAN_SHA256}  /tmp/phpstan.phar" | sha256sum -c -
+
+      - name: Run phpstan
+        run: php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ PHP_CS_FIXER_VERSION := 3.92.0
 # Re-derive this hash from the official GitHub release page/checksums when
 # bumping PHP_CS_FIXER_VERSION — never copy it from elsewhere.
 PHP_CS_FIXER_SHA256  := 7ae9440e7ac8dca47d632cf07719d43bc65c0deef460d95c3cfea81979895f99
+PHPSTAN_VERSION      := 2.2.5
+# Re-derive this hash from the official GitHub release page/checksums when
+# bumping PHPSTAN_VERSION — never copy it from elsewhere.
+PHPSTAN_SHA256       := 1b2f03384ebcfd67053b06b69cbc0b9f62bf239349f69eaf723649409789e2e6
 ADMIN_MAIL  := exampleuser@two.inc
 ADMIN_PASSWD := examplepassword123
 export PORT
@@ -33,7 +37,7 @@ TWO_ENVIRONMENT      ?= sandbox
 TWO_STORE_COUNTRY    ?= NO
 export TWO_STORE_COUNTRY
 
-.PHONY: help install configure run debug stop clean flush logs proxy archive test patch minor major format bumpver-patch bumpver-minor bumpver-major
+.PHONY: help install configure run debug stop clean flush logs proxy archive test patch minor major format phpstan bumpver-patch bumpver-minor bumpver-major
 
 .DEFAULT_GOAL := help
 
@@ -149,6 +153,13 @@ format:
 		php -r \"copy('https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v$(PHP_CS_FIXER_VERSION)/php-cs-fixer.phar', '/tmp/php-cs-fixer.phar');\" \
 		&& echo '$(PHP_CS_FIXER_SHA256)  /tmp/php-cs-fixer.phar' | sha256sum -c - \
 		&& php /tmp/php-cs-fixer.phar fix --config=.php-cs-fixer.dist.php"
+
+## Run phpstan static analysis (same gate CI runs)
+phpstan:
+	docker run --rm -v "$(CURDIR)":/app -w /app php:8.2-cli bash -c "\
+		php -r \"copy('https://github.com/phpstan/phpstan/releases/download/$(PHPSTAN_VERSION)/phpstan.phar', '/tmp/phpstan.phar');\" \
+		&& echo '$(PHPSTAN_SHA256)  /tmp/phpstan.phar' | sha256sum -c - \
+		&& php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G"
 
 # Requires bumpver on PATH (pip install bumpver / pipx install bumpver),
 # same implicit prerequisite as magento-plugin / woocommerce-plugin.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1345 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceRetrievalService.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 2
+			path: classes/TwoInvoiceRetrievalService.php
+
+		-
+			message: '#^Access to constant TEMPLATE_INVOICE on an unknown class PDF\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 12
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Call to static method getInstance\(\) on an unknown class Db\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 2
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Function pSQL not found\.$#'
+			identifier: function.notFound
+			count: 3
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Instantiated class PDF not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: classes/TwoInvoiceUploadService.php
+
+		-
+			message: '#^Access to an undefined property AdminTwopaymentInvoiceController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 1
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Access to an undefined property AdminTwopaymentInvoiceController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 3
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Call to static method redirectAdmin\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/admin/AdminTwopaymentInvoiceController.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentCancelModuleFrontController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 4
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentCancelModuleFrontController\:\:\$errors\.$#'
+			identifier: property.notFound
+			count: 10
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentCancelModuleFrontController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 30
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to an undefined method TwopaymentCancelModuleFrontController\:\:redirectWithNotifications\(\)\.$#'
+			identifier: method.notFound
+			count: 10
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:postProcess\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 5
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 5
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 4
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 3
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Instantiated class Cart not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/cancel.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentConfirmationModuleFrontController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 9
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentConfirmationModuleFrontController\:\:\$errors\.$#'
+			identifier: property.notFound
+			count: 24
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentConfirmationModuleFrontController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 96
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to an undefined method TwopaymentConfirmationModuleFrontController\:\:redirectWithNotifications\(\)\.$#'
+			identifier: method.notFound
+			count: 24
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:postProcess\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 13
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 9
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 4
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 6
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 8
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Call to static method redirect\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Instantiated class Cart not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Instantiated class Currency not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 4
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Variable \$current_snapshot_hash might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: controllers/front/confirmation.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentInvoiceModuleFrontController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentInvoiceModuleFrontController\:\:\$errors\.$#'
+			identifier: property.notFound
+			count: 3
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentInvoiceModuleFrontController\:\:\$info\.$#'
+			identifier: property.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentInvoiceModuleFrontController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 6
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to an undefined method TwopaymentInvoiceModuleFrontController\:\:redirectWithNotifications\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:postProcess\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 2
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/invoice.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentOrderintentModuleFrontController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 32
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentOrderintentModuleFrontController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 26
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:init\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:initContent\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:postProcess\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 20
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method getIsoById\(\) on an unknown class Country\.$#'
+			identifier: class.notFound
+			count: 3
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method getToken\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 20
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 6
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Instantiated class Address not found\.$#'
+			identifier: class.notFound
+			count: 4
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Instantiated class Currency not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Variable \$sessionCompanyId in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: controllers/front/orderintent.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentPaymentModuleFrontController\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 5
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentPaymentModuleFrontController\:\:\$errors\.$#'
+			identifier: property.notFound
+			count: 6
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Access to an undefined property TwopaymentPaymentModuleFrontController\:\:\$module\.$#'
+			identifier: property.notFound
+			count: 43
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to an undefined method TwopaymentPaymentModuleFrontController\:\:redirectWithNotifications\(\)\.$#'
+			identifier: method.notFound
+			count: 6
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to an undefined static method Module\:\:getPaymentModules\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to an undefined static method ModuleFrontController\:\:postProcess\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 12
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method getToken\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 9
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 4
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Call to static method redirect\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 3
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Instantiated class Address not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Instantiated class Currency not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: controllers/front/payment.php
+
+		-
+			message: '#^Access to static property \$definition on an unknown class Address\.$#'
+			identifier: class.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method CustomerAddressFormatterCore\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method CustomerAddressFormatterCore\:\:getCountry\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method CustomerAddressFormatterCore\:\:getFormat\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method CustomerAddressFormatterCore\:\:setCountry\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method Module\:\:isEnabled\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to an undefined static method Module\:\:isInstalled\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 3
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Class FormField not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Instantiated class FormField not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Parameter \$country of method CustomerAddressFormatter\:\:__construct\(\) has invalid type Country\.$#'
+			identifier: class.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Parameter \$country of method CustomerAddressFormatter\:\:setCountry\(\) has invalid type Country\.$#'
+			identifier: class.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Parameter \$field of method CustomerAddressFormatter\:\:applyFieldDefinitionMetadata\(\) has invalid type FormField\.$#'
+			identifier: class.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Parameter \$field of method CustomerAddressFormatter\:\:insertFieldAfter\(\) has invalid type FormField\.$#'
+			identifier: class.notFound
+			count: 1
+			path: override/classes/form/CustomerAddressFormatter.php
+
+		-
+			message: '#^Access to an undefined property \$this\(Twopayment\)\:\:\$_path\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property \$this\(Twopayment\)\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$_path\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$active\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$api_key\.$#'
+			identifier: property.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$author\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$author_address\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$bootstrap\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$context\.$#'
+			identifier: property.notFound
+			count: 59
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$currentOrder\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$displayName\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$enable_company_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$enable_company_name\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$enable_department\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$enable_order_intent\.$#'
+			identifier: property.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$enable_project\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$finalize_purchase_shipping\.$#'
+			identifier: property.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$identifier\.$#'
+			identifier: property.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$languages\.$#'
+			identifier: property.notFound
+			count: 6
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$merchant_short_name\.$#'
+			identifier: property.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$module_key\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 26
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$ps_versions_compliancy\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$tab\.$#'
+			identifier: property.notFound
+			count: 5
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$table\.$#'
+			identifier: property.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$use_account_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to an undefined property Twopayment\:\:\$version\.$#'
+			identifier: property.notFound
+			count: 7
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant BOTH on an unknown class Cart\.$#'
+			identifier: class.notFound
+			count: 6
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant CONTEXT_ALL on an unknown class Shop\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant ONLY_DISCOUNTS on an unknown class Cart\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant ONLY_SHIPPING on an unknown class Cart\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant ONLY_WRAPPING on an unknown class Cart\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant SHIPPING_METHOD_PRICE on an unknown class Carrier\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Access to constant SHIPPING_METHOD_WEIGHT on an unknown class Carrier\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:display\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:displayConfirmation\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:displayError\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:displayWarning\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:getPathUri\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:isRegisteredInHook\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:l\(\)\.$#'
+			identifier: method.notFound
+			count: 329
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:registerHook\(\)\.$#'
+			identifier: method.notFound
+			count: 17
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:unregisterHook\(\)\.$#'
+			identifier: method.notFound
+			count: 16
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined method Twopayment\:\:validateOrder\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined static method Module\:\:isInstalled\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined static method PaymentModule\:\:__construct\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined static method PaymentModule\:\:install\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to an undefined static method PaymentModule\:\:uninstall\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method addJsDef\(\) on an unknown class Media\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method addLog\(\) on an unknown class PrestaShopLogger\.$#'
+			identifier: class.notFound
+			count: 163
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method addSqlAssociation\(\) on an unknown class Shop\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method autoAddToCart\(\) on an unknown class CartRule\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method cleanHistoryCache\(\) on an unknown class Order\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method deleteByIdCart\(\) on an unknown class SpecificPrice\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method deleteByName\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 24
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method displayPrice\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method flushCache\(\) on an unknown class SpecificPrice\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method flushPriceCache\(\) on an unknown class Product\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method get\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 167
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getAdminTokenLite\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 5
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getCartIdStatic\(\) on an unknown class Order\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getContext\(\) on an unknown class Context\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getCountries\(\) on an unknown class Country\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getCover\(\) on an unknown class Image\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getFormattedName\(\) on an unknown class ImageType\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getIdByIsoCode\(\) on an unknown class Currency\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getIdFromClassName\(\) on an unknown class Tab\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getIdsByProductId\(\) on an unknown class SpecificPrice\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getInstance\(\) on an unknown class Db\.$#'
+			identifier: class.notFound
+			count: 31
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getIsoById\(\) on an unknown class Country\.$#'
+			identifier: class.notFound
+			count: 5
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getLanguages\(\) on an unknown class Language\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getManager\(\) on an unknown class TaxManagerFactory\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getNameById\(\) on an unknown class State\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getOrderByCartId\(\) on an unknown class Order\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getOrderStates\(\) on an unknown class OrderState\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getProductCategoriesFull\(\) on an unknown class Product\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getTaxRulesGroups\(\) on an unknown class TaxRulesGroup\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getToken\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method getValue\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 88
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method isEmpty\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 74
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method isFeatureActive\(\) on an unknown class Shop\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method isLoadedObject\(\) on an unknown class Validate\.$#'
+			identifier: class.notFound
+			count: 68
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method isSubmit\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method setContext\(\) on an unknown class Shop\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method strlen\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method strtolower\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method strtoupper\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 7
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method substr\(\) on an unknown class Tools\.$#'
+			identifier: class.notFound
+			count: 13
+			path: twopayment.php
+
+		-
+			message: '#^Call to static method updateValue\(\) on an unknown class Configuration\.$#'
+			identifier: class.notFound
+			count: 84
+			path: twopayment.php
+
+		-
+			message: '#^Constant _DB_PREFIX_ not found\.$#'
+			identifier: constant.notFound
+			count: 21
+			path: twopayment.php
+
+		-
+			message: '#^Constant _MYSQL_ENGINE_ not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Constant _PS_CACHE_DIR_ not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Function pSQL not found\.$#'
+			identifier: function.notFound
+			count: 51
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Address not found\.$#'
+			identifier: class.notFound
+			count: 12
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Carrier not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Cart not found\.$#'
+			identifier: class.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Currency not found\.$#'
+			identifier: class.notFound
+			count: 13
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Customer not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class HelperForm not found\.$#'
+			identifier: class.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Order not found\.$#'
+			identifier: class.notFound
+			count: 5
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class OrderCarrier not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class OrderHistory not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class OrderState not found\.$#'
+			identifier: class.notFound
+			count: 7
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class PrestaShopException not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class PrestaShop\\PrestaShop\\Core\\Payment\\PaymentOption not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Product not found\.$#'
+			identifier: class.notFound
+			count: 4
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class SpecificPrice not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class Tab not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: twopayment.php
+
+		-
+			message: '#^Instantiated class TaxRulesGroup not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: twopayment.php

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Minimal PrestaShop core-class stubs for static analysis only.
+ *
+ * This file is never loaded at runtime — PrestaShop core provides the real
+ * classes when the module is installed in a shop. It exists solely so
+ * phpstan can resolve the base classes this module extends (`extends X`
+ * requires phpstan's reflection to know X exists; without a stub, phpstan
+ * treats these as "non-ignorable" errors that cannot be baselined).
+ *
+ * Keep this file to the bare minimum needed to unblock class resolution —
+ * do not add method bodies or business logic here. Everything else
+ * (undefined methods/properties on these classes, e.g. Configuration::get())
+ * is handled by phpstan-baseline.neon instead, since those errors are
+ * ignorable.
+ */
+
+declare(strict_types=1);
+
+if (!class_exists('Module', false)) {
+    class Module
+    {
+    }
+}
+
+if (!class_exists('PaymentModule', false)) {
+    class PaymentModule extends Module
+    {
+    }
+}
+
+if (!class_exists('Controller', false)) {
+    class Controller
+    {
+    }
+}
+
+if (!class_exists('FrontController', false)) {
+    class FrontController extends Controller
+    {
+    }
+}
+
+if (!class_exists('ModuleFrontController', false)) {
+    class ModuleFrontController extends FrontController
+    {
+    }
+}
+
+if (!class_exists('AdminController', false)) {
+    class AdminController extends Controller
+    {
+    }
+}
+
+if (!class_exists('ModuleAdminController', false)) {
+    class ModuleAdminController extends AdminController
+    {
+    }
+}
+
+if (!class_exists('CustomerAddressFormatterCore', false)) {
+    class CustomerAddressFormatterCore
+    {
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+    paths:
+        - twopayment.php
+        - classes
+        - controllers
+        - override
+    fileExtensions:
+        - php
+    excludePaths:
+        - tests/*
+    scanFiles:
+        - phpstan-stubs.php

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -213,6 +213,13 @@ namespace {
     {
     }
 
+    // Guarded the same way phpstan-stubs.php guards its PrestaShop core
+    // stand-ins: these three classes are only ever loaded together with the
+    // rest of this bootstrap in the offline test process, but the guard is
+    // cheap insurance against a "cannot redeclare class" fatal if a future
+    // refactor ever loads this file alongside another stub source in the
+    // same PHP process.
+    if (!class_exists('ModuleFrontController', false)) {
     class ModuleFrontController
     {
         public $module;
@@ -233,7 +240,9 @@ namespace {
             throw new StubRedirect((string) $url);
         }
     }
+    }
 
+    if (!class_exists('Module', false)) {
     class Module
     {
         public int $id = 1;
@@ -248,7 +257,9 @@ namespace {
             return (string) $name === 'twopayment';
         }
     }
+    }
 
+    if (!class_exists('PaymentModule', false)) {
     class PaymentModule extends Module
     {
         public string $name = 'twopayment';
@@ -309,6 +320,7 @@ namespace {
 
             return $filtered;
         }
+    }
     }
 
     class Context


### PR DESCRIPTION
## Summary

TWO-25107 audited PS CI as running only `php -l` + the bespoke TinyAssert runner (`tests/run.php`), and framed the gap as "the repo ships a PHPUnit suite that CI never executes, plus no phpstan." On investigation neither half of that first framing held up:

- `tests/run.php` is not PHPUnit — no composer, no test framework, just a hand-rolled `TinyAssert` class asserting via exceptions. `AGENTS.md` documents this as deliberate ("self-contained runner, no composer deps").
- CI already runs it — `.github/workflows/tests.yml`'s single job has a `Run offline test suite: php tests/run.php` step.

So there was no PHPUnit-wiring work to do. Posting a corrective comment on TWO-25107 with this finding. This PR delivers the one gap that *is* real: static analysis.

- Leaves the existing lint + TinyAssert job untouched.
- Adds a `phpstan` CI job: level 1 over `twopayment.php`/`classes`/`controllers`/`override` (tests/ excluded, same pattern as magento-plugin's `Test/*` exclusion).
- `phpstan-stubs.php`: minimal analysis-only stand-ins for the 4 PrestaShop core classes this module extends (`Module`, `PaymentModule`, `ModuleFrontController`, `ModuleAdminController`, `CustomerAddressFormatterCore`) — without these, phpstan can't resolve `extends X` and throws non-ignorable errors that can't be baselined. Never loaded at runtime.
- `phpstan-baseline.neon`: baselines the 2046 pre-existing findings (mostly calls into PrestaShop core APIs phpstan can't see without full core stubs) so the gate is green on HEAD but fails on any *new* violation.
- phpstan.phar is downloaded pinned by version+sha256 in CI (and via a new `make phpstan` target), matching the existing php-cs-fixer pattern — no composer.json introduced, so the module's "no composer deps" posture is unchanged.

## Test plan

- [x] `php tests/run.php` still passes unchanged (existing TinyAssert suite untouched).
- [x] `phpstan analyse` is green on HEAD (baseline absorbs pre-existing findings).
- [x] Deliberately introduced an undefined-method call locally — phpstan caught it (`method.notFound`, not swallowed by baseline) — then reverted before committing, proving the gate bites.
- [x] All three jobs (lint/TinyAssert matrix, phpstan) will show in the PR checks.
- [ ] Corrective comment posted on TWO-25107 explaining the false PHPUnit premise (separate step, tracked alongside this PR).

— posted by Claude