### PR TITLE
TWO-24768/fix: surface checkout failures to AJAX checkout front-ends

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
           php -l tests/DefaultPaymentTermSpec.php
           php -l tests/MinimumOrderGateSpec.php
           php -l tests/FxRatesSpec.php
+          php -l tests/AjaxCheckoutFailureSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Checkout failures now reach AJAX checkout front-ends instead of vanishing** (TWO-24768)
+  - The payment controller's only failure signal was a 302 back to the order page with the message flashed into the session. A checkout that posts the payment form over XHR rather than navigating (PrestaShop's own checkout module does) follows that redirect, receives the order page HTML with HTTP 200, cannot distinguish it from success, and leaves the buyer on a checkout that never moves
+  - AJAX callers (identified by `X-Requested-With: XMLHttpRequest`, or an `Accept` that asks for JSON and does not accept HTML) now receive `HTTP 400` with a JSON body carrying `error`, `message` and `redirect_url`. Ordinary browser form posts keep the existing redirect-with-notification behaviour unchanged
+  - Every failure exit in the payment controller now goes through the single `failCheckout()` boundary. Five of them - including the provider-rejection path that produced the reported silent hang - previously redirected inline and so bypassed it entirely
+  - Failures that deliberately carry no buyer-facing text (internal errors logged for the merchant) now emit a generic message to AJAX callers rather than an empty string, so the caller always has something to render
+
 ### Changed
 - **Invoice upload is now gated on the merchant record, not an admin toggle** (TWO-25111, per decision TWO-25106 Option A)
   - The plugin-side invoice upload (own-invoice merchants) now triggers only when the `invoice_distributed_by_merchant` flag on the Two merchant record (`GET /v1/merchant`) is true - the same signal checkout-api itself enforces (TWO-24761), and the same gating model Magento (TWO-24758) and WooCommerce (TWO-24757) use

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -248,8 +248,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                 }
             }
 
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+            $this->failCheckout($message);
+            return;
         }
 
         if (isset($response['id']) && $response['id']) {
@@ -311,8 +311,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                     // Best effort cleanup when local attempt persistence fails.
                     $this->module->cancelTwoOrderBestEffort((string)$response['id'], 'attempt_persist_failed');
                 }
-                $this->errors[] = $this->module->l('Temporary checkout issue. Please try again.');
-                $this->redirectWithNotifications('index.php?controller=order');
+                $this->failCheckout($this->module->l('Temporary checkout issue. Please try again.'));
+                return;
             }
 
             // Fraud Verification Skip (Must be enabled by Two on request)
@@ -365,9 +365,10 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                     );
                     
                     // Generic error message - don't expose fraud verification skip details to customer
-                    $message = $this->module->l('Unable to process your payment at this time. Please contact the store owner for assistance.');
-                    $this->errors[] = $message;
-                    $this->redirectWithNotifications('index.php?controller=order');
+                    $this->failCheckout(
+                        $this->module->l('Unable to process your payment at this time. Please contact the store owner for assistance.')
+                    );
+                    return;
                 }
             } else {
                 // Standard flow - redirect to Two's payment_url for verification
@@ -391,8 +392,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                             $cancelled ? 2 : 3
                         );
                     }
-                    $this->errors[] = $this->module->l('Unable to redirect to payment provider. Please try again.');
-                    $this->redirectWithNotifications('index.php?controller=order');
+                    $this->failCheckout($this->module->l('Unable to redirect to payment provider. Please try again.'));
+                    return;
                 }
 
                 Tools::redirect($response['payment_url']);
@@ -402,14 +403,25 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                 'TwoPayment: Two API created response without id for cart ' . $cart->id . ', attempt ' . $attempt_token,
                 3
             );
-            $message = $this->module->l('Something went wrong please contact store owner.');
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+            $this->failCheckout($this->module->l('Something went wrong please contact store owner.'));
+            return;
         }
     }
 
     /**
-     * Redirect checkout flow back to order page with optional user-facing error.
+     * Report a checkout failure to whoever submitted the payment form.
+     *
+     * A browser navigation gets what it has always got: a 302 back to the
+     * order page with the message flashed into the session notifications.
+     *
+     * An AJAX caller cannot use that. It follows the 302 transparently,
+     * receives the order page's HTML with HTTP 200, has no way to tell that
+     * from a success, and leaves the buyer staring at a checkout that never
+     * moves - the message is rendered into a page nobody ever displays.
+     * Checkout front-ends that post the payment form over XHR instead of
+     * navigating (PrestaShop's own checkout module among them) hit exactly
+     * this. For those callers, answer with a machine-readable JSON error and
+     * a non-2xx status so the failure is impossible to mistake for success.
      *
      * @param string $message
      * @param string $logMessage
@@ -421,12 +433,93 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
         if (!Tools::isEmpty($logMessage)) {
             PrestaShopLogger::addLog($logMessage, (int)$severity);
         }
-        if (!Tools::isEmpty($message)) {
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+
+        $redirectUrl = 'index.php?controller=order';
+
+        if (self::isTwoAjaxCheckoutRequest($_SERVER)) {
+            $this->emitTwoCheckoutJsonFailure(self::buildTwoCheckoutFailurePayload(
+                $message,
+                // Several internal failures deliberately carry no buyer-facing
+                // text (the detail belongs in the log, not on the storefront).
+                // An AJAX caller still needs something to render, or the fix
+                // reproduces the silent hang one layer up.
+                $this->module->l('Unable to process your order with Two payment. Please choose another payment method or contact the store.'),
+                $redirectUrl
+            ));
             return;
         }
-        Tools::redirect('index.php?controller=order');
+
+        if (!Tools::isEmpty($message)) {
+            $this->errors[] = $message;
+            $this->redirectWithNotifications($redirectUrl);
+            return;
+        }
+        Tools::redirect($redirectUrl);
+    }
+
+    /**
+     * Whether the payment form was submitted by an AJAX caller rather than by
+     * a top-level browser navigation.
+     *
+     * XMLHttpRequest-based checkouts (jQuery, and PrestaShop's own checkout
+     * JS) announce themselves with X-Requested-With. fetch() callers do not,
+     * so also treat a request that asks for JSON and does not accept HTML as
+     * AJAX - a page navigation always accepts HTML.
+     *
+     * @param array $server Request server variables ($_SERVER shape).
+     * @return bool
+     */
+    public static function isTwoAjaxCheckoutRequest(array $server)
+    {
+        $requestedWith = isset($server['HTTP_X_REQUESTED_WITH'])
+            ? strtolower(trim((string)$server['HTTP_X_REQUESTED_WITH']))
+            : '';
+        if ($requestedWith === 'xmlhttprequest') {
+            return true;
+        }
+
+        $accept = isset($server['HTTP_ACCEPT']) ? strtolower((string)$server['HTTP_ACCEPT']) : '';
+        return strpos($accept, 'application/json') !== false
+            && strpos($accept, 'text/html') === false;
+    }
+
+    /**
+     * Build the JSON body handed to an AJAX caller when checkout fails.
+     *
+     * @param string $message Buyer-facing message, may be empty.
+     * @param string $fallbackMessage Used when $message carries no text.
+     * @param string $redirectUrl Where a caller that prefers to navigate should go.
+     * @return array
+     */
+    public static function buildTwoCheckoutFailurePayload($message, $fallbackMessage, $redirectUrl)
+    {
+        $text = trim((string)$message);
+        if ($text === '') {
+            $text = trim((string)$fallbackMessage);
+        }
+
+        return array(
+            'error' => true,
+            'message' => $text,
+            'redirect_url' => (string)$redirectUrl,
+        );
+    }
+
+    /**
+     * Write the JSON failure body and stop. Isolated so tests can observe the
+     * payload without the process-terminating side effects.
+     *
+     * @param array $payload
+     * @return void
+     */
+    protected function emitTwoCheckoutJsonFailure(array $payload)
+    {
+        if (!headers_sent()) {
+            header('Content-Type: application/json');
+            http_response_code(Twopayment::HTTP_STATUS_BAD_REQUEST);
+        }
+        echo json_encode($payload);
+        exit;
     }
 
 }

--- a/tests/AjaxCheckoutFailureSpec.php
+++ b/tests/AjaxCheckoutFailureSpec.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../controllers/front/payment.php';
+
+/**
+ * TWO-24768: a checkout failure must reach whoever submitted the payment form.
+ *
+ * The payment controller's only failure signal used to be a 302 back to the
+ * order page with the message flashed into the session. A checkout front-end
+ * that posts the payment form over XHR instead of navigating - PrestaShop's
+ * own checkout module does - follows that redirect transparently, gets the
+ * order page's HTML with HTTP 200, and has nothing it can recognise as a
+ * failure. The buyer sees a checkout that never moves.
+ *
+ * These specs drive the real controller over the stub core, with the provider
+ * call canned, and assert on the response the caller actually receives.
+ */
+final class AjaxCheckoutFailureSpec
+{
+    private const CART_ID = 9601;
+    private const CUSTOMER_ID = 9001;
+    private const ADDRESS_ID = 9201;
+
+    public static function runAll(): void
+    {
+        self::testXmlHttpRequestHeaderIsDetectedAsAjax();
+        self::testJsonOnlyAcceptHeaderIsDetectedAsAjax();
+        self::testBrowserNavigationIsNotDetectedAsAjax();
+        self::testFailurePayloadFallsBackWhenMessageIsEmpty();
+        self::testProviderRejectionReachesAjaxCallerAsJsonError();
+        self::testProviderRejectionStillRedirectsBrowserNavigation();
+    }
+
+    /* ---- request-shape detection ---- */
+
+    private static function testXmlHttpRequestHeaderIsDetectedAsAjax(): void
+    {
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest', 'HTTP_ACCEPT' => '*/*']
+        ), 'XMLHttpRequest header must be treated as an AJAX submit');
+
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_X_REQUESTED_WITH' => ' xmlhttprequest ']
+        ), 'header comparison must be case- and whitespace-insensitive');
+    }
+
+    private static function testJsonOnlyAcceptHeaderIsDetectedAsAjax(): void
+    {
+        // fetch() callers send no X-Requested-With at all.
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'application/json, text/plain, */*']
+        ), 'a JSON-only Accept cannot be a page navigation');
+    }
+
+    private static function testBrowserNavigationIsNotDetectedAsAjax(): void
+    {
+        TinyAssert::false(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8']
+        ), 'an ordinary form post must keep the redirect behaviour');
+
+        TinyAssert::false(
+            TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest([]),
+            'a request with no headers at all must not be guessed as AJAX'
+        );
+
+        // Some front-ends ask for JSON *and* accept HTML; that is still a
+        // navigation, so the redirect must stay.
+        TinyAssert::false(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'text/html,application/json']
+        ), 'accepting HTML means the caller can render the order page');
+    }
+
+    private static function testFailurePayloadFallsBackWhenMessageIsEmpty(): void
+    {
+        // Internal failures deliberately carry no buyer-facing text. Emitting
+        // an empty message would reproduce the silent hang in the caller's UI.
+        $payload = TwopaymentPaymentModuleFrontController::buildTwoCheckoutFailurePayload(
+            '   ',
+            'Generic failure text.',
+            'index.php?controller=order'
+        );
+        TinyAssert::true($payload['error'], 'payload must be flagged as an error');
+        TinyAssert::same('Generic failure text.', $payload['message']);
+        TinyAssert::same('index.php?controller=order', $payload['redirect_url']);
+
+        $specific = TwopaymentPaymentModuleFrontController::buildTwoCheckoutFailurePayload(
+            'Payment method configuration error.',
+            'Generic failure text.',
+            'index.php?controller=order'
+        );
+        TinyAssert::same('Payment method configuration error.', $specific['message']);
+    }
+
+    /* ---- end-to-end through postProcess ---- */
+
+    /**
+     * Provider rejects order creation (the shape seen in the wild: a store
+     * with no usable API key, so /v1/order answers 401). This path never went
+     * through failCheckout at all - it redirected inline - so it is the one
+     * that actually stranded buyers.
+     */
+    private static function testProviderRejectionReachesAjaxCallerAsJsonError(): void
+    {
+        $controller = self::makeController();
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        try {
+            self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
+
+        TinyAssert::count(1, $controller->emitted);
+        $payload = $controller->emitted[0];
+        TinyAssert::true($payload['error'], 'AJAX caller must receive an explicit error flag');
+        TinyAssert::same(
+            'Payment method configuration error. Please contact the store.',
+            $payload['message'],
+            'the 401 message must survive to the caller instead of being flashed into a session nobody reads'
+        );
+        TinyAssert::same('index.php?controller=order', $payload['redirect_url']);
+        TinyAssert::count(0, $controller->errors);
+    }
+
+    private static function testProviderRejectionStillRedirectsBrowserNavigation(): void
+    {
+        $controller = self::makeController();
+        $_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml';
+
+        try {
+            $redirect = self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_ACCEPT']);
+        }
+
+        TinyAssert::count(0, $controller->emitted, 'a navigation must not be answered with JSON');
+        TinyAssert::true(
+            $redirect !== null && strpos($redirect->getMessage(), 'controller=order') !== false,
+            'browser navigation must still be redirected back to checkout'
+        );
+        TinyAssert::count(1, $controller->errors);
+        TinyAssert::same(
+            'Payment method configuration error. Please contact the store.',
+            $controller->errors[0]
+        );
+    }
+
+    /* ---- fixtures ---- */
+
+    private static function runPostProcess($controller): ?StubRedirect
+    {
+        try {
+            $controller->postProcess();
+        } catch (StubRedirect $redirect) {
+            return $redirect;
+        } catch (StubJsonFailureEmitted $emitted) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static function makeController()
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+        Tools::resetTestValues();
+        Tools::setTestValue('token', Tools::getToken(false));
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[33] = 'FR';
+        StubStore::$addresses[self::ADDRESS_ID] = [
+            'id_country' => 33,
+            'company' => 'Acme FR SAS',
+            'companyid' => 'FR123456789',
+            'address1' => '10 Rue de Paris',
+            'city' => 'Paris',
+            'postcode' => '75001',
+            'phone' => '+33100000000',
+            'loaded' => true,
+        ];
+        StubStore::$customers[self::CUSTOMER_ID] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Eva',
+            'lastname' => 'Martin',
+            'secure_key' => 'secure-key-9001',
+            'loaded' => true,
+        ];
+        StubStore::$carts[self::CART_ID] = [
+            'id_customer' => self::CUSTOMER_ID,
+            'id_currency' => 978,
+            'id_address_invoice' => self::ADDRESS_ID,
+            'id_address_delivery' => self::ADDRESS_ID,
+            'id_carrier' => 0,
+            'id_lang' => 1,
+        ];
+
+        $context = Context::getContext();
+        $context->cart = new Cart(self::CART_ID);
+        $context->cookie->two_order_intent_approved = '1';
+
+        $controller = new class extends TwopaymentPaymentModuleFrontController {
+            /** @var array<int,array> */
+            public array $emitted = [];
+
+            protected function emitTwoCheckoutJsonFailure(array $payload)
+            {
+                $this->emitted[] = $payload;
+                // Stands in for the production `exit` without killing the
+                // test process.
+                throw new StubJsonFailureEmitted('json failure emitted');
+            }
+        };
+        $controller->module = self::makeModule();
+
+        return $controller;
+    }
+
+    /**
+     * Module double: everything the controller needs up to the provider call
+     * is canned, and /v1/order answers 401 (no usable API key).
+     */
+    private static function makeModule(): Twopayment
+    {
+        return new class extends TwopaymentTestHarness {
+            public function isCartCurrencySupportedByTwo($cart)
+            {
+                return true;
+            }
+
+            public function getTwoCheckoutCompanyData($address)
+            {
+                return ['company_name' => 'Acme FR SAS', 'organization_number' => 'FR123456789'];
+            }
+
+            public function maybeCleanupStaleTwoCheckoutAttempts($force = false)
+            {
+                return 0;
+            }
+
+            public function checkTwoOrderIntentApprovalAtPayment($cart, $customer, $currency, $address)
+            {
+                return ['approved' => true, 'status' => 'APPROVED', 'http_status' => 200, 'message' => ''];
+            }
+
+            public function generateTwoCheckoutAttemptToken($id_cart, $id_customer)
+            {
+                return 'attempt-ajax-1';
+            }
+
+            public function buildTwoMerchantOrderId($attempt_token, $id_cart)
+            {
+                return 'merchant-ajax-1';
+            }
+
+            public function getTwoNewOrderData($merchant_order_id, $cart, $merchant_urls = null, $syncSurchargeCartLine = true)
+            {
+                return ['gross_amount' => '100.00'];
+            }
+
+            public function calculateTwoCheckoutSnapshotHash($cart, $paymentdata)
+            {
+                return 'snapshot-hash';
+            }
+
+            public function buildTwoOrderCreateIdempotencyKey($cart, $snapshot_hash)
+            {
+                return 'idempotency-key';
+            }
+
+            public function buildTwoApiResponseLogSummary($response)
+            {
+                return ['http_status' => isset($response['http_status']) ? (int) $response['http_status'] : 0];
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 401];
+            }
+        };
+    }
+}
+
+class StubJsonFailureEmitted extends Exception
+{
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -256,6 +256,12 @@ namespace {
         {
             return (string) $name === 'twopayment';
         }
+
+        /** @return array<int,array{name:string}> */
+        public static function getPaymentModules(): array
+        {
+            return [['name' => 'twopayment']];
+        }
     }
     }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -5528,6 +5528,7 @@ require __DIR__ . '/MinimumOrderGateSpec.php';
 require __DIR__ . '/InvoiceUploadGateSpec.php';
 require __DIR__ . '/FxRatesSpec.php';
 require __DIR__ . '/TwoSoleTraderSpec.php';
+require __DIR__ . '/AjaxCheckoutFailureSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5546,6 +5547,7 @@ $tests = [
     'InvoiceUploadGateSpec::runAll' => [InvoiceUploadGateSpec::class, 'runAll'],
     'FxRatesSpec::runAll' => [FxRatesSpec::class, 'runAll'],
     'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
+    'AjaxCheckoutFailureSpec::runAll' => [AjaxCheckoutFailureSpec::class, 'runAll'],
 ];
 
 $failed = 0;


### PR DESCRIPTION
Fixes the silent-hang class of checkout failure reported in TWO-24768.

## The mechanism (as found in the code, not as described in the ticket)

`controllers/front/payment.php` signalled every failure identically: push the message onto `$this->errors`, then `redirectWithNotifications('index.php?controller=order')` — a 302 with the text flashed into the session.

That works for exactly one caller shape: a top-level browser navigation, which lands on the order page and renders the notification.

An AJAX caller cannot use it. It follows the 302 transparently, receives the order page's HTML with **HTTP 200**, has no field it can read as a failure, and cannot distinguish the response from a success. The buyer is left on a checkout that never moves; the error message is rendered into a page nobody ever displays. Checkout front-ends that post the payment form over XHR rather than navigating hit exactly this.

**One correction to the ticket's description.** The ticket locates the bug at `failCheckout()`. The reported case does not go through `failCheckout()` at all. The provider-rejection path (order creation answered 401 because no usable API key is configured) built its message inline and called `redirectWithNotifications()` directly — as did four other exits. Patching `failCheckout()` alone, as the ticket's suggested diff does, would have left the reported case broken. So this PR does both: adds the AJAX branch at the boundary, and routes every failure exit through that boundary.

## The change

- `failCheckout()` detects an AJAX caller and answers with a JSON body (`error`, `message`, `redirect_url`) and `HTTP 400` instead of a redirect. A non-2xx status means even a caller that only checks `response.ok` unhangs; a caller that parses the body gets the specific message.
- Detection is header-based and additive to the ticket's proposal: `X-Requested-With: XMLHttpRequest`, **plus** an `Accept` that asks for `application/json` and does not accept `text/html`. `fetch()` callers send no `X-Requested-With`, and a page navigation always accepts HTML, so the second test adds coverage without capturing navigations.
- Browser form posts are unchanged — same redirect, same session notification, same message.
- The five inline `$this->errors[] = …; redirectWithNotifications(…)` exits now call `failCheckout()`. Each returns explicitly rather than relying on the redirect terminating the request; behaviour is identical either way, the `return` just stops the flow depending on a side effect.
- Failures that deliberately carry no buyer-facing text (detail belongs in the shop log) fall back to a generic message for AJAX callers. Emitting `'message' => ''` — as the ticket's diff does — would reproduce the silent hang one layer up.
- `emitTwoCheckoutJsonFailure()` is a small `protected` seam so the payload is observable in tests without the process-terminating `exit`.

## Relationship to adjacent work

Same family as the loud reconciliation and order-intent failures that landed for TWO-24755 — an error that never reaches the buyer — but from the transport side rather than the message side. That work made the *text* specific; this makes the *response* legible to a non-navigating caller. No overlap, nothing undone.

Deliberately out of scope: broader checkout-module compatibility, which stays with TWO-24770. This PR only fixes the swallowed failure.

## Verification

New spec `tests/AjaxCheckoutFailureSpec.php` drives the real controller's `postProcess()` over the stub core with the provider call canned to 401 — the reported shape — and asserts:

- under `X-Requested-With: XMLHttpRequest`, the JSON error reaches the caller with the 401-specific message intact and nothing left in `$errors`
- under a browser `Accept`, the redirect still happens with the message in `$errors` and no JSON emitted
- header-detection edge cases (case/whitespace, JSON-only `Accept`, `Accept` containing both JSON and HTML, no headers at all)
- the empty-message fallback

The end-to-end spec was confirmed to fail against the pre-fix controller **behaviourally**, not just on a missing method: with the new static helpers grafted onto the pre-fix file but the failure paths untouched, the AJAX case emits zero JSON payloads (`Expected count 1, got 0`) because it redirects instead.

```
$ php tests/run.php
...
PASS AjaxCheckoutFailureSpec::runAll
All tests passed.

$ phpstan analyse --configuration=phpstan.neon   # run as CI does, core sources pinned to 1.7.6.0
 [OK] No errors
```

`php-cs-fixer --dry-run` on the touched controller reports only pre-existing trailing whitespace on untouched lines; left alone as out of scope (and ungated in CI).

Not done, flagging rather than doing: no module version bump — say the word if this should carry one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)