### PR TITLE
TWO-25161/fix: source shipping cost and declared tax rate from the cart, not a Carrier object

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -170,8 +170,19 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
             $cart_snapshot_hash = $this->module->calculateTwoCheckoutSnapshotHash($cart, $paymentdata);
             $idempotency_key = $this->module->buildTwoOrderCreateIdempotencyKey($cart, $cart_snapshot_hash);
         } catch (Exception $e) {
+            // Surface WHY the payload could not be built. Every exception on
+            // this path is a deterministic, plugin-generated diagnostic about
+            // the cart's own amounts (no credentials, no provider internals),
+            // and withholding it is what left the buyer staring at a spinner
+            // with a generic message in TWO-25161.
+            $message = $this->module->l('Two could not build this order from your cart.');
+            $detail = trim((string)$e->getMessage());
+            if ($detail !== '') {
+                $message .= ' ' . sprintf($this->module->l('Details: %s.'), $detail);
+            }
+            $message .= ' ' . $this->module->l('Please review your cart and try again, or contact the store.');
             $this->failCheckout(
-                $this->module->l('Unable to process your order with Two payment. Please review your cart and try again.'),
+                $message,
                 'TwoPayment: Failed building order payload for cart ' . $cart->id . ' - ' . $e->getMessage(),
                 3
             );

--- a/tests/ShippingCostSourcingSpec.php
+++ b/tests/ShippingCostSourcingSpec.php
@@ -16,6 +16,12 @@ declare(strict_types=1);
  * `id_carrier = 0` is still NOT blessed: the protection that matters - the
  * cart's totals must be internally coherent - is unchanged, and a genuinely
  * incoherent cart is still refused, now with a message that names the amounts.
+ *
+ * The shipping tax RATE is never derived from those amounts. It is relayed from
+ * the tax-rules group declared by the carriers in the cart's own selected
+ * delivery option, which stay enumerable even with `id_carrier = 0`. When no
+ * such carrier exists at all (PrestaShop's carrier_list = [0 => 0] sentinel)
+ * the order is refused rather than shipped with a guessed rate.
  */
 final class ShippingCostSourcingSpec
 {
@@ -24,6 +30,50 @@ final class ShippingCostSourcingSpec
         self::testCarrierlessCartKeepsShippingCostAndReconciles();
         self::testIncoherentCartIsRejectedWithSpecificMessage();
         self::testFreeShippingCarrierlessCartStillBuilds();
+        self::testUnloadableCarrierRefusesRatherThanGuessTheRate();
+        self::testMixedDeclaredRatesSplitIntoOneLinePerRate();
+    }
+
+    /**
+     * Core-shaped delivery-option fixture: one address, one option key, one
+     * entry per carrier in `carrier_list` with a loaded `Carrier` instance -
+     * exactly what Cart::getDeliveryOptionList() hands back.
+     *
+     * @param array<int,array{net:float,gross:float,group:int}> $carriers By carrier id
+     */
+    private static function seedDeliveryOption(int $cartId, int $addressId, array $carriers): void
+    {
+        $carrierList = [];
+        $optionKey = '';
+        foreach ($carriers as $idCarrier => $spec) {
+            StubStore::$carriers[$idCarrier] = [
+                'name' => 'Carrier ' . $idCarrier,
+                'delay' => '',
+                'tax_rules_group_id' => $spec['group'],
+            ];
+            $carrierList[$idCarrier] = [
+                'price_with_tax' => $spec['gross'],
+                'price_without_tax' => $spec['net'],
+                'instance' => new Carrier($idCarrier),
+            ];
+            $optionKey .= $idCarrier . ',';
+        }
+
+        StubStore::$cartDeliveryOptionLists[$cartId] = [
+            $addressId => [$optionKey => ['carrier_list' => $carrierList]],
+        ];
+    }
+
+    /** Did any log line mention this fragment? */
+    private static function loggedContains(string $needle): bool
+    {
+        foreach (PrestaShopLogger::$logs as $entry) {
+            if (strpos((string) $entry['message'], $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static function reset(): void
@@ -99,8 +149,9 @@ final class ShippingCostSourcingSpec
 
     /**
      * (a) id_carrier = 0 with a non-zero shipping total: the shipping cost
-     * survives into the payload and the submitted order total matches the cart
-     * total. This is the LG regression - 29.00 of shipping used to disappear.
+     * survives into the payload, the submitted order total matches the cart
+     * total, and the rate is the one DECLARED by the carrier in the cart's
+     * selected delivery option - not one computed from the amounts.
      */
     private static function testCarrierlessCartKeepsShippingCostAndReconciles(): void
     {
@@ -117,6 +168,14 @@ final class ShippingCostSourcingSpec
         // The whole point: no carrier is selectable on this cart.
         $cart->id_carrier = 0;
         self::seedProductLine($cart, 9121);
+
+        // The carrier that priced the shipping is still enumerable from the
+        // cart's delivery option even though id_carrier is 0, and it declares
+        // tax-rules group 7101 = 21%.
+        StubStore::$taxRuleRates[7101] = 21.0;
+        self::seedDeliveryOption(9101, 9111, [
+            7001 => ['net' => 23.97, 'gross' => 29.00, 'group' => 7101],
+        ]);
 
         // 29.00 gross shipping at 21% -> 23.9669 net (unrounded, as PrestaShop
         // reports it). Cart total 121.00 + 29.00 = 150.00 gross / 123.9669 net.
@@ -147,15 +206,167 @@ final class ShippingCostSourcingSpec
         TinyAssert::same('29.00', (string)$shipping['gross_amount'], 'Shipping gross must come from the cart, not a Carrier');
         TinyAssert::same('23.97', (string)$shipping['net_amount']);
         TinyAssert::same('5.03', (string)$shipping['tax_amount']);
-        // Rate mirrored from the UNROUNDED cart totals: exactly 21%, not the
-        // 20.98% the 2dp pair would imply.
+        // DECLARED, not derived: 21% comes from the carrier's tax-rules group.
+        // The 2dp amounts on this line imply 20.98% (5.03 / 23.97), so a
+        // derivation would have relayed the wrong rate here.
         TinyAssert::same('0.21', (string)$shipping['tax_rate']);
-        TinyAssert::same('Shipping', (string)$shipping['name'], 'No carrier means the generic shipping label');
+        TinyAssert::same('Shipping', (string)$shipping['name'], 'No carrier on the cart means the generic shipping label');
+
+        // The resolved carrier and tax-rules-group IDs are logged, so the case
+        // a live cart hits is confirmable from the shop log.
+        TinyAssert::true(
+            self::loggedContains('carrier=7001 tax_rules_group=7101 rate=21%'),
+            'The resolved carrier and tax-rules-group IDs must be logged'
+        );
 
         // The submitted order total matches the cart total - the mismatch of
         // exactly the shipping cost is gone.
         TinyAssert::same('150.00', (string)$payload['gross_amount']);
         TinyAssert::same('123.97', (string)$payload['net_amount']);
+    }
+
+    /**
+     * (d) The genuine hole, closed loudly: a product with no available carrier
+     * makes PrestaShop set carrier_list = [0 => 0], so `new Carrier(0)` is
+     * unloadable and no tax-rules group exists - yet getPackageShippingCost()
+     * still prices the shipping through its internal default-carrier fallback.
+     * No rate may be derived, guessed, or silently sent as 0 there.
+     */
+    private static function testUnloadableCarrierRefusesRatherThanGuessTheRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9104, 9114);
+        $cart = new Cart(9104);
+        $cart->id_customer = 9104;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9114;
+        $cart->id_address_delivery = 9114;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9124);
+
+        // PrestaShop's no-available-carrier sentinel, verbatim.
+        StubStore::$cartDeliveryOptionLists[9104] = [
+            9114 => ['0,' => ['carrier_list' => [0 => 0]]],
+        ];
+
+        StubStore::$cartTotals[9104] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 23.9669,
+                Cart::BOTH => 123.9669,
+            ],
+        ];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoNewOrderData('merchant-attempt-9104', $cart, self::merchantUrls());
+            },
+            'No deliverable carrier for the cart shipping cost: PrestaShop reports no available carrier ' .
+            '(carrier_list = [0 => 0]) for this cart, so there is no declared shipping tax-rules group to relay'
+        );
+
+        // The refusal names the condition and the numbers behind it.
+        TinyAssert::true(
+            self::loggedContains('cart 9104, id_carrier=0, shipping=29.00'),
+            'The refusal must log the cart, id_carrier and shipping amount'
+        );
+    }
+
+    /**
+     * (e) A delivery option spanning carriers with DIFFERENT declared rates is
+     * split into one SHIPPING_FEE line per rate, weighted by the per-carrier
+     * nets already in carrier_list. No blended rate, no arbitrary pick, and the
+     * per-rate amounts still sum to the cart's own shipping total.
+     */
+    private static function testMixedDeclaredRatesSplitIntoOneLinePerRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9105, 9115);
+        $cart = new Cart(9105);
+        $cart->id_customer = 9105;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9115;
+        $cart->id_address_delivery = 9115;
+        $cart->id_lang = 1;
+        // Two carriers in one option means core cannot put a single carrier id
+        // on the cart, which is precisely the mixed-rate case.
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9125);
+
+        StubStore::$taxRuleRates[7201] = 21.0;
+        StubStore::$taxRuleRates[7202] = 10.0;
+        self::seedDeliveryOption(9105, 9115, [
+            7011 => ['net' => 10.00, 'gross' => 12.10, 'group' => 7201],
+            7012 => ['net' => 16.00, 'gross' => 17.60, 'group' => 7202],
+        ]);
+
+        // Shipping 29.70 gross / 26.00 net; cart 121.00 + 29.70 = 150.70 gross,
+        // 100.00 + 26.00 = 126.00 net.
+        StubStore::$cartTotals[9105] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.70,
+                Cart::BOTH => 150.70,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 26.00,
+                Cart::BOTH => 126.00,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9105', $cart, self::merchantUrls());
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        TinyAssert::count(2, $shippingLines, 'Mixed declared rates must emit one shipping line per rate');
+
+        $byRate = [];
+        $grossSum = 0.0;
+        $netSum = 0.0;
+        $taxSum = 0.0;
+        foreach ($shippingLines as $line) {
+            $byRate[(string)$line['tax_rate']] = $line;
+            $grossSum += (float)$line['gross_amount'];
+            $netSum += (float)$line['net_amount'];
+            $taxSum += (float)$line['tax_amount'];
+        }
+
+        TinyAssert::true(isset($byRate['0.21']), 'The 21% carrier must keep its own declared rate');
+        TinyAssert::true(isset($byRate['0.1']), 'The 10% carrier must keep its own declared rate');
+        TinyAssert::same('10.00', (string)$byRate['0.21']['net_amount']);
+        TinyAssert::same('2.10', (string)$byRate['0.21']['tax_amount']);
+        TinyAssert::same('16.00', (string)$byRate['0.1']['net_amount']);
+        TinyAssert::same('1.60', (string)$byRate['0.1']['tax_amount']);
+
+        // Per-rate amounts sum to the cart's authoritative shipping total.
+        TinyAssert::same('29.70', number_format($grossSum, 2, '.', ''));
+        TinyAssert::same('26.00', number_format($netSum, 2, '.', ''));
+        TinyAssert::same('3.70', number_format($taxSum, 2, '.', ''));
+
+        // Both carriers and both groups are logged.
+        TinyAssert::true(
+            self::loggedContains('carrier=7011 tax_rules_group=7201 rate=21%; carrier=7012 tax_rules_group=7202 rate=10%'),
+            'Both resolved carriers and tax-rules groups must be logged'
+        );
+
+        TinyAssert::same('150.70', (string)$payload['gross_amount']);
+        TinyAssert::same('126.00', (string)$payload['net_amount']);
     }
 
     /**

--- a/tests/ShippingCostSourcingSpec.php
+++ b/tests/ShippingCostSourcingSpec.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-25161 - shipping-cost sourcing must not depend on a Carrier object.
+ *
+ * A merchant who prices shipping through symbolic "logistics carriers" leaves
+ * `id_carrier = 0` on a cart that still carries a real shipping cost. The old
+ * builder keyed the SHIPPING_FEE line off `new Carrier($cart->id_carrier)`, so
+ * that cost silently vanished from the payload and the cart-vs-lines
+ * reconciliation gate rejected the order with an order-total mismatch of
+ * exactly the shipping amount.
+ *
+ * The cart is now the authority (Cart::getOrderTotal(..., Cart::ONLY_SHIPPING)).
+ * `id_carrier = 0` is still NOT blessed: the protection that matters - the
+ * cart's totals must be internally coherent - is unchanged, and a genuinely
+ * incoherent cart is still refused, now with a message that names the amounts.
+ */
+final class ShippingCostSourcingSpec
+{
+    public static function runAll(): void
+    {
+        self::testCarrierlessCartKeepsShippingCostAndReconciles();
+        self::testIncoherentCartIsRejectedWithSpecificMessage();
+        self::testFreeShippingCarrierlessCartStillBuilds();
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+    }
+
+    /** Shared buyer/currency/address fixture for a carrier-less ES cart. */
+    private static function seedCommonFixtures(int $cartId, int $addressId): void
+    {
+        StubStore::$customers[$cartId] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Javier',
+            'lastname' => 'Moreno',
+            'secure_key' => 'secure-key-' . $cartId,
+            'loaded' => true,
+        ];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[34] = 'ES';
+        StubStore::$addresses[$addressId] = [
+            'id_country' => 34,
+            'company' => 'LOGISTICS SHOP',
+            'companyid' => 'E20468708',
+            'address1' => 'Calle Uno 1',
+            'city' => 'Madrid',
+            'postcode' => '28001',
+            'phone' => '666666601',
+            'loaded' => true,
+        ];
+    }
+
+    /**
+     * Single 21% product line, 100.00 net / 121.00 gross, on a cart with NO
+     * carrier at all (StubStore::$carriers left empty, so `new Carrier(0)` is
+     * an unloaded object exactly like a shop whose shipping is priced outside
+     * the carrier table).
+     */
+    private static function seedProductLine(Cart $cart, int $productId): void
+    {
+        StubStore::$cartProducts[$cart->id] = [[
+            'id_product' => $productId,
+            'link_rewrite' => 'logistics-product',
+            'name' => 'Logistics Product',
+            'description_short' => 'Product',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 121.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[$productId] = [['name' => 'General']];
+        StubStore::$images[$productId] = ['id_image' => $productId];
+        StubStore::$products[$productId]['id_tax_rules_group'] = 9000 + $productId;
+        StubStore::$taxRuleRates[9000 + $productId] = 21.0;
+    }
+
+    private static function merchantUrls(): array
+    {
+        return [
+            'merchant_confirmation_url' => 'https://shop.local/confirm',
+            'merchant_cancel_order_url' => 'https://shop.local/cancel',
+            'merchant_edit_order_url' => '',
+            'merchant_order_verification_failed_url' => '',
+            'merchant_invoice_url' => '',
+            'merchant_shipping_document_url' => '',
+        ];
+    }
+
+    /**
+     * (a) id_carrier = 0 with a non-zero shipping total: the shipping cost
+     * survives into the payload and the submitted order total matches the cart
+     * total. This is the LG regression - 29.00 of shipping used to disappear.
+     */
+    private static function testCarrierlessCartKeepsShippingCostAndReconciles(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9101, 9111);
+        $cart = new Cart(9101);
+        $cart->id_customer = 9101;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9111;
+        $cart->id_address_delivery = 9111;
+        $cart->id_lang = 1;
+        // The whole point: no carrier is selectable on this cart.
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9121);
+
+        // 29.00 gross shipping at 21% -> 23.9669 net (unrounded, as PrestaShop
+        // reports it). Cart total 121.00 + 29.00 = 150.00 gross / 123.9669 net.
+        StubStore::$cartTotals[9101] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 23.9669,
+                Cart::BOTH => 123.9669,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9101', $cart, self::merchantUrls());
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        TinyAssert::count(1, $shippingLines);
+        $shipping = $shippingLines[0];
+        TinyAssert::same('29.00', (string)$shipping['gross_amount'], 'Shipping gross must come from the cart, not a Carrier');
+        TinyAssert::same('23.97', (string)$shipping['net_amount']);
+        TinyAssert::same('5.03', (string)$shipping['tax_amount']);
+        // Rate mirrored from the UNROUNDED cart totals: exactly 21%, not the
+        // 20.98% the 2dp pair would imply.
+        TinyAssert::same('0.21', (string)$shipping['tax_rate']);
+        TinyAssert::same('Shipping', (string)$shipping['name'], 'No carrier means the generic shipping label');
+
+        // The submitted order total matches the cart total - the mismatch of
+        // exactly the shipping cost is gone.
+        TinyAssert::same('150.00', (string)$payload['gross_amount']);
+        TinyAssert::same('123.97', (string)$payload['net_amount']);
+    }
+
+    /**
+     * (b) A genuinely incoherent cart (line items + shipping + tax do not add
+     * up to the cart's own order total) is still refused - and the refusal
+     * names the amounts instead of the old opaque one-liner.
+     */
+    private static function testIncoherentCartIsRejectedWithSpecificMessage(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9102, 9112);
+        $cart = new Cart(9102);
+        $cart->id_customer = 9102;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9112;
+        $cart->id_address_delivery = 9112;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9122);
+
+        // Cart claims a 150.00 gross total but reports NO shipping and no
+        // discount - 29.00 of it is attributable to nothing the cart exposes.
+        // Nothing can build a payload that reconciles with that.
+        StubStore::$cartTotals[9102] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 123.97,
+            ],
+        ];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoNewOrderData('merchant-attempt-9102', $cart, self::merchantUrls());
+            },
+            'Order totals do not reconcile with cart totals: cart total 150.00 vs order lines 121.00 (difference 29.00)'
+        );
+    }
+
+    /**
+     * (c) A carrier-less cart that genuinely has no shipping cost (free
+     * shipping) still builds - no phantom shipping line, totals still match.
+     */
+    private static function testFreeShippingCarrierlessCartStillBuilds(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9103, 9113);
+        $cart = new Cart(9103);
+        $cart->id_customer = 9103;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9113;
+        $cart->id_address_delivery = 9113;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9123);
+
+        StubStore::$cartTotals[9103] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 121.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 100.00,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9103', $cart, self::merchantUrls());
+
+        foreach ($payload['line_items'] as $line) {
+            TinyAssert::notSame('SHIPPING_FEE', (string)($line['type'] ?? ''), 'A zero-shipping cart must emit no shipping line');
+        }
+        TinyAssert::same('121.00', (string)$payload['gross_amount']);
+        TinyAssert::same('100.00', (string)$payload['net_amount']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,24 @@ namespace {
         public static array $cartTotals = [];
         public static array $cartShipping = [];
         public static array $cartRules = [];
+        /**
+         * Cart::getDeliveryOptionList() fixtures by cart id, core-shaped:
+         *   [id_address => [option_key => ['carrier_list' => [id_carrier => [
+         *       'price_with_tax' => float, 'price_without_tax' => float,
+         *       'instance' => Carrier,
+         *   ]]]]]
+         * The no-available-carrier sentinel is carrier_list = [0 => 0].
+         *
+         * @var array<int,array>
+         */
+        public static array $cartDeliveryOptionLists = [];
+        /**
+         * Cart::getDeliveryOption() overrides by cart id. Unset means the stub
+         * auto-selects the first option per address, like core does.
+         *
+         * @var array<int,array|false>
+         */
+        public static array $cartDeliveryOptions = [];
         public static array $moduleCurrencies = [];
         public static array $productCategories = [];
         public static array $images = [];
@@ -145,6 +163,8 @@ namespace {
             self::$cartTotals = [];
             self::$cartShipping = [];
             self::$cartRules = [];
+            self::$cartDeliveryOptionLists = [];
+            self::$cartDeliveryOptions = [];
             self::$orderCarriers = [];
             self::$carts = [];
             self::$tabIds = ['AdminTwopaymentInvoice' => 1];
@@ -1311,6 +1331,36 @@ namespace {
         public function getCartRules(): array
         {
             return StubStore::$cartRules[$this->id] ?? [];
+        }
+
+        public function getDeliveryOptionList($defaultCountry = null, $flush = false): array
+        {
+            return StubStore::$cartDeliveryOptionLists[$this->id] ?? [];
+        }
+
+        /**
+         * Core-faithful enough for the plugin's use: an explicit fixture wins,
+         * otherwise auto-select the first option for each address, which is
+         * what core falls back to when nothing is selected or the selection no
+         * longer validates.
+         *
+         * @return array<int,string>|false
+         */
+        public function getDeliveryOption($defaultCountry = null, $dontAutoSelectOptions = false, $useCache = true)
+        {
+            if (array_key_exists($this->id, StubStore::$cartDeliveryOptions)) {
+                return StubStore::$cartDeliveryOptions[$this->id];
+            }
+
+            $selected = [];
+            foreach (StubStore::$cartDeliveryOptionLists[$this->id] ?? [] as $idAddress => $options) {
+                $keys = array_keys((array) $options);
+                if ($keys !== []) {
+                    $selected[(int) $idAddress] = (string) $keys[0];
+                }
+            }
+
+            return $selected;
         }
 
         public function getAverageProductsTaxRate(): float

--- a/tests/run.php
+++ b/tests/run.php
@@ -5528,6 +5528,7 @@ require __DIR__ . '/MinimumOrderGateSpec.php';
 require __DIR__ . '/InvoiceUploadGateSpec.php';
 require __DIR__ . '/FxRatesSpec.php';
 require __DIR__ . '/TwoSoleTraderSpec.php';
+require __DIR__ . '/ShippingCostSourcingSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5546,6 +5547,7 @@ $tests = [
     'InvoiceUploadGateSpec::runAll' => [InvoiceUploadGateSpec::class, 'runAll'],
     'FxRatesSpec::runAll' => [FxRatesSpec::class, 'runAll'],
     'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
+    'ShippingCostSourcingSpec::runAll' => [ShippingCostSourcingSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -3227,7 +3227,16 @@ class Twopayment extends PaymentModule
                     ', Tolerance=' . $this->getTwoRoundAmount(self::ORDER_RECONCILIATION_TOLERANCE),
                     3
                 );
-                throw new Exception('Order totals do not reconcile with cart totals');
+                // Carry the numbers in the exception, not just the log: this
+                // message is what the buyer-facing decline path renders, and an
+                // opaque rejection here is what made TWO-25161 take two weeks
+                // of email to diagnose.
+                throw new Exception(
+                    'Order totals do not reconcile with cart totals: cart total ' .
+                    $this->getTwoRoundAmount(round((float)$cart->getOrderTotal(true, Cart::BOTH), 2)) .
+                    ' vs order lines ' . $this->getTwoRoundAmount($lineTotals['gross']) .
+                    ' (difference ' . $this->getTwoRoundAmount($max_reconciliation_diff_cents / 100) . ')'
+                );
             }
 
             PrestaShopLogger::addLog(
@@ -3605,7 +3614,13 @@ class Twopayment extends PaymentModule
             $exceptionMessage = (string)$e->getMessage();
             if (stripos($exceptionMessage, 'reconcile') !== false) {
                 $result['status'] = 'reconciliation_mismatch';
-                $result['message'] = $this->l('Unable to process your order with Two payment. Please review your cart and try again.');
+                // Specific, not generic: name the actual failure and quote the
+                // amounts, so a merchant-side cart/shipping misconfiguration is
+                // diagnosable from the checkout page instead of only from the
+                // shop log (TWO-25161).
+                $result['message'] = $this->l('Two could not accept this order because the cart total does not match the total of the order lines.')
+                    . ' ' . $exceptionMessage . '. '
+                    . $this->l('This is usually a shipping or discount amount the cart has not applied yet. Please refresh your cart and try again, or contact the store.');
             } else {
                 $result['status'] = 'payload_error';
             }
@@ -4302,46 +4317,54 @@ class Twopayment extends PaymentModule
             }
         }
 
-        // Add shipping as a line item if applicable
-        // BEST PRACTICE: Use getPackageShippingCost() to get actual carrier cost BEFORE free shipping rules
-        // This fixes the issue where getOrderTotal(ONLY_SHIPPING) returns 0 when free shipping cart rules are active
-        $shipping_cost_with_tax = 0;
-        $shipping_cost_without_tax = 0;
-        
-        if (Validate::isLoadedObject($carrier)) {
-            // Method 1: Get package shipping cost directly from carrier (ignores free shipping rules)
+        // SHIPPING AMOUNT SOURCING (TWO-25161): the CART is the authority, not
+        // the Carrier object. Cart::getOrderTotal(..., Cart::ONLY_SHIPPING) is
+        // the very figure PrestaShop folded into Cart::BOTH, so it is the only
+        // shipping amount that can reconcile with the cart total - and it
+        // resolves without a loadable Carrier. Merchants who price shipping
+        // through symbolic "logistics carriers" leave id_carrier = 0 on a cart
+        // that nonetheless carries a real shipping cost; keying the shipping
+        // line off `new Carrier($cart->id_carrier)` silently dropped that cost
+        // and the reconciliation gate then rejected the whole order.
+        //
+        // getPackageShippingCost() survives only as a fallback for the case it
+        // was originally added for: a shop where a free-shipping cart rule
+        // zeroes ONLY_SHIPPING while the same amount reappears as a shipping
+        // discount, so the payload needs the pre-discount carrier price to stay
+        // coherent. That fallback is inherently carrier-bound and stays gated
+        // on a loadable carrier.
+        $shipping_gross = round((float)$cart->getOrderTotal(true, Cart::ONLY_SHIPPING), 2);
+        $shipping_net = round((float)$cart->getOrderTotal(false, Cart::ONLY_SHIPPING), 2);
+
+        if ($shipping_gross <= 0 && Validate::isLoadedObject($carrier)) {
             // Parameters: id_carrier, use_tax, country, product_list, id_zone
-            $shipping_cost_with_tax = $cart->getPackageShippingCost((int)$cart->id_carrier, true, null, null, null);
-            $shipping_cost_without_tax = $cart->getPackageShippingCost((int)$cart->id_carrier, false, null, null, null);
-            
-            // Fallback: If getPackageShippingCost returns 0 or false, try getOrderTotal
-            // This handles edge cases where carrier pricing might be complex
-            if ($shipping_cost_with_tax <= 0) {
-                $shipping_cost_with_tax = (float)$cart->getOrderTotal(true, Cart::ONLY_SHIPPING);
-                $shipping_cost_without_tax = (float)$cart->getOrderTotal(false, Cart::ONLY_SHIPPING);
+            $package_gross = (float)$cart->getPackageShippingCost((int)$cart->id_carrier, true, null, null, null);
+            $package_net = (float)$cart->getPackageShippingCost((int)$cart->id_carrier, false, null, null, null);
+            if ($package_gross > 0) {
+                $shipping_gross = round($package_gross, 2);
+                $shipping_net = round($package_net, 2);
             }
         }
-        
-        if (Validate::isLoadedObject($carrier) && $shipping_cost_with_tax > 0) {
+
+        if ($shipping_gross > 0) {
             // Keep shipping monetary values canonical to PrestaShop totals.
-            $shipping_net = round((float)$shipping_cost_without_tax, 2);
-            $shipping_gross = round((float)$shipping_cost_with_tax, 2);
             $shipping_tax_amount = round($shipping_gross - $shipping_net, 2);
 
-            $shipping_name = $carrier->name ? $carrier->name : $this->l('Shipping');
+            $carrier_is_loaded = Validate::isLoadedObject($carrier);
+            $shipping_name = ($carrier_is_loaded && $carrier->name) ? $carrier->name : $this->l('Shipping');
             $shipping_delay = '';
-            if ($carrier->delay && is_array($carrier->delay)) {
-                $shipping_delay = isset($carrier->delay[$cart->id_lang]) ? 
-                    $carrier->delay[$cart->id_lang] : 
+            if ($carrier_is_loaded && $carrier->delay && is_array($carrier->delay)) {
+                $shipping_delay = isset($carrier->delay[$cart->id_lang]) ?
+                    $carrier->delay[$cart->id_lang] :
                     reset($carrier->delay);
-            } elseif ($carrier->delay) {
+            } elseif ($carrier_is_loaded && $carrier->delay) {
                 $shipping_delay = $carrier->delay;
             }
-            
+
             $shipping_description = $shipping_delay ? $shipping_delay : $this->l('Shipping cost for order');
-            if ($carrier->shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
+            if ($carrier_is_loaded && $carrier->shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
                 $shipping_description .= ' ' . sprintf($this->l('(by weight)'));
-            } elseif ($carrier->shipping_method == Carrier::SHIPPING_METHOD_PRICE) {
+            } elseif ($carrier_is_loaded && $carrier->shipping_method == Carrier::SHIPPING_METHOD_PRICE) {
                 $shipping_description .= ' ' . sprintf($this->l('(by price)'));
             }
 
@@ -4369,7 +4392,17 @@ class Twopayment extends PaymentModule
                 // DECLARED-RATE RELAY: the shipping rate is the carrier's own
                 // tax-rules group resolved at the cart's tax address — never
                 // derived from tax/net, never snapped.
-                $shipping_tax_rate_decimal = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
+                //
+                // With no resolvable carrier there is no tax-rules group to
+                // relay (PrestaShop has no shop-level shipping tax group), so
+                // the rate is taken from the shipping tax PrestaShop itself
+                // applied to this cart. That is still the merchant's own
+                // declaration - the amounts come from whatever priced the
+                // shipping - and the assertion below keeps the line internally
+                // consistent either way.
+                $shipping_tax_rate_decimal = $carrier_is_loaded
+                    ? $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart)
+                    : $this->getTwoCartShippingImpliedTaxRateDecimal($cart, $shipping_net, $shipping_tax_amount);
                 $this->assertTwoDeclaredRateReconcilesWithAmounts(
                     'shipping (' . $shipping_name . ')',
                     $shipping_net,
@@ -5691,6 +5724,58 @@ class Twopayment extends PaymentModule
         // RATE source uses the same PS_TAX_ADDRESS_TYPE address PrestaShop's
         // getPackageShippingCost() used for the shipping AMOUNTS.
         return $this->getTwoConfiguredTaxRateDecimalForGroup((int) $carrier->getIdTaxRulesGroup(), $cart);
+    }
+
+    /**
+     * Shipping tax rate for a cart with NO resolvable carrier (TWO-25161).
+     *
+     * PrestaShop attaches the shipping tax-rules group to the carrier row and
+     * nowhere else, so a cart whose shipping is priced outside the carrier
+     * table (symbolic "logistics carriers", id_carrier = 0) has no declared
+     * group to relay. What it does have is the shipping tax PrestaShop itself
+     * put in the cart totals, and that is the number the buyer is being
+     * charged. Mirroring it keeps the emitted line internally consistent and
+     * the payload reconciled with the cart; the caller still runs the
+     * declared-rate assertion, which fails loud on a contradictory pair (e.g.
+     * zero net carrying tax).
+     *
+     * This is deliberately narrow: it applies ONLY when no carrier could be
+     * loaded. A loaded carrier always relays its configured group, never a
+     * rate derived from amounts.
+     *
+     * The ratio is taken from the UNROUNDED cart totals: a shop charging a
+     * clean 21% on 29.00 gross reports 23.9669 net, which yields exactly 0.21,
+     * whereas the 2dp-rounded pair (23.97 / 5.03) would imply 20.98%.
+     *
+     * @param Cart $cart
+     * @param float $shipping_net Emitted 2dp shipping net
+     * @param float $shipping_tax Emitted 2dp shipping tax
+     * @return float Decimal rate normalised to 2dp-of-percent
+     */
+    private function getTwoCartShippingImpliedTaxRateDecimal($cart, $shipping_net, $shipping_tax)
+    {
+        $shipping_net = round((float) $shipping_net, 2);
+        $shipping_tax = round((float) $shipping_tax, 2);
+        if ($shipping_net <= 0 || $shipping_tax <= 0) {
+            return 0.0;
+        }
+
+        $raw_net = (float) $cart->getOrderTotal(false, Cart::ONLY_SHIPPING);
+        $raw_gross = (float) $cart->getOrderTotal(true, Cart::ONLY_SHIPPING);
+        $ratio = ($raw_net > 0 && $raw_gross > $raw_net)
+            ? (($raw_gross - $raw_net) / $raw_net)
+            : ($shipping_tax / $shipping_net);
+
+        $rate = $this->normalizeTwoTaxRateToPercentPrecision($ratio);
+        PrestaShopLogger::addLog(
+            'TwoPayment: Cart ' . (int) $cart->id . ' has no resolvable carrier (id_carrier=' .
+            (int) $cart->id_carrier . '); shipping tax rate mirrored from the cart\'s own shipping totals at ' .
+            round($rate * 100, 2) . '% (net=' . $this->getTwoRoundAmount($shipping_net) .
+            ', tax=' . $this->getTwoRoundAmount($shipping_tax) . ').',
+            2
+        );
+
+        return $rate;
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -4388,21 +4388,23 @@ class Twopayment extends PaymentModule
                 ) as $segment) {
                     $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
                 }
-            } else {
+            } elseif ($carrier_is_loaded) {
                 // DECLARED-RATE RELAY: the shipping rate is the carrier's own
                 // tax-rules group resolved at the cart's tax address — never
                 // derived from tax/net, never snapped.
-                //
-                // With no resolvable carrier there is no tax-rules group to
-                // relay (PrestaShop has no shop-level shipping tax group), so
-                // the rate is taken from the shipping tax PrestaShop itself
-                // applied to this cart. That is still the merchant's own
-                // declaration - the amounts come from whatever priced the
-                // shipping - and the assertion below keeps the line internally
-                // consistent either way.
-                $shipping_tax_rate_decimal = $carrier_is_loaded
-                    ? $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart)
-                    : $this->getTwoCartShippingImpliedTaxRateDecimal($cart, $shipping_net, $shipping_tax_amount);
+                $shipping_tax_rate_decimal = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
+                // Diagnostic (TWO-25161): which carrier and which tax-rules
+                // group actually supplied the rate. The carrier-list chain was
+                // verified against core sources, never executed against a real
+                // merchant's carrier table, so the resolved IDs are logged on
+                // every shipping line to confirm the case a live cart hits.
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Cart ' . (int) $cart->id . ' relayed the declared shipping tax rate from ' .
+                    'carrier ' . (int) $cart->id_carrier . ' (tax_rules_group=' .
+                    (int) $carrier->getIdTaxRulesGroup() . ', rate=' .
+                    round($shipping_tax_rate_decimal * 100, 2) . '%).',
+                    1
+                );
                 $this->assertTwoDeclaredRateReconcilesWithAmounts(
                     'shipping (' . $shipping_name . ')',
                     $shipping_net,
@@ -4415,6 +4417,46 @@ class Twopayment extends PaymentModule
                     'gross' => $shipping_gross,
                     'rate' => $shipping_tax_rate_decimal,
                 ]);
+            } else {
+                // No loadable `id_carrier`, but the carriers that priced the
+                // shipping are still enumerable from the cart's own delivery
+                // option, and each one declares a tax-rules group. Relay that.
+                // A rate computed from the shipping amounts is NOT an option:
+                // 2dp-rounded figures cannot tell a clean 21% from 20.98%, and
+                // the relayed rate is asserted against the amounts again at
+                // invoicing time.
+                $shipping_rate_classes = $this->resolveTwoCartShippingRateClasses($cart, $shipping_gross);
+
+                if (count($shipping_rate_classes) > 1) {
+                    // MIXED DECLARED RATES: the selected delivery option spans
+                    // carriers whose tax-rules groups resolve differently. Emit
+                    // one SHIPPING_FEE line per rate, weighted by the
+                    // per-carrier nets the cart already holds — never a blended
+                    // rate, never one carrier's rate applied to all of them.
+                    foreach ($this->splitTwoChargeAcrossRateClasses(
+                        $shipping_net,
+                        $shipping_tax_amount,
+                        $shipping_rate_classes,
+                        'shipping'
+                    ) as $segment) {
+                        $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
+                    }
+                } else {
+                    $shipping_rate_class = reset($shipping_rate_classes);
+                    $shipping_tax_rate_decimal = (float) $shipping_rate_class['rate'];
+                    $this->assertTwoDeclaredRateReconcilesWithAmounts(
+                        'shipping (' . $shipping_name . ')',
+                        $shipping_net,
+                        $shipping_tax_amount,
+                        $shipping_tax_rate_decimal
+                    );
+                    $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, [
+                        'net' => $shipping_net,
+                        'tax' => $shipping_tax_amount,
+                        'gross' => $shipping_gross,
+                        'rate' => $shipping_tax_rate_decimal,
+                    ]);
+                }
             }
         }
 
@@ -4557,6 +4599,34 @@ class Twopayment extends PaymentModule
                 3
             );
             throw new Exception('Cannot attribute ' . $label . ' tax under PS_ATCP_SHIPWRAP: no product rate classes');
+        }
+
+        return $this->splitTwoChargeAcrossRateClasses($charge_net, $charge_tax, $classes, $label);
+    }
+
+    /**
+     * Split a charge across an already-resolved set of canonical rate classes,
+     * reconciling the rounded sub-lines to the PrestaShop-authoritative totals
+     * cent-exactly (largest-remainder on net, bounded per-line nudge on tax).
+     * Fails loud when no rate-consistent distribution can hit the target.
+     *
+     * Shared by the PS_ATCP_SHIPWRAP product-rate-class split and the
+     * mixed-declared-rate shipping split (TWO-25161): both need one line per
+     * canonical rate whose amounts still sum to the cart's own totals.
+     *
+     * @param float $charge_net PrestaShop-authoritative net for the charge
+     * @param float $charge_tax PrestaShop-authoritative tax for the charge
+     * @param array<string,array{rate:float,net_weight:float}> $classes Keyed by formatted rate
+     * @param string $label For error messages ('shipping', 'gift wrapping')
+     * @return array<int,array{net:float,tax:float,gross:float,rate:float}>
+     * @throws Exception
+     */
+    private function splitTwoChargeAcrossRateClasses($charge_net, $charge_tax, $classes, $label)
+    {
+        $charge_net = round(max(0, (float) $charge_net), 2);
+        $charge_tax = round((float) $charge_tax, 2);
+        if (empty($classes) || ($charge_net <= 0 && $charge_tax <= 0)) {
+            return [];
         }
 
         $net_weights = [];
@@ -5727,55 +5797,155 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Shipping tax rate for a cart with NO resolvable carrier (TWO-25161).
+     * Declared shipping tax rate classes for a cart with no loadable
+     * `id_carrier` (TWO-25161).
      *
-     * PrestaShop attaches the shipping tax-rules group to the carrier row and
-     * nowhere else, so a cart whose shipping is priced outside the carrier
-     * table (symbolic "logistics carriers", id_carrier = 0) has no declared
-     * group to relay. What it does have is the shipping tax PrestaShop itself
-     * put in the cart totals, and that is the number the buyer is being
-     * charged. Mirroring it keeps the emitted line internally consistent and
-     * the payload reconciled with the cart; the caller still runs the
-     * declared-rate assertion, which fails loud on a contradictory pair (e.g.
-     * zero net carrying tax).
+     * PrestaShop keeps the shipping tax-rules group on the carrier row and
+     * nowhere else — there is no shop-level shipping tax group — but the
+     * carriers that priced the shipping stay enumerable from the cart even when
+     * `id_carrier` is 0. `Cart::getOrderTotal(*, ONLY_SHIPPING)` nulls a
+     * non-positive `id_carrier` and routes to `Cart::getTotalShippingCost()`,
+     * which sums the delivery-option entry selected by
+     * `Cart::getDeliveryOption()` out of `Cart::getDeliveryOptionList()`. Each
+     * entry's `carrier_list` is keyed by REAL carrier IDs and carries a loaded
+     * `Carrier` under 'instance', whose declared tax-rules group is the very
+     * group core taxed the shipping with (`$carrier->getTaxesRate($address)`).
+     * So the rate relayed here is the merchant's own declaration, resolved
+     * through the shared group resolver, and is never computed from amounts.
      *
-     * This is deliberately narrow: it applies ONLY when no carrier could be
-     * loaded. A loaded carrier always relays its configured group, never a
-     * rate derived from amounts.
-     *
-     * The ratio is taken from the UNROUNDED cart totals: a shop charging a
-     * clean 21% on 29.00 gross reports 23.9669 net, which yields exactly 0.21,
-     * whereas the 2dp-rounded pair (23.97 / 5.03) would imply 20.98%.
+     * Deriving the rate from tax/net was rejected on rounding grounds: at 2dp a
+     * clean 21% and 20.98% are indistinguishable, and checkout-api asserts the
+     * relayed rate against the amounts again during invoice validation, so a
+     * derived rate surfaces later as a bad invoice rather than a loud failure
+     * here.
      *
      * @param Cart $cart
-     * @param float $shipping_net Emitted 2dp shipping net
-     * @param float $shipping_tax Emitted 2dp shipping tax
-     * @return float Decimal rate normalised to 2dp-of-percent
+     * @param float $shipping_gross Authoritative 2dp shipping gross, for the failure message
+     * @return array<string,array{rate:float,net_weight:float}> Keyed by formatted rate
+     * @throws Exception When no carrier with a declared tax-rules group can be resolved
      */
-    private function getTwoCartShippingImpliedTaxRateDecimal($cart, $shipping_net, $shipping_tax)
+    private function resolveTwoCartShippingRateClasses($cart, $shipping_gross)
     {
-        $shipping_net = round((float) $shipping_net, 2);
-        $shipping_tax = round((float) $shipping_tax, 2);
-        if ($shipping_net <= 0 || $shipping_tax <= 0) {
-            return 0.0;
+        $selected_options = $cart->getDeliveryOption(null, false, false);
+        $option_list = $cart->getDeliveryOptionList();
+
+        $classes = [];
+        $diagnostics = [];
+
+        if (is_array($selected_options) && is_array($option_list)) {
+            foreach ($selected_options as $id_address => $option_key) {
+                if (
+                    !isset($option_list[$id_address][$option_key]['carrier_list'])
+                    || !is_array($option_list[$id_address][$option_key]['carrier_list'])
+                ) {
+                    continue;
+                }
+
+                foreach ($option_list[$id_address][$option_key]['carrier_list'] as $id_carrier => $data) {
+                    $id_carrier = (int) $id_carrier;
+                    $instance = (is_array($data) && isset($data['instance'])) ? $data['instance'] : null;
+                    if (
+                        $id_carrier <= 0
+                        || !is_object($instance)
+                        || !Validate::isLoadedObject($instance)
+                        || !method_exists($instance, 'getIdTaxRulesGroup')
+                    ) {
+                        // PrestaShop's no-available-carrier sentinel: when a
+                        // product has no carrier that can deliver it,
+                        // Cart::getPackageList() sets carrier_list = [0 => 0],
+                        // so there is no carrier row and no declared tax-rules
+                        // group — while getPackageShippingCost() can still
+                        // return a non-zero price from its own internal
+                        // PS_CARRIER_DEFAULT / cheapest-in-range fallback.
+                        // Inferring a rate from that price is exactly what must
+                        // not happen, and silently sending 0% would misreport
+                        // the merchant's VAT. Refuse the order instead.
+                        throw $this->buildTwoShippingRateUnresolvableException(
+                            $cart,
+                            $shipping_gross,
+                            (int) $id_address,
+                            (string) $option_key,
+                            $id_carrier
+                        );
+                    }
+
+                    $group_id = (int) $instance->getIdTaxRulesGroup();
+                    $rate = $this->getTwoConfiguredTaxRateDecimalForGroup($group_id, $cart);
+                    $rate_key = $this->formatTwoTaxRate($rate);
+                    if (!isset($classes[$rate_key])) {
+                        $classes[$rate_key] = ['rate' => $rate, 'net_weight' => 0.0];
+                    }
+                    // Per-carrier nets are already in carrier_list and sum to
+                    // the option's own total_price_without_tax, so they are the
+                    // correct weights for splitting a mixed-rate option.
+                    $classes[$rate_key]['net_weight'] += isset($data['price_without_tax'])
+                        ? max(0.0, round((float) $data['price_without_tax'], 2))
+                        : 0.0;
+                    $diagnostics[] = 'carrier=' . $id_carrier . ' tax_rules_group=' . $group_id .
+                        ' rate=' . round($rate * 100, 2) . '%';
+                }
+            }
         }
 
-        $raw_net = (float) $cart->getOrderTotal(false, Cart::ONLY_SHIPPING);
-        $raw_gross = (float) $cart->getOrderTotal(true, Cart::ONLY_SHIPPING);
-        $ratio = ($raw_net > 0 && $raw_gross > $raw_net)
-            ? (($raw_gross - $raw_net) / $raw_net)
-            : ($shipping_tax / $shipping_net);
+        if (empty($classes)) {
+            throw $this->buildTwoShippingRateUnresolvableException($cart, $shipping_gross, 0, '', 0);
+        }
 
-        $rate = $this->normalizeTwoTaxRateToPercentPrecision($ratio);
+        // Diagnostic (TWO-25161): this chain was verified against PrestaShop
+        // core sources, never executed against a real merchant's carrier table.
+        // Logging the resolved carrier and tax-rules-group IDs is how the case
+        // a live cart actually hits gets confirmed in the field.
         PrestaShopLogger::addLog(
-            'TwoPayment: Cart ' . (int) $cart->id . ' has no resolvable carrier (id_carrier=' .
-            (int) $cart->id_carrier . '); shipping tax rate mirrored from the cart\'s own shipping totals at ' .
-            round($rate * 100, 2) . '% (net=' . $this->getTwoRoundAmount($shipping_net) .
-            ', tax=' . $this->getTwoRoundAmount($shipping_tax) . ').',
-            2
+            'TwoPayment: Cart ' . (int) $cart->id . ' (id_carrier=' . (int) $cart->id_carrier .
+            ') resolved ' . count($classes) . ' declared shipping tax rate(s) from its delivery-option ' .
+            'carrier list: ' . implode('; ', $diagnostics) . '.',
+            1
         );
 
-        return $rate;
+        return $classes;
+    }
+
+    /**
+     * Build the loud rejection for a cart whose shipping cost has no declared
+     * tax rate behind it (TWO-25161).
+     *
+     * Returned rather than thrown so the call sites read as `throw $this->...`
+     * and static analysis keeps seeing them as terminal.
+     *
+     * @param Cart $cart
+     * @param float $shipping_gross
+     * @param int $id_address Delivery address whose option failed, 0 if none resolved
+     * @param string $option_key Selected delivery-option key ('0,' for the sentinel)
+     * @param int $id_carrier Offending carrier id (0 for the sentinel)
+     * @return Exception
+     */
+    private function buildTwoShippingRateUnresolvableException(
+        $cart,
+        $shipping_gross,
+        $id_address,
+        $option_key,
+        $id_carrier
+    ) {
+        $detail = 'cart ' . (int) $cart->id . ', id_carrier=' . (int) $cart->id_carrier .
+            ', shipping=' . $this->getTwoRoundAmount($shipping_gross) .
+            ', delivery address=' . (int) $id_address .
+            ', delivery option key=' . ($option_key === '' ? '(none)' : $option_key) .
+            ', carrier in list=' . (int) $id_carrier;
+
+        PrestaShopLogger::addLog(
+            'TwoPayment: No deliverable carrier for the cart shipping cost, so no declared shipping ' .
+            'tax rate exists to relay (' . $detail . '). PrestaShop reports no available carrier for at ' .
+            'least one product (carrier_list = [0 => 0]) while still pricing the shipping through its ' .
+            'internal default-carrier fallback. Configure a carrier that covers this delivery address ' .
+            'and the cart contents.',
+            3
+        );
+
+        return new Exception(
+            'No deliverable carrier for the cart shipping cost: PrestaShop reports no available carrier ' .
+            '(carrier_list = [0 => 0]) for this cart, so there is no declared shipping tax-rules group ' .
+            'to relay (' . $detail . ')'
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

The `SHIPPING_FEE` payload line was built only when `new Carrier($cart->id_carrier)` produced a loaded object, and the shipping amount itself came from `Cart::getPackageShippingCost($cart->id_carrier, ...)`. Both depend on the cart pointing at a real row in the carrier table.

A merchant who prices shipping through symbolic "logistics carriers" — several such carriers whose prices sum to the real shipping cost — leaves `id_carrier = 0` on a cart that nonetheless carries a genuine shipping charge. In that case the plugin lost the shipping amount entirely: the payload was short by exactly the shipping cost, the cart-vs-lines reconciliation gate correctly refused to submit it, and the buyer saw only "Your order could not be processed with Two. Please check your cart and try again." A cart qualifying for free shipping went through fine — there was no shipping cost to lose, which is what pinned the diagnosis down.

## Why this is not "allow `id_carrier = 0`"

For every other merchant `id_carrier = 0` means *no shipping method selected*, and that cart genuinely is not ready to submit. Rejecting it is correct and must stay correct. What was wrong was the *dependency*: the plugin asked a Carrier object for something the cart already knows.

So the amount now comes from the cart:

```php
$cart->getOrderTotal(true, Cart::ONLY_SHIPPING);
$cart->getOrderTotal(false, Cart::ONLY_SHIPPING);
```

This is the very figure PrestaShop folded into `Cart::BOTH`, so it is the only shipping amount that *can* reconcile with the cart total, and it resolves with or without taxes and with or without a loadable carrier.

The readiness protection is unchanged and is not keyed on `id_carrier` at all: `validateTwoOrderReconciliationAgainstCart()` already requires the cart's totals to be internally coherent (line items + shipping + tax == the cart's own order total). That is the check that stops a half-built cart from being submitted, and it does not care how shipping was configured. **No new merchant toggle** — a coherent cart is a coherent cart.

## The shipping tax rate: declared, never derived

**An earlier revision of this branch inferred the rate from the shipping tax and net amounts when no carrier was loadable. That approach was reviewed and rejected on rounding-risk grounds, and it is gone.** At two decimal places a clean 21% is indistinguishable from 20.98% — 23.97 net carrying 5.03 tax implies 20.98% — and a wrong rate is not absorbed silently downstream: `LineItemRequestSchema.tax_rate` is required with no default, so it cannot be omitted, and invoice validation asserts the rate against the amounts again later. A derived rate therefore surfaces as a bad invoice and bad VAT reporting rather than as a loud failure at checkout. `getTwoCartShippingImpliedTaxRateDecimal()` and its only caller are deleted; no rate is computed from amounts anywhere on this path.

A **declared** rate is reachable, and the premise that a cart without `id_carrier` has no carrier behind its shipping cost turns out to be false:

- `Cart::getOrderTotal(*, ONLY_SHIPPING)` nulls a non-positive `id_carrier` and routes to `Cart::getTotalShippingCost()`.
- That sums the delivery-option entry selected by `Cart::getDeliveryOption()` out of `Cart::getDeliveryOptionList()`.
- Each entry's `carrier_list` is keyed by **real carrier IDs** and carries a loaded `Carrier` under `'instance'`.
- Core's own shipping tax is that carrier's declared tax-rules group: `$carrier->getTaxesRate($address)` → `TaxManagerFactory::getManager($address, $carrier->getIdTaxRulesGroup())`.

So the carriers that priced the shipping stay enumerable from the cart, and the plugin's existing `getTwoConfiguredTaxRateDecimalForGroup()` turns them into declared rates with no new tax machinery. There is no shop-level shipping tax group in PrestaShop (`grep SHIPPING_TAX` over core: zero hits), so the carrier list is the only authoritative source. Verified against core extracted from 1.7.6.5, 8 and 9 — identical behaviour on every point.

### Mixed rates split, they do not blend

When the selected delivery option spans carriers whose tax-rules groups resolve differently, one `SHIPPING_FEE` line is emitted **per rate**, weighted by the per-carrier nets already in `carrier_list` (which sum to the option's own `total_price_without_tax`). No blended rate, and no single carrier's rate applied to the rest.

This reuses the cent-exact reconciliation the `PS_ATCP_SHIPWRAP` split already had: its allocation and bounded-nudge tail is extracted into `splitTwoChargeAcrossRateClasses()`, now shared by both callers. The per-rate amounts sum to PrestaShop's authoritative shipping total, or the split fails loud.

### The one genuine hole fails loud

A product with no available carrier makes `Cart::getPackageList()` set `carrier_list = [0 => 0]`, so `new Carrier(0)` is unloadable and no tax-rules group exists — while `getPackageShippingCost()` can still price the shipping through its internal `PS_CARRIER_DEFAULT` / cheapest-in-range fallback. Reimplementing that private fallback is not on the table, deriving a rate is what this PR removes, and silently sending 0% would misreport the merchant's VAT. **The order is refused**, with a message naming the condition and quoting the cart, `id_carrier`, shipping amount and resolved delivery-option key.

### Diagnostic logging

The resolved carrier ID(s) and tax-rules-group ID(s) are logged on both shipping paths. The chain above is verified against core sources but has **never been executed against a real merchant's carrier table**, so this log is how the case a live cart actually hits gets confirmed in the field.

## What changed

- **Shipping amount**: sourced from `Cart::ONLY_SHIPPING`. `getPackageShippingCost()` survives strictly as a fallback for the case it was originally added for — a shop where a free-shipping cart rule zeroes `ONLY_SHIPPING` while the same amount reappears as a shipping discount, so the payload needs the pre-discount carrier price to stay coherent. That fallback is inherently carrier-bound and remains gated on a loadable carrier.
- **Shipping rate**: relayed from the declared tax-rules group of the carrier(s) in the cart's selected delivery option, split per rate when they differ, refused when none is loadable. A loadable `id_carrier` still relays that carrier's group as before.
- **Carrier is now cosmetic for presentation**: when loadable it still supplies the line name, the delay text and the by-weight/by-price suffix. With no carrier the line uses the generic "Shipping" label.
- **Rejections now say what failed.** The reconciliation exception carries the cart total, the order-lines total and the difference; `controllers/front/payment.php` surfaces that detail instead of the generic "please review your cart"; and the order-intent decline message names the actual failure. These strings are plugin-generated diagnostics about the cart's own amounts — no credentials, no provider internals. The opacity of the old message is a large part of why this issue took two weeks of email round-trips to identify.

## Tests

`tests/ShippingCostSourcingSpec.php`:

1. `id_carrier = 0` with a non-zero shipping total — the shipping line survives, the submitted order total matches the cart total, and the rate is the **declared** 21% from the carrier's tax-rules group. The 2dp amounts on that line imply 20.98%, so a derivation would relay the wrong rate here.
2. A genuinely incoherent cart — still rejected, and rejected with the specific message quoting both totals and the difference.
3. A carrier-less free-shipping cart — still builds, with no phantom shipping line.
4. `carrier_list = [0 => 0]` with a non-zero shipping cost — refused with the specific unresolvable-carrier message, and the cart/`id_carrier`/amount logged.
5. A mixed-rate delivery option — two shipping lines at 21% and 10%, with per-rate amounts summing to the cart's shipping total, and both carriers and groups logged.

Tests 1, 4 and 5 were each verified to **fail against the previous head** of this branch — missing diagnostic log, no exception thrown, and one blended line instead of two, respectively. The `Cart` test stub gains core-shaped `getDeliveryOption()` / `getDeliveryOptionList()` fixtures.

Full suite (`php tests/run.php`) and `phpstan` (reproduced with the same pinned PrestaShop 1.7.6.0 core clone CI uses, `[OK] No errors`) are both green locally.

## Credit

Root cause identified by **Javier Moreno at Webimpacto**, who traced the failure to the `Carrier` object being unconstructable from `id_carrier = 0` and proposed `getOrderTotal(true, Cart::ONLY_SHIPPING)` as the carrier-independent source. Also his report that the checkout loader spins with no information even in debug mode — which is why the loud-rejection changes ride along with this fix rather than waiting.

## Follow-ups (not in this PR)

- Frontend order-intent (`controllers/front/orderintent.php`) error surfacing — the spinning-loader half of the opacity problem, tracked separately.
- Parity audit: whether WooCommerce and Magento have the same brittleness, i.e. depend on a resolvable shipping-method object to learn the shipping amount. Tracked on the parity epic.

Linear: TWO-25161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
