### PR TITLE
TWO-25161 + TWO-24768 + TWO-24769 + TWO-24799: consolidated PrestaShop checkout fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           php -l controllers/front/invoice.php
           php -l controllers/admin/AdminTwopaymentInvoiceController.php
           php -l classes/TwoInvoiceRetrievalService.php
+          php -l classes/TwoCheckoutAmountException.php
           php -l tests/bootstrap.php
           php -l tests/TwoInvoiceRetrievalSpec.php
           php -l tests/CustomerAddressFormatterOverrideSpec.php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
           php -l tests/FxRatesSpec.php
           php -l tests/AjaxCheckoutFailureSpec.php
           php -l tests/CheckoutLatencySpec.php
+          php -l tests/ShippingCostSourcingSpec.php
+          php -l tests/FulfilledStatusMappingSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
           php -l tests/MinimumOrderGateSpec.php
           php -l tests/FxRatesSpec.php
           php -l tests/AjaxCheckoutFailureSpec.php
+          php -l tests/CheckoutLatencySpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
           php -l tests/DefaultPaymentTermSpec.php
           php -l tests/MinimumOrderGateSpec.php
           php -l tests/FxRatesSpec.php
+          php -l tests/AjaxCheckoutFailureSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Checkout failures now reach AJAX checkout front-ends instead of vanishing** (TWO-24768)
+  - The payment controller's only failure signal was a 302 back to the order page with the message flashed into the session. A checkout that posts the payment form over XHR rather than navigating (PrestaShop's own checkout module does) follows that redirect, receives the order page HTML with HTTP 200, cannot distinguish it from success, and leaves the buyer on a checkout that never moves
+  - AJAX callers (identified by `X-Requested-With: XMLHttpRequest`, or an `Accept` that asks for JSON and does not accept HTML) now receive `HTTP 400` with a JSON body carrying `error`, `message` and `redirect_url`. Ordinary browser form posts keep the existing redirect-with-notification behaviour unchanged
+  - Every failure exit in the payment controller now goes through the single `failCheckout()` boundary. Five of them - including the provider-rejection path that produced the reported silent hang - previously redirected inline and so bypassed it entirely
+  - Failures that deliberately carry no buyer-facing text (internal errors logged for the merchant) now emit a generic message to AJAX callers rather than an empty string, so the caller always has something to render
+
 ### Changed
 - **Invoice upload is now gated on the merchant record, not an admin toggle** (TWO-25111, per decision TWO-25106 Option A)
   - The plugin-side invoice upload (own-invoice merchants) now triggers only when the `invoice_distributed_by_merchant` flag on the Two merchant record (`GET /v1/merchant`) is true - the same signal checkout-api itself enforces (TWO-24761), and the same gating model Magento (TWO-24758) and WooCommerce (TWO-24757) use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AJAX callers (identified by `X-Requested-With: XMLHttpRequest`, or an `Accept` that asks for JSON and does not accept HTML) now receive `HTTP 400` with a JSON body carrying `error`, `message` and `redirect_url`. Ordinary browser form posts keep the existing redirect-with-notification behaviour unchanged
   - Every failure exit in the payment controller now goes through the single `failCheckout()` boundary. Five of them - including the provider-rejection path that produced the reported silent hang - previously redirected inline and so bypassed it entirely
   - Failures that deliberately carry no buyer-facing text (internal errors logged for the merchant) now emit a generic message to AJAX callers rather than an empty string, so the caller always has something to render
+- **"Two: Order Fulfilled - Trigger Statuses" multi-select now renders its saved selection** (TWO-24769)
+  - PrestaShop core's `HelperForm::generate()` rewrites a multi-select field's name in place (`$params['name'] .= '[]'`) and the admin form template then resolves the pre-selection with `$fields_value[$input.name]`, i.e. under the `[]`-suffixed key - verified identical in PS 1.7.6.5, 8.x and 9.x. The module populated only the plain key, so every option rendered unselected even though the stored value was correct (display-only; fulfillment triggering reads the configuration directly and was never affected)
+  - The pre-selection IDs are normalised to strings, matching the `id_order_state` the option values are built from, so the comparison no longer relies on PrestaShop's loose `==` in the template
+  - The custom-order-state recovery path (`ensureCustomStatesExist()`, which fires when Two's own order states are missing) wrote `PS_TWO_OS_FULFILLED_MAP` as a bare status ID rather than the JSON array every other writer uses - three divergent storage formats for one key. It now writes the canonical JSON array, and the 2.6.2 upgrade script normalises any value a store is already holding in the legacy format
+  - Module version bumped to `2.6.2`
 
 ### Changed
 - **Invoice upload is now gated on the merchant record, not an admin toggle** (TWO-25111, per decision TWO-25106 Option A)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The pre-selection IDs are normalised to strings, matching the `id_order_state` the option values are built from, so the comparison no longer relies on PrestaShop's loose `==` in the template
   - The custom-order-state recovery path (`ensureCustomStatesExist()`, which fires when Two's own order states are missing) wrote `PS_TWO_OS_FULFILLED_MAP` as a bare status ID rather than the JSON array every other writer uses - three divergent storage formats for one key. It now writes the canonical JSON array, and the 2.6.2 upgrade script normalises any value a store is already holding in the legacy format
   - Module version bumped to `2.6.2`
+- **Shipping amount and shipping VAT rate now come from the cart, not from a loadable carrier** (TWO-25161)
+  - The shipping line's amount is sourced from the cart's own shipping total rather than being gated on constructing a `Carrier` object. Carts with no resolvable carrier previously dropped the shipping amount from the Two payload entirely - the order's totals no longer reconciled with the shop's - and now reconcile
+  - The shipping VAT rate is the platform-declared rate resolved from the cart's carrier list, never derived from `tax / net`, consistent with the line-item rate relay (TWO-24880)
+  - When the selected delivery option spans several tax-rules groups, the shipping charge is split into one line per declared rate instead of emitting a single blended rate
+- **Checkout-path latency: 12 buyer-blocking round trips reduced to 5** (TWO-24799)
+  - Company lookups that Two cannot resolve are now negatively cached (short TTL, keyed on org number + country + address ID), so a saved address carrying an unresolvable org number no longer re-pays the verification round trip on every checkout update
+  - Order-intent calls are deduped against a session-scoped decision snapshot, so a checkout update that moves no decision input reuses the previous decision instead of re-running the intent call
+  - Measured over a six-step checkout session
 
 ### Changed
 - **Invoice upload is now gated on the merchant record, not an admin toggle** (TWO-25111, per decision TWO-25106 Option A)

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -3,7 +3,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.5.0"
+current_version = "2.6.2"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/classes/TwoCheckoutAmountException.php
+++ b/classes/TwoCheckoutAmountException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The plugin's own buyer-actionable amount diagnostic.
+ *
+ * Payload building walks a lot of PrestaShop core (TaxManagerFactory, Address,
+ * Carrier, DB reads), so an exception escaping that path is NOT necessarily
+ * something the plugin wrote: a PrestaShopDatabaseException would carry SQL
+ * text, table and column names. Relaying an arbitrary exception message to the
+ * buyer — into the storefront notification and, since TWO-24768, into the AJAX
+ * JSON body — is an information disclosure on a public storefront.
+ *
+ * This type is the marker for the narrow set of conditions where the message IS
+ * meant for the buyer: the cart-vs-lines reconciliation diagnostics and the
+ * loud shipping-tax-rate refusal, all of which quote nothing but the cart's own
+ * amounts and identifiers. Everything else is logged server-side and answered
+ * with a generic message.
+ *
+ * Deliberately a type rather than a string convention: the order-intent path
+ * already classifies these failures with `stripos($msg, 'reconcile')`, which is
+ * a fragile classifier (it misses the shipping refusal and misreads the
+ * PS_ATCP_SHIPWRAP split failure), and a second string test would compound that
+ * rather than replace it.
+ *
+ * TWO-25161.
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class TwoCheckoutAmountException extends Exception
+{
+}

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.1]]></version>
+    <version><![CDATA[2.6.2]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -417,11 +417,44 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             // Get order intent data
             $paymentdata = $this->module->getTwoIntentOrderData($cart, $customer, $currency, $address);
 
-            // Return payload only (frontend will call Two API directly)
-            $this->sendJsonResponse(json_encode([
+            // TWO-24799: snapshot-dedupe the UX-only intent check. Every
+            // checkout update (payment-option toggle, surcharge cart-line
+            // refresh, payment form re-render) re-runs this handler and the
+            // browser then pays a 2.5-3s /v1/order_intent round trip, even when
+            // none of the decision inputs moved. Hand the browser back the
+            // decision it already got for this exact snapshot so it can skip
+            // that call. Any cart, address, country or company change yields a
+            // different hash and the call happens for real.
+            //
+            // This is a UX cache only: the authoritative gate remains
+            // Twopayment::checkTwoOrderIntentApprovalAtPayment() at payment
+            // submit, which always calls the provider and is never served from
+            // here.
+            $snapshotHash = $this->module->calculateTwoOrderIntentSnapshotHash($cart, $paymentdata);
+            $cachedDecision = $this->module->getTwoCachedOrderIntentDecision($snapshotHash);
+            $this->module->markTwoPendingOrderIntentSnapshot($snapshotHash);
+
+            $response = [
                 'success' => true,
-                'payload' => $paymentdata
-            ]));
+                'payload' => $paymentdata,
+            ];
+
+            if ($cachedDecision !== null) {
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Reused cached order intent decision for unchanged snapshot (approved=' .
+                    ($cachedDecision['approved'] ? '1' : '0') . ')',
+                    1
+                );
+                $response['intent_decision'] = [
+                    'approved' => (bool) $cachedDecision['approved'],
+                    'timestamp' => (int) $cachedDecision['timestamp'],
+                ];
+            }
+
+            $this->context->cookie->write();
+
+            // Return payload only (frontend will call Two API directly)
+            $this->sendJsonResponse(json_encode($response));
             return;
         } catch (Exception $e) {
             // Log exception for debugging
@@ -464,7 +497,13 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         // Store in PrestaShop cookie (session-based) for server-side validation
         $this->context->cookie->two_order_intent_approved = $approved ? '1' : '0';
         $this->context->cookie->two_order_intent_timestamp = (string)$timestamp;
-        
+
+        // TWO-24799: bind the reported decision to the snapshot hash the server
+        // computed when it handed this browser the payload, so the next
+        // checkout update with identical decision inputs can skip the provider
+        // round trip. The hash is never taken from the request.
+        $this->module->storeTwoOrderIntentDecisionForPendingSnapshot($approved);
+
         // Write cookie to ensure it's saved
         $this->context->cookie->write();
 
@@ -494,6 +533,10 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         // Clear order intent result from cookie
         unset($this->context->cookie->two_order_intent_approved);
         unset($this->context->cookie->two_order_intent_timestamp);
+        // TWO-24799: the buyer switching away from Two is an explicit reset, so
+        // the deduped decision goes with it - a later switch back re-checks for
+        // real rather than reviving a decision the buyer never sees confirmed.
+        $this->module->clearTwoCachedOrderIntentDecision();
         $this->context->cookie->write();
 
         PrestaShopLogger::addLog('TwoPayment: Order intent result cleared from session', 1);
@@ -674,7 +717,16 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
                         1
                     );
                     
-                    $verifiedCompany = $this->module->verifyCompanyByOrgNumber($existingOrgNumber, $countryIso);
+                    // TWO-24799: memoises both outcomes for the session. The
+                    // success path was already cached below via the
+                    // two_company_* cookie; this also stops an unresolvable org
+                    // number re-paying a blocking company lookup on every
+                    // checkout update.
+                    $verifiedCompany = $this->module->getTwoVerifiedCompanyForOrgNumber(
+                        $existingOrgNumber,
+                        $countryIso,
+                        $selectedAddressId
+                    );
                     
                     if ($verifiedCompany && !empty($verifiedCompany['organization_number'])) {
                         // SUCCESS! We have verified company data from existing address

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -170,21 +170,31 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
             $cart_snapshot_hash = $this->module->calculateTwoCheckoutSnapshotHash($cart, $paymentdata);
             $idempotency_key = $this->module->buildTwoOrderCreateIdempotencyKey($cart, $cart_snapshot_hash);
         } catch (Exception $e) {
-            // Surface WHY the payload could not be built. Every exception on
-            // this path is a deterministic, plugin-generated diagnostic about
-            // the cart's own amounts (no credentials, no provider internals),
-            // and withholding it is what left the buyer staring at a spinner
-            // with a generic message in TWO-25161.
+            // Surface WHY the payload could not be built - but only when the
+            // plugin itself raised the failure as a buyer-actionable amount
+            // diagnostic (TwoCheckoutAmountException). Withholding that detail
+            // is what left the buyer staring at a spinner with a generic
+            // message in TWO-25161, and since TWO-24768 the same string also
+            // goes into the AJAX JSON body.
+            //
+            // Payload building walks PrestaShop core (TaxManagerFactory,
+            // Address, Carrier, DB reads), so an arbitrary exception can reach
+            // here: a PrestaShopDatabaseException would put SQL text and
+            // table/column names on a public storefront. Those get the generic
+            // message, with the real exception class and message logged at
+            // severity 4 so nothing is lost for diagnosis.
+            $isBuyerActionable = $e instanceof TwoCheckoutAmountException;
             $message = $this->module->l('Two could not build this order from your cart.');
-            $detail = trim((string)$e->getMessage());
+            $detail = $isBuyerActionable ? trim((string)$e->getMessage()) : '';
             if ($detail !== '') {
                 $message .= ' ' . sprintf($this->module->l('Details: %s.'), $detail);
             }
             $message .= ' ' . $this->module->l('Please review your cart and try again, or contact the store.');
             $this->failCheckout(
                 $message,
-                'TwoPayment: Failed building order payload for cart ' . $cart->id . ' - ' . $e->getMessage(),
-                3
+                'TwoPayment: Failed building order payload for cart ' . $cart->id . ' - [' .
+                get_class($e) . '] ' . $e->getMessage(),
+                $isBuyerActionable ? 3 : 4
             );
             return;
         }

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -170,8 +170,19 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
             $cart_snapshot_hash = $this->module->calculateTwoCheckoutSnapshotHash($cart, $paymentdata);
             $idempotency_key = $this->module->buildTwoOrderCreateIdempotencyKey($cart, $cart_snapshot_hash);
         } catch (Exception $e) {
+            // Surface WHY the payload could not be built. Every exception on
+            // this path is a deterministic, plugin-generated diagnostic about
+            // the cart's own amounts (no credentials, no provider internals),
+            // and withholding it is what left the buyer staring at a spinner
+            // with a generic message in TWO-25161.
+            $message = $this->module->l('Two could not build this order from your cart.');
+            $detail = trim((string)$e->getMessage());
+            if ($detail !== '') {
+                $message .= ' ' . sprintf($this->module->l('Details: %s.'), $detail);
+            }
+            $message .= ' ' . $this->module->l('Please review your cart and try again, or contact the store.');
             $this->failCheckout(
-                $this->module->l('Unable to process your order with Two payment. Please review your cart and try again.'),
+                $message,
                 'TwoPayment: Failed building order payload for cart ' . $cart->id . ' - ' . $e->getMessage(),
                 3
             );

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -259,8 +259,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                 }
             }
 
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+            $this->failCheckout($message);
+            return;
         }
 
         if (isset($response['id']) && $response['id']) {
@@ -322,8 +322,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                     // Best effort cleanup when local attempt persistence fails.
                     $this->module->cancelTwoOrderBestEffort((string)$response['id'], 'attempt_persist_failed');
                 }
-                $this->errors[] = $this->module->l('Temporary checkout issue. Please try again.');
-                $this->redirectWithNotifications('index.php?controller=order');
+                $this->failCheckout($this->module->l('Temporary checkout issue. Please try again.'));
+                return;
             }
 
             // Fraud Verification Skip (Must be enabled by Two on request)
@@ -376,9 +376,10 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                     );
                     
                     // Generic error message - don't expose fraud verification skip details to customer
-                    $message = $this->module->l('Unable to process your payment at this time. Please contact the store owner for assistance.');
-                    $this->errors[] = $message;
-                    $this->redirectWithNotifications('index.php?controller=order');
+                    $this->failCheckout(
+                        $this->module->l('Unable to process your payment at this time. Please contact the store owner for assistance.')
+                    );
+                    return;
                 }
             } else {
                 // Standard flow - redirect to Two's payment_url for verification
@@ -402,8 +403,8 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                             $cancelled ? 2 : 3
                         );
                     }
-                    $this->errors[] = $this->module->l('Unable to redirect to payment provider. Please try again.');
-                    $this->redirectWithNotifications('index.php?controller=order');
+                    $this->failCheckout($this->module->l('Unable to redirect to payment provider. Please try again.'));
+                    return;
                 }
 
                 Tools::redirect($response['payment_url']);
@@ -413,14 +414,25 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
                 'TwoPayment: Two API created response without id for cart ' . $cart->id . ', attempt ' . $attempt_token,
                 3
             );
-            $message = $this->module->l('Something went wrong please contact store owner.');
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+            $this->failCheckout($this->module->l('Something went wrong please contact store owner.'));
+            return;
         }
     }
 
     /**
-     * Redirect checkout flow back to order page with optional user-facing error.
+     * Report a checkout failure to whoever submitted the payment form.
+     *
+     * A browser navigation gets what it has always got: a 302 back to the
+     * order page with the message flashed into the session notifications.
+     *
+     * An AJAX caller cannot use that. It follows the 302 transparently,
+     * receives the order page's HTML with HTTP 200, has no way to tell that
+     * from a success, and leaves the buyer staring at a checkout that never
+     * moves - the message is rendered into a page nobody ever displays.
+     * Checkout front-ends that post the payment form over XHR instead of
+     * navigating (PrestaShop's own checkout module among them) hit exactly
+     * this. For those callers, answer with a machine-readable JSON error and
+     * a non-2xx status so the failure is impossible to mistake for success.
      *
      * @param string $message
      * @param string $logMessage
@@ -432,12 +444,93 @@ class TwopaymentPaymentModuleFrontController extends ModuleFrontController
         if (!Tools::isEmpty($logMessage)) {
             PrestaShopLogger::addLog($logMessage, (int)$severity);
         }
-        if (!Tools::isEmpty($message)) {
-            $this->errors[] = $message;
-            $this->redirectWithNotifications('index.php?controller=order');
+
+        $redirectUrl = 'index.php?controller=order';
+
+        if (self::isTwoAjaxCheckoutRequest($_SERVER)) {
+            $this->emitTwoCheckoutJsonFailure(self::buildTwoCheckoutFailurePayload(
+                $message,
+                // Several internal failures deliberately carry no buyer-facing
+                // text (the detail belongs in the log, not on the storefront).
+                // An AJAX caller still needs something to render, or the fix
+                // reproduces the silent hang one layer up.
+                $this->module->l('Unable to process your order with Two payment. Please choose another payment method or contact the store.'),
+                $redirectUrl
+            ));
             return;
         }
-        Tools::redirect('index.php?controller=order');
+
+        if (!Tools::isEmpty($message)) {
+            $this->errors[] = $message;
+            $this->redirectWithNotifications($redirectUrl);
+            return;
+        }
+        Tools::redirect($redirectUrl);
+    }
+
+    /**
+     * Whether the payment form was submitted by an AJAX caller rather than by
+     * a top-level browser navigation.
+     *
+     * XMLHttpRequest-based checkouts (jQuery, and PrestaShop's own checkout
+     * JS) announce themselves with X-Requested-With. fetch() callers do not,
+     * so also treat a request that asks for JSON and does not accept HTML as
+     * AJAX - a page navigation always accepts HTML.
+     *
+     * @param array $server Request server variables ($_SERVER shape).
+     * @return bool
+     */
+    public static function isTwoAjaxCheckoutRequest(array $server)
+    {
+        $requestedWith = isset($server['HTTP_X_REQUESTED_WITH'])
+            ? strtolower(trim((string)$server['HTTP_X_REQUESTED_WITH']))
+            : '';
+        if ($requestedWith === 'xmlhttprequest') {
+            return true;
+        }
+
+        $accept = isset($server['HTTP_ACCEPT']) ? strtolower((string)$server['HTTP_ACCEPT']) : '';
+        return strpos($accept, 'application/json') !== false
+            && strpos($accept, 'text/html') === false;
+    }
+
+    /**
+     * Build the JSON body handed to an AJAX caller when checkout fails.
+     *
+     * @param string $message Buyer-facing message, may be empty.
+     * @param string $fallbackMessage Used when $message carries no text.
+     * @param string $redirectUrl Where a caller that prefers to navigate should go.
+     * @return array
+     */
+    public static function buildTwoCheckoutFailurePayload($message, $fallbackMessage, $redirectUrl)
+    {
+        $text = trim((string)$message);
+        if ($text === '') {
+            $text = trim((string)$fallbackMessage);
+        }
+
+        return array(
+            'error' => true,
+            'message' => $text,
+            'redirect_url' => (string)$redirectUrl,
+        );
+    }
+
+    /**
+     * Write the JSON failure body and stop. Isolated so tests can observe the
+     * payload without the process-terminating side effects.
+     *
+     * @param array $payload
+     * @return void
+     */
+    protected function emitTwoCheckoutJsonFailure(array $payload)
+    {
+        if (!headers_sent()) {
+            header('Content-Type: application/json');
+            http_response_code(Twopayment::HTTP_STATUS_BAD_REQUEST);
+        }
+        echo json_encode($payload);
+        exit;
     }
 
 }

--- a/tests/AjaxCheckoutFailureSpec.php
+++ b/tests/AjaxCheckoutFailureSpec.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../controllers/front/payment.php';
+
+/**
+ * TWO-24768: a checkout failure must reach whoever submitted the payment form.
+ *
+ * The payment controller's only failure signal used to be a 302 back to the
+ * order page with the message flashed into the session. A checkout front-end
+ * that posts the payment form over XHR instead of navigating - PrestaShop's
+ * own checkout module does - follows that redirect transparently, gets the
+ * order page's HTML with HTTP 200, and has nothing it can recognise as a
+ * failure. The buyer sees a checkout that never moves.
+ *
+ * These specs drive the real controller over the stub core, with the provider
+ * call canned, and assert on the response the caller actually receives.
+ */
+final class AjaxCheckoutFailureSpec
+{
+    private const CART_ID = 9601;
+    private const CUSTOMER_ID = 9001;
+    private const ADDRESS_ID = 9201;
+
+    public static function runAll(): void
+    {
+        self::testXmlHttpRequestHeaderIsDetectedAsAjax();
+        self::testJsonOnlyAcceptHeaderIsDetectedAsAjax();
+        self::testBrowserNavigationIsNotDetectedAsAjax();
+        self::testFailurePayloadFallsBackWhenMessageIsEmpty();
+        self::testProviderRejectionReachesAjaxCallerAsJsonError();
+        self::testProviderRejectionStillRedirectsBrowserNavigation();
+    }
+
+    /* ---- request-shape detection ---- */
+
+    private static function testXmlHttpRequestHeaderIsDetectedAsAjax(): void
+    {
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest', 'HTTP_ACCEPT' => '*/*']
+        ), 'XMLHttpRequest header must be treated as an AJAX submit');
+
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_X_REQUESTED_WITH' => ' xmlhttprequest ']
+        ), 'header comparison must be case- and whitespace-insensitive');
+    }
+
+    private static function testJsonOnlyAcceptHeaderIsDetectedAsAjax(): void
+    {
+        // fetch() callers send no X-Requested-With at all.
+        TinyAssert::true(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'application/json, text/plain, */*']
+        ), 'a JSON-only Accept cannot be a page navigation');
+    }
+
+    private static function testBrowserNavigationIsNotDetectedAsAjax(): void
+    {
+        TinyAssert::false(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8']
+        ), 'an ordinary form post must keep the redirect behaviour');
+
+        TinyAssert::false(
+            TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest([]),
+            'a request with no headers at all must not be guessed as AJAX'
+        );
+
+        // Some front-ends ask for JSON *and* accept HTML; that is still a
+        // navigation, so the redirect must stay.
+        TinyAssert::false(TwopaymentPaymentModuleFrontController::isTwoAjaxCheckoutRequest(
+            ['HTTP_ACCEPT' => 'text/html,application/json']
+        ), 'accepting HTML means the caller can render the order page');
+    }
+
+    private static function testFailurePayloadFallsBackWhenMessageIsEmpty(): void
+    {
+        // Internal failures deliberately carry no buyer-facing text. Emitting
+        // an empty message would reproduce the silent hang in the caller's UI.
+        $payload = TwopaymentPaymentModuleFrontController::buildTwoCheckoutFailurePayload(
+            '   ',
+            'Generic failure text.',
+            'index.php?controller=order'
+        );
+        TinyAssert::true($payload['error'], 'payload must be flagged as an error');
+        TinyAssert::same('Generic failure text.', $payload['message']);
+        TinyAssert::same('index.php?controller=order', $payload['redirect_url']);
+
+        $specific = TwopaymentPaymentModuleFrontController::buildTwoCheckoutFailurePayload(
+            'Payment method configuration error.',
+            'Generic failure text.',
+            'index.php?controller=order'
+        );
+        TinyAssert::same('Payment method configuration error.', $specific['message']);
+    }
+
+    /* ---- end-to-end through postProcess ---- */
+
+    /**
+     * Provider rejects order creation (the shape seen in the wild: a store
+     * with no usable API key, so /v1/order answers 401). This path never went
+     * through failCheckout at all - it redirected inline - so it is the one
+     * that actually stranded buyers.
+     */
+    private static function testProviderRejectionReachesAjaxCallerAsJsonError(): void
+    {
+        $controller = self::makeController();
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        try {
+            self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
+
+        TinyAssert::count(1, $controller->emitted);
+        $payload = $controller->emitted[0];
+        TinyAssert::true($payload['error'], 'AJAX caller must receive an explicit error flag');
+        TinyAssert::same(
+            'Payment method configuration error. Please contact the store.',
+            $payload['message'],
+            'the 401 message must survive to the caller instead of being flashed into a session nobody reads'
+        );
+        TinyAssert::same('index.php?controller=order', $payload['redirect_url']);
+        TinyAssert::count(0, $controller->errors);
+    }
+
+    private static function testProviderRejectionStillRedirectsBrowserNavigation(): void
+    {
+        $controller = self::makeController();
+        $_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml';
+
+        try {
+            $redirect = self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_ACCEPT']);
+        }
+
+        TinyAssert::count(0, $controller->emitted, 'a navigation must not be answered with JSON');
+        TinyAssert::true(
+            $redirect !== null && strpos($redirect->getMessage(), 'controller=order') !== false,
+            'browser navigation must still be redirected back to checkout'
+        );
+        TinyAssert::count(1, $controller->errors);
+        TinyAssert::same(
+            'Payment method configuration error. Please contact the store.',
+            $controller->errors[0]
+        );
+    }
+
+    /* ---- fixtures ---- */
+
+    private static function runPostProcess($controller): ?StubRedirect
+    {
+        try {
+            $controller->postProcess();
+        } catch (StubRedirect $redirect) {
+            return $redirect;
+        } catch (StubJsonFailureEmitted $emitted) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static function makeController()
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+        Tools::resetTestValues();
+        Tools::setTestValue('token', Tools::getToken(false));
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[33] = 'FR';
+        StubStore::$addresses[self::ADDRESS_ID] = [
+            'id_country' => 33,
+            'company' => 'Acme FR SAS',
+            'companyid' => 'FR123456789',
+            'address1' => '10 Rue de Paris',
+            'city' => 'Paris',
+            'postcode' => '75001',
+            'phone' => '+33100000000',
+            'loaded' => true,
+        ];
+        StubStore::$customers[self::CUSTOMER_ID] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Eva',
+            'lastname' => 'Martin',
+            'secure_key' => 'secure-key-9001',
+            'loaded' => true,
+        ];
+        StubStore::$carts[self::CART_ID] = [
+            'id_customer' => self::CUSTOMER_ID,
+            'id_currency' => 978,
+            'id_address_invoice' => self::ADDRESS_ID,
+            'id_address_delivery' => self::ADDRESS_ID,
+            'id_carrier' => 0,
+            'id_lang' => 1,
+        ];
+
+        $context = Context::getContext();
+        $context->cart = new Cart(self::CART_ID);
+        $context->cookie->two_order_intent_approved = '1';
+
+        $controller = new class extends TwopaymentPaymentModuleFrontController {
+            /** @var array<int,array> */
+            public array $emitted = [];
+
+            protected function emitTwoCheckoutJsonFailure(array $payload)
+            {
+                $this->emitted[] = $payload;
+                // Stands in for the production `exit` without killing the
+                // test process.
+                throw new StubJsonFailureEmitted('json failure emitted');
+            }
+        };
+        $controller->module = self::makeModule();
+
+        return $controller;
+    }
+
+    /**
+     * Module double: everything the controller needs up to the provider call
+     * is canned, and /v1/order answers 401 (no usable API key).
+     */
+    private static function makeModule(): Twopayment
+    {
+        return new class extends TwopaymentTestHarness {
+            public function isCartCurrencySupportedByTwo($cart)
+            {
+                return true;
+            }
+
+            public function getTwoCheckoutCompanyData($address)
+            {
+                return ['company_name' => 'Acme FR SAS', 'organization_number' => 'FR123456789'];
+            }
+
+            public function maybeCleanupStaleTwoCheckoutAttempts($force = false)
+            {
+                return 0;
+            }
+
+            public function checkTwoOrderIntentApprovalAtPayment($cart, $customer, $currency, $address)
+            {
+                return ['approved' => true, 'status' => 'APPROVED', 'http_status' => 200, 'message' => ''];
+            }
+
+            public function generateTwoCheckoutAttemptToken($id_cart, $id_customer)
+            {
+                return 'attempt-ajax-1';
+            }
+
+            public function buildTwoMerchantOrderId($attempt_token, $id_cart)
+            {
+                return 'merchant-ajax-1';
+            }
+
+            public function getTwoNewOrderData($merchant_order_id, $cart, $merchant_urls = null, $syncSurchargeCartLine = true)
+            {
+                return ['gross_amount' => '100.00'];
+            }
+
+            public function calculateTwoCheckoutSnapshotHash($cart, $paymentdata)
+            {
+                return 'snapshot-hash';
+            }
+
+            public function buildTwoOrderCreateIdempotencyKey($cart, $snapshot_hash)
+            {
+                return 'idempotency-key';
+            }
+
+            public function buildTwoApiResponseLogSummary($response)
+            {
+                return ['http_status' => isset($response['http_status']) ? (int) $response['http_status'] : 0];
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                return ['http_status' => 401];
+            }
+        };
+    }
+}
+
+class StubJsonFailureEmitted extends Exception
+{
+}

--- a/tests/AjaxCheckoutFailureSpec.php
+++ b/tests/AjaxCheckoutFailureSpec.php
@@ -31,6 +31,96 @@ final class AjaxCheckoutFailureSpec
         self::testFailurePayloadFallsBackWhenMessageIsEmpty();
         self::testProviderRejectionReachesAjaxCallerAsJsonError();
         self::testProviderRejectionStillRedirectsBrowserNavigation();
+        self::testNonPluginExceptionIsNotRelayedToTheBuyer();
+        self::testPluginAmountDiagnosticStillReachesTheBuyer();
+    }
+
+    /* ---- payload-build failures: what the buyer is allowed to see ---- */
+
+    /**
+     * TWO-25161 information disclosure: payload building walks PrestaShop core,
+     * so a core exception can reach the controller's catch. Its message must
+     * NOT be relayed - a PrestaShopDatabaseException carries SQL text and
+     * table/column names, and since TWO-24768 the same string is also written
+     * into the AJAX JSON body. The buyer gets the generic message; the real
+     * exception class and message are logged.
+     */
+    private static function testNonPluginExceptionIsNotRelayedToTheBuyer(): void
+    {
+        $sql = 'Unknown column \'tax_rules_group\' in \'field list\'<br />' .
+            'SELECT * FROM ps_carrier_tax_rules_group_shop WHERE id_carrier = 7';
+        $controller = self::makeController(new PrestaShopDatabaseException($sql));
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        try {
+            self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
+
+        TinyAssert::count(1, $controller->emitted);
+        $payload = $controller->emitted[0];
+        TinyAssert::same(
+            'Two could not build this order from your cart. ' .
+            'Please review your cart and try again, or contact the store.',
+            $payload['message'],
+            'a core exception must yield the generic buyer message, with no detail appended'
+        );
+        TinyAssert::false(
+            strpos($payload['message'], 'ps_carrier_tax_rules_group_shop') !== false,
+            'SQL text must never reach the buyer'
+        );
+
+        // Diagnosability is not lost: the real exception is in the shop log,
+        // with its class named.
+        TinyAssert::true(
+            self::loggedContains('[PrestaShopDatabaseException]'),
+            'the real exception class must be logged'
+        );
+        TinyAssert::true(
+            self::loggedContains('ps_carrier_tax_rules_group_shop'),
+            'the real exception message must be logged'
+        );
+    }
+
+    /**
+     * No regression on the deliberate part of TWO-25161: an amount diagnostic
+     * the plugin itself raised still reaches the buyer with its numbers intact.
+     * That detail is what makes a merchant-side cart/shipping misconfiguration
+     * diagnosable from the checkout page.
+     */
+    private static function testPluginAmountDiagnosticStillReachesTheBuyer(): void
+    {
+        $diagnostic = 'Order totals do not reconcile with cart totals: cart total 150.00 ' .
+            'vs order lines 121.00 (difference 29.00)';
+        $controller = self::makeController(new TwoCheckoutAmountException($diagnostic));
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        try {
+            self::runPostProcess($controller);
+        } finally {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
+
+        TinyAssert::count(1, $controller->emitted);
+        TinyAssert::same(
+            'Two could not build this order from your cart. Details: ' . $diagnostic . '. ' .
+            'Please review your cart and try again, or contact the store.',
+            $controller->emitted[0]['message'],
+            'a plugin-raised amount diagnostic must keep reaching the buyer'
+        );
+    }
+
+    /** Did any log line mention this fragment? */
+    private static function loggedContains(string $needle): bool
+    {
+        foreach (PrestaShopLogger::$logs as $entry) {
+            if (strpos((string) $entry['message'], $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /* ---- request-shape detection ---- */
@@ -162,7 +252,10 @@ final class AjaxCheckoutFailureSpec
         return null;
     }
 
-    private static function makeController()
+    /**
+     * @param Exception|null $payloadException Thrown by getTwoNewOrderData() when set
+     */
+    private static function makeController($payloadException = null)
     {
         StubStore::reset();
         PrestaShopLogger::reset();
@@ -213,18 +306,30 @@ final class AjaxCheckoutFailureSpec
                 throw new StubJsonFailureEmitted('json failure emitted');
             }
         };
-        $controller->module = self::makeModule();
+        $controller->module = self::makeModule($payloadException);
 
         return $controller;
     }
 
     /**
      * Module double: everything the controller needs up to the provider call
-     * is canned, and /v1/order answers 401 (no usable API key).
+     * is canned, and /v1/order answers 401 (no usable API key). Passing an
+     * exception makes the payload build itself fail instead.
+     *
+     * @param Exception|null $payloadException
      */
-    private static function makeModule(): Twopayment
+    private static function makeModule($payloadException = null): Twopayment
     {
-        return new class extends TwopaymentTestHarness {
+        return new class($payloadException) extends TwopaymentTestHarness {
+            /** @var Exception|null */
+            private $payloadException;
+
+            public function __construct($payloadException = null)
+            {
+                parent::__construct();
+                $this->payloadException = $payloadException;
+            }
+
             public function isCartCurrencySupportedByTwo($cart)
             {
                 return true;
@@ -257,6 +362,10 @@ final class AjaxCheckoutFailureSpec
 
             public function getTwoNewOrderData($merchant_order_id, $cart, $merchant_urls = null, $syncSurchargeCartLine = true)
             {
+                if ($this->payloadException !== null) {
+                    throw $this->payloadException;
+                }
+
                 return ['gross_amount' => '100.00'];
             }
 

--- a/tests/CheckoutLatencySpec.php
+++ b/tests/CheckoutLatencySpec.php
@@ -1,0 +1,564 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-24799 - checkout-path latency: the nested company lookup and the
+ * order-intent snapshot dedupe. Contract under test:
+ *
+ *  - Nested company lookup. An org number found on a saved address is verified
+ *    against /companies/v2/company on the buyer-blocking path. The SUCCESS path
+ *    was already memoised (the caller writes the resolved company into the
+ *    two_company_* cookie); the MISS path was not, so an unresolvable org number
+ *    re-paid that blocking round trip on every checkout update, forever
+ *    returning the same null. getTwoVerifiedCompanyForOrgNumber() memoises both,
+ *    keyed on org number + country + address ID so editing any of the three
+ *    re-verifies instead of inheriting the miss.
+ *
+ *  - Order-intent snapshot dedupe. Every checkout update re-runs the intent
+ *    handler and the browser then pays a 2.5-3s /v1/order_intent round trip even
+ *    when no decision input moved. calculateTwoOrderIntentSnapshotHash() keys a
+ *    session-scoped decision cache on the full decision snapshot. It composes -
+ *    never replaces - the cart snapshot hash used for order-create idempotency,
+ *    mixing in the buyer identity that hash deliberately omits.
+ *
+ *  - Invalidation is the load-bearing property. A country switch, a cart change,
+ *    a company change and an address switch must each bust the cache; a stale
+ *    decision served across any of them is a correctness bug (country-switch
+ *    staleness being a tracked bug class here, TWO-24867). Every bust case below
+ *    asserts the provider IS called again.
+ *
+ *  - The cache is UX-only. checkTwoOrderIntentApprovalAtPayment() is the
+ *    authoritative gate and always calls the provider, even with a fresh
+ *    approved decision cached for the identical snapshot.
+ */
+final class CheckoutLatencySpec
+{
+    public static function runAll(): void
+    {
+        // Nested company lookup
+        self::testRepeatedUnverifiableOrgNumberIsLookedUpOnlyOnce();
+        self::testVerifiedOrgNumberIsLookedUpOnlyOnce();
+        self::testCountryChangeBustsTheVerificationMiss();
+        self::testOrgNumberChangeBustsTheVerificationMiss();
+        self::testAddressSwitchBustsTheVerificationMiss();
+        self::testVerificationMissExpiresAfterTtl();
+        self::testSuccessfulVerificationForgetsAnEarlierMiss();
+
+        // Order-intent snapshot dedupe
+        self::testUnchangedSnapshotIsServedFromCache();
+        self::testCachedDecisionPreservesDeclineAsWellAsApproval();
+        self::testCartChangeBustsTheCachedDecision();
+        self::testCountrySwitchBustsTheCachedDecision();
+        self::testCompanyChangeBustsTheCachedDecisionOnTheSameCart();
+        self::testAddressSwitchBustsTheCachedDecision();
+        self::testCachedDecisionExpiresAfterTtl();
+        self::testDecisionIsNeverStoredWithoutAPendingSnapshot();
+        self::testClearingDropsTheCachedDecision();
+        self::testIntentHashIsNotTheOrderCreateIdempotencySnapshotHash();
+
+        // The authoritative gate is never served from the cache
+        self::testPaymentSubmitAlwaysCallsProviderDespiteCachedApproval();
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        Tools::resetTestValues();
+        PrestaShopLogger::reset();
+        Context::getContext()->cookie = new Cookie();
+    }
+
+    // -----------------------------------------------------------------
+    // Nested company lookup
+    // -----------------------------------------------------------------
+
+    /**
+     * Module that counts /companies/v2/company round trips instead of making
+     * them. $resolvable maps "ORGNUMBER|COUNTRY" to a verified company.
+     */
+    private static function countingModule(array $resolvable = []): TwopaymentTestHarness
+    {
+        return new class($resolvable) extends TwopaymentTestHarness {
+            public int $companyLookups = 0;
+            /** @var array<string,array{name:string,organization_number:string}> */
+            private array $resolvable;
+
+            public function __construct(array $resolvable)
+            {
+                parent::__construct();
+                $this->resolvable = $resolvable;
+            }
+
+            public function verifyCompanyByOrgNumber($orgNumber, $countryIso)
+            {
+                ++$this->companyLookups;
+                $key = strtoupper(trim((string) $orgNumber)) . '|' . strtoupper(trim((string) $countryIso));
+
+                return $this->resolvable[$key] ?? null;
+            }
+        };
+    }
+
+    /**
+     * The measured regression: six checkout updates against an address whose org
+     * number Two cannot resolve used to cost six blocking lookups. One now.
+     */
+    private static function testRepeatedUnverifiableOrgNumberIsLookedUpOnlyOnce(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        for ($i = 0; $i < 6; ++$i) {
+            $result = $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+            TinyAssert::same(null, $result, 'An unresolvable org number must keep resolving to null');
+        }
+
+        TinyAssert::same(1, $module->companyLookups, 'Six identical checkout updates must cost one company lookup');
+    }
+
+    private static function testVerifiedOrgNumberIsLookedUpOnlyOnce(): void
+    {
+        self::reset();
+        $module = self::countingModule([
+            'B12345678|ES' => ['name' => 'ACME S.L.', 'organization_number' => 'B12345678'],
+        ]);
+
+        // The success path is memoised by the caller's two_company_* cookie, so
+        // assert the resolved value is stable rather than re-deriving it here.
+        for ($i = 0; $i < 4; ++$i) {
+            $result = $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+            TinyAssert::same('ACME S.L.', $result['name']);
+        }
+
+        TinyAssert::same(4, $module->companyLookups, 'A verified org number is cached by the caller, not by the miss marker');
+    }
+
+    private static function testCountryChangeBustsTheVerificationMiss(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        TinyAssert::same(1, $module->companyLookups);
+
+        // Country switch: must NOT inherit the ES miss (TWO-24867 bug class).
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'GB', 1901);
+        TinyAssert::same(2, $module->companyLookups, 'A country switch must re-verify the org number');
+    }
+
+    private static function testOrgNumberChangeBustsTheVerificationMiss(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        $module->getTwoVerifiedCompanyForOrgNumber('B87654321', 'ES', 1901);
+
+        TinyAssert::same(2, $module->companyLookups, 'A corrected org number must re-verify');
+    }
+
+    private static function testAddressSwitchBustsTheVerificationMiss(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1902);
+
+        TinyAssert::same(2, $module->companyLookups, 'Switching billing address must re-verify');
+    }
+
+    /**
+     * The miss is a latency guard, not a verdict: a provider hiccup must
+     * self-heal inside the same checkout session.
+     */
+    private static function testVerificationMissExpiresAfterTtl(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        TinyAssert::same(1, $module->companyLookups);
+
+        // Age the marker past its TTL.
+        $encoded = (string) Context::getContext()->cookie->two_company_verify_miss;
+        $decoded = json_decode($encoded, true);
+        $decoded['at'] = time() - (Twopayment::COMPANY_VERIFY_MISS_CACHE_TTL + 1);
+        Context::getContext()->cookie->two_company_verify_miss = json_encode($decoded);
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        TinyAssert::same(2, $module->companyLookups, 'An expired miss must re-verify');
+    }
+
+    private static function testSuccessfulVerificationForgetsAnEarlierMiss(): void
+    {
+        self::reset();
+        $module = self::countingModule();
+
+        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
+        TinyAssert::true(!Tools::isEmpty((string) Context::getContext()->cookie->two_company_verify_miss));
+
+        // A different, resolvable org number on the same address.
+        $resolving = self::countingModule([
+            'B87654321|ES' => ['name' => 'ACME S.L.', 'organization_number' => 'B87654321'],
+        ]);
+        $resolving->getTwoVerifiedCompanyForOrgNumber('B87654321', 'ES', 1901);
+
+        TinyAssert::true(
+            Tools::isEmpty((string) (Context::getContext()->cookie->two_company_verify_miss ?? '')),
+            'A successful verification must clear the stale miss marker'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Order-intent snapshot dedupe
+    // -----------------------------------------------------------------
+
+    /**
+     * Minimal intent payload. Only the fields the snapshot hash reads matter;
+     * $overrides mutates one decision input at a time.
+     */
+    private static function intentPayload(array $overrides = []): array
+    {
+        $payload = [
+            'gross_amount' => '121.00',
+            'net_amount' => '100.00',
+            'tax_amount' => '21.00',
+            'discount_amount' => '0.00',
+            'currency' => 'EUR',
+            'invoice_type' => 'FUNDED_INVOICE',
+            'buyer' => [
+                'company' => [
+                    'company_name' => 'ACME S.L.',
+                    'country_prefix' => 'ES',
+                    'organization_number' => 'B12345678',
+                    'website' => '',
+                ],
+            ],
+            'billing_address' => ['country' => 'ES', 'city' => 'Madrid'],
+            'shipping_address' => ['country' => 'ES', 'city' => 'Madrid'],
+            'line_items' => [[
+                'type' => 'PHYSICAL',
+                'quantity' => 1,
+                'unit_price' => '100.00',
+                'net_amount' => '100.00',
+                'tax_amount' => '21.00',
+                'gross_amount' => '121.00',
+                'discount_amount' => '0.00',
+                'tax_rate' => '0.21',
+            ]],
+        ];
+
+        foreach ($overrides as $path => $value) {
+            $keys = explode('.', (string) $path);
+            $cursor = &$payload;
+            foreach ($keys as $depth => $key) {
+                if ($depth === count($keys) - 1) {
+                    $cursor[$key] = $value;
+                } else {
+                    $cursor = &$cursor[$key];
+                }
+            }
+            unset($cursor);
+        }
+
+        return $payload;
+    }
+
+    private static function cart(int $idAddress = 1901): Cart
+    {
+        $cart = new Cart(901);
+        $cart->id_customer = 901;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = $idAddress;
+        $cart->id_address_delivery = $idAddress;
+        $cart->id_carrier = 0;
+        $cart->id_lang = 1;
+
+        return $cart;
+    }
+
+    /**
+     * One checkout update as the handler runs it: hash the snapshot, look for a
+     * cached decision, mark the snapshot pending, call the provider only on a
+     * miss, then record whatever decision came back.
+     *
+     * @return bool Whether the provider round trip actually happened
+     */
+    private static function checkoutUpdate(
+        Twopayment $module,
+        Cart $cart,
+        array $payload,
+        bool $approved = true
+    ): bool {
+        $hash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        $cached = $module->getTwoCachedOrderIntentDecision($hash);
+        $module->markTwoPendingOrderIntentSnapshot($hash);
+
+        $calledProvider = false;
+        if ($cached === null) {
+            $calledProvider = true;
+        } else {
+            TinyAssert::same($approved, $cached['approved'], 'A cached decision must round-trip its approval verbatim');
+        }
+
+        // The browser reports the decision either way.
+        $module->storeTwoOrderIntentDecisionForPendingSnapshot($approved);
+
+        return $calledProvider;
+    }
+
+    /**
+     * The measured regression: four checkout updates with byte-identical
+     * decision inputs used to cost four /v1/order_intent round trips. One now.
+     */
+    private static function testUnchangedSnapshotIsServedFromCache(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        $calls = 0;
+        for ($i = 0; $i < 4; ++$i) {
+            $calls += self::checkoutUpdate($module, $cart, $payload) ? 1 : 0;
+        }
+
+        TinyAssert::same(1, $calls, 'Four unchanged checkout updates must cost one intent round trip');
+    }
+
+    private static function testCachedDecisionPreservesDeclineAsWellAsApproval(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        TinyAssert::true(self::checkoutUpdate($module, $cart, $payload, false));
+        // checkoutUpdate() asserts the cached approval matches on the hit.
+        TinyAssert::false(self::checkoutUpdate($module, $cart, $payload, false), 'A cached decline must dedupe too');
+
+        $hash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        TinyAssert::false($module->getTwoCachedOrderIntentDecision($hash)['approved']);
+    }
+
+    private static function testCartChangeBustsTheCachedDecision(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+
+        TinyAssert::true(self::checkoutUpdate($module, $cart, self::intentPayload()));
+
+        // Buyer bumps the quantity: gross and the line item both move.
+        $changed = self::intentPayload([
+            'gross_amount' => '242.00',
+            'line_items' => [[
+                'type' => 'PHYSICAL',
+                'quantity' => 2,
+                'unit_price' => '100.00',
+                'net_amount' => '200.00',
+                'tax_amount' => '42.00',
+                'gross_amount' => '242.00',
+                'discount_amount' => '0.00',
+                'tax_rate' => '0.21',
+            ]],
+        ]);
+
+        TinyAssert::true(
+            self::checkoutUpdate($module, $cart, $changed),
+            'A cart change must re-run the intent check, never serve the old decision'
+        );
+    }
+
+    /**
+     * Country-switch staleness is a tracked bug class here (TWO-24867): a cache
+     * that survives a country switch is a correctness bug, not a latency win.
+     */
+    private static function testCountrySwitchBustsTheCachedDecision(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+
+        TinyAssert::true(self::checkoutUpdate($module, $cart, self::intentPayload()));
+
+        $switched = self::intentPayload([
+            'buyer.company.country_prefix' => 'GB',
+            'billing_address' => ['country' => 'GB', 'city' => 'London'],
+            'shipping_address' => ['country' => 'GB', 'city' => 'London'],
+        ]);
+
+        TinyAssert::true(
+            self::checkoutUpdate($module, $cart, $switched),
+            'A country switch must re-run the intent check'
+        );
+    }
+
+    /**
+     * The buyer re-runs company search and picks a different company against the
+     * same saved address and unchanged cart. The order-create snapshot hash
+     * cannot see this; the intent hash must.
+     */
+    private static function testCompanyChangeBustsTheCachedDecisionOnTheSameCart(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+
+        TinyAssert::true(self::checkoutUpdate($module, $cart, self::intentPayload()));
+
+        $reselected = self::intentPayload([
+            'buyer.company.company_name' => 'OTHER TRADING S.L.',
+            'buyer.company.organization_number' => 'B87654321',
+        ]);
+
+        TinyAssert::true(
+            self::checkoutUpdate($module, $cart, $reselected),
+            'Choosing a different company must re-run the intent check'
+        );
+    }
+
+    private static function testAddressSwitchBustsTheCachedDecision(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $payload = self::intentPayload();
+
+        TinyAssert::true(self::checkoutUpdate($module, self::cart(1901), $payload));
+        TinyAssert::true(
+            self::checkoutUpdate($module, self::cart(1902), $payload),
+            'Switching to another saved address must re-run the intent check'
+        );
+    }
+
+    private static function testCachedDecisionExpiresAfterTtl(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        TinyAssert::true(self::checkoutUpdate($module, $cart, $payload));
+
+        $decoded = json_decode((string) Context::getContext()->cookie->two_order_intent_decision, true);
+        $decoded['at'] = time() - (Twopayment::ORDER_INTENT_DECISION_CACHE_TTL + 1);
+        Context::getContext()->cookie->two_order_intent_decision = json_encode($decoded);
+
+        $hash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        TinyAssert::same(null, $module->getTwoCachedOrderIntentDecision($hash), 'An expired decision must not be served');
+    }
+
+    /**
+     * The hash is never taken from the request: with nothing pending, a reported
+     * decision is dropped rather than bound to an attacker-chosen snapshot.
+     */
+    private static function testDecisionIsNeverStoredWithoutAPendingSnapshot(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        TinyAssert::same('', $module->storeTwoOrderIntentDecisionForPendingSnapshot(true));
+
+        $hash = $module->calculateTwoOrderIntentSnapshotHash(self::cart(), self::intentPayload());
+        TinyAssert::same(null, $module->getTwoCachedOrderIntentDecision($hash));
+    }
+
+    private static function testClearingDropsTheCachedDecision(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        self::checkoutUpdate($module, $cart, $payload);
+        $hash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        TinyAssert::notSame(null, $module->getTwoCachedOrderIntentDecision($hash));
+
+        $module->clearTwoCachedOrderIntentDecision();
+
+        TinyAssert::same(null, $module->getTwoCachedOrderIntentDecision($hash), 'Switching away from Two must drop the decision');
+    }
+
+    /**
+     * The intent hash composes the order-create snapshot hash but must not BE
+     * it - reusing it directly would let a company change slip through, and
+     * changing the create hash would rewrite order-create idempotency keys.
+     */
+    private static function testIntentHashIsNotTheOrderCreateIdempotencySnapshotHash(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        $intentHash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        $createHash = $module->calculateTwoCheckoutSnapshotHash($cart, $payload);
+        TinyAssert::notSame($createHash, $intentHash);
+
+        // A company-only change moves the intent hash and leaves the create
+        // snapshot hash alone, which is exactly why the two cannot be shared.
+        $reselected = self::intentPayload([
+            'buyer.company.company_name' => 'OTHER TRADING S.L.',
+            'buyer.company.organization_number' => 'B87654321',
+        ]);
+        TinyAssert::notSame($intentHash, $module->calculateTwoOrderIntentSnapshotHash($cart, $reselected));
+        TinyAssert::same($createHash, $module->calculateTwoCheckoutSnapshotHash($cart, $reselected));
+    }
+
+    // -----------------------------------------------------------------
+    // The authoritative gate is never served from the cache
+    // -----------------------------------------------------------------
+
+    /**
+     * The dedupe is UX-only. Payment submit must still call the provider even
+     * with a fresh approved decision cached for the identical snapshot.
+     */
+    private static function testPaymentSubmitAlwaysCallsProviderDespiteCachedApproval(): void
+    {
+        self::reset();
+
+        $module = new class extends TwopaymentTestHarness {
+            public int $providerCalls = 0;
+
+            public function getTwoIntentOrderData($cart, $customer, $currency, $address)
+            {
+                return CheckoutLatencySpec::publicIntentPayload();
+            }
+
+            protected function shouldRunStrictOrderIntentParityAtPayment()
+            {
+                return false;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                if ($endpoint === '/v1/order_intent') {
+                    ++$this->providerCalls;
+                }
+
+                return ['http_status' => 200, 'approved' => true];
+            }
+        };
+
+        $cart = self::cart();
+        $payload = self::intentPayload();
+
+        // Prime the UX cache with a fresh approval for this exact snapshot.
+        self::checkoutUpdate($module, $cart, $payload, true);
+        $hash = $module->calculateTwoOrderIntentSnapshotHash($cart, $payload);
+        TinyAssert::notSame(null, $module->getTwoCachedOrderIntentDecision($hash));
+
+        $result = $module->checkTwoOrderIntentApprovalAtPayment($cart, new Customer(), new Currency(), new Address());
+
+        TinyAssert::true($result['approved']);
+        TinyAssert::same(1, $module->providerCalls, 'The authoritative payment-submit check must never be served from the UX cache');
+    }
+
+    /** Exposed for the anonymous harness above. */
+    public static function publicIntentPayload(): array
+    {
+        return self::intentPayload();
+    }
+}

--- a/tests/FulfilledStatusMappingSpec.php
+++ b/tests/FulfilledStatusMappingSpec.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for the "Two: Order Fulfilled - Trigger Statuses" multi-select
+ * (PS_TWO_OS_FULFILLED_MAP) - TWO-24769.
+ *
+ * PrestaShop core's HelperForm::generate() rewrites a multi-select field's name
+ * in place ($params['name'] .= '[]') and the form template resolves the
+ * pre-selection with $fields_value[$input.name], i.e. under the rewritten
+ * '[]'-suffixed key. Identical in PS 1.7.6.x, 8.x and 9.x. These tests pin:
+ *
+ *  - the multi-select pre-selection is exposed under that '[]' key (and the
+ *    plain key), for every selected status, after a save-then-read-back cycle;
+ *  - the IDs are strings, matching the id_order_state the option values are
+ *    built from, so the comparison holds even under a strict comparison;
+ *  - every writer of PS_TWO_OS_FULFILLED_MAP stores the same JSON array format,
+ *    including the ensureCustomStatesExist() runtime recovery path which used to
+ *    write a bare status ID;
+ *  - the 2.6.2 upgrade normalises a legacy bare-ID value already in a database.
+ */
+final class FulfilledStatusMappingSpec
+{
+    public static function runAll(): void
+    {
+        self::testSaveThenReadBackPreSelectsEverySelectedStatus();
+        self::testReadBackNormalisesIdsToStrings();
+        self::testLegacyBareIdValueStillPreSelects();
+        self::testUnsetValueDefaultsToShippedStatus();
+        self::testCustomStateRecoveryWritesJsonArrayFormat();
+        self::testUpgrade262NormalisesLegacyBareIdValue();
+        self::testUpgrade262LeavesCanonicalValueUntouched();
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+        Tools::resetTestValues();
+        Configuration::updateValue('PS_OS_SHIPPING', 4);
+    }
+
+    /** @return array<string,mixed> */
+    private static function formValues(TwopaymentTestHarness $module): array
+    {
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoOrderStatusFormValues');
+
+        return $method->invoke($module);
+    }
+
+    /** @param array<int,string> $postedIds */
+    private static function save(TwopaymentTestHarness $module, array $postedIds): void
+    {
+        Tools::setTestValue('PS_TWO_OS_FULFILLED_MAP', $postedIds);
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoOrderStatusFormValues');
+        $method->invoke($module);
+    }
+
+    private static function testSaveThenReadBackPreSelectsEverySelectedStatus(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // Two statuses selected in the admin multi-select. PHP parses the
+        // '[]'-suffixed field name into an array of strings in $_POST.
+        self::save($module, ['3', '4']);
+
+        TinyAssert::same('[3,4]', Configuration::get('PS_TWO_OS_FULFILLED_MAP'));
+
+        $values = self::formValues($module);
+
+        // The '[]' key is the one the core form template actually reads.
+        TinyAssert::same(['3', '4'], $values['PS_TWO_OS_FULFILLED_MAP[]']);
+        TinyAssert::same(['3', '4'], $values['PS_TWO_OS_FULFILLED_MAP']);
+    }
+
+    private static function testReadBackNormalisesIdsToStrings(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // json_decode() of the stored value yields PHP ints, while the option
+        // values come from id_order_state as database strings.
+        Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', json_encode([3, 5]));
+
+        $values = self::formValues($module);
+
+        TinyAssert::same(['3', '5'], $values['PS_TWO_OS_FULFILLED_MAP[]']);
+        foreach ($values['PS_TWO_OS_FULFILLED_MAP[]'] as $id) {
+            TinyAssert::true(is_string($id));
+        }
+    }
+
+    private static function testLegacyBareIdValueStillPreSelects(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // Pre-2.1.2 format, and what ensureCustomStatesExist() wrote before 2.6.2.
+        Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', '4');
+
+        $values = self::formValues($module);
+
+        TinyAssert::same(['4'], $values['PS_TWO_OS_FULFILLED_MAP[]']);
+    }
+
+    private static function testUnsetValueDefaultsToShippedStatus(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $values = self::formValues($module);
+
+        TinyAssert::same(['4'], $values['PS_TWO_OS_FULFILLED_MAP[]']);
+    }
+
+    private static function testCustomStateRecoveryWritesJsonArrayFormat(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // No Two custom states and no mappings: the recovery path creates the
+        // states and seeds the default mappings.
+        $method = new ReflectionMethod(Twopayment::class, 'ensureCustomStatesExist');
+        $method->invoke($module);
+
+        TinyAssert::same('[4]', Configuration::get('PS_TWO_OS_FULFILLED_MAP'));
+
+        // And the value it wrote must round-trip through the form reader.
+        TinyAssert::same(['4'], self::formValues($module)['PS_TWO_OS_FULFILLED_MAP[]']);
+    }
+
+    private static function testUpgrade262NormalisesLegacyBareIdValue(): void
+    {
+        self::reset();
+        require_once dirname(__DIR__) . '/upgrade/upgrade-2.6.2.php';
+
+        Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', '3');
+
+        TinyAssert::true(upgrade_module_2_6_2(new TwopaymentTestHarness()));
+        TinyAssert::same('[3]', Configuration::get('PS_TWO_OS_FULFILLED_MAP'));
+    }
+
+    private static function testUpgrade262LeavesCanonicalValueUntouched(): void
+    {
+        self::reset();
+        require_once dirname(__DIR__) . '/upgrade/upgrade-2.6.2.php';
+
+        Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', '[3,4]');
+
+        TinyAssert::true(upgrade_module_2_6_2(new TwopaymentTestHarness()));
+        TinyAssert::same('[3,4]', Configuration::get('PS_TWO_OS_FULFILLED_MAP'));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+}

--- a/tests/ShippingCostSourcingSpec.php
+++ b/tests/ShippingCostSourcingSpec.php
@@ -32,6 +32,7 @@ final class ShippingCostSourcingSpec
         self::testFreeShippingCarrierlessCartStillBuilds();
         self::testUnloadableCarrierRefusesRatherThanGuessTheRate();
         self::testMixedDeclaredRatesSplitIntoOneLinePerRate();
+        self::testStaleIdCarrierOnMultiAddressCartStillSplitsPerRate();
     }
 
     /**
@@ -62,6 +63,20 @@ final class ShippingCostSourcingSpec
         StubStore::$cartDeliveryOptionLists[$cartId] = [
             $addressId => [$optionKey => ['carrier_list' => $carrierList]],
         ];
+    }
+
+    /**
+     * Same fixture, merged in rather than replacing: a ship-to-multiple-
+     * addresses cart has one delivery-option entry per address, which is the
+     * shape core hands back and the shape `id_carrier` cannot represent.
+     *
+     * @param array<int,array{net:float,gross:float,group:int}> $carriers By carrier id
+     */
+    private static function seedDeliveryOptionForAddress(int $cartId, int $addressId, array $carriers): void
+    {
+        $existing = StubStore::$cartDeliveryOptionLists[$cartId] ?? [];
+        self::seedDeliveryOption($cartId, $addressId, $carriers);
+        StubStore::$cartDeliveryOptionLists[$cartId] = $existing + StubStore::$cartDeliveryOptionLists[$cartId];
     }
 
     /** Did any log line mention this fragment? */
@@ -366,6 +381,120 @@ final class ShippingCostSourcingSpec
         );
 
         TinyAssert::same('150.70', (string)$payload['gross_amount']);
+        TinyAssert::same('126.00', (string)$payload['net_amount']);
+    }
+
+    /**
+     * (f) The stale-`id_carrier` case: core's Cart::setDeliveryOption() only
+     * recomputes `id_carrier` when the cart has a SINGLE delivery option, so a
+     * ship-to-multiple-addresses cart keeps a non-zero, loadable `id_carrier`
+     * while its shipping total spans several tax-rules groups.
+     *
+     * Gating the per-rate split on carrier loadability applied that one
+     * carrier's declared group to the whole shipping total, and - the reason
+     * this is not a cosmetic edge case - the resulting blend lands INSIDE the
+     * 2-cent reconciliation tolerance, so it passed silently and put a wrong
+     * declared rate on a real invoice. Here: 25.00 at 21% plus 1.00 at 20% is
+     * 5.45 tax, while 26.00 at a flat 21% implies 5.46 - one cent of divergence,
+     * well inside TAX_FORMULA_TOLERANCE.
+     *
+     * The decision must come from how many groups the delivery option spans,
+     * never from whether `id_carrier` loads.
+     */
+    private static function testStaleIdCarrierOnMultiAddressCartStillSplitsPerRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9106, 9116);
+        $cart = new Cart(9106);
+        $cart->id_customer = 9106;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9116;
+        $cart->id_address_delivery = 9116;
+        $cart->id_lang = 1;
+        self::seedProductLine($cart, 9126);
+
+        StubStore::$taxRuleRates[7301] = 21.0;
+        StubStore::$taxRuleRates[7302] = 20.0;
+        // Two packages, one per delivery address, each with its own carrier and
+        // its own declared tax-rules group.
+        self::seedDeliveryOption(9106, 9116, [
+            7021 => ['net' => 25.00, 'gross' => 30.25, 'group' => 7301],
+        ]);
+        self::seedDeliveryOptionForAddress(9106, 9117, [
+            7022 => ['net' => 1.00, 'gross' => 1.20, 'group' => 7302],
+        ]);
+
+        // The stale value core left behind: carrier 7021 loads, and its 21% is
+        // the rate the old gate would have applied to all 26.00.
+        $cart->id_carrier = 7021;
+
+        // Shipping 31.45 gross / 26.00 net (5.25 + 0.20 tax).
+        StubStore::$cartTotals[9106] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 31.45,
+                Cart::BOTH => 152.45,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 26.00,
+                Cart::BOTH => 126.00,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9106', $cart, self::merchantUrls());
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        TinyAssert::count(
+            2,
+            $shippingLines,
+            'A stale id_carrier must not collapse a multi-group delivery option into one rate'
+        );
+
+        $byRate = [];
+        $grossSum = 0.0;
+        $netSum = 0.0;
+        $taxSum = 0.0;
+        foreach ($shippingLines as $line) {
+            $byRate[(string)$line['tax_rate']] = $line;
+            $grossSum += (float)$line['gross_amount'];
+            $netSum += (float)$line['net_amount'];
+            $taxSum += (float)$line['tax_amount'];
+        }
+
+        TinyAssert::true(isset($byRate['0.21']), 'The 21% package keeps its own declared rate');
+        TinyAssert::true(isset($byRate['0.2']), 'The 20% package keeps its own declared rate');
+        TinyAssert::same('25.00', (string)$byRate['0.21']['net_amount']);
+        TinyAssert::same('5.25', (string)$byRate['0.21']['tax_amount']);
+        TinyAssert::same('1.00', (string)$byRate['0.2']['net_amount']);
+        TinyAssert::same('0.20', (string)$byRate['0.2']['tax_amount']);
+
+        // Cent-exact against PrestaShop's own shipping totals, so nothing hides
+        // in the reconciliation tolerance.
+        TinyAssert::same('31.45', number_format($grossSum, 2, '.', ''));
+        TinyAssert::same('26.00', number_format($netSum, 2, '.', ''));
+        TinyAssert::same('5.45', number_format($taxSum, 2, '.', ''));
+
+        // Both carriers were resolved from the delivery option even though
+        // id_carrier pointed at one of them.
+        TinyAssert::true(
+            self::loggedContains('carrier=7021 tax_rules_group=7301 rate=21%'),
+            'The delivery option carrier list must be walked, not id_carrier'
+        );
+        TinyAssert::true(
+            self::loggedContains('carrier=7022 tax_rules_group=7302 rate=20%'),
+            'The second package carrier must be resolved too'
+        );
+
+        TinyAssert::same('152.45', (string)$payload['gross_amount']);
         TinyAssert::same('126.00', (string)$payload['net_amount']);
     }
 

--- a/tests/ShippingCostSourcingSpec.php
+++ b/tests/ShippingCostSourcingSpec.php
@@ -87,8 +87,8 @@ final class ShippingCostSourcingSpec
     {
         StubStore::$customers[$cartId] = [
             'email' => 'buyer@example.com',
-            'firstname' => 'Javier',
-            'lastname' => 'Moreno',
+            'firstname' => 'Pia',
+            'lastname' => 'Sol',
             'secure_key' => 'secure-key-' . $cartId,
             'loaded' => true,
         ];

--- a/tests/ShippingCostSourcingSpec.php
+++ b/tests/ShippingCostSourcingSpec.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TWO-25161 - shipping-cost sourcing must not depend on a Carrier object.
+ *
+ * A merchant who prices shipping through symbolic "logistics carriers" leaves
+ * `id_carrier = 0` on a cart that still carries a real shipping cost. The old
+ * builder keyed the SHIPPING_FEE line off `new Carrier($cart->id_carrier)`, so
+ * that cost silently vanished from the payload and the cart-vs-lines
+ * reconciliation gate rejected the order with an order-total mismatch of
+ * exactly the shipping amount.
+ *
+ * The cart is now the authority (Cart::getOrderTotal(..., Cart::ONLY_SHIPPING)).
+ * `id_carrier = 0` is still NOT blessed: the protection that matters - the
+ * cart's totals must be internally coherent - is unchanged, and a genuinely
+ * incoherent cart is still refused, now with a message that names the amounts.
+ *
+ * The shipping tax RATE is never derived from those amounts. It is relayed from
+ * the tax-rules group declared by the carriers in the cart's own selected
+ * delivery option, which stay enumerable even with `id_carrier = 0`. When no
+ * such carrier exists at all (PrestaShop's carrier_list = [0 => 0] sentinel)
+ * the order is refused rather than shipped with a guessed rate.
+ */
+final class ShippingCostSourcingSpec
+{
+    public static function runAll(): void
+    {
+        self::testCarrierlessCartKeepsShippingCostAndReconciles();
+        self::testIncoherentCartIsRejectedWithSpecificMessage();
+        self::testFreeShippingCarrierlessCartStillBuilds();
+        self::testUnloadableCarrierRefusesRatherThanGuessTheRate();
+        self::testMixedDeclaredRatesSplitIntoOneLinePerRate();
+    }
+
+    /**
+     * Core-shaped delivery-option fixture: one address, one option key, one
+     * entry per carrier in `carrier_list` with a loaded `Carrier` instance -
+     * exactly what Cart::getDeliveryOptionList() hands back.
+     *
+     * @param array<int,array{net:float,gross:float,group:int}> $carriers By carrier id
+     */
+    private static function seedDeliveryOption(int $cartId, int $addressId, array $carriers): void
+    {
+        $carrierList = [];
+        $optionKey = '';
+        foreach ($carriers as $idCarrier => $spec) {
+            StubStore::$carriers[$idCarrier] = [
+                'name' => 'Carrier ' . $idCarrier,
+                'delay' => '',
+                'tax_rules_group_id' => $spec['group'],
+            ];
+            $carrierList[$idCarrier] = [
+                'price_with_tax' => $spec['gross'],
+                'price_without_tax' => $spec['net'],
+                'instance' => new Carrier($idCarrier),
+            ];
+            $optionKey .= $idCarrier . ',';
+        }
+
+        StubStore::$cartDeliveryOptionLists[$cartId] = [
+            $addressId => [$optionKey => ['carrier_list' => $carrierList]],
+        ];
+    }
+
+    /** Did any log line mention this fragment? */
+    private static function loggedContains(string $needle): bool
+    {
+        foreach (PrestaShopLogger::$logs as $entry) {
+            if (strpos((string) $entry['message'], $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+    }
+
+    /** Shared buyer/currency/address fixture for a carrier-less ES cart. */
+    private static function seedCommonFixtures(int $cartId, int $addressId): void
+    {
+        StubStore::$customers[$cartId] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Javier',
+            'lastname' => 'Moreno',
+            'secure_key' => 'secure-key-' . $cartId,
+            'loaded' => true,
+        ];
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[34] = 'ES';
+        StubStore::$addresses[$addressId] = [
+            'id_country' => 34,
+            'company' => 'LOGISTICS SHOP',
+            'companyid' => 'E20468708',
+            'address1' => 'Calle Uno 1',
+            'city' => 'Madrid',
+            'postcode' => '28001',
+            'phone' => '666666601',
+            'loaded' => true,
+        ];
+    }
+
+    /**
+     * Single 21% product line, 100.00 net / 121.00 gross, on a cart with NO
+     * carrier at all (StubStore::$carriers left empty, so `new Carrier(0)` is
+     * an unloaded object exactly like a shop whose shipping is priced outside
+     * the carrier table).
+     */
+    private static function seedProductLine(Cart $cart, int $productId): void
+    {
+        StubStore::$cartProducts[$cart->id] = [[
+            'id_product' => $productId,
+            'link_rewrite' => 'logistics-product',
+            'name' => 'Logistics Product',
+            'description_short' => 'Product',
+            'manufacturer_name' => 'ACME',
+            'ean13' => '',
+            'upc' => '',
+            'total' => 100.00,
+            'total_wt' => 121.00,
+            'cart_quantity' => 1,
+            'rate' => 21.0,
+            'price' => 100.00,
+            'reduction' => 0,
+        ]];
+        StubStore::$productCategories[$productId] = [['name' => 'General']];
+        StubStore::$images[$productId] = ['id_image' => $productId];
+        StubStore::$products[$productId]['id_tax_rules_group'] = 9000 + $productId;
+        StubStore::$taxRuleRates[9000 + $productId] = 21.0;
+    }
+
+    private static function merchantUrls(): array
+    {
+        return [
+            'merchant_confirmation_url' => 'https://shop.local/confirm',
+            'merchant_cancel_order_url' => 'https://shop.local/cancel',
+            'merchant_edit_order_url' => '',
+            'merchant_order_verification_failed_url' => '',
+            'merchant_invoice_url' => '',
+            'merchant_shipping_document_url' => '',
+        ];
+    }
+
+    /**
+     * (a) id_carrier = 0 with a non-zero shipping total: the shipping cost
+     * survives into the payload, the submitted order total matches the cart
+     * total, and the rate is the one DECLARED by the carrier in the cart's
+     * selected delivery option - not one computed from the amounts.
+     */
+    private static function testCarrierlessCartKeepsShippingCostAndReconciles(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9101, 9111);
+        $cart = new Cart(9101);
+        $cart->id_customer = 9101;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9111;
+        $cart->id_address_delivery = 9111;
+        $cart->id_lang = 1;
+        // The whole point: no carrier is selectable on this cart.
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9121);
+
+        // The carrier that priced the shipping is still enumerable from the
+        // cart's delivery option even though id_carrier is 0, and it declares
+        // tax-rules group 7101 = 21%.
+        StubStore::$taxRuleRates[7101] = 21.0;
+        self::seedDeliveryOption(9101, 9111, [
+            7001 => ['net' => 23.97, 'gross' => 29.00, 'group' => 7101],
+        ]);
+
+        // 29.00 gross shipping at 21% -> 23.9669 net (unrounded, as PrestaShop
+        // reports it). Cart total 121.00 + 29.00 = 150.00 gross / 123.9669 net.
+        StubStore::$cartTotals[9101] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 23.9669,
+                Cart::BOTH => 123.9669,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9101', $cart, self::merchantUrls());
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        TinyAssert::count(1, $shippingLines);
+        $shipping = $shippingLines[0];
+        TinyAssert::same('29.00', (string)$shipping['gross_amount'], 'Shipping gross must come from the cart, not a Carrier');
+        TinyAssert::same('23.97', (string)$shipping['net_amount']);
+        TinyAssert::same('5.03', (string)$shipping['tax_amount']);
+        // DECLARED, not derived: 21% comes from the carrier's tax-rules group.
+        // The 2dp amounts on this line imply 20.98% (5.03 / 23.97), so a
+        // derivation would have relayed the wrong rate here.
+        TinyAssert::same('0.21', (string)$shipping['tax_rate']);
+        TinyAssert::same('Shipping', (string)$shipping['name'], 'No carrier on the cart means the generic shipping label');
+
+        // The resolved carrier and tax-rules-group IDs are logged, so the case
+        // a live cart hits is confirmable from the shop log.
+        TinyAssert::true(
+            self::loggedContains('carrier=7001 tax_rules_group=7101 rate=21%'),
+            'The resolved carrier and tax-rules-group IDs must be logged'
+        );
+
+        // The submitted order total matches the cart total - the mismatch of
+        // exactly the shipping cost is gone.
+        TinyAssert::same('150.00', (string)$payload['gross_amount']);
+        TinyAssert::same('123.97', (string)$payload['net_amount']);
+    }
+
+    /**
+     * (d) The genuine hole, closed loudly: a product with no available carrier
+     * makes PrestaShop set carrier_list = [0 => 0], so `new Carrier(0)` is
+     * unloadable and no tax-rules group exists - yet getPackageShippingCost()
+     * still prices the shipping through its internal default-carrier fallback.
+     * No rate may be derived, guessed, or silently sent as 0 there.
+     */
+    private static function testUnloadableCarrierRefusesRatherThanGuessTheRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9104, 9114);
+        $cart = new Cart(9104);
+        $cart->id_customer = 9104;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9114;
+        $cart->id_address_delivery = 9114;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9124);
+
+        // PrestaShop's no-available-carrier sentinel, verbatim.
+        StubStore::$cartDeliveryOptionLists[9104] = [
+            9114 => ['0,' => ['carrier_list' => [0 => 0]]],
+        ];
+
+        StubStore::$cartTotals[9104] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 23.9669,
+                Cart::BOTH => 123.9669,
+            ],
+        ];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoNewOrderData('merchant-attempt-9104', $cart, self::merchantUrls());
+            },
+            'No deliverable carrier for the cart shipping cost: PrestaShop reports no available carrier ' .
+            '(carrier_list = [0 => 0]) for this cart, so there is no declared shipping tax-rules group to relay'
+        );
+
+        // The refusal names the condition and the numbers behind it.
+        TinyAssert::true(
+            self::loggedContains('cart 9104, id_carrier=0, shipping=29.00'),
+            'The refusal must log the cart, id_carrier and shipping amount'
+        );
+    }
+
+    /**
+     * (e) A delivery option spanning carriers with DIFFERENT declared rates is
+     * split into one SHIPPING_FEE line per rate, weighted by the per-carrier
+     * nets already in carrier_list. No blended rate, no arbitrary pick, and the
+     * per-rate amounts still sum to the cart's own shipping total.
+     */
+    private static function testMixedDeclaredRatesSplitIntoOneLinePerRate(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9105, 9115);
+        $cart = new Cart(9105);
+        $cart->id_customer = 9105;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9115;
+        $cart->id_address_delivery = 9115;
+        $cart->id_lang = 1;
+        // Two carriers in one option means core cannot put a single carrier id
+        // on the cart, which is precisely the mixed-rate case.
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9125);
+
+        StubStore::$taxRuleRates[7201] = 21.0;
+        StubStore::$taxRuleRates[7202] = 10.0;
+        self::seedDeliveryOption(9105, 9115, [
+            7011 => ['net' => 10.00, 'gross' => 12.10, 'group' => 7201],
+            7012 => ['net' => 16.00, 'gross' => 17.60, 'group' => 7202],
+        ]);
+
+        // Shipping 29.70 gross / 26.00 net; cart 121.00 + 29.70 = 150.70 gross,
+        // 100.00 + 26.00 = 126.00 net.
+        StubStore::$cartTotals[9105] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 29.70,
+                Cart::BOTH => 150.70,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 26.00,
+                Cart::BOTH => 126.00,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9105', $cart, self::merchantUrls());
+
+        $shippingLines = [];
+        foreach ($payload['line_items'] as $line) {
+            if ((string)($line['type'] ?? '') === 'SHIPPING_FEE') {
+                $shippingLines[] = $line;
+            }
+        }
+
+        TinyAssert::count(2, $shippingLines, 'Mixed declared rates must emit one shipping line per rate');
+
+        $byRate = [];
+        $grossSum = 0.0;
+        $netSum = 0.0;
+        $taxSum = 0.0;
+        foreach ($shippingLines as $line) {
+            $byRate[(string)$line['tax_rate']] = $line;
+            $grossSum += (float)$line['gross_amount'];
+            $netSum += (float)$line['net_amount'];
+            $taxSum += (float)$line['tax_amount'];
+        }
+
+        TinyAssert::true(isset($byRate['0.21']), 'The 21% carrier must keep its own declared rate');
+        TinyAssert::true(isset($byRate['0.1']), 'The 10% carrier must keep its own declared rate');
+        TinyAssert::same('10.00', (string)$byRate['0.21']['net_amount']);
+        TinyAssert::same('2.10', (string)$byRate['0.21']['tax_amount']);
+        TinyAssert::same('16.00', (string)$byRate['0.1']['net_amount']);
+        TinyAssert::same('1.60', (string)$byRate['0.1']['tax_amount']);
+
+        // Per-rate amounts sum to the cart's authoritative shipping total.
+        TinyAssert::same('29.70', number_format($grossSum, 2, '.', ''));
+        TinyAssert::same('26.00', number_format($netSum, 2, '.', ''));
+        TinyAssert::same('3.70', number_format($taxSum, 2, '.', ''));
+
+        // Both carriers and both groups are logged.
+        TinyAssert::true(
+            self::loggedContains('carrier=7011 tax_rules_group=7201 rate=21%; carrier=7012 tax_rules_group=7202 rate=10%'),
+            'Both resolved carriers and tax-rules groups must be logged'
+        );
+
+        TinyAssert::same('150.70', (string)$payload['gross_amount']);
+        TinyAssert::same('126.00', (string)$payload['net_amount']);
+    }
+
+    /**
+     * (b) A genuinely incoherent cart (line items + shipping + tax do not add
+     * up to the cart's own order total) is still refused - and the refusal
+     * names the amounts instead of the old opaque one-liner.
+     */
+    private static function testIncoherentCartIsRejectedWithSpecificMessage(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9102, 9112);
+        $cart = new Cart(9102);
+        $cart->id_customer = 9102;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9112;
+        $cart->id_address_delivery = 9112;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9122);
+
+        // Cart claims a 150.00 gross total but reports NO shipping and no
+        // discount - 29.00 of it is attributable to nothing the cart exposes.
+        // Nothing can build a payload that reconciles with that.
+        StubStore::$cartTotals[9102] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 150.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 123.97,
+            ],
+        ];
+
+        TinyAssert::throws(
+            static function () use ($module, $cart): void {
+                $module->getTwoNewOrderData('merchant-attempt-9102', $cart, self::merchantUrls());
+            },
+            'Order totals do not reconcile with cart totals: cart total 150.00 vs order lines 121.00 (difference 29.00)'
+        );
+    }
+
+    /**
+     * (c) A carrier-less cart that genuinely has no shipping cost (free
+     * shipping) still builds - no phantom shipping line, totals still match.
+     */
+    private static function testFreeShippingCarrierlessCartStillBuilds(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        self::seedCommonFixtures(9103, 9113);
+        $cart = new Cart(9103);
+        $cart->id_customer = 9103;
+        $cart->id_currency = 978;
+        $cart->id_address_invoice = 9113;
+        $cart->id_address_delivery = 9113;
+        $cart->id_lang = 1;
+        $cart->id_carrier = 0;
+        self::seedProductLine($cart, 9123);
+
+        StubStore::$cartTotals[9103] = [
+            true => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 121.00,
+            ],
+            false => [
+                Cart::ONLY_DISCOUNTS => 0.00,
+                Cart::ONLY_SHIPPING => 0.00,
+                Cart::BOTH => 100.00,
+            ],
+        ];
+
+        $payload = $module->getTwoNewOrderData('merchant-attempt-9103', $cart, self::merchantUrls());
+
+        foreach ($payload['line_items'] as $line) {
+            TinyAssert::notSame('SHIPPING_FEE', (string)($line['type'] ?? ''), 'A zero-shipping cart must emit no shipping line');
+        }
+        TinyAssert::same('121.00', (string)$payload['gross_amount']);
+        TinyAssert::same('100.00', (string)$payload['net_amount']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -80,6 +80,8 @@ namespace {
         public static array $dbExecuteSResponses = [];
         public static array $dbLastExecuteS = [];
         public static array $orderCarriers = [];
+        /** @var array<int,array{id_order_state:string,name:string}> Override for OrderState::getOrderStates() */
+        public static array $orderStates = [];
         public static array $carts = [];
         /** @var array<string,int> Registered admin tab ids by class name */
         public static array $tabIds = ['AdminTwopaymentInvoice' => 1];
@@ -193,6 +195,7 @@ namespace {
             self::$dbLocks = [];
             self::$surchargeSyncSeqs = [];
             self::$orderDetails = [];
+            self::$orderStates = [];
             self::$dbExecuted = [];
             self::$dbTriggers = [];
             self::$orders = [];
@@ -1505,11 +1508,13 @@ namespace {
         }
     }
 
+    #[\AllowDynamicProperties]
     class OrderState
     {
         public bool $loaded = true;
         public int $id = 1;
-        public $name = '';
+        /** @var string|array<int,string> String once loaded by id; array<id_lang,string> while being built. */
+        public $name = [];
         public int $invoice = 0;
         public int $delivery = 0;
         public int $shipped = 0;
@@ -1549,7 +1554,32 @@ namespace {
 
         public function add(): bool
         {
+            // Core assigns a fresh auto-increment id on insert. Returning a
+            // distinct id per insert matters for createTwoOrderState(), which
+            // creates six states in one pass and stores each id in configuration.
+            $this->id = StubStore::$nextId++;
+
             return true;
+        }
+
+        /**
+         * Mirrors OrderStateCore::getOrderStates(): id_order_state comes back from
+         * the database as a string, which matters for pre-selection comparisons.
+         *
+         * @return array<int,array{id_order_state:string,name:string}>
+         */
+        public static function getOrderStates($idLang = null): array
+        {
+            if (!empty(StubStore::$orderStates)) {
+                return StubStore::$orderStates;
+            }
+
+            return [
+                ['id_order_state' => '2', 'name' => 'Payment accepted'],
+                ['id_order_state' => '3', 'name' => 'Processing in progress'],
+                ['id_order_state' => '4', 'name' => 'Shipped'],
+                ['id_order_state' => '5', 'name' => 'Delivered'],
+            ];
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -228,6 +228,17 @@ namespace {
     }
 
     /**
+     * Core's DB failure type. Present here because the payload-build path walks
+     * core (TaxManagerFactory, Address, Carrier, DB reads), so it is the shape
+     * of "an exception the plugin did NOT raise" reaching the payment
+     * controller's catch — and its message carries SQL text that must never be
+     * relayed to a buyer (TWO-25161).
+     */
+    class PrestaShopDatabaseException extends PrestaShopException
+    {
+    }
+
+    /**
      * Thrown by the front-controller stubs wherever real PrestaShop would
      * redirect-and-exit, so controller specs observe the redirect instead of
      * falling through code the real flow never reaches.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,24 @@ namespace {
         public static array $cartTotals = [];
         public static array $cartShipping = [];
         public static array $cartRules = [];
+        /**
+         * Cart::getDeliveryOptionList() fixtures by cart id, core-shaped:
+         *   [id_address => [option_key => ['carrier_list' => [id_carrier => [
+         *       'price_with_tax' => float, 'price_without_tax' => float,
+         *       'instance' => Carrier,
+         *   ]]]]]
+         * The no-available-carrier sentinel is carrier_list = [0 => 0].
+         *
+         * @var array<int,array>
+         */
+        public static array $cartDeliveryOptionLists = [];
+        /**
+         * Cart::getDeliveryOption() overrides by cart id. Unset means the stub
+         * auto-selects the first option per address, like core does.
+         *
+         * @var array<int,array|false>
+         */
+        public static array $cartDeliveryOptions = [];
         public static array $moduleCurrencies = [];
         public static array $productCategories = [];
         public static array $images = [];
@@ -145,6 +163,8 @@ namespace {
             self::$cartTotals = [];
             self::$cartShipping = [];
             self::$cartRules = [];
+            self::$cartDeliveryOptionLists = [];
+            self::$cartDeliveryOptions = [];
             self::$orderCarriers = [];
             self::$carts = [];
             self::$tabIds = ['AdminTwopaymentInvoice' => 1];
@@ -1311,6 +1331,36 @@ namespace {
         public function getCartRules(): array
         {
             return StubStore::$cartRules[$this->id] ?? [];
+        }
+
+        public function getDeliveryOptionList($defaultCountry = null, $flush = false): array
+        {
+            return StubStore::$cartDeliveryOptionLists[$this->id] ?? [];
+        }
+
+        /**
+         * Core-faithful enough for the plugin's use: an explicit fixture wins,
+         * otherwise auto-select the first option for each address, which is
+         * what core falls back to when nothing is selected or the selection no
+         * longer validates.
+         *
+         * @return array<int,string>|false
+         */
+        public function getDeliveryOption($defaultCountry = null, $dontAutoSelectOptions = false, $useCache = true)
+        {
+            if (array_key_exists($this->id, StubStore::$cartDeliveryOptions)) {
+                return StubStore::$cartDeliveryOptions[$this->id];
+            }
+
+            $selected = [];
+            foreach (StubStore::$cartDeliveryOptionLists[$this->id] ?? [] as $idAddress => $options) {
+                $keys = array_keys((array) $options);
+                if ($keys !== []) {
+                    $selected[(int) $idAddress] = (string) $keys[0];
+                }
+            }
+
+            return $selected;
         }
 
         public function getAverageProductsTaxRate(): float

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -276,6 +276,12 @@ namespace {
         {
             return (string) $name === 'twopayment';
         }
+
+        /** @return array<int,array{name:string}> */
+        public static function getPaymentModules(): array
+        {
+            return [['name' => 'twopayment']];
+        }
     }
     }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -5529,6 +5529,7 @@ require __DIR__ . '/InvoiceUploadGateSpec.php';
 require __DIR__ . '/FxRatesSpec.php';
 require __DIR__ . '/TwoSoleTraderSpec.php';
 require __DIR__ . '/ShippingCostSourcingSpec.php';
+require __DIR__ . '/AjaxCheckoutFailureSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5548,6 +5549,7 @@ $tests = [
     'FxRatesSpec::runAll' => [FxRatesSpec::class, 'runAll'],
     'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
     'ShippingCostSourcingSpec::runAll' => [ShippingCostSourcingSpec::class, 'runAll'],
+    'AjaxCheckoutFailureSpec::runAll' => [AjaxCheckoutFailureSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -5531,6 +5531,7 @@ require __DIR__ . '/TwoSoleTraderSpec.php';
 require __DIR__ . '/ShippingCostSourcingSpec.php';
 require __DIR__ . '/AjaxCheckoutFailureSpec.php';
 require __DIR__ . '/CheckoutLatencySpec.php';
+require __DIR__ . '/FulfilledStatusMappingSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5552,6 +5553,7 @@ $tests = [
     'ShippingCostSourcingSpec::runAll' => [ShippingCostSourcingSpec::class, 'runAll'],
     'AjaxCheckoutFailureSpec::runAll' => [AjaxCheckoutFailureSpec::class, 'runAll'],
     'CheckoutLatencySpec::runAll' => [CheckoutLatencySpec::class, 'runAll'],
+    'FulfilledStatusMappingSpec::runAll' => [FulfilledStatusMappingSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -5530,6 +5530,7 @@ require __DIR__ . '/FxRatesSpec.php';
 require __DIR__ . '/TwoSoleTraderSpec.php';
 require __DIR__ . '/ShippingCostSourcingSpec.php';
 require __DIR__ . '/AjaxCheckoutFailureSpec.php';
+require __DIR__ . '/CheckoutLatencySpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5550,6 +5551,7 @@ $tests = [
     'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
     'ShippingCostSourcingSpec::runAll' => [ShippingCostSourcingSpec::class, 'runAll'],
     'AjaxCheckoutFailureSpec::runAll' => [AjaxCheckoutFailureSpec::class, 'runAll'],
+    'CheckoutLatencySpec::runAll' => [CheckoutLatencySpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/tests/run.php
+++ b/tests/run.php
@@ -5528,6 +5528,7 @@ require __DIR__ . '/MinimumOrderGateSpec.php';
 require __DIR__ . '/InvoiceUploadGateSpec.php';
 require __DIR__ . '/FxRatesSpec.php';
 require __DIR__ . '/TwoSoleTraderSpec.php';
+require __DIR__ . '/ShippingCostSourcingSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5546,6 +5547,7 @@ $tests = [
     'InvoiceUploadGateSpec::runAll' => [InvoiceUploadGateSpec::class, 'runAll'],
     'FxRatesSpec::runAll' => [FxRatesSpec::class, 'runAll'],
     'TwoSoleTraderSpec::runAll' => [TwoSoleTraderSpec::class, 'runAll'],
+    'ShippingCostSourcingSpec::runAll' => [ShippingCostSourcingSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -136,6 +136,17 @@ class Twopayment extends PaymentModule
     const COOKIE_EXPIRY_ONE_HOUR = 3600; // 1 hour
     const ATTEMPT_RETENTION_DAYS = 90; // Keep attempt telemetry for 90 days
     const ATTEMPT_CLEANUP_INTERVAL_SECONDS = 86400; // Run cleanup at most once per day
+    // TWO-24799: how long a UX-only order-intent decision stays reusable for an
+    // unchanged decision snapshot. Deliberately short - this only suppresses the
+    // repeat /v1/order_intent round trip behind an identical snapshot hash, and
+    // the authoritative check at payment submit
+    // (checkTwoOrderIntentApprovalAtPayment) is never served from this cache.
+    const ORDER_INTENT_DECISION_CACHE_TTL = 300; // 5 minutes
+    // TWO-24799: how long an unverifiable org number stays remembered as a miss.
+    // The success path is already cached indefinitely (for the cookie's lifetime)
+    // by the two_company_* company cookie, so only the miss needs its own TTL -
+    // short enough that a provider blip self-heals inside one checkout session.
+    const COMPANY_VERIFY_MISS_CACHE_TTL = 300; // 5 minutes
     // Cross-request cache for the buyer fee-share quote (POST /v1/pricing/order/fee).
     // fetchTwoTermFee() already request-scopes the quote via $this->twoFeeCache, but
     // that array is rebuilt from scratch on every HTTP request (e.g. each order-intent
@@ -10739,6 +10750,285 @@ class Twopayment extends PaymentModule
     {
         $snapshot = $this->buildTwoCheckoutSnapshot($cart, $paymentdata);
         return hash('sha256', json_encode($snapshot, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * Calculate the decision snapshot hash for a UX-only order-intent check
+     * (TWO-24799).
+     *
+     * Composed from - never a replacement for - the cart snapshot hash used by
+     * order-create idempotency. That hash covers the cart, currency, address
+     * IDs and every line item, but it deliberately says nothing about WHO is
+     * buying, and the buyer's company is the primary input Two decides on. A
+     * buyer who re-runs company search and picks a different company against
+     * the same saved address would otherwise produce an identical hash, so the
+     * buyer identity is mixed in explicitly here.
+     *
+     * @param Cart $cart
+     * @param array $paymentdata Order-intent payload as built by getTwoIntentOrderData()
+     * @return string
+     */
+    public function calculateTwoOrderIntentSnapshotHash($cart, $paymentdata)
+    {
+        $company = array();
+        if (isset($paymentdata['buyer']['company']) && is_array($paymentdata['buyer']['company'])) {
+            $company = $paymentdata['buyer']['company'];
+        }
+
+        $identity = array(
+            'company_name' => isset($company['company_name']) ? trim((string)$company['company_name']) : '',
+            'organization_number' => isset($company['organization_number']) ? trim((string)$company['organization_number']) : '',
+            'country_prefix' => isset($company['country_prefix']) ? strtoupper(trim((string)$company['country_prefix'])) : '',
+            // Country lives on the address blocks too, and a country switch MUST
+            // bust this hash (TWO-24867 tracks country-switch staleness as a bug
+            // class here), so both are folded in rather than trusted separately.
+            'billing_country' => isset($paymentdata['billing_address']['country'])
+                ? strtoupper(trim((string)$paymentdata['billing_address']['country']))
+                : '',
+            'shipping_country' => isset($paymentdata['shipping_address']['country'])
+                ? strtoupper(trim((string)$paymentdata['shipping_address']['country']))
+                : '',
+            'invoice_type' => isset($paymentdata['invoice_type']) ? (string)$paymentdata['invoice_type'] : '',
+        );
+
+        $seed = 'order_intent|'
+            . $this->calculateTwoCheckoutSnapshotHash($cart, $paymentdata) . '|'
+            . json_encode($identity, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return hash('sha256', $seed);
+    }
+
+    /**
+     * Record the snapshot hash the browser is about to run an intent check for,
+     * so the decision it reports back can be bound to the right snapshot
+     * (TWO-24799).
+     *
+     * The browser makes the /v1/order_intent call today, so it - not the server
+     * - learns the outcome. Rather than trusting a client-supplied hash, the
+     * server remembers the hash it just computed and binds the reported
+     * decision to that. When TWO-25162 moves the call behind the plugin backend
+     * the server will know the outcome first-hand and can write the decision
+     * directly; the cache read/write pair below is unchanged by that.
+     *
+     * @param string $snapshot_hash
+     * @return void
+     */
+    public function markTwoPendingOrderIntentSnapshot($snapshot_hash)
+    {
+        $snapshot_hash = trim((string)$snapshot_hash);
+        if (Tools::isEmpty($snapshot_hash)) {
+            return;
+        }
+
+        $this->context->cookie->two_order_intent_pending_hash = $snapshot_hash;
+        $this->context->cookie->setExpire(time() + self::COOKIE_EXPIRY_ONE_HOUR);
+    }
+
+    /**
+     * Bind the decision the browser reported to the pending snapshot hash
+     * (TWO-24799).
+     *
+     * @param bool $approved
+     * @return string The snapshot hash the decision was stored against, '' when none was pending
+     */
+    public function storeTwoOrderIntentDecisionForPendingSnapshot($approved)
+    {
+        $snapshot_hash = isset($this->context->cookie->two_order_intent_pending_hash)
+            ? trim((string)$this->context->cookie->two_order_intent_pending_hash)
+            : '';
+        if (Tools::isEmpty($snapshot_hash)) {
+            return '';
+        }
+
+        $this->context->cookie->two_order_intent_decision = json_encode(array(
+            'hash' => $snapshot_hash,
+            'approved' => (bool)$approved ? 1 : 0,
+            'at' => time(),
+        ));
+        $this->context->cookie->setExpire(time() + self::COOKIE_EXPIRY_ONE_HOUR);
+
+        return $snapshot_hash;
+    }
+
+    /**
+     * Read back a still-valid intent decision for a snapshot hash (TWO-24799).
+     *
+     * Returns null - never a stale decision - whenever the snapshot differs, the
+     * entry has aged past ORDER_INTENT_DECISION_CACHE_TTL, or the stored value
+     * is unreadable. Any cart, address, country or company change produces a
+     * different hash, so this cannot survive the buyer editing their order.
+     *
+     * @param string $snapshot_hash
+     * @return array{approved:bool,timestamp:int}|null
+     */
+    public function getTwoCachedOrderIntentDecision($snapshot_hash)
+    {
+        $snapshot_hash = trim((string)$snapshot_hash);
+        if (Tools::isEmpty($snapshot_hash)) {
+            return null;
+        }
+
+        $encoded = isset($this->context->cookie->two_order_intent_decision)
+            ? (string)$this->context->cookie->two_order_intent_decision
+            : '';
+        if (Tools::isEmpty($encoded)) {
+            return null;
+        }
+
+        $decoded = json_decode($encoded, true);
+        if (!is_array($decoded) || !isset($decoded['hash'], $decoded['approved'], $decoded['at'])) {
+            return null;
+        }
+
+        if (!hash_equals((string)$decoded['hash'], $snapshot_hash)) {
+            return null;
+        }
+
+        $age = time() - (int)$decoded['at'];
+        if ($age < 0 || $age > self::ORDER_INTENT_DECISION_CACHE_TTL) {
+            return null;
+        }
+
+        return array(
+            'approved' => (bool)(int)$decoded['approved'],
+            'timestamp' => (int)$decoded['at'],
+        );
+    }
+
+    /**
+     * Drop any cached intent decision (TWO-24799).
+     *
+     * @return void
+     */
+    public function clearTwoCachedOrderIntentDecision()
+    {
+        unset($this->context->cookie->two_order_intent_decision);
+        unset($this->context->cookie->two_order_intent_pending_hash);
+    }
+
+    /**
+     * Verify an org number found on a saved address, memoising BOTH outcomes for
+     * the checkout session (TWO-24799).
+     *
+     * The success path was already cached: verifyCompanyByOrgNumber()'s caller
+     * writes the resolved company into the two_company_* cookie, so a verified
+     * org number costs one lookup per session. The MISS path was not cached at
+     * all, so an address carrying an org number Two cannot resolve (a typo, a
+     * deregistered company, or a provider hiccup) paid a fresh blocking
+     * /companies/v2/company round trip on every single checkout update, at the
+     * 30s API_TIMEOUT_SHORT budget, forever returning the same null.
+     *
+     * The miss marker is keyed on org number + country + address ID, so editing
+     * any of the three re-verifies immediately instead of inheriting the miss.
+     *
+     * @param string $orgNumber
+     * @param string $countryIso
+     * @param int $addressId
+     * @return array{name:string,organization_number:string}|null
+     */
+    public function getTwoVerifiedCompanyForOrgNumber($orgNumber, $countryIso, $addressId)
+    {
+        $key = $this->buildTwoCompanyVerifyCacheKey($orgNumber, $countryIso, $addressId);
+
+        if ($key !== '' && $this->hasTwoCompanyVerifyMiss($key)) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Skipped org-number verification - cached miss for country=' .
+                strtoupper(trim((string)$countryIso)) . ', address=' . (int)$addressId,
+                1
+            );
+            return null;
+        }
+
+        $verified = $this->verifyCompanyByOrgNumber($orgNumber, $countryIso);
+
+        if ($verified && !empty($verified['organization_number'])) {
+            // Success: forget any stale miss so a later re-check is not blocked.
+            $this->clearTwoCompanyVerifyMiss();
+            return $verified;
+        }
+
+        if ($key !== '') {
+            $this->recordTwoCompanyVerifyMiss($key);
+        }
+
+        return null;
+    }
+
+    /**
+     * Cache key for an org-number verification attempt (TWO-24799).
+     *
+     * @param string $orgNumber
+     * @param string $countryIso
+     * @param int $addressId
+     * @return string '' when the inputs cannot form a usable key
+     */
+    private function buildTwoCompanyVerifyCacheKey($orgNumber, $countryIso, $addressId)
+    {
+        $orgNumber = strtoupper(preg_replace('/[\s\-]/', '', trim((string)$orgNumber)));
+        $countryIso = strtoupper(trim((string)$countryIso));
+        if (Tools::isEmpty($orgNumber) || Tools::isEmpty($countryIso)) {
+            return '';
+        }
+
+        return hash('sha256', 'company_verify|' . $orgNumber . '|' . $countryIso . '|' . (int)$addressId);
+    }
+
+    /**
+     * Whether this exact verification attempt is a remembered, unexpired miss.
+     *
+     * @param string $key
+     * @return bool
+     */
+    private function hasTwoCompanyVerifyMiss($key)
+    {
+        $encoded = isset($this->context->cookie->two_company_verify_miss)
+            ? (string)$this->context->cookie->two_company_verify_miss
+            : '';
+        if (Tools::isEmpty($encoded)) {
+            return false;
+        }
+
+        $decoded = json_decode($encoded, true);
+        if (!is_array($decoded) || !isset($decoded['key'], $decoded['at'])) {
+            return false;
+        }
+
+        if (!hash_equals((string)$decoded['key'], (string)$key)) {
+            return false;
+        }
+
+        $age = time() - (int)$decoded['at'];
+
+        return $age >= 0 && $age <= self::COMPANY_VERIFY_MISS_CACHE_TTL;
+    }
+
+    /**
+     * Remember an org number that Two could not resolve.
+     *
+     * Single-slot by design: the buyer has one billing address in play at a
+     * time, so one marker keeps the cookie bounded while still covering the
+     * repeat-update case this exists for.
+     *
+     * @param string $key
+     * @return void
+     */
+    private function recordTwoCompanyVerifyMiss($key)
+    {
+        $this->context->cookie->two_company_verify_miss = json_encode(array(
+            'key' => (string)$key,
+            'at' => time(),
+        ));
+        $this->context->cookie->setExpire(time() + self::COOKIE_EXPIRY_ONE_HOUR);
+    }
+
+    /**
+     * Forget the remembered verification miss (TWO-24799).
+     *
+     * @return void
+     */
+    public function clearTwoCompanyVerifyMiss()
+    {
+        unset($this->context->cookie->two_company_verify_miss);
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -3227,7 +3227,16 @@ class Twopayment extends PaymentModule
                     ', Tolerance=' . $this->getTwoRoundAmount(self::ORDER_RECONCILIATION_TOLERANCE),
                     3
                 );
-                throw new Exception('Order totals do not reconcile with cart totals');
+                // Carry the numbers in the exception, not just the log: this
+                // message is what the buyer-facing decline path renders, and an
+                // opaque rejection here is what made TWO-25161 take two weeks
+                // of email to diagnose.
+                throw new Exception(
+                    'Order totals do not reconcile with cart totals: cart total ' .
+                    $this->getTwoRoundAmount(round((float)$cart->getOrderTotal(true, Cart::BOTH), 2)) .
+                    ' vs order lines ' . $this->getTwoRoundAmount($lineTotals['gross']) .
+                    ' (difference ' . $this->getTwoRoundAmount($max_reconciliation_diff_cents / 100) . ')'
+                );
             }
 
             PrestaShopLogger::addLog(
@@ -3605,7 +3614,13 @@ class Twopayment extends PaymentModule
             $exceptionMessage = (string)$e->getMessage();
             if (stripos($exceptionMessage, 'reconcile') !== false) {
                 $result['status'] = 'reconciliation_mismatch';
-                $result['message'] = $this->l('Unable to process your order with Two payment. Please review your cart and try again.');
+                // Specific, not generic: name the actual failure and quote the
+                // amounts, so a merchant-side cart/shipping misconfiguration is
+                // diagnosable from the checkout page instead of only from the
+                // shop log (TWO-25161).
+                $result['message'] = $this->l('Two could not accept this order because the cart total does not match the total of the order lines.')
+                    . ' ' . $exceptionMessage . '. '
+                    . $this->l('This is usually a shipping or discount amount the cart has not applied yet. Please refresh your cart and try again, or contact the store.');
             } else {
                 $result['status'] = 'payload_error';
             }
@@ -4302,46 +4317,54 @@ class Twopayment extends PaymentModule
             }
         }
 
-        // Add shipping as a line item if applicable
-        // BEST PRACTICE: Use getPackageShippingCost() to get actual carrier cost BEFORE free shipping rules
-        // This fixes the issue where getOrderTotal(ONLY_SHIPPING) returns 0 when free shipping cart rules are active
-        $shipping_cost_with_tax = 0;
-        $shipping_cost_without_tax = 0;
-        
-        if (Validate::isLoadedObject($carrier)) {
-            // Method 1: Get package shipping cost directly from carrier (ignores free shipping rules)
+        // SHIPPING AMOUNT SOURCING (TWO-25161): the CART is the authority, not
+        // the Carrier object. Cart::getOrderTotal(..., Cart::ONLY_SHIPPING) is
+        // the very figure PrestaShop folded into Cart::BOTH, so it is the only
+        // shipping amount that can reconcile with the cart total - and it
+        // resolves without a loadable Carrier. Merchants who price shipping
+        // through symbolic "logistics carriers" leave id_carrier = 0 on a cart
+        // that nonetheless carries a real shipping cost; keying the shipping
+        // line off `new Carrier($cart->id_carrier)` silently dropped that cost
+        // and the reconciliation gate then rejected the whole order.
+        //
+        // getPackageShippingCost() survives only as a fallback for the case it
+        // was originally added for: a shop where a free-shipping cart rule
+        // zeroes ONLY_SHIPPING while the same amount reappears as a shipping
+        // discount, so the payload needs the pre-discount carrier price to stay
+        // coherent. That fallback is inherently carrier-bound and stays gated
+        // on a loadable carrier.
+        $shipping_gross = round((float)$cart->getOrderTotal(true, Cart::ONLY_SHIPPING), 2);
+        $shipping_net = round((float)$cart->getOrderTotal(false, Cart::ONLY_SHIPPING), 2);
+
+        if ($shipping_gross <= 0 && Validate::isLoadedObject($carrier)) {
             // Parameters: id_carrier, use_tax, country, product_list, id_zone
-            $shipping_cost_with_tax = $cart->getPackageShippingCost((int)$cart->id_carrier, true, null, null, null);
-            $shipping_cost_without_tax = $cart->getPackageShippingCost((int)$cart->id_carrier, false, null, null, null);
-            
-            // Fallback: If getPackageShippingCost returns 0 or false, try getOrderTotal
-            // This handles edge cases where carrier pricing might be complex
-            if ($shipping_cost_with_tax <= 0) {
-                $shipping_cost_with_tax = (float)$cart->getOrderTotal(true, Cart::ONLY_SHIPPING);
-                $shipping_cost_without_tax = (float)$cart->getOrderTotal(false, Cart::ONLY_SHIPPING);
+            $package_gross = (float)$cart->getPackageShippingCost((int)$cart->id_carrier, true, null, null, null);
+            $package_net = (float)$cart->getPackageShippingCost((int)$cart->id_carrier, false, null, null, null);
+            if ($package_gross > 0) {
+                $shipping_gross = round($package_gross, 2);
+                $shipping_net = round($package_net, 2);
             }
         }
-        
-        if (Validate::isLoadedObject($carrier) && $shipping_cost_with_tax > 0) {
+
+        if ($shipping_gross > 0) {
             // Keep shipping monetary values canonical to PrestaShop totals.
-            $shipping_net = round((float)$shipping_cost_without_tax, 2);
-            $shipping_gross = round((float)$shipping_cost_with_tax, 2);
             $shipping_tax_amount = round($shipping_gross - $shipping_net, 2);
 
-            $shipping_name = $carrier->name ? $carrier->name : $this->l('Shipping');
+            $carrier_is_loaded = Validate::isLoadedObject($carrier);
+            $shipping_name = ($carrier_is_loaded && $carrier->name) ? $carrier->name : $this->l('Shipping');
             $shipping_delay = '';
-            if ($carrier->delay && is_array($carrier->delay)) {
-                $shipping_delay = isset($carrier->delay[$cart->id_lang]) ? 
-                    $carrier->delay[$cart->id_lang] : 
+            if ($carrier_is_loaded && $carrier->delay && is_array($carrier->delay)) {
+                $shipping_delay = isset($carrier->delay[$cart->id_lang]) ?
+                    $carrier->delay[$cart->id_lang] :
                     reset($carrier->delay);
-            } elseif ($carrier->delay) {
+            } elseif ($carrier_is_loaded && $carrier->delay) {
                 $shipping_delay = $carrier->delay;
             }
-            
+
             $shipping_description = $shipping_delay ? $shipping_delay : $this->l('Shipping cost for order');
-            if ($carrier->shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
+            if ($carrier_is_loaded && $carrier->shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
                 $shipping_description .= ' ' . sprintf($this->l('(by weight)'));
-            } elseif ($carrier->shipping_method == Carrier::SHIPPING_METHOD_PRICE) {
+            } elseif ($carrier_is_loaded && $carrier->shipping_method == Carrier::SHIPPING_METHOD_PRICE) {
                 $shipping_description .= ' ' . sprintf($this->l('(by price)'));
             }
 
@@ -4365,11 +4388,23 @@ class Twopayment extends PaymentModule
                 ) as $segment) {
                     $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
                 }
-            } else {
+            } elseif ($carrier_is_loaded) {
                 // DECLARED-RATE RELAY: the shipping rate is the carrier's own
                 // tax-rules group resolved at the cart's tax address — never
                 // derived from tax/net, never snapped.
                 $shipping_tax_rate_decimal = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
+                // Diagnostic (TWO-25161): which carrier and which tax-rules
+                // group actually supplied the rate. The carrier-list chain was
+                // verified against core sources, never executed against a real
+                // merchant's carrier table, so the resolved IDs are logged on
+                // every shipping line to confirm the case a live cart hits.
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Cart ' . (int) $cart->id . ' relayed the declared shipping tax rate from ' .
+                    'carrier ' . (int) $cart->id_carrier . ' (tax_rules_group=' .
+                    (int) $carrier->getIdTaxRulesGroup() . ', rate=' .
+                    round($shipping_tax_rate_decimal * 100, 2) . '%).',
+                    1
+                );
                 $this->assertTwoDeclaredRateReconcilesWithAmounts(
                     'shipping (' . $shipping_name . ')',
                     $shipping_net,
@@ -4382,6 +4417,46 @@ class Twopayment extends PaymentModule
                     'gross' => $shipping_gross,
                     'rate' => $shipping_tax_rate_decimal,
                 ]);
+            } else {
+                // No loadable `id_carrier`, but the carriers that priced the
+                // shipping are still enumerable from the cart's own delivery
+                // option, and each one declares a tax-rules group. Relay that.
+                // A rate computed from the shipping amounts is NOT an option:
+                // 2dp-rounded figures cannot tell a clean 21% from 20.98%, and
+                // the relayed rate is asserted against the amounts again at
+                // invoicing time.
+                $shipping_rate_classes = $this->resolveTwoCartShippingRateClasses($cart, $shipping_gross);
+
+                if (count($shipping_rate_classes) > 1) {
+                    // MIXED DECLARED RATES: the selected delivery option spans
+                    // carriers whose tax-rules groups resolve differently. Emit
+                    // one SHIPPING_FEE line per rate, weighted by the
+                    // per-carrier nets the cart already holds — never a blended
+                    // rate, never one carrier's rate applied to all of them.
+                    foreach ($this->splitTwoChargeAcrossRateClasses(
+                        $shipping_net,
+                        $shipping_tax_amount,
+                        $shipping_rate_classes,
+                        'shipping'
+                    ) as $segment) {
+                        $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
+                    }
+                } else {
+                    $shipping_rate_class = reset($shipping_rate_classes);
+                    $shipping_tax_rate_decimal = (float) $shipping_rate_class['rate'];
+                    $this->assertTwoDeclaredRateReconcilesWithAmounts(
+                        'shipping (' . $shipping_name . ')',
+                        $shipping_net,
+                        $shipping_tax_amount,
+                        $shipping_tax_rate_decimal
+                    );
+                    $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, [
+                        'net' => $shipping_net,
+                        'tax' => $shipping_tax_amount,
+                        'gross' => $shipping_gross,
+                        'rate' => $shipping_tax_rate_decimal,
+                    ]);
+                }
             }
         }
 
@@ -4524,6 +4599,34 @@ class Twopayment extends PaymentModule
                 3
             );
             throw new Exception('Cannot attribute ' . $label . ' tax under PS_ATCP_SHIPWRAP: no product rate classes');
+        }
+
+        return $this->splitTwoChargeAcrossRateClasses($charge_net, $charge_tax, $classes, $label);
+    }
+
+    /**
+     * Split a charge across an already-resolved set of canonical rate classes,
+     * reconciling the rounded sub-lines to the PrestaShop-authoritative totals
+     * cent-exactly (largest-remainder on net, bounded per-line nudge on tax).
+     * Fails loud when no rate-consistent distribution can hit the target.
+     *
+     * Shared by the PS_ATCP_SHIPWRAP product-rate-class split and the
+     * mixed-declared-rate shipping split (TWO-25161): both need one line per
+     * canonical rate whose amounts still sum to the cart's own totals.
+     *
+     * @param float $charge_net PrestaShop-authoritative net for the charge
+     * @param float $charge_tax PrestaShop-authoritative tax for the charge
+     * @param array<string,array{rate:float,net_weight:float}> $classes Keyed by formatted rate
+     * @param string $label For error messages ('shipping', 'gift wrapping')
+     * @return array<int,array{net:float,tax:float,gross:float,rate:float}>
+     * @throws Exception
+     */
+    private function splitTwoChargeAcrossRateClasses($charge_net, $charge_tax, $classes, $label)
+    {
+        $charge_net = round(max(0, (float) $charge_net), 2);
+        $charge_tax = round((float) $charge_tax, 2);
+        if (empty($classes) || ($charge_net <= 0 && $charge_tax <= 0)) {
+            return [];
         }
 
         $net_weights = [];
@@ -5691,6 +5794,158 @@ class Twopayment extends PaymentModule
         // RATE source uses the same PS_TAX_ADDRESS_TYPE address PrestaShop's
         // getPackageShippingCost() used for the shipping AMOUNTS.
         return $this->getTwoConfiguredTaxRateDecimalForGroup((int) $carrier->getIdTaxRulesGroup(), $cart);
+    }
+
+    /**
+     * Declared shipping tax rate classes for a cart with no loadable
+     * `id_carrier` (TWO-25161).
+     *
+     * PrestaShop keeps the shipping tax-rules group on the carrier row and
+     * nowhere else — there is no shop-level shipping tax group — but the
+     * carriers that priced the shipping stay enumerable from the cart even when
+     * `id_carrier` is 0. `Cart::getOrderTotal(*, ONLY_SHIPPING)` nulls a
+     * non-positive `id_carrier` and routes to `Cart::getTotalShippingCost()`,
+     * which sums the delivery-option entry selected by
+     * `Cart::getDeliveryOption()` out of `Cart::getDeliveryOptionList()`. Each
+     * entry's `carrier_list` is keyed by REAL carrier IDs and carries a loaded
+     * `Carrier` under 'instance', whose declared tax-rules group is the very
+     * group core taxed the shipping with (`$carrier->getTaxesRate($address)`).
+     * So the rate relayed here is the merchant's own declaration, resolved
+     * through the shared group resolver, and is never computed from amounts.
+     *
+     * Deriving the rate from tax/net was rejected on rounding grounds: at 2dp a
+     * clean 21% and 20.98% are indistinguishable, and checkout-api asserts the
+     * relayed rate against the amounts again during invoice validation, so a
+     * derived rate surfaces later as a bad invoice rather than a loud failure
+     * here.
+     *
+     * @param Cart $cart
+     * @param float $shipping_gross Authoritative 2dp shipping gross, for the failure message
+     * @return array<string,array{rate:float,net_weight:float}> Keyed by formatted rate
+     * @throws Exception When no carrier with a declared tax-rules group can be resolved
+     */
+    private function resolveTwoCartShippingRateClasses($cart, $shipping_gross)
+    {
+        $selected_options = $cart->getDeliveryOption(null, false, false);
+        $option_list = $cart->getDeliveryOptionList();
+
+        $classes = [];
+        $diagnostics = [];
+
+        if (is_array($selected_options) && is_array($option_list)) {
+            foreach ($selected_options as $id_address => $option_key) {
+                if (
+                    !isset($option_list[$id_address][$option_key]['carrier_list'])
+                    || !is_array($option_list[$id_address][$option_key]['carrier_list'])
+                ) {
+                    continue;
+                }
+
+                foreach ($option_list[$id_address][$option_key]['carrier_list'] as $id_carrier => $data) {
+                    $id_carrier = (int) $id_carrier;
+                    $instance = (is_array($data) && isset($data['instance'])) ? $data['instance'] : null;
+                    if (
+                        $id_carrier <= 0
+                        || !is_object($instance)
+                        || !Validate::isLoadedObject($instance)
+                        || !method_exists($instance, 'getIdTaxRulesGroup')
+                    ) {
+                        // PrestaShop's no-available-carrier sentinel: when a
+                        // product has no carrier that can deliver it,
+                        // Cart::getPackageList() sets carrier_list = [0 => 0],
+                        // so there is no carrier row and no declared tax-rules
+                        // group — while getPackageShippingCost() can still
+                        // return a non-zero price from its own internal
+                        // PS_CARRIER_DEFAULT / cheapest-in-range fallback.
+                        // Inferring a rate from that price is exactly what must
+                        // not happen, and silently sending 0% would misreport
+                        // the merchant's VAT. Refuse the order instead.
+                        throw $this->buildTwoShippingRateUnresolvableException(
+                            $cart,
+                            $shipping_gross,
+                            (int) $id_address,
+                            (string) $option_key,
+                            $id_carrier
+                        );
+                    }
+
+                    $group_id = (int) $instance->getIdTaxRulesGroup();
+                    $rate = $this->getTwoConfiguredTaxRateDecimalForGroup($group_id, $cart);
+                    $rate_key = $this->formatTwoTaxRate($rate);
+                    if (!isset($classes[$rate_key])) {
+                        $classes[$rate_key] = ['rate' => $rate, 'net_weight' => 0.0];
+                    }
+                    // Per-carrier nets are already in carrier_list and sum to
+                    // the option's own total_price_without_tax, so they are the
+                    // correct weights for splitting a mixed-rate option.
+                    $classes[$rate_key]['net_weight'] += isset($data['price_without_tax'])
+                        ? max(0.0, round((float) $data['price_without_tax'], 2))
+                        : 0.0;
+                    $diagnostics[] = 'carrier=' . $id_carrier . ' tax_rules_group=' . $group_id .
+                        ' rate=' . round($rate * 100, 2) . '%';
+                }
+            }
+        }
+
+        if (empty($classes)) {
+            throw $this->buildTwoShippingRateUnresolvableException($cart, $shipping_gross, 0, '', 0);
+        }
+
+        // Diagnostic (TWO-25161): this chain was verified against PrestaShop
+        // core sources, never executed against a real merchant's carrier table.
+        // Logging the resolved carrier and tax-rules-group IDs is how the case
+        // a live cart actually hits gets confirmed in the field.
+        PrestaShopLogger::addLog(
+            'TwoPayment: Cart ' . (int) $cart->id . ' (id_carrier=' . (int) $cart->id_carrier .
+            ') resolved ' . count($classes) . ' declared shipping tax rate(s) from its delivery-option ' .
+            'carrier list: ' . implode('; ', $diagnostics) . '.',
+            1
+        );
+
+        return $classes;
+    }
+
+    /**
+     * Build the loud rejection for a cart whose shipping cost has no declared
+     * tax rate behind it (TWO-25161).
+     *
+     * Returned rather than thrown so the call sites read as `throw $this->...`
+     * and static analysis keeps seeing them as terminal.
+     *
+     * @param Cart $cart
+     * @param float $shipping_gross
+     * @param int $id_address Delivery address whose option failed, 0 if none resolved
+     * @param string $option_key Selected delivery-option key ('0,' for the sentinel)
+     * @param int $id_carrier Offending carrier id (0 for the sentinel)
+     * @return Exception
+     */
+    private function buildTwoShippingRateUnresolvableException(
+        $cart,
+        $shipping_gross,
+        $id_address,
+        $option_key,
+        $id_carrier
+    ) {
+        $detail = 'cart ' . (int) $cart->id . ', id_carrier=' . (int) $cart->id_carrier .
+            ', shipping=' . $this->getTwoRoundAmount($shipping_gross) .
+            ', delivery address=' . (int) $id_address .
+            ', delivery option key=' . ($option_key === '' ? '(none)' : $option_key) .
+            ', carrier in list=' . (int) $id_carrier;
+
+        PrestaShopLogger::addLog(
+            'TwoPayment: No deliverable carrier for the cart shipping cost, so no declared shipping ' .
+            'tax rate exists to relay (' . $detail . '). PrestaShop reports no available carrier for at ' .
+            'least one product (carrier_list = [0 => 0]) while still pricing the shipping through its ' .
+            'internal default-carrier fallback. Configure a carrier that covers this delivery address ' .
+            'and the cart contents.',
+            3
+        );
+
+        return new Exception(
+            'No deliverable carrier for the cart shipping cost: PrestaShop reports no available carrier ' .
+            '(carrier_list = [0 => 0]) for this cart, so there is no declared shipping tax-rules group ' .
+            'to relay (' . $detail . ')'
+        );
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -195,7 +195,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.1';
+        $this->version = '2.6.2';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -236,7 +236,10 @@ class Twopayment extends PaymentModule
             if (!Configuration::get('PS_TWO_OS_AWAITING_VERIFICATION_MAP')) {
                 Configuration::updateValue('PS_TWO_OS_AWAITING_VERIFICATION_MAP', Configuration::get('PS_OS_PREPARATION'));
                 Configuration::updateValue('PS_TWO_OS_VERIFIED_PENDING_FULFILLMENT_MAP', Configuration::get('PS_OS_PREPARATION'));
-                Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', Configuration::get('PS_OS_SHIPPING'));
+                // JSON array, matching install() and the admin form save path - this
+                // recovery path used to write a bare status ID, leaving three
+                // divergent storage formats for one configuration key.
+                Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', json_encode(array((int)Configuration::get('PS_OS_SHIPPING'))));
                 Configuration::updateValue('PS_TWO_OS_PAYMENT_ERROR_MAP', Configuration::get('PS_OS_ERROR'));
                 Configuration::updateValue('PS_TWO_OS_CANCELLED_MAP', Configuration::get('PS_OS_CANCELED'));
                 Configuration::updateValue('PS_TWO_OS_REFUNDED_MAP', Configuration::get('PS_OS_REFUND'));
@@ -1914,20 +1917,29 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_OS_AWAITING_VERIFICATION_MAP'] = Tools::getValue('PS_TWO_OS_AWAITING_VERIFICATION_MAP', Configuration::get('PS_TWO_OS_AWAITING_VERIFICATION_MAP'));
         $fields_values['PS_TWO_OS_VERIFIED_PENDING_FULFILLMENT_MAP'] = Tools::getValue('PS_TWO_OS_VERIFIED_PENDING_FULFILLMENT_MAP', Configuration::get('PS_TWO_OS_VERIFIED_PENDING_FULFILLMENT_MAP'));
         
-        // Handle multi-select for fulfillment statuses
+        // Handle multi-select for fulfillment statuses.
+        //
+        // PrestaShop core's HelperForm::generate() rewrites a multi-select field's
+        // name in place ($params['name'] .= '[]', classes/helper/HelperForm.php) and
+        // the form template then looks the pre-selection up under that rewritten
+        // name ($fields_value[$input.name] in
+        // admin/themes/default/template/helpers/form/form.tpl). That is the same in
+        // PS 1.7.6.x, 8.x and 9.x, so the '[]'-suffixed key is the one that decides
+        // which options render as selected; the plain key is kept populated for any
+        // reader that addresses the field by its declared name.
+        //
+        // The IDs are normalised to strings because the template compares each
+        // stored value against the option's id_order_state, which comes back from
+        // the database as a string; a strict comparison in a future PS release
+        // would otherwise silently drop every pre-selection.
         $fulfilled_map = Configuration::get('PS_TWO_OS_FULFILLED_MAP');
-        if ($fulfilled_map) {
-            // Decode JSON array or split comma-separated values
-            $fulfilled_ids = json_decode($fulfilled_map, true);
-            if (!is_array($fulfilled_ids)) {
-                // Backward compatibility: if it's a single ID, convert to array
-                $fulfilled_ids = array($fulfilled_map);
-            }
-            $fulfilled_ids_value = $fulfilled_ids;
-        } else {
-            // Default to Shipped status
-            $fulfilled_ids_value = array(Configuration::get('PS_OS_SHIPPING'));
+        $fulfilled_ids = $fulfilled_map ? json_decode($fulfilled_map, true) : null;
+        if (!is_array($fulfilled_ids)) {
+            // Backward compatibility: a single bare status ID (the pre-2.1.2 format,
+            // and what the custom-state recovery path wrote before 2.6.2).
+            $fulfilled_ids = $fulfilled_map ? array($fulfilled_map) : array(Configuration::get('PS_OS_SHIPPING'));
         }
+        $fulfilled_ids_value = array_values(array_map('strval', array_filter(array_map('intval', $fulfilled_ids))));
         $fields_values['PS_TWO_OS_FULFILLED_MAP'] = $fulfilled_ids_value;
         $fields_values['PS_TWO_OS_FULFILLED_MAP[]'] = $fulfilled_ids_value;
         

--- a/twopayment.php
+++ b/twopayment.php
@@ -13,6 +13,7 @@ if (!defined('_PS_VERSION_')) {
 
 require_once dirname(__FILE__) . '/classes/TwoSurchargeCalculator.php';
 require_once dirname(__FILE__) . '/classes/TwoSoleTrader.php';
+require_once dirname(__FILE__) . '/classes/TwoCheckoutAmountException.php';
 
 class Twopayment extends PaymentModule
 {
@@ -3253,8 +3254,9 @@ class Twopayment extends PaymentModule
                 // Carry the numbers in the exception, not just the log: this
                 // message is what the buyer-facing decline path renders, and an
                 // opaque rejection here is what made TWO-25161 take two weeks
-                // of email to diagnose.
-                throw new Exception(
+                // of email to diagnose. TwoCheckoutAmountException is what
+                // authorises that relay — see the class docblock.
+                throw new TwoCheckoutAmountException(
                     'Order totals do not reconcile with cart totals: cart total ' .
                     $this->getTwoRoundAmount(round((float)$cart->getOrderTotal(true, Cart::BOTH), 2)) .
                     ' vs order lines ' . $this->getTwoRoundAmount($lineTotals['gross']) .
@@ -3285,7 +3287,7 @@ class Twopayment extends PaymentModule
                 $this->getTwoRoundAmount($subtotalsTotals['gross']) . ')',
                 3
             );
-            throw new Exception('Tax subtotals do not reconcile with line items');
+            throw new TwoCheckoutAmountException('Tax subtotals do not reconcile with line items');
         }
 
         // Offset pricing fee (buyer surcharge) — appended AFTER product-line
@@ -4738,7 +4740,7 @@ class Twopayment extends PaymentModule
      * @param float $tax_amount Emitted 2dp tax amount
      * @param float $rate_decimal Declared decimal rate (e.g. 0.21)
      * @return void
-     * @throws Exception
+     * @throws TwoCheckoutAmountException
      */
     private function assertTwoDeclaredRateReconcilesWithAmounts($label, $net_amount, $tax_amount, $rate_decimal)
     {
@@ -4758,7 +4760,7 @@ class Twopayment extends PaymentModule
             '. Check the tax rules configured for this line (tax rules group, address-specific rules).',
             3
         );
-        throw new Exception(
+        throw new TwoCheckoutAmountException(
             'Declared tax rate diverges from applied tax amounts for ' . $label
         );
     }
@@ -5845,7 +5847,7 @@ class Twopayment extends PaymentModule
      * @param Cart $cart
      * @param float $shipping_gross Authoritative 2dp shipping gross, for the failure message
      * @return array<string,array{rate:float,net_weight:float}> Keyed by formatted rate
-     * @throws Exception When no carrier with a declared tax-rules group can be resolved
+     * @throws TwoCheckoutAmountException When no carrier with a declared tax-rules group can be resolved
      */
     private function resolveTwoCartShippingRateClasses($cart, $shipping_gross)
     {
@@ -5940,7 +5942,7 @@ class Twopayment extends PaymentModule
      * @param int $id_address Delivery address whose option failed, 0 if none resolved
      * @param string $option_key Selected delivery-option key ('0,' for the sentinel)
      * @param int $id_carrier Offending carrier id (0 for the sentinel)
-     * @return Exception
+     * @return TwoCheckoutAmountException
      */
     private function buildTwoShippingRateUnresolvableException(
         $cart,
@@ -5964,7 +5966,10 @@ class Twopayment extends PaymentModule
             3
         );
 
-        return new Exception(
+        // Buyer-facing by type: the detail is nothing but the cart's own
+        // amounts and identifiers, and naming the condition on the checkout
+        // page is the whole point of the loud refusal (TWO-25161).
+        return new TwoCheckoutAmountException(
             'No deliverable carrier for the cart shipping cost: PrestaShop reports no available carrier ' .
             '(carrier_list = [0 => 0]) for this cart, so there is no declared shipping tax-rules group ' .
             'to relay (' . $detail . ')'

--- a/twopayment.php
+++ b/twopayment.php
@@ -4413,51 +4413,39 @@ class Twopayment extends PaymentModule
                 ) as $segment) {
                     $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, $segment);
                 }
-            } elseif ($carrier_is_loaded) {
-                // DECLARED-RATE RELAY: the shipping rate is the carrier's own
-                // tax-rules group resolved at the cart's tax address — never
-                // derived from tax/net, never snapped.
-                $shipping_tax_rate_decimal = $this->getTwoCarrierConfiguredTaxRateDecimal($carrier, $cart);
-                // Diagnostic (TWO-25161): which carrier and which tax-rules
-                // group actually supplied the rate. The carrier-list chain was
-                // verified against core sources, never executed against a real
-                // merchant's carrier table, so the resolved IDs are logged on
-                // every shipping line to confirm the case a live cart hits.
-                PrestaShopLogger::addLog(
-                    'TwoPayment: Cart ' . (int) $cart->id . ' relayed the declared shipping tax rate from ' .
-                    'carrier ' . (int) $cart->id_carrier . ' (tax_rules_group=' .
-                    (int) $carrier->getIdTaxRulesGroup() . ', rate=' .
-                    round($shipping_tax_rate_decimal * 100, 2) . '%).',
-                    1
-                );
-                $this->assertTwoDeclaredRateReconcilesWithAmounts(
-                    'shipping (' . $shipping_name . ')',
-                    $shipping_net,
-                    $shipping_tax_amount,
-                    $shipping_tax_rate_decimal
-                );
-                $items[] = $this->buildTwoChargeLineFromSegment($shipping_line_template, [
-                    'net' => $shipping_net,
-                    'tax' => $shipping_tax_amount,
-                    'gross' => $shipping_gross,
-                    'rate' => $shipping_tax_rate_decimal,
-                ]);
             } else {
-                // No loadable `id_carrier`, but the carriers that priced the
-                // shipping are still enumerable from the cart's own delivery
-                // option, and each one declares a tax-rules group. Relay that.
-                // A rate computed from the shipping amounts is NOT an option:
-                // 2dp-rounded figures cannot tell a clean 21% from 20.98%, and
-                // the relayed rate is asserted against the amounts again at
-                // invoicing time.
-                $shipping_rate_classes = $this->resolveTwoCartShippingRateClasses($cart, $shipping_gross);
+                // DECLARED-RATE RELAY: the shipping rate is always a tax-rules
+                // group the merchant declared on a carrier, resolved at the
+                // cart's tax address — never derived from tax/net, never
+                // snapped, never blended. A rate computed from the shipping
+                // amounts is NOT an option: 2dp-rounded figures cannot tell a
+                // clean 21% from 20.98%, and the relayed rate is asserted
+                // against the amounts again at invoicing time.
+                //
+                // The question that decides one line or several is how many
+                // tax-rules groups the SELECTED DELIVERY OPTION spans — NOT
+                // whether `$cart->id_carrier` happens to load. Core's
+                // Cart::setDeliveryOption() only recomputes `id_carrier` when
+                // the cart has a single delivery option, so a ship-to-multiple-
+                // addresses cart keeps a stale non-zero `id_carrier`. Gating the
+                // split on carrier loadability applied that one carrier's group
+                // to a shipping total spanning several, and the resulting blend
+                // hid inside the 2-cent reconciliation tolerance instead of
+                // failing — the exact class of silent approximation this change
+                // exists to remove. `id_carrier` now only supplies the line's
+                // name, delay text and by-weight/by-price suffix (above).
+                $shipping_rate_classes = $this->resolveTwoCartShippingRateClasses(
+                    $cart,
+                    $shipping_gross,
+                    $carrier_is_loaded ? $carrier : null
+                );
 
                 if (count($shipping_rate_classes) > 1) {
-                    // MIXED DECLARED RATES: the selected delivery option spans
-                    // carriers whose tax-rules groups resolve differently. Emit
-                    // one SHIPPING_FEE line per rate, weighted by the
-                    // per-carrier nets the cart already holds — never a blended
-                    // rate, never one carrier's rate applied to all of them.
+                    // MIXED DECLARED RATES: the delivery option spans carriers
+                    // whose tax-rules groups resolve differently. Emit one
+                    // SHIPPING_FEE line per rate, weighted by the per-carrier
+                    // nets the cart already holds — never one carrier's rate
+                    // applied to all of them.
                     foreach ($this->splitTwoChargeAcrossRateClasses(
                         $shipping_net,
                         $shipping_tax_amount,
@@ -5822,8 +5810,16 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Declared shipping tax rate classes for a cart with no loadable
-     * `id_carrier` (TWO-25161).
+     * Declared shipping tax rate classes for a cart, resolved from the cart's
+     * own selected delivery option (TWO-25161).
+     *
+     * The delivery option is the authority here, not `$cart->id_carrier`: core
+     * only recomputes `id_carrier` when the cart has a single delivery option,
+     * so a ship-to-multiple-addresses cart carries a stale non-zero
+     * `id_carrier` while its shipping total spans several tax-rules groups. The
+     * caller therefore always asks this resolver, and passes the loaded carrier
+     * (when there is one) only as the fallback for a cart whose delivery option
+     * cannot be read at all.
      *
      * PrestaShop keeps the shipping tax-rules group on the carrier row and
      * nowhere else — there is no shop-level shipping tax group — but the
@@ -5846,10 +5842,12 @@ class Twopayment extends PaymentModule
      *
      * @param Cart $cart
      * @param float $shipping_gross Authoritative 2dp shipping gross, for the failure message
+     * @param Carrier|null $fallback_carrier Cart's loaded carrier, used only when the
+     *                                       delivery option yields no carrier at all
      * @return array<string,array{rate:float,net_weight:float}> Keyed by formatted rate
      * @throws TwoCheckoutAmountException When no carrier with a declared tax-rules group can be resolved
      */
-    private function resolveTwoCartShippingRateClasses($cart, $shipping_gross)
+    private function resolveTwoCartShippingRateClasses($cart, $shipping_gross, $fallback_carrier = null)
     {
         $selected_options = $cart->getDeliveryOption(null, false, false);
         $option_list = $cart->getDeliveryOptionList();
@@ -5884,7 +5882,10 @@ class Twopayment extends PaymentModule
                         // PS_CARRIER_DEFAULT / cheapest-in-range fallback.
                         // Inferring a rate from that price is exactly what must
                         // not happen, and silently sending 0% would misreport
-                        // the merchant's VAT. Refuse the order instead.
+                        // the merchant's VAT. Refuse the order instead — also
+                        // when `$cart->id_carrier` happens to load, because a
+                        // stale carrier's group is not the group core taxed
+                        // this option's shipping with.
                         throw $this->buildTwoShippingRateUnresolvableException(
                             $cart,
                             $shipping_gross,
@@ -5913,6 +5914,33 @@ class Twopayment extends PaymentModule
         }
 
         if (empty($classes)) {
+            // The delivery option could not be read at all (no option list, or
+            // a shape this version of core does not expose). A cart whose
+            // `id_carrier` loads still has a merchant-declared group on that
+            // carrier row, which is a declared rate and not an approximation,
+            // so relay it — this is the pre-TWO-25161 behaviour, kept as the
+            // fallback rather than as the primary path.
+            if (is_object($fallback_carrier) && Validate::isLoadedObject($fallback_carrier)) {
+                $fallback_group_id = method_exists($fallback_carrier, 'getIdTaxRulesGroup')
+                    ? (int) $fallback_carrier->getIdTaxRulesGroup()
+                    : 0;
+                $fallback_rate = $this->getTwoCarrierConfiguredTaxRateDecimal($fallback_carrier, $cart);
+                PrestaShopLogger::addLog(
+                    'TwoPayment: Cart ' . (int) $cart->id . ' exposed no readable delivery-option carrier ' .
+                    'list; relaying the declared shipping tax rate from its own carrier ' .
+                    (int) $cart->id_carrier . ' (tax_rules_group=' . $fallback_group_id . ', rate=' .
+                    round($fallback_rate * 100, 2) . '%).',
+                    1
+                );
+
+                return [
+                    $this->formatTwoTaxRate($fallback_rate) => [
+                        'rate' => $fallback_rate,
+                        'net_weight' => max(0.0, (float) $shipping_gross),
+                    ],
+                ];
+            }
+
             throw $this->buildTwoShippingRateUnresolvableException($cart, $shipping_gross, 0, '', 0);
         }
 

--- a/upgrade/upgrade-2.6.2.php
+++ b/upgrade/upgrade-2.6.2.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.2
+ *
+ * Fulfilled-status mapping storage normalisation (TWO-24769).
+ *
+ * PS_TWO_OS_FULFILLED_MAP is meant to hold a JSON array of order-status
+ * IDs. upgrade-2.6.2 exists because a runtime recovery path
+ * (ensureCustomStatesExist(), which fires when Two's custom order states
+ * are missing) wrote a bare status ID instead, so a store that lost its
+ * custom states after the 2.1.2 migration could be sitting on the legacy
+ * single-ID format again. The reader still tolerates that format, but
+ * leaving it in the database keeps a trap open for any future refactor
+ * that drops the compatibility branch.
+ *
+ * This rewrites whatever is stored into the canonical JSON int-array form.
+ * The selection itself is preserved; a value that yields no usable IDs
+ * falls back to the shop's Shipped status, which is the module default.
+ *
+ * Created: 2026-07-27
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_2($module)
+{
+    $stored = Configuration::get('PS_TWO_OS_FULFILLED_MAP');
+
+    $ids = $stored ? json_decode($stored, true) : null;
+    if (!is_array($ids)) {
+        $ids = $stored ? array($stored) : array();
+    }
+
+    $ids = array_values(array_unique(array_filter(array_map('intval', $ids))));
+    if (empty($ids)) {
+        $ids = array((int) Configuration::get('PS_OS_SHIPPING'));
+    }
+
+    $normalised = json_encode($ids);
+    if ($normalised !== $stored) {
+        Configuration::updateValue('PS_TWO_OS_FULFILLED_MAP', $normalised);
+
+        PrestaShopLogger::addLog(
+            'Two Payment v2.6.2 upgrade: normalised PS_TWO_OS_FULFILLED_MAP to JSON array format (' . $normalised . ')',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}

--- a/views/js/modules/TwoOrderIntent.js
+++ b/views/js/modules/TwoOrderIntent.js
@@ -71,7 +71,8 @@ class TwoOrderIntent {
                 // Backend returns status codes: 'no_company', 'incomplete_company' if needed
                 return this.fetchOrderIntentPayload(formData);
             })
-            .then(payload => {
+            .then(built => {
+                const payload = built ? built.payload : null;
                 const payloadCompany = (
                     payload &&
                     payload.buyer &&
@@ -80,6 +81,21 @@ class TwoOrderIntent {
                 ) ? String(payload.buyer.company.company_name).trim() : '';
                 if (payloadCompany) {
                     this.lastCompany = payloadCompany;
+                }
+                // TWO-24799: the server recognised this exact decision snapshot
+                // and returned the decision it already has, so skip the 2.5-3s
+                // /v1/order_intent round trip. The server only does this when
+                // every decision input (cart, addresses, country, company,
+                // amounts) is byte-identical to the checked snapshot; anything
+                // the buyer edits produces a different hash and no decision,
+                // and the authoritative re-check still runs at payment submit.
+                if (built && built.intentDecision) {
+                    return {
+                        success: true,
+                        approved: !!built.intentDecision.approved,
+                        message: '',
+                        rawResponse: { approved: !!built.intentDecision.approved, deduped: true }
+                    };
                 }
                 return this.callTwoOrderIntent(payload);
             })
@@ -281,7 +297,12 @@ class TwoOrderIntent {
                 timeout: 15000,
                 success: (response) => {
                     if (response && response.success && response.payload) {
-                        resolve(response.payload);
+                        // TWO-24799: intent_decision is present only when the
+                        // server matched an unchanged decision snapshot.
+                        resolve({
+                            payload: response.payload,
+                            intentDecision: response.intent_decision || null
+                        });
                     } else if (response && response.error) {
                         reject(new Error(response.error));
                     } else {


### PR DESCRIPTION
Consolidates four PrestaShop checkout changes that all landed on `payment.php` / `twopayment.php` and could not be merged independently without conflicting. Supersedes and closes PR #79, PR #80, PR #81 and PR #82 in this repo.

**One commit per ticket** — the diff is reviewable per change, and each commit's message is the one that was reviewed on its original PR (PR #79's two commits are squashed into one, since the second superseded the first's approach to the tax rate).

| Commit | Ticket | Change |
|---|---|---|
| `3a475e7` | [TWO-25161](https://linear.app/two-inc/issue/TWO-25161) | Shipping cost and declared shipping tax rate sourced from the cart |
| `5faff4a` | [TWO-24768](https://linear.app/two-inc/issue/TWO-24768) | Checkout failures surfaced to AJAX checkout front-ends |
| `b2de5d0` | [TWO-24799](https://linear.app/two-inc/issue/TWO-24799) | Checkout latency: company-lookup and order-intent caching |
| `11647e8` | [TWO-24769](https://linear.app/two-inc/issue/TWO-24769) | Fulfilled-status multi-select renders its saved selection; 2.6.1 -> 2.6.2 |
| `af2e025` | — | `chore`: sync `bumpver.toml` with the shipped version |
| `dcdd075` | — | `chore`: syntax-check all four new specs in CI |

---

## 1. TWO-25161 — shipping cost and declared tax rate from the cart (customer-facing blocker)

The `SHIPPING_FEE` payload line was built only when `new Carrier($cart->id_carrier)` produced a loaded object, and the amount came from `Cart::getPackageShippingCost()`. Both depend on the cart pointing at a real carrier row.

A merchant who prices shipping through several symbolic "logistics carriers" whose prices sum to the real shipping cost leaves `id_carrier = 0` on a cart that nonetheless carries a genuine shipping charge. The plugin lost the shipping amount entirely: the payload was short by exactly the shipping cost, the cart-vs-lines reconciliation gate correctly refused to submit it, and the buyer saw only "Your order could not be processed with Two." A free-shipping cart went through fine — there was no shipping cost to lose, which is what pinned the diagnosis down.

This is **not** "allow `id_carrier = 0`". For every other merchant that value means *no shipping method selected*, and such a cart genuinely is not ready. What was wrong was the *dependency*: the plugin asked a `Carrier` object for something the cart already knows.

- **Amount** now comes from `Cart::getOrderTotal(*, Cart::ONLY_SHIPPING)` — the very figure PrestaShop folded into `Cart::BOTH`, so the only shipping amount that *can* reconcile with the cart total, resolvable with or without a loadable carrier. `getPackageShippingCost()` survives strictly as the carrier-bound fallback for the case it was added for (a free-shipping cart rule zeroing `ONLY_SHIPPING` while the same amount reappears as a shipping discount).
- **Rate is declared, never derived.** An earlier revision inferred it from the tax and net amounts; that was rejected on rounding grounds and is gone. At 2dp a clean 21% is indistinguishable from 20.98% (23.97 net carrying 5.03 tax implies 20.98%), and `LineItemRequestSchema.tax_rate` is required with no default while invoice validation re-asserts the rate against the amounts later — so a derived rate surfaces as a bad invoice and bad VAT reporting, not as a loud checkout failure.
- The declared rate is reachable because the premise that a carrier-less cart has no carrier behind its shipping cost is false: `ONLY_SHIPPING` routes to `Cart::getTotalShippingCost()`, which sums the delivery-option entry from `Cart::getDeliveryOptionList()`, whose `carrier_list` is keyed by **real carrier IDs** with a loaded `Carrier` under `'instance'`. Core's own shipping tax is that carrier's declared tax-rules group. There is no shop-level shipping tax group in PrestaShop, so the carrier list is the only authoritative source. Verified against core extracted from 1.7.6.5, 8 and 9 — identical on every point.
- **Mixed rates split, they do not blend.** One `SHIPPING_FEE` line per rate, weighted by the per-carrier nets already in `carrier_list`. Reuses the cent-exact allocation the `PS_ATCP_SHIPWRAP` split already had, extracted into a shared `splitTwoChargeAcrossRateClasses()`; the per-rate amounts sum to PrestaShop's authoritative shipping total or the split fails loud.
- **The one genuine hole fails loud.** A product with no available carrier makes `carrier_list = [0 => 0]`, so no tax-rules group exists while `getPackageShippingCost()` can still price the shipping through its private fallback. The order is refused, with a message naming the condition and quoting the cart, `id_carrier`, amount and delivery-option key. Sending 0% would misreport the merchant's VAT.
- Resolved carrier and tax-rules-group IDs are logged on both shipping paths — the chain is verified against core sources but has never been executed against a real merchant's carrier table, so this log is how the live case gets confirmed in the field.
- **Rejections now say what failed**: the reconciliation exception carries the cart total, the order-lines total and the difference, and the payment controller surfaces that detail instead of the generic "please review your cart". The opacity of the old message is a large part of why this took two weeks of email to identify.

## 2. TWO-24768 — checkout failures reach AJAX front-ends

`controllers/front/payment.php` signalled every failure identically: push onto `$this->errors`, then `redirectWithNotifications()`. That works for exactly one caller shape — a top-level browser navigation. An AJAX caller follows the 302 transparently, receives the order page's HTML with **HTTP 200**, cannot distinguish it from success, and leaves the buyer on a checkout that never moves.

One correction to the ticket: the reported case does not go through `failCheckout()` at all. The provider-rejection path built its message inline and redirected directly, as did four other exits — so patching `failCheckout()` alone would have left the reported case broken.

- `failCheckout()` detects an AJAX caller and answers `HTTP 400` with a JSON body (`error`, `message`, `redirect_url`). A non-2xx status unhangs even a caller that only checks `response.ok`.
- Detection is header-based: `X-Requested-With: XMLHttpRequest`, **plus** an `Accept` that asks for JSON and does not accept HTML (`fetch()` sends no `X-Requested-With`; a navigation always accepts HTML).
- All five inline redirect exits now route through that single boundary. Browser form posts are unchanged.
- Failures that deliberately carry no buyer-facing text fall back to a generic message for AJAX callers — emitting `'message' => ''` would reproduce the silent hang one layer up.

Combined with change 1, TWO-25161's specific reconciliation detail is now what an AJAX caller receives in the JSON body. Both halves of the opacity problem close together. The strings are plugin-generated diagnostics about the cart's own amounts — no credentials, no provider internals.

## 3. TWO-24799 — checkout latency

Both wins from the 2026-06-11 checkout-call census on the ticket. Measured 12 -> 5 buyer-blocking provider round trips over a scripted six-step checkout session.

- **Company verification**: the success path was already memoised via the `two_company_*` cookie; the **miss** path was not cached at all, so an org number Two cannot resolve re-paid a 30s-budget blocking round trip on every checkout update, forever returning the same `null`. `getTwoVerifiedCompanyForOrgNumber()` memoises both outcomes, keyed on org number + country + address ID, with a short TTL on the miss (it is a latency guard, not a verdict — a provider blip must self-heal inside the session).
- **Order-intent dedupe**: `calculateTwoOrderIntentSnapshotHash()` keys a session-scoped decision cache on the full decision snapshot. It **composes — never replaces —** `calculateTwoCheckoutSnapshotHash()`, mixing in the buyer identity that hash deliberately omits. That distinction is load-bearing: a buyer picking a different company against the same saved address and unchanged cart produces an identical *cart* snapshot hash, and serving a cached decision there would be wrong; changing the create hash to cover company would rewrite existing order-create idempotency keys. Because the browser makes the provider call today, the server records the hash it computed as *pending* and binds the reported decision to it — the hash is never taken from the request.

Invalidation is asserted per input: country switch, cart change, company change on the same cart, address switch, TTL expiry on both caches, switching away from Two clearing the decision, and the authoritative gate (`checkTwoOrderIntentApprovalAtPayment()`) always calling the provider even against a freshly cached approval for the identical snapshot.

## 4. TWO-24769 — fulfilled-status multi-select renders its saved selection

`HelperForm::generate()` rewrites a multi-select's field name in place (`$params['name'] .= '[]'`) and the form template then resolves the pre-selection with `$fields_value[$input.name]` — by that point the `[]`-suffixed key. The module populated only the plain key, so every option rendered unselected even when the stored value was correct. Display-only: the "Currently active:" label and `isFulfillmentTriggerStatus()` both read `Configuration` directly, so triggering was never affected. Verified identical in PS 1.7.6.5, 8.x and 9.x.

- Stored IDs are normalised to strings before being exposed under both keys, matching the `id_order_state` the option values come from, so the comparison no longer relies on the template's loose `==`.
- `ensureCustomStatesExist()` (the recovery path that fires when Two's own order states are missing) wrote `PS_TWO_OS_FULFILLED_MAP` as a bare status ID — a third divergent storage format for one key. It now writes the canonical JSON array.
- `upgrade/upgrade-2.6.2.php` normalises whatever a store currently holds, preserving the selection. Module version bumped `2.6.1` -> `2.6.2` so the script actually runs.

## 5. `chore`: `bumpver.toml` was stale by two minor versions

`bumpver.toml` recorded `current_version = "2.5.0"`, stale since the 2.6.0 and 2.6.1 bumps, while its `[tool.bumpver.file_patterns]` rewrite exactly the two files that carry the module version — `twopayment.php` (`this->version`) and `config.xml` (`<version>`), both at 2.6.2 after change 4. `make patch` would therefore have computed 2.5.1 from the stale value and rewritten both files **downward**. `tag` and `push` are both off in this repo's config, so it would have committed locally rather than reaching origin on its own — but the next release cut would have shipped a version regression. Set to 2.6.2.

---

## Conflicts resolved in consolidating

Applied in dependency order — TWO-25161 first (largest `twopayment.php` change), then TWO-24768's error-path restructure on top of it, then TWO-24799, then TWO-24769 last since it owns the version bump.

- **`controllers/front/payment.php`** (TWO-25161 x TWO-24768) — auto-merged, and verified by hand rather than trusted. TWO-25161 replaced the generic payload-build failure message with a detailed one and kept the existing `failCheckout()` call; TWO-24768 rewrote `failCheckout()`'s body and rerouted five other exits through it. The two are orthogonal: message content vs transport. The composition is strictly better than either alone — the detailed reconciliation text is now what an AJAX caller reads out of the JSON body. Each rerouted exit was checked to still terminate (`return` after `failCheckout()`, `exit` inside the JSON emitter).
- **`tests/run.php`** (all four) — every changeset appended its spec to the `require` list and the `$tests` map at the same two lines. Resolved by keeping all four, in application order. Verified the require count and the `$tests` entry count still match (20 each).
- **`.github/workflows/tests.yml`** (TWO-24768 x TWO-24799) — same shape, both `php -l` lines kept.
- **`CHANGELOG.md`** (TWO-24768 x TWO-24769) — both entries kept under the single existing `### Fixed` heading, in application order.
- **`tests/bootstrap.php`** (three changesets, each extending core stubs) — auto-merged into disjoint regions; reviewed for duplicated or overwritten stub methods, none found.
- **`twopayment.php`** (TWO-25161, TWO-24799, TWO-24769) — auto-merged into disjoint regions. The one interaction worth checking is that TWO-24799's intent snapshot hash composes the cart snapshot hash over a payload TWO-25161 changed (a delivery option spanning tax-rules groups now emits several `SHIPPING_FEE` lines). The hash is computed over the payload as built, so multi-line shipping is covered rather than bypassed, and no cache key is stale. Reviewed for duplicate method or constant definitions across the three changesets, none found.

Nothing was dropped and no test was weakened: all four tickets' specs run and pass together.

**Noted, not fixed** (each was out of scope on its own PR and still is): TWO-25161 and TWO-24799 carry no `CHANGELOG.md` entry, so the 2.6.2 release notes currently describe only the two changes that wrote one. Worth a follow-up before the release is cut.

## Verification

`php tests/run.php` on the consolidated branch, all specs including all four new ones:

```
$ make test          # docker php:8.2-cli, as the Makefile defines it
...
PASS TwoSoleTraderSpec::runAll
PASS ShippingCostSourcingSpec::runAll
PASS AjaxCheckoutFailureSpec::runAll
PASS CheckoutLatencySpec::runAll
PASS FulfilledStatusMappingSpec::runAll
All tests passed.
```

phpstan run the way CI runs it — phpstan 2.2.5 (the pinned version), against a PrestaShop core clone pinned to 1.7.6.0 with the runtime class aliases generated by `dev/ci/generate-ps-class-aliases.php`:

```
$ php dev/ci/generate-ps-class-aliases.php /tmp/prestashop-core /tmp/prestashop-class-aliases.php
Wrote 266 aliases to /tmp/prestashop-class-aliases.php

$ php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G
 [OK] No errors
```

`php -l` clean on every touched PHP file, `node --check` clean on `views/js/modules/TwoOrderIntent.js`, and `config.xml` parses.

## Credit

Root cause of the shipping failure identified by **Javier Moreno at Webimpacto**, who traced it to the `Carrier` object being unconstructable from `id_carrier = 0` and proposed `getOrderTotal(true, Cart::ONLY_SHIPPING)` as the carrier-independent source. Also his report that the checkout loader spins with no information even in debug mode — which is why the loud-failure changes (TWO-25161's detail and TWO-24768's transport) ride along rather than waiting.

## Follow-ups (not in this PR)

- Frontend order-intent (`controllers/front/orderintent.php`) error surfacing — the spinning-loader half of the opacity problem, tracked separately.
- Parity audit: whether WooCommerce and Magento depend on a resolvable shipping-method object to learn the shipping amount. Tracked on the parity epic.
- WooCommerce / Magento intent dedupe, and this repo's caller-less `TwoOrderIntent.startMonitoring()` 5s interval (harmless today, a latency landmine if wired up).
- `CHANGELOG.md` entries for TWO-25161 and TWO-24799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
