### PR TITLE
TWO-25166: gate sole trader on country only, drop PS_TWO_ENABLE_SOLE_TRADER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now validates the emitted amounts and also asserts `gross == net + tax` exactly
 
 ### Removed
+- **`PS_TWO_ENABLE_SOLE_TRADER` admin setting retired - sole trader is gated on country only** (TWO-25166, umbrella TWO-25163)
+  - The "Enable sole trader checkout" switch is removed from the module configuration page. Whether a buyer can check out as a sole trader is Two's registry answer for their billing country (`GET /registry/v1/supported-company-types/<ISO>`, TWO-24753 - the UK and US currently), never a merchant preference; this matches Magento's toggle-less behaviour, the cross-plugin target state
+  - `TwoSoleTrader::isEnabled()` is gone and `isAvailable()` now consults the registry alone. The registry country check was already the barrier the order-intent controller enforced before minting delegated-authority tokens, so removing the toggle does not widen access to that endpoint - the country gate is unchanged and still fails closed on a cart with no invoice address
+  - Both PrestaShop staging shops had the feature invisible because `install()` and the 2.6.1 upgrade both wrote an explicit `0` default; the 2.6.3 upgrade script deletes the stored row, and uninstall still clears it for shops that never ran the upgrade
+  - Module version bumped to `2.6.3`
+
 - **`PS_TWO_USE_OWN_INVOICES` admin setting retired** (TWO-25111)
   - The "Upload Own Invoices to Two" switch is removed from the module configuration page; the upgrade script deletes the configuration row and any leftover value has zero effect (covered by unit test)
   - Merchants who had the toggle enabled were server-side whitelisted, and all previously-whitelisted merchants already carry `invoice_distributed_by_merchant = true` (TWO-24761), so no merchant loses the feature on upgrade
@@ -54,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Failure posture: a failed refresh serves the last-known-good table and retries after a short backoff; gate conversions fail closed only when no table was ever fetched, display conversions fail soft
   - Fixed surcharge amounts and caps (configured in the shop default currency) are converted into the quote currency before the pricing call, replacing the previous single-currency pinning; an unconvertible figure omits the fee quote instead of sending a wrong-currency amount
 - **Sole trader checkout** (TWO-24755, WooCommerce/Magento parity)
-  - The payment step shows a Business / Sole trader toggle for buyers in countries where Two's registry supports sole traders (`GET /registry/v1/supported-company-types/<ISO>`, currently the UK and US), gated by a new "Enable sole trader checkout" admin toggle (default off)
+  - The payment step shows a Business / Sole trader toggle for buyers in countries where Two's registry supports sole traders (`GET /registry/v1/supported-company-types/<ISO>`, currently the UK and US). That country answer is the only gate - there is no merchant admin toggle (TWO-25166)
   - Choosing Sole Trader mints delegation + autofill tokens server-side with the merchant API key and opens Two's hosted signup popup; on completion the buyer's company data autofills from `GET /autofill/v1/buyer/current` (case-insensitive email match) and persists through the existing company-save path, so order-intent and payment run unchanged
   - Module version bumped to `2.6.1`
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -3,7 +3,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.6.2"
+current_version = "2.6.3"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -10,11 +10,13 @@
  * Matches the Magento/WooCommerce plugins' model: there is NO account-type
  * selector on the address form (B2B checkout - the company field is
  * always present). Instead the payment step shows a Business / Sole
- * trader TOGGLE, gated by two layers that both must pass:
- *  - country-level legal truth from the registry endpoint
- *    GET /registry/v1/supported-company-types/<ISO> (TWO-24753) - GB/US
- *    currently, NO/SE not, and
- *  - the merchant's PS_TWO_ENABLE_SOLE_TRADER admin toggle (default off).
+ * trader TOGGLE, gated on ONE thing only: country-level legal truth from
+ * the registry endpoint GET /registry/v1/supported-company-types/<ISO>
+ * (TWO-24753) - GB/US currently, NO/SE not. There is deliberately no
+ * merchant admin toggle (the former PS_TWO_ENABLE_SOLE_TRADER was removed
+ * in TWO-25166): whether a buyer in a country can be a sole trader is
+ * Two's registry answer, not a merchant preference, and Magento's
+ * toggle-less behaviour is the cross-plugin target state (TWO-25163).
  *
  * Picking Sole Trader mints two delegated-authority tokens server-side
  * with the merchant API key, the buyer registers or logs in through
@@ -76,19 +78,11 @@ class TwoSoleTrader
     );
 
     /**
-     * Whether the merchant has opted into sole trader checkout at all.
-     * The toggle is the ONLY gate on the merchant side - there is no
-     * account-type mode to also satisfy (that selector feature has been
-     * removed; TWO-24755 rework).
-     */
-    public static function isEnabled()
-    {
-        return (int) Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') === 1;
-    }
-
-    /**
      * Whether the Sole Trader toggle should be offered for a billing
-     * country: merchant toggle on AND the country legally supports it.
+     * country. The registry's answer for that country is the ONLY gate -
+     * and it is also the security barrier the order-intent controller
+     * relies on before minting delegated-authority tokens, so it must
+     * stay the single source of truth here (TWO-25166).
      *
      * @param Twopayment $module
      * @param string $countryIso
@@ -97,8 +91,7 @@ class TwoSoleTrader
      */
     public static function isAvailable($module, $countryIso)
     {
-        return self::isEnabled()
-            && in_array(self::SOLE_TRADER, self::getSupportedCompanyTypes($module, $countryIso), true);
+        return in_array(self::SOLE_TRADER, self::getSupportedCompanyTypes($module, $countryIso), true);
     }
 
     /**

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.2]]></version>
+    <version><![CDATA[2.6.3]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/dev/probe-payment.php
+++ b/dev/probe-payment.php
@@ -22,7 +22,6 @@ echo "merchant_short_name='" . $mod->merchant_short_name . "'\n";
 echo "api_key_empty=" . (empty($mod->api_key) ? 'YES' : 'no') . "\n";
 echo "cart id_address_invoice=" . $cart->id_address_invoice . "\n";
 echo "cart id_carrier=" . $cart->id_carrier . "\n";
-echo "PS_TWO_ENABLE_SOLE_TRADER=" . Configuration::get('PS_TWO_ENABLE_SOLE_TRADER') . "\n";
 if ($cart->id_address_invoice) {
     $addr = new Address($cart->id_address_invoice);
     echo "billing address loaded: " . (Validate::isLoadedObject($addr) ? 'yes' : 'NO') . "\n";

--- a/tests/TwoSoleTraderSpec.php
+++ b/tests/TwoSoleTraderSpec.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 /**
- * Unit spec for the sole-trader business logic (TWO-24755, toggle rework):
- * the merchant toggle is the sole merchant-side gate (no account-type
- * mode dependency - that selector feature has been removed), registry-only
+ * Unit spec for the sole-trader business logic (TWO-24755; toggle removal
+ * TWO-25166): the registry's country answer is the ONLY gate - no merchant
+ * configuration and no account-type mode are consulted (both features have
+ * been removed), registry-only
  * response semantics (empty list = business-only checkout), fail-soft vs
  * fail-closed registry/token handling, the cookie cache's single-slot/TTL
  * behaviour, and that the address form carries no account_type field.
@@ -39,9 +40,10 @@ final class TwoSoleTraderSpec
     public static function runAll(): void
     {
         $tests = [
-            'testIsEnabledFollowsToggleOnly',
-            'testAvailableWhenRegistryAndToggleAgree',
-            'testHiddenWhenToggleOff',
+            'testAvailableInRegistryCapableCountryWithNoConfig',
+            'testRetiredToggleValueHasNoEffect',
+            'testUpgradeDeletesRetiredToggle',
+            'testAvailableWhenRegistryAllowsCountry',
             'testHiddenWhenRegistryOmitsIt',
             'testRegistryErrorFallsBackToNoSoleTrader',
             'testRegistryRejectsMalformedCountry',
@@ -87,23 +89,69 @@ final class TwoSoleTraderSpec
     }
 
     /**
-     * The toggle is the ONLY merchant-side gate now - there is no
-     * account-type mode to also satisfy (that selector feature is
-     * removed; TWO-24755 rework).
+     * The registry's country answer is the ONLY gate (TWO-25166): no
+     * merchant configuration is consulted at all, so a store with no
+     * sole-trader config row whatsoever offers the flow in a
+     * registry-capable country.
      */
-    private static function testIsEnabledFollowsToggleOnly(): void
-    {
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
-        TinyAssert::true(TwoSoleTrader::isEnabled());
-
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
-        TinyAssert::false(TwoSoleTrader::isEnabled());
-    }
-
-    private static function testAvailableWhenRegistryAndToggleAgree(): void
+    private static function testAvailableInRegistryCapableCountryWithNoConfig(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TinyAssert::false(
+            Configuration::hasKey('PS_TWO_ENABLE_SOLE_TRADER'),
+            'This test must exercise a store with no sole-trader configuration row at all'
+        );
+        TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
+    }
+
+    /**
+     * The retired merchant toggle is dead weight: a stored 0 - which is
+     * exactly what install() and upgrade-2.6.1 wrote, and why the feature
+     * was invisible on both PrestaShop staging shops - must no longer
+     * suppress the flow.
+     */
+    private static function testRetiredToggleValueHasNoEffect(): void
+    {
+        $module = self::harness(
+            ['PS_TWO_ENABLE_SOLE_TRADER' => 0],
+            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
+        );
+        TinyAssert::true(
+            TwoSoleTrader::isAvailable($module, 'GB'),
+            'A leftover PS_TWO_ENABLE_SOLE_TRADER=0 row must not gate sole trader checkout'
+        );
+        TinyAssert::false(
+            method_exists('TwoSoleTrader', 'isEnabled'),
+            'TwoSoleTrader::isEnabled() is retired - the country answer is the only gate'
+        );
+    }
+
+    /**
+     * The 2.6.3 upgrade deletes the retired configuration row rather than
+     * leaving a dead value a future reader could mistake for live config.
+     */
+    private static function testUpgradeDeletesRetiredToggle(): void
+    {
+        require_once dirname(__DIR__) . '/upgrade/upgrade-2.6.3.php';
+
+        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0);
+        TinyAssert::true(upgrade_module_2_6_3(new TwopaymentTestHarness()));
+        TinyAssert::false(
+            Configuration::hasKey('PS_TWO_ENABLE_SOLE_TRADER'),
+            'upgrade-2.6.3 must delete the retired PS_TWO_ENABLE_SOLE_TRADER row'
+        );
+
+        // Idempotent on a store that never had the row
+        TinyAssert::true(upgrade_module_2_6_3(new TwopaymentTestHarness()));
+    }
+
+    private static function testAvailableWhenRegistryAllowsCountry(): void
+    {
+        $module = self::harness(
+            [],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TinyAssert::true(TwoSoleTrader::isAvailable($module, 'GB'));
@@ -112,21 +160,12 @@ final class TwoSoleTraderSpec
         TinyAssert::true(TwoSoleTrader::isAvailable($module, 'gb'));
     }
 
-    private static function testHiddenWhenToggleOff(): void
-    {
-        $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 0],
-            ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
-        );
-        TinyAssert::false(TwoSoleTrader::isAvailable($module, 'GB'));
-    }
-
     private static function testHiddenWhenRegistryOmitsIt(): void
     {
         // Registered businesses need no registry enrollment, so the endpoint
         // deliberately omits them: an empty list means business-only checkout.
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
             ['/registry/v1/supported-company-types/' => self::registryOk([])]
         );
         TinyAssert::false(TwoSoleTrader::isAvailable($module, 'NO'));
@@ -135,13 +174,12 @@ final class TwoSoleTraderSpec
     private static function testRegistryErrorFallsBackToNoSoleTrader(): void
     {
         // Network error (transport returns false)
-        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
+        $module = self::harness([], []);
         TinyAssert::same([], TwoSoleTrader::getSupportedCompanyTypes($module, 'GB'));
 
         // Non-200
         TwoSoleTrader::resetCache();
         StubStore::reset();
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
         $module->cannedResponses = [
             '/registry/v1/supported-company-types/' => ['http_status' => 404],
         ];
@@ -150,7 +188,6 @@ final class TwoSoleTraderSpec
         // 200 with malformed body
         TwoSoleTrader::resetCache();
         StubStore::reset();
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
         $module->cannedResponses = [
             '/registry/v1/supported-company-types/' => ['http_status' => 200, 'data' => 'junk'],
         ];
@@ -160,7 +197,7 @@ final class TwoSoleTraderSpec
     private static function testRegistryRejectsMalformedCountry(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         // Never hits the API for junk country input
@@ -173,7 +210,7 @@ final class TwoSoleTraderSpec
     private static function testRegistryResponseCachedPerRequest(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
             ['/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER'])]
         );
         TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
@@ -195,7 +232,7 @@ final class TwoSoleTraderSpec
     private static function testCookieCacheIsSingleSlotAndOverwritesOnCountryChange(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
             [
                 '/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER']),
                 '/registry/v1/supported-company-types/US' => self::registryOk([]),
@@ -222,7 +259,7 @@ final class TwoSoleTraderSpec
     private static function testCookieCacheExpiresAfterTtl(): void
     {
         $module = self::harness(
-            ['PS_TWO_ENABLE_SOLE_TRADER' => 1],
+            [],
             ['/registry/v1/supported-company-types/GB' => self::registryOk(['SOLE_TRADER'])]
         );
         $cookie = Context::getContext()->cookie;
@@ -245,7 +282,7 @@ final class TwoSoleTraderSpec
      */
     private static function testFetchErrorIsNotCached(): void
     {
-        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
+        $module = self::harness([], []);
         // No canned response for GB => setTwoPaymentRequest returns false => fetch error
         $types = TwoSoleTrader::getSupportedCompanyTypes($module, 'GB');
         TinyAssert::same([], $types);
@@ -261,7 +298,7 @@ final class TwoSoleTraderSpec
 
     private static function testTokenMintReadsHeaderAndFailsClosed(): void
     {
-        $module = self::harness(['PS_TWO_ENABLE_SOLE_TRADER' => 1], []);
+        $module = self::harness([], []);
 
         // Happy path: both mints return the token header (case handled by
         // the transport, which lower-cases header names)
@@ -327,7 +364,7 @@ final class TwoSoleTraderSpec
 
     /**
      * The address form carries no account_type field regardless of
-     * sole-trader toggle/registry state - that selector feature has been
+     * sole-trader registry state - that selector feature has been
      * removed entirely (TWO-24755 rework). Sole traders enrol via the
      * payment-step toggle, not the address form.
      */
@@ -344,8 +381,6 @@ final class TwoSoleTraderSpec
                 return (string) $message;
             }
         };
-
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 1);
 
         $country = new Country();
         $format = (new CustomerAddressFormatter($country, $translator, []))->getFormat();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -466,6 +466,11 @@ namespace {
             return true;
         }
 
+        public static function hasKey($key, $idLang = null, $idShopGroup = null, $idShop = null): bool
+        {
+            return array_key_exists($key, StubStore::$configuration);
+        }
+
         public static function deleteByName($key): bool
         {
             unset(StubStore::$configuration[$key]);

--- a/twopayment.php
+++ b/twopayment.php
@@ -196,7 +196,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.2';
+        $this->version = '2.6.3';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -379,7 +379,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', 1);
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', 0); // Default: off; merchant opts in (TWO-24755)
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1); // Enabled by default; can be disabled for compatibility
@@ -616,6 +615,10 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_ENABLE_PROJECT');
         Configuration::deleteByName('PS_TWO_ENABLE_TAX_SUBTOTALS');
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
+        // Retired admin toggle (TWO-25166) - sole trader is gated on the
+        // registry's country answer alone now. Shops upgraded from <=2.6.2
+        // may still carry the row; upgrade-2.6.3 deletes it, this covers
+        // uninstall-without-upgrade.
         Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER');
         Configuration::deleteByName('PS_TWO_DEBUG_MODE');
         Configuration::deleteByName(self::CONFIG_MERCHANT_INVOICE_DISTRIBUTED);
@@ -1336,26 +1339,6 @@ class Twopayment extends PaymentModule
                 'input' => array(
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Enable sole trader checkout'),
-                        'name' => 'PS_TWO_ENABLE_SOLE_TRADER',
-                        'is_bool' => true,
-                        'desc' => $this->l('Shows a Business / Sole trader toggle on the payment step for buyers in countries where Two supports sole traders (currently the UK and US).'),
-                        'required' => true,
-                        'values' => array(
-                            array(
-                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_ON',
-                                'value' => 1,
-                                'label' => $this->l('Yes')
-                            ),
-                            array(
-                                'id' => 'PS_TWO_ENABLE_SOLE_TRADER_OFF',
-                                'value' => 0,
-                                'label' => $this->l('No')
-                            ),
-                        ),
-                    ),
-                    array(
-                        'type' => 'switch',
                         'label' => $this->l('Activate company name auto-complete'),
                         'name' => 'PS_TWO_ENABLE_COMPANY_NAME',
                         'is_bool' => true,
@@ -1467,7 +1450,6 @@ class Twopayment extends PaymentModule
     protected function getTwoOtherFormValues()
     {
         $fields_values = array();
-        $fields_values['PS_TWO_ENABLE_SOLE_TRADER'] = Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER', Configuration::get('PS_TWO_ENABLE_SOLE_TRADER'));
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
@@ -1483,7 +1465,6 @@ class Twopayment extends PaymentModule
 
     protected function saveTwoOtherFormValues()
     {
-        Configuration::updateValue('PS_TWO_ENABLE_SOLE_TRADER', Tools::getValue('PS_TWO_ENABLE_SOLE_TRADER'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
@@ -2986,14 +2967,6 @@ class Twopayment extends PaymentModule
                 'enable_department' => $this->enable_department,
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,
-                'sole_trader' => array(
-                    // Only the feature flag - the availability check runs
-                    // live per billing country via soleTraderAvailability,
-                    // and the signup URL / resolved invoice country come
-                    // from soleTraderTokens (see classes/TwoSoleTrader.php
-                    // and controllers/front/orderintent.php).
-                    'enabled' => TwoSoleTrader::isEnabled() ? 1 : 0,
-                ),
                 'shop_country' => (string) Context::getContext()->country->iso_code,
                 'order_intent_url' => $this->context->link->getModuleLink($this->name, 'orderintent'),
                 'ajax_token' => Tools::getToken(false),

--- a/upgrade/upgrade-2.6.3.php
+++ b/upgrade/upgrade-2.6.3.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.3
+ *
+ * Sole trader is gated on country only (TWO-25166): the
+ * PS_TWO_ENABLE_SOLE_TRADER merchant toggle is removed from the module
+ * entirely. Whether a buyer in a country can check out as a sole trader
+ * is Two's registry answer (GET /registry/v1/supported-company-types,
+ * TWO-24753 - GB/US currently), not a merchant preference, and Magento's
+ * toggle-less behaviour is the cross-plugin target state (TWO-25163).
+ *
+ * Existing installs carry a stored row for the key - upgrade-2.6.1
+ * explicitly wrote a 0 default, and install() did too, which is why the
+ * feature was invisible on both PrestaShop staging shops. Nothing reads
+ * the key any more, so this deletes it rather than leaving a dead row
+ * that a future reader could mistake for live configuration.
+ *
+ * Created: 2026-07-27
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_3($module)
+{
+    if (Configuration::hasKey('PS_TWO_ENABLE_SOLE_TRADER')) {
+        Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER');
+
+        PrestaShopLogger::addLog(
+            'Two Payment v2.6.3 upgrade: removed retired PS_TWO_ENABLE_SOLE_TRADER toggle - sole trader is gated on the registry country answer only (TWO-25166)',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -3,9 +3,10 @@
  * (TWO-24755).
  *
  * Renders a Business / Sole trader toggle on the payment step - the same
- * model as the Magento and WooCommerce plugins - shown only where Two's
- * registry says the billing country supports sole traders AND the
- * merchant has enabled the feature. There is no account-type selector on
+ * model as the Magento and WooCommerce plugins - shown wherever Two's
+ * registry says the billing country supports sole traders. That country
+ * answer is the only gate; there is no merchant opt-in toggle
+ * (TWO-25166). There is no account-type selector on
  * the address form; the buyer always enters company details (B2B), and
  * sole traders enrol from this toggle.
  *
@@ -22,7 +23,6 @@
 class TwoSoleTrader {
     constructor(config) {
         this.config = {
-            enabled: false,
             checkoutHost: '',
             orderIntentUrl: '',
             ajaxToken: '',
@@ -51,9 +51,7 @@ class TwoSoleTrader {
         this.nextRetryAt = 0;
         this.retryCooldownMs = 5000;
 
-        if (this.config.enabled) {
-            this.init();
-        }
+        this.init();
     }
 
     init() {

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -120,16 +120,16 @@
             // Store global reference for modules
             window.TwoCheckoutManager_Instance = checkoutManager;
 
-            // Sole trader flow (TWO-24755) - separate presentation module,
-            // active only when the merchant enabled it.
+            // Sole trader flow (TWO-24755) - separate presentation module.
+            // Always constructed; whether the toggle actually renders is
+            // decided per billing country by the server-side registry
+            // answer via soleTraderAvailability (TWO-25166 removed the
+            // merchant opt-in toggle that used to gate this too).
             if (
                 typeof TwoSoleTrader !== 'undefined' &&
-                twopayment.sole_trader &&
-                String(twopayment.sole_trader.enabled) === '1' &&
                 !window.TwoSoleTrader_Instance
             ) {
                 window.TwoSoleTrader_Instance = new TwoSoleTrader({
-                    enabled: true,
                     checkoutHost: twopayment.checkout_host,
                     orderIntentUrl: twopayment.order_intent_url,
                     ajaxToken: twopayment.ajax_token,


### PR DESCRIPTION
## What

Removes the `PS_TWO_ENABLE_SOLE_TRADER` merchant toggle from the PrestaShop module. Sole trader eligibility is Two's registry answer for the buyer's billing country (`GET /registry/v1/supported-company-types/<ISO>`, Linear TWO-24753 — GB/US currently), never a merchant preference. Magento's toggle-less behaviour is the cross-plugin target state (Linear TWO-25163); this is the PrestaShop half of Linear TWO-25166, alongside woocommerce-plugin PR #374.

## Changes

- `TwoSoleTrader::isEnabled()` deleted; `isAvailable()` now consults the registry alone.
- Admin switch, `install()` default and every reader removed. The install default wrote `0` (and `upgrade-2.6.1` did too), which is why the feature was invisible on both PrestaShop staging shops all along.
- Uninstall cleanup: the existing `Configuration::deleteByName('PS_TWO_ENABLE_SOLE_TRADER')` is kept and annotated, not duplicated.
- `upgrade/upgrade-2.6.3.php` deletes the stored row on existing installs. Module version, `config.xml` and `bumpver.toml` bumped to **2.6.3** — 2.6.2 shipped earlier today in PR #83 with `upgrade-2.6.2.php` already present, so a 2.6.2-named script would never fire.
- Payment-step JS module is now always constructed; the live per-country availability call decides whether the toggle renders. The `sole_trader.enabled` JS def is gone.
- `dev/probe-payment.php` no longer prints the retired key.

## Authorisation angle

Checked, as flagged from the WooCommerce half. The one privileged path is `ajaxProcessSoleTraderTokens` in `controllers/front/orderintent.php`, which mints two delegated-authority tokens with the merchant API key. It gates on `TwoSoleTrader::isAvailable()` against the **cart's invoice-address country** (never a client-supplied `country` param) and fails closed when no invoice address is set. Removing the toggle leaves that country check as the sole and unchanged barrier, so access is not widened: every country that could mint before can still mint, and no new country becomes mintable — the registry decides, exactly as it did behind the toggle. `isAvailable()` carries a comment recording that it is security-bearing.

## Tests

`tests/TwoSoleTraderSpec.php` reworked: a registry-capable country (GB) enables the flow with **no** config row at all, a non-capable country (registry returns an empty list) does not, a leftover `PS_TWO_ENABLE_SOLE_TRADER=0` row has no effect, `isEnabled()` is asserted gone, and `upgrade_module_2_6_3()` deletes the row idempotently. `Configuration::hasKey()` added to the test stub.

Verified the new assertions fail before the fix — restoring the pre-change `classes/TwoSoleTrader.php` and removing the upgrade script gives `FAIL TwoSoleTraderSpec::runAll: Expected true, got false`; with the fix in place all 15 specs pass and `php tests/run.php` exits 0. phpstan (pinned, PS 1.7.6.0 sparse core + generated class aliases, same invocation as CI): `[OK] No errors`.