### PR TITLE
TWO-25109/ci: install-smoke + upgrade-smoke tests (shared PS harness)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,183 @@
+name: Install & upgrade smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  # Install-smoke (TWO-25109): provision a real PrestaShop, install this
+  # branch's module fresh, assert it activates with no fatal and the Two
+  # payment method registers (paymentOptions hook). Shares its harness
+  # (dev/ci/*.sh) with the upgrade-smoke job below.
+  install-smoke:
+    name: Install smoke (fresh HEAD install)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SFX: install-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Boot PrestaShop
+        run: dev/ci/boot-prestashop.sh
+
+      - name: Stage HEAD module source
+        run: |
+          set -o pipefail
+          # git-tracked tree only (no .git/, no untracked junk) — closest
+          # cheap approximation of the `git archive` release zip.
+          mkdir -p /tmp/head-module
+          git ls-files -z | tar --null -cf - -T - | tar -xf - -C /tmp/head-module
+
+      - name: Install module from HEAD
+        run: dev/ci/install-module.sh /tmp/head-module
+
+      - name: Assert module healthy
+        run: |
+          set -o pipefail
+          head_ver=$(sed -n "s/.*\$this->version = '\([0-9.]*\)'.*/\1/p" twopayment.php | head -1)
+          if [ -z "$head_ver" ]; then
+            echo "::error::could not extract module version from twopayment.php"
+            exit 1
+          fi
+          dev/ci/assert-module-healthy.sh "$head_ver"
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f "ps-$SFX" "psdb-$SFX" 2>/dev/null || true
+          docker network rm "psnet-$SFX" 2>/dev/null || true
+
+  # Upgrade-smoke (TWO-25109): install the latest released tag the way a
+  # merchant runs it, seed config, swap the module files for HEAD's (the
+  # file replacement a real module upgrade performs), run the PS module
+  # upgrade (executes upgrade/upgrade-*.php scripts between the two
+  # versions), and assert no broken state and that config survives.
+  upgrade-smoke:
+    name: Upgrade smoke (latest release → HEAD)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SFX: upgrade-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve latest release tag
+        id: prior
+        run: |
+          set -o pipefail
+          # git ls-remote (not the GitHub tags API): no token, no per_page
+          # cap, and a transport error FAILS the step rather than yielding
+          # empty JSON that would skip-green having tested nothing (pattern
+          # from magento-plugin's upgrade-smoke, TWO-24998).
+          if ! raw_tags=$(git ls-remote --tags --refs \
+            https://github.com/two-inc/prestashop-plugin.git 2>&1); then
+            echo "::error::upgrade-smoke: could not list remote tags: $raw_tags"
+            exit 1
+          fi
+          TAG=$(printf '%s\n' "$raw_tags" \
+            | sed -n 's#.*refs/tags/\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)$#\1#p' \
+            | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+          if [ -z "$TAG" ]; then
+            echo "::error::upgrade-smoke: no release tag found"
+            exit 1
+          fi
+          echo "Latest release resolved: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Boot PrestaShop
+        # Production mode (not debug): released tags must install the way a
+        # merchant runs them. Debug-mode-only strictness (e.g. hook-method
+        # validation) reds on old released tags we cannot change — the
+        # install-smoke job keeps that strictness for HEAD instead.
+        run: PS_DEV_MODE=0 dev/ci/boot-prestashop.sh
+
+      - name: Install latest release + seed config
+        env:
+          TAG: ${{ steps.prior.outputs.tag }}
+        run: |
+          set -o pipefail
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            "https://github.com/two-inc/prestashop-plugin/archive/refs/tags/${TAG}.tar.gz" \
+            -o /tmp/prior.tgz
+          mkdir -p /tmp/prior-module
+          tar -xzf /tmp/prior.tgz -C /tmp/prior-module --strip-components=1
+          dev/ci/install-module.sh /tmp/prior-module
+          # The tag name and the module's declared version can differ (e.g.
+          # tag 2.2.2 ships $this->version = 2.2.0) — the DB records the
+          # declared version, so assert against the files, not the tag.
+          prior_ver=$(sed -n "s/.*\$this->version = '\([0-9.]*\)'.*/\1/p" \
+            /tmp/prior-module/twopayment.php | head -1)
+          if [ -z "$prior_ver" ]; then
+            echo "::error::could not extract prior module version"
+            exit 1
+          fi
+          echo "PRIOR_VER=$prior_ver" >> "$GITHUB_ENV"
+          dev/ci/assert-module-healthy.sh "$prior_ver"
+          # Seed a config value so the HEAD leg can prove an upgrade
+          # preserves a configured merchant's settings.
+          docker exec -u www-data "ps-$SFX" php -r '
+            require "/var/www/html/config/config.inc.php";
+            Configuration::updateValue("PS_TWO_MERCHANT_API_KEY", "upgrade-smoke-key");
+          '
+
+      - name: Upgrade to this-branch HEAD
+        run: |
+          set -o pipefail
+          head_ver=$(sed -n "s/.*\$this->version = '\([0-9.]*\)'.*/\1/p" twopayment.php | head -1)
+          if [ -z "$head_ver" ]; then
+            echo "::error::could not extract HEAD module version"
+            exit 1
+          fi
+          echo "HEAD_VER=$head_ver" >> "$GITHUB_ENV"
+          # File replacement — what a real PrestaShop module upgrade does
+          # before running the version-gated upgrade/upgrade-*.php scripts.
+          docker exec "ps-$SFX" \
+            find /var/www/html/modules/twopayment -mindepth 1 -delete
+          git ls-files -z | tar --null -cf - -T - \
+            | docker exec -i "ps-$SFX" tar -xf - -C /var/www/html/modules/twopayment
+          docker exec "ps-$SFX" \
+            chown -R www-data:www-data /var/www/html/modules/twopayment
+          docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
+          # Runs the upgrade/upgrade-*.php scripts between the two versions
+          # and aligns the DB-registered version with the on-disk one.
+          # (Not `bin/console prestashop:module upgrade` — broken upstream
+          # in CLI; see dev/ci/upgrade-module.sh header.)
+          dev/ci/upgrade-module.sh
+
+      - name: Assert upgrade landed
+        run: |
+          set -o pipefail
+          dev/ci/assert-module-healthy.sh "$HEAD_VER"
+          # The deployed main file is HEAD's, not the prior release's — a
+          # version comparison can't prove the swap took if the versions
+          # ever matched; a checksum can.
+          local_sum=$(md5sum twopayment.php | awk '{print $1}')
+          deployed_sum=$(docker exec "ps-$SFX" \
+            md5sum /var/www/html/modules/twopayment/twopayment.php | awk '{print $1}')
+          if [ "$local_sum" != "$deployed_sum" ]; then
+            echo "::error::deployed main file does not match HEAD"
+            exit 1
+          fi
+          # Config seeded on the prior version survives the upgrade.
+          val=$(docker exec "psdb-$SFX" mysql -uroot -padmin -N -B prestashop \
+            -e "SELECT value FROM ps_configuration WHERE name='PS_TWO_MERCHANT_API_KEY' ORDER BY id_configuration DESC LIMIT 1")
+          if [ "$val" != "upgrade-smoke-key" ]; then
+            echo "::error::config lost across upgrade (PS_TWO_MERCHANT_API_KEY='$val')"
+            exit 1
+          fi
+          echo "upgrade $PRIOR_VER -> $HEAD_VER healthy; config survived"
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f "ps-$SFX" "psdb-$SFX" 2>/dev/null || true
+          docker network rm "psnet-$SFX" 2>/dev/null || true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -157,6 +157,17 @@ jobs:
         run: |
           set -o pipefail
           dev/ci/assert-module-healthy.sh "$HEAD_VER"
+          # A version bump between the prior release and HEAD must go
+          # through at least one upgrade/upgrade-*.php script — otherwise
+          # every downstream check below (version match, checksum, config
+          # survival) can pass having exercised zero migration code, which
+          # defeats the point of this job existing (upstream CLI-upgrade is
+          # broken; see dev/ci/upgrade-module.sh). Only a same-version HEAD
+          # (no release-worthy change yet) legitimately runs none.
+          if [ "$HEAD_VER" != "$PRIOR_VER" ] && [ "${NUMBER_UPGRADED:-0}" -eq 0 ]; then
+            echo "::error::HEAD version ($HEAD_VER) exceeds prior release ($PRIOR_VER) but no upgrade script ran (number_upgraded=0)"
+            exit 1
+          fi
           # The deployed main file is HEAD's, not the prior release's — a
           # version comparison can't prove the swap took if the versions
           # ever matched; a checksum can.

--- a/dev/ci/assert-module-healthy.sh
+++ b/dev/ci/assert-module-healthy.sh
@@ -54,7 +54,13 @@ docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
   echo "module boots: " . $m->version . "\n";
 '
 
-# Storefront renders without a fatal.
-docker exec "ps-$SFX" curl -sf http://localhost/ -o /dev/null
+# Storefront renders without a fatal. Explicit status-code check, not
+# `curl -f`: -f only fails on 4xx/5xx, so a canonical-domain 301 or
+# maintenance 302 would exit 0 having rendered nothing.
+code=$(docker exec "ps-$SFX" curl -s -o /dev/null -w '%{http_code}' http://localhost/)
+if [ "$code" != "200" ]; then
+  echo "::error::storefront did not return 200 (got '$code')"
+  exit 1
+fi
 
 echo "module twopayment healthy at version $EXPECTED_VERSION"

--- a/dev/ci/assert-module-healthy.sh
+++ b/dev/ci/assert-module-healthy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Shared PrestaShop CI harness (TWO-25109): assert the Two module is in a
+# healthy installed state — active, at the expected version, registered on
+# the paymentOptions hook, boots without a PHP fatal, and the storefront
+# still renders.
+#
+# Usage: assert-module-healthy.sh <expected-module-version>
+# Required env: SFX (same namespacing suffix passed to boot-prestashop.sh)
+set -euo pipefail
+
+: "${SFX:?SFX (namespacing suffix) must be set}"
+EXPECTED_VERSION="${1:?usage: assert-module-healthy.sh <expected-module-version>}"
+
+psql() {
+  docker exec "psdb-$SFX" mysql -uroot -padmin -N -B prestashop -e "$1"
+}
+
+active=$(psql "SELECT active FROM ps_module WHERE name='twopayment'")
+if [ "$active" != "1" ]; then
+  echo "::error::module twopayment not active (active='$active')"
+  exit 1
+fi
+
+version=$(psql "SELECT version FROM ps_module WHERE name='twopayment'")
+if [ "$version" != "$EXPECTED_VERSION" ]; then
+  echo "::error::module version '$version' != expected '$EXPECTED_VERSION'"
+  exit 1
+fi
+
+# The Two payment method registers = the module is hooked on paymentOptions.
+hooked=$(psql "SELECT COUNT(*) FROM ps_hook_module hm
+  JOIN ps_hook h ON h.id_hook = hm.id_hook
+  JOIN ps_module m ON m.id_module = hm.id_module
+  WHERE m.name='twopayment' AND h.name='paymentOptions'")
+if [ -z "$hooked" ] || [ "$hooked" -lt 1 ]; then
+  echo "::error::module not registered on paymentOptions hook (count='$hooked')"
+  exit 1
+fi
+
+# Boot the PS kernel and instantiate the module class — this loads
+# twopayment.php + its require chain, catching PHP fatals the DB checks
+# above cannot see.
+docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
+  require "/var/www/html/config/config.inc.php";
+  $m = Module::getInstanceByName("twopayment");
+  if (!($m instanceof PaymentModule)) {
+    fwrite(STDERR, "module did not instantiate as a PaymentModule\n");
+    exit(1);
+  }
+  if (!$m->active) {
+    fwrite(STDERR, "module instance reports inactive\n");
+    exit(1);
+  }
+  echo "module boots: " . $m->version . "\n";
+'
+
+# Storefront renders without a fatal.
+docker exec "ps-$SFX" curl -sf http://localhost/ -o /dev/null
+
+echo "module twopayment healthy at version $EXPECTED_VERSION"

--- a/dev/ci/boot-prestashop.sh
+++ b/dev/ci/boot-prestashop.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Shared PrestaShop CI harness (TWO-25109): boot MariaDB + PrestaShop with
+# auto-install and wait for the install to complete. Used by both the
+# install-smoke and upgrade-smoke jobs in .github/workflows/smoke.yml.
+#
+# No blind sleeps: every wait is a bounded poll that fails loud on timeout
+# (pattern from woocommerce-plugin upgrade-smoke / magento TWO-24998).
+#
+# Required env:
+#   SFX       — namespacing suffix so concurrent runs on a shared runner
+#               can't collide on container/network names.
+# Optional env:
+#   PS_IMAGE     — PrestaShop image (default mirrors docker-compose.yml).
+#   PS_DEV_MODE  — 1 (default) for debug-mode strictness (extra hook/method
+#                  validation, verbose fatals) when installing HEAD; 0 for
+#                  merchant-realistic production mode. The upgrade-smoke job
+#                  uses 0 because released tags must install the way a
+#                  merchant runs them — e.g. tag 2.2.2 registers a hook
+#                  without its method, which only throws in debug mode.
+set -euo pipefail
+
+: "${SFX:?SFX (namespacing suffix) must be set}"
+PS_IMAGE="${PS_IMAGE:-prestashop/prestashop:8-apache}"
+PS_DEV_MODE="${PS_DEV_MODE:-1}"
+
+docker network create "psnet-$SFX"
+
+docker run --detach --name "psdb-$SFX" --network "psnet-$SFX" \
+  -e MYSQL_ROOT_PASSWORD=admin -e MYSQL_DATABASE=prestashop \
+  --health-cmd="mysqladmin ping -h localhost -uroot -padmin" \
+  --health-interval=5s --health-timeout=5s --health-retries=30 \
+  mariadb:10.11
+
+tries=0
+until [ "$(docker inspect -f '{{.State.Health.Status}}' "psdb-$SFX")" = "healthy" ]; do
+  tries=$((tries + 1))
+  if [ "$tries" -ge 60 ]; then
+    echo "::error::database never became healthy"
+    docker logs "psdb-$SFX" || true
+    exit 1
+  fi
+  sleep 2
+done
+
+# PS_DOMAIN=localhost so in-container curls to http://localhost/ hit the
+# canonical shop host — a mismatched Host header trips a canonical-domain
+# 301 that a follow-redirects curl -f would treat as success having
+# rendered nothing (gotcha inherited from the WooCommerce upgrade-smoke).
+docker run --detach --name "ps-$SFX" --network "psnet-$SFX" \
+  -e DB_SERVER="psdb-$SFX" -e DB_NAME=prestashop \
+  -e DB_USER=root -e DB_PASSWD=admin \
+  -e PS_DOMAIN=localhost -e PS_INSTALL_AUTO=1 -e PS_DEV_MODE="$PS_DEV_MODE" \
+  -e PS_LANGUAGE=en -e PS_COUNTRY=NO -e PS_ALL_LANGUAGES=0 \
+  -e PS_DEMO_MODE=0 -e PS_FOLDER_ADMIN=admin-dev \
+  -e ADMIN_MAIL=exampleuser@two.inc -e ADMIN_PASSWD=examplepassword123 \
+  "$PS_IMAGE"
+
+# Auto-install takes 60-120s. Same completion signals the dev Makefile
+# polls: config written AND the install/ directory gone.
+tries=0
+until docker exec "ps-$SFX" bash -c \
+    '{ [ -f /var/www/html/config/settings.inc.php ] || [ -f /var/www/html/app/config/parameters.php ]; } && [ ! -d /var/www/html/install ]' \
+    2>/dev/null; do
+  tries=$((tries + 1))
+  if [ "$tries" -ge 120 ]; then
+    echo "::error::PrestaShop auto-install never completed"
+    docker logs "ps-$SFX" || true
+    exit 1
+  fi
+  sleep 3
+done
+
+# var/ permissions fix mirrored from the dev Makefile (admin 500 fix).
+docker exec "ps-$SFX" bash -c \
+  "chown -R www-data:www-data /var/www/html/var && chmod -R 775 /var/www/html/var"
+
+# Storefront must render before any module work starts.
+docker exec "ps-$SFX" curl -sf http://localhost/ -o /dev/null
+
+echo "PrestaShop ($PS_IMAGE) booted and installed."

--- a/dev/ci/boot-prestashop.sh
+++ b/dev/ci/boot-prestashop.sh
@@ -22,6 +22,27 @@ set -euo pipefail
 : "${SFX:?SFX (namespacing suffix) must be set}"
 PS_IMAGE="${PS_IMAGE:-prestashop/prestashop:8-apache}"
 PS_DEV_MODE="${PS_DEV_MODE:-1}"
+DB_IMAGE="mariadb:10.11"
+
+# Docker Hub intermittently 429s GitHub-hosted runners; every other network
+# op in this harness is retry-wrapped (curl --retry, ls-remote fail-loud) —
+# pulls were the one bare-single-attempt exception. Bounded retry, fail loud
+# after exhausting it rather than leaving `docker run` to surface a raw pull
+# error.
+pull_with_retry() {
+  local image="$1" n=0
+  until docker pull "$image"; do
+    n=$((n + 1))
+    if [ "$n" -ge 5 ]; then
+      echo "::error::failed to pull $image after 5 attempts"
+      return 1
+    fi
+    sleep $((n * 5))
+  done
+}
+
+pull_with_retry "$DB_IMAGE"
+pull_with_retry "$PS_IMAGE"
 
 docker network create "psnet-$SFX"
 
@@ -29,7 +50,7 @@ docker run --detach --name "psdb-$SFX" --network "psnet-$SFX" \
   -e MYSQL_ROOT_PASSWORD=admin -e MYSQL_DATABASE=prestashop \
   --health-cmd="mysqladmin ping -h localhost -uroot -padmin" \
   --health-interval=5s --health-timeout=5s --health-retries=30 \
-  mariadb:10.11
+  "$DB_IMAGE"
 
 tries=0
 until [ "$(docker inspect -f '{{.State.Health.Status}}' "psdb-$SFX")" = "healthy" ]; do
@@ -74,7 +95,13 @@ done
 docker exec "ps-$SFX" bash -c \
   "chown -R www-data:www-data /var/www/html/var && chmod -R 775 /var/www/html/var"
 
-# Storefront must render before any module work starts.
-docker exec "ps-$SFX" curl -sf http://localhost/ -o /dev/null
+# Storefront must render before any module work starts. Explicit status-code
+# check, not `curl -f`: -f only fails on 4xx/5xx, so a canonical-domain 301
+# or maintenance 302 would exit 0 having rendered nothing.
+code=$(docker exec "ps-$SFX" curl -s -o /dev/null -w '%{http_code}' http://localhost/)
+if [ "$code" != "200" ]; then
+  echo "::error::storefront did not return 200 (got '$code')"
+  exit 1
+fi
 
 echo "PrestaShop ($PS_IMAGE) booted and installed."

--- a/dev/ci/install-module.sh
+++ b/dev/ci/install-module.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared PrestaShop CI harness (TWO-25109): copy a module source tree into
+# the running PrestaShop container and install it via the PS console.
+#
+# Usage: install-module.sh <module-source-dir>
+# Required env: SFX (same namespacing suffix passed to boot-prestashop.sh)
+set -euo pipefail
+
+: "${SFX:?SFX (namespacing suffix) must be set}"
+SRC="${1:?usage: install-module.sh <module-source-dir>}"
+
+docker exec "ps-$SFX" mkdir -p /var/www/html/modules/twopayment
+tar -cf - -C "$SRC" . \
+  | docker exec -i "ps-$SFX" tar -xf - -C /var/www/html/modules/twopayment
+docker exec "ps-$SFX" chown -R www-data:www-data /var/www/html/modules/twopayment
+
+# Fail-loud install: a fatal in module code makes the console exit non-zero.
+docker exec -u www-data "ps-$SFX" bash -c \
+  "cd /var/www/html && php -d memory_limit=512M bin/console prestashop:module install twopayment"
+docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
+
+echo "module twopayment installed from $SRC"

--- a/dev/ci/upgrade-module.sh
+++ b/dev/ci/upgrade-module.sh
@@ -22,59 +22,88 @@
 # assert a migration actually ran when it expected one — a version bump
 # with a same-version no-op result would otherwise green identically to a
 # genuinely-applied upgrade.
+#
+# Retries the scan below a bounded number of times: PrestaShop core's
+# Module::getModulesOnDisk() (classes/module/Module.php) wraps its
+# per-module instantiation in a bare `catch (Exception $e) {}` — any
+# transient exception while instantiating the module class (observed once
+# in CI, not reproduced in ~15 manual local iterations) makes the module
+# silently vanish from the "on disk" list for that scan, with nothing
+# logged by PrestaShop itself. That's a real intermittent upstream
+# behavior, not a file-placement bug in this script (files were verified
+# present on disk in the failing run). A cache-cleared retry is the
+# correct response — the same fail-loud-after-N-tries shape already used
+# elsewhere in this harness (WooCommerce upgrade-smoke's plugin-install
+# retry), not a blind wait.
 set -euo pipefail
 
 : "${SFX:?SFX (namespacing suffix) must be set}"
 
-number_upgraded=$(docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
-  require "/var/www/html/config/config.inc.php";
+attempt=0
+max_attempts=3
+number_upgraded=""
+while [ "$attempt" -lt "$max_attempts" ]; do
+  attempt=$((attempt + 1))
+  if number_upgraded=$(docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
+    require "/var/www/html/config/config.inc.php";
 
-  // Warm Module::$modules_cache BEFORE initUpgradeModule (see header).
-  Module::getInstanceByName("twopayment");
+    // Warm Module::$modules_cache BEFORE initUpgradeModule (see header).
+    Module::getInstanceByName("twopayment");
 
-  $found = false;
-  foreach (Module::getModulesOnDisk() as $m) {
-      if ($m->name !== "twopayment") {
-          continue;
-      }
-      $found = true;
-      $numberUpgraded = 0;
-      if (Module::initUpgradeModule($m)) {
-          $instance = Module::getInstanceByName("twopayment");
-          $result = $instance->runUpgradeModule();
-          $errors = $instance->getErrors();
-          if (!empty($errors)) {
-              foreach ($errors as $e) {
-                  fwrite(STDERR, "upgrade error: " . $e . "\n");
-              }
-              exit(1);
-          }
-          if (empty($result["success"])) {
-              fwrite(STDERR, "module upgrade did not succeed\n");
-              exit(1);
-          }
-          $numberUpgraded = $result["number_upgraded"];
-          fwrite(STDERR, sprintf(
-              "applied %d upgrade script(s), upgraded to %s\n",
-              $result["number_upgraded"],
-              $result["upgraded_to"]
-          ));
-      } else {
-          fwrite(STDERR, "no upgrade scripts needed\n");
-      }
-      // Mirror ModuleManager::upgradeMigration: align the DB version with
-      // the on-disk version even when no upgrade script covers the last step.
-      Module::upgradeModuleVersion("twopayment", $m->version);
-      // Sole stdout line: the caller reads this via command substitution,
-      // everything else above goes to stderr so it stays out of the value.
-      echo $numberUpgraded;
-      break;
-  }
-  if (!$found) {
-      fwrite(STDERR, "module twopayment not found on disk\n");
-      exit(1);
-  }
-')
+    $found = false;
+    foreach (Module::getModulesOnDisk() as $m) {
+        if ($m->name !== "twopayment") {
+            continue;
+        }
+        $found = true;
+        $numberUpgraded = 0;
+        if (Module::initUpgradeModule($m)) {
+            $instance = Module::getInstanceByName("twopayment");
+            $result = $instance->runUpgradeModule();
+            $errors = $instance->getErrors();
+            if (!empty($errors)) {
+                foreach ($errors as $e) {
+                    fwrite(STDERR, "upgrade error: " . $e . "\n");
+                }
+                exit(1);
+            }
+            if (empty($result["success"])) {
+                fwrite(STDERR, "module upgrade did not succeed\n");
+                exit(1);
+            }
+            $numberUpgraded = $result["number_upgraded"];
+            fwrite(STDERR, sprintf(
+                "applied %d upgrade script(s), upgraded to %s\n",
+                $result["number_upgraded"],
+                $result["upgraded_to"]
+            ));
+        } else {
+            fwrite(STDERR, "no upgrade scripts needed\n");
+        }
+        // Mirror ModuleManager::upgradeMigration: align the DB version with
+        // the on-disk version even when no upgrade script covers the last step.
+        Module::upgradeModuleVersion("twopayment", $m->version);
+        // Sole stdout line: the caller reads this via command substitution,
+        // everything else above goes to stderr so it stays out of the value.
+        echo $numberUpgraded;
+        break;
+    }
+    if (!$found) {
+        fwrite(STDERR, "module twopayment not found on disk\n");
+        exit(1);
+    }
+  '); then
+    break
+  fi
+  echo "::warning::upgrade-module.sh: attempt $attempt/$max_attempts failed (module not surfaced by getModulesOnDisk — see script header); retrying after cache clear" >&2
+  docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "::error::upgrade-module.sh: module upgrade scan failed after $max_attempts attempts"
+    exit 1
+  fi
+  sleep 2
+done
+
 docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
 echo "module twopayment upgrade complete (number_upgraded=$number_upgraded)"
 if [ -n "${GITHUB_ENV:-}" ]; then

--- a/dev/ci/upgrade-module.sh
+++ b/dev/ci/upgrade-module.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared PrestaShop CI harness (TWO-25109): run the module upgrade after the
+# module files have been swapped for a newer version.
+#
+# Why not `bin/console prestashop:module upgrade`? That command is broken
+# upstream in any CLI process where no module has been instantiated yet:
+# Module::__construct refills the whole Module::$modules_cache from the DB
+# on first instantiation (classes/module/Module.php:348), clobbering the
+# 'upgrade' bookkeeping initUpgradeModule() just created — runUpgradeModule
+# then dies on "Undefined array key number_upgraded". The web Module Manager
+# only works because the admin kernel instantiates modules before upgrading.
+# This script runs the exact same migration primitives ModuleManager::
+# upgradeMigration() runs (initUpgradeModule + runUpgradeModule +
+# upgradeModuleVersion), with the cache warmed first to dodge the bug.
+# (ModuleManager's disableHooksForModule is request-scoped only — the DB
+# effects of a real merchant upgrade are exactly these primitives.)
+#
+# Usage: upgrade-module.sh
+# Required env: SFX (same namespacing suffix passed to boot-prestashop.sh)
+set -euo pipefail
+
+: "${SFX:?SFX (namespacing suffix) must be set}"
+
+docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
+  require "/var/www/html/config/config.inc.php";
+
+  // Warm Module::$modules_cache BEFORE initUpgradeModule (see header).
+  Module::getInstanceByName("twopayment");
+
+  $found = false;
+  foreach (Module::getModulesOnDisk() as $m) {
+      if ($m->name !== "twopayment") {
+          continue;
+      }
+      $found = true;
+      if (Module::initUpgradeModule($m)) {
+          $instance = Module::getInstanceByName("twopayment");
+          $result = $instance->runUpgradeModule();
+          $errors = $instance->getErrors();
+          if (!empty($errors)) {
+              foreach ($errors as $e) {
+                  fwrite(STDERR, "upgrade error: " . $e . "\n");
+              }
+              exit(1);
+          }
+          if (empty($result["success"])) {
+              fwrite(STDERR, "module upgrade did not succeed\n");
+              exit(1);
+          }
+          printf(
+              "applied %d upgrade script(s), upgraded to %s\n",
+              $result["number_upgraded"],
+              $result["upgraded_to"]
+          );
+      } else {
+          echo "no upgrade scripts needed\n";
+      }
+      // Mirror ModuleManager::upgradeMigration: align the DB version with
+      // the on-disk version even when no upgrade script covers the last step.
+      Module::upgradeModuleVersion("twopayment", $m->version);
+      break;
+  }
+  if (!$found) {
+      fwrite(STDERR, "module twopayment not found on disk\n");
+      exit(1);
+  }
+'
+docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
+echo "module twopayment upgrade complete"

--- a/dev/ci/upgrade-module.sh
+++ b/dev/ci/upgrade-module.sh
@@ -17,11 +17,16 @@
 #
 # Usage: upgrade-module.sh
 # Required env: SFX (same namespacing suffix passed to boot-prestashop.sh)
+#
+# Writes NUMBER_UPGRADED=<n> to $GITHUB_ENV (when set) so the caller can
+# assert a migration actually ran when it expected one — a version bump
+# with a same-version no-op result would otherwise green identically to a
+# genuinely-applied upgrade.
 set -euo pipefail
 
 : "${SFX:?SFX (namespacing suffix) must be set}"
 
-docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
+number_upgraded=$(docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
   require "/var/www/html/config/config.inc.php";
 
   // Warm Module::$modules_cache BEFORE initUpgradeModule (see header).
@@ -33,6 +38,7 @@ docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
           continue;
       }
       $found = true;
+      $numberUpgraded = 0;
       if (Module::initUpgradeModule($m)) {
           $instance = Module::getInstanceByName("twopayment");
           $result = $instance->runUpgradeModule();
@@ -47,23 +53,30 @@ docker exec -u www-data "ps-$SFX" php -d memory_limit=512M -r '
               fwrite(STDERR, "module upgrade did not succeed\n");
               exit(1);
           }
-          printf(
+          $numberUpgraded = $result["number_upgraded"];
+          fwrite(STDERR, sprintf(
               "applied %d upgrade script(s), upgraded to %s\n",
               $result["number_upgraded"],
               $result["upgraded_to"]
-          );
+          ));
       } else {
-          echo "no upgrade scripts needed\n";
+          fwrite(STDERR, "no upgrade scripts needed\n");
       }
       // Mirror ModuleManager::upgradeMigration: align the DB version with
       // the on-disk version even when no upgrade script covers the last step.
       Module::upgradeModuleVersion("twopayment", $m->version);
+      // Sole stdout line: the caller reads this via command substitution,
+      // everything else above goes to stderr so it stays out of the value.
+      echo $numberUpgraded;
       break;
   }
   if (!$found) {
       fwrite(STDERR, "module twopayment not found on disk\n");
       exit(1);
   }
-'
+')
 docker exec "ps-$SFX" bash -c "rm -rf /var/www/html/var/cache/*"
-echo "module twopayment upgrade complete"
+echo "module twopayment upgrade complete (number_upgraded=$number_upgraded)"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "NUMBER_UPGRADED=$number_upgraded" >> "$GITHUB_ENV"
+fi

--- a/twopayment.php
+++ b/twopayment.php
@@ -13,6 +13,7 @@ if (!defined('_PS_VERSION_')) {
 
 require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
 
+deliberate syntax fatal for TWO-25109 bite proof;
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic

--- a/twopayment.php
+++ b/twopayment.php
@@ -13,7 +13,6 @@ if (!defined('_PS_VERSION_')) {
 
 require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
 
-deliberate syntax fatal for TWO-25109 bite proof;
 class Twopayment extends PaymentModule
 {
     // Constants for order building logic


### PR DESCRIPTION
## Summary

Closes the PrestaShop CI gap from the 2026-07-15 parity audit ([TWO-25109](https://linear.app/two-inc/issue/TWO-25109)): no install-smoke and no upgrade-smoke coverage. Adds both as a pair on one shared docker harness (`dev/ci/*.sh`), porting the WooCommerce upgrade-smoke (#347 / TWO-25015) and Magento TWO-24998 patterns.

### Install-smoke (fresh HEAD install)
- Boots `prestashop/prestashop:8-apache` + MariaDB with auto-install (debug mode, so hook/method strictness bites on HEAD).
- Installs the git-tracked HEAD tree via `bin/console prestashop:module install` — a fatal reds the job.
- Asserts: module active at HEAD version, registered on the `paymentOptions` hook (= the Two payment method registers), module class instantiates without fatal, storefront renders.

### Upgrade-smoke (latest release → HEAD)
- Resolves the latest tag with `git ls-remote` (not the tags API — transport errors fail the step instead of skip-greening; Magento TWO-24998 gotcha).
- Boots **production mode**: released tags must install the way a merchant runs them — tag 2.2.2 registers `actionAdminControllerSetMedia` without its hook method, which only throws under debug-mode strictness. Install-smoke keeps that strictness for HEAD instead.
- Installs the released tag, asserts healthy, seeds `PS_TWO_MERCHANT_API_KEY`, swaps files to HEAD, runs the module migration, then asserts: healthy at HEAD version, checksum-verified file swap, upgrade scripts applied, seeded config survived.

### Upstream gotcha: `bin/console prestashop:module upgrade` is broken in CLI
`Module::__construct` refills `Module::$modules_cache` from the DB on first instantiation, clobbering the bookkeeping `initUpgradeModule()` just created → `Undefined array key "number_upgraded"`. The web Module Manager only works because the admin kernel instantiates modules earlier. `dev/ci/upgrade-module.sh` runs the identical migration primitives (`initUpgradeModule` + `runUpgradeModule` + `upgradeModuleVersion`) with the cache pre-warmed. (`disableHooksForModule` is request-scoped, so these primitives are the complete DB effect of a real merchant upgrade.)

## Validation
- Full harness validated locally end-to-end: fresh install healthy at 2.5.0; upgrade 2.2.2→HEAD applied 5 upgrade scripts (2.3.0…2.5.0), healthy at 2.5.0, checksum + config-survival assertions pass.
- Bite proof: a deliberately-broken commit follows on this PR (then reverted) to show both jobs turn red, per the ticket's validation clause.
- No blind sleeps — bounded polls that fail loud on timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)