### PR TITLE
TWO-25184/fix: warm the FX cache on settings-save, not on the first shopper

### DIFF
--- a/tests/FxRatesSpec.php
+++ b/tests/FxRatesSpec.php
@@ -38,6 +38,149 @@ final class FxRatesSpec
         self::testGateJudgesCrossCurrencyBasketOnEndpointRate();
         self::testFixedSurchargeAndCapConvertedIntoQuoteCurrency();
         self::testUnconvertibleFixedSurchargeOmitsQuote();
+        self::testSettingsSaveWarmsColdCache();
+        self::testSettingsSaveWarmRespectsFailureBackoffAndMissingKey();
+        self::testMerchantIdentityChangeClearsFxClockSoWarmFetchRuns();
+    }
+
+    /**
+     * Settings-save harness: the same stubbed-wire module as fxModule, plus
+     * an entry point for the protected general-form save and an injectable
+     * verified merchant id (what the real save gets from API-key
+     * verification).
+     */
+    private static function saveModule($fxResponse, ?string $verifiedMerchantId = null): object
+    {
+        $module = new class (['/refdata/v1/fx-rates' => $fxResponse]) extends TwopaymentTestHarness {
+            public int $fxFetchCount = 0;
+            private array $responsesByEndpoint;
+
+            public function __construct(array $responsesByEndpoint)
+            {
+                parent::__construct();
+                $this->responsesByEndpoint = $responsesByEndpoint;
+            }
+
+            public function setTwoPaymentRequest($endpoint, $payload = [], $method = 'POST', $additional_headers = [], $timeout = null)
+            {
+                if ($endpoint === '/refdata/v1/fx-rates') {
+                    $this->fxFetchCount++;
+                }
+                $response = $this->responsesByEndpoint[$endpoint] ?? ['http_status' => 500];
+                return is_callable($response) ? $response($payload) : $response;
+            }
+
+            public function setVerifiedMerchantIdForTest(?string $id): void
+            {
+                $this->verifiedMerchantId = $id;
+            }
+
+            public function saveGeneralForTest(): void
+            {
+                $this->saveTwoGeneralFormValues();
+            }
+        };
+        $module->setVerifiedMerchantIdForTest($verifiedMerchantId);
+        return $module;
+    }
+
+    /** POST values a minimal valid general-form save needs. */
+    private static function generalFormPost(string $apiKey = 'test-api-key'): void
+    {
+        Tools::setTestValue('PS_TWO_ENVIRONMENT', 'development');
+        Tools::setTestValue('PS_TWO_TITLE_1', 'Two title');
+        Tools::setTestValue('PS_TWO_SUB_TITLE_1', 'Two subtitle');
+        Tools::setTestValue('PS_TWO_MERCHANT_SHORT_NAME', 'merchant');
+        Tools::setTestValue('PS_TWO_MERCHANT_API_KEY', $apiKey);
+    }
+
+    /**
+     * TWO-25184: the module has no scheduler, so a fresh install's cache
+     * stayed empty until the FIRST shopper reached checkout and paid the
+     * fetch inline (or failed closed when it failed). Saving the settings -
+     * the moment the API key first exists - must warm it instead.
+     */
+    private static function testSettingsSaveWarmsColdCache(): void
+    {
+        self::reset();
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, '');
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, 0);
+        $module = self::saveModule(self::ratesResponse());
+        self::generalFormPost();
+
+        $module->saveGeneralForTest();
+
+        TinyAssert::same(1, $module->fxFetchCount, 'a settings save on a cold cache must warm it');
+        TinyAssert::same('2026-07-14', $module->getTwoFxRatesTable()['as_of']);
+        // Warm, so a checkout conversion is served from cache - no inline
+        // fetch on the hot path.
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+        TinyAssert::same(1, $module->fxFetchCount);
+    }
+
+    private static function testSettingsSaveWarmRespectsFailureBackoffAndMissingKey(): void
+    {
+        self::reset();
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, '');
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, 0);
+        $module = self::saveModule(['http_status' => 500]);
+        self::generalFormPost();
+
+        // A merchant re-saving a form against a dead endpoint must not turn
+        // the save button into an unthrottled fetch trigger: the failure
+        // backoff absorbs the repeat.
+        $module->saveGeneralForTest();
+        TinyAssert::same(1, $module->fxFetchCount);
+        $module->saveGeneralForTest();
+        TinyAssert::same(1, $module->fxFetchCount, 'FX_RATES_RETRY_BACKOFF must absorb a repeated save');
+
+        // No API key: nothing to authenticate a fetch with, so no wire call
+        // at all (the endpoint is merchant-API-key authenticated).
+        self::reset();
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, '');
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, 0);
+        $keyless = self::saveModule(self::ratesResponse());
+        self::generalFormPost('');
+        $keyless->saveGeneralForTest();
+        TinyAssert::same(0, $keyless->fxFetchCount, 'a keyless save must not touch the wire');
+    }
+
+    private static function testMerchantIdentityChangeClearsFxClockSoWarmFetchRuns(): void
+    {
+        self::reset();
+        // A table fetched minutes ago under the OLD merchant identity: its
+        // clock is well inside the 6h TTL and would suppress the warm-up
+        // fetch for hours after the key swap.
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-01',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.2],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time());
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'm-old');
+
+        $module = self::saveModule(self::ratesResponse(), 'm-new');
+        self::generalFormPost('new-api-key');
+        $module->saveGeneralForTest();
+
+        TinyAssert::same(1, $module->fxFetchCount, 'an identity change must not leave the warm fetch TTL-suppressed');
+        // Fresh rate replaced the pre-swap one (0.2 -> 0.1).
+        TinyAssert::same(100.0, $module->convertTwoAmountBetweenCurrencies(10.0, 'EUR', 'NOK'));
+
+        // Unchanged identity: the clock is untouched, so the TTL still holds
+        // the fetch off - a save is not a cache-buster.
+        self::reset();
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES, json_encode([
+            'base' => 'EUR',
+            'as_of' => '2026-07-01',
+            'rates' => ['EUR' => 1.0, 'NOK' => 0.2],
+        ]));
+        Configuration::updateValue(Twopayment::CONFIG_FX_RATES_TS, time());
+        Configuration::updateValue('PS_TWO_MERCHANT_ID', 'm-same');
+        $same = self::saveModule(self::ratesResponse(), 'm-same');
+        self::generalFormPost();
+        $same->saveGeneralForTest();
+        TinyAssert::same(0, $same->fxFetchCount, 'a save within the TTL must not refetch');
     }
 
     /**

--- a/twopayment.php
+++ b/twopayment.php
@@ -968,6 +968,13 @@ class Twopayment extends PaymentModule
                 // Merchant identity changed: drop the cached term list so
                 // serve-stale never bridges the old merchant's terms (TWO-24813).
                 $this->invalidateMerchantAvailableTerms();
+                // Same for the FX refresh clock (TWO-25184): the rates
+                // themselves are merchant-independent, so the last-known-good
+                // TABLE stays (it is the gate's only fallback), but the new
+                // identity may be a different environment - and a clock still
+                // inside its 6h TTL would suppress the warm-up fetch that
+                // follows this save for up to six hours.
+                Configuration::updateValue(self::CONFIG_FX_RATES_TS, 0);
             }
             Configuration::updateValue('PS_TWO_MERCHANT_ID', $this->verifiedMerchantId);
             Configuration::updateValue('PS_TWO_API_KEY_VERIFIED', 1);
@@ -975,6 +982,16 @@ class Twopayment extends PaymentModule
             // Ensure flag not stale when verification fails/non-run
             Configuration::updateValue('PS_TWO_API_KEY_VERIFIED', 0);
         }
+
+        // Warm the FX cache (TWO-25184). The API key has just been written,
+        // so this is the earliest moment a refdata fetch can authenticate,
+        // and the module has no scheduler of its own: without this the FIRST
+        // shopper to reach checkout pays the fetch inline, and every
+        // conversion in that request fails closed if it fails, because no
+        // table has ever been stored. refreshTwoFxRates is TTL/backoff-gated
+        // and bumps its clock before the wire call, so repeated saves cannot
+        // hammer the endpoint; it also no-ops without an API key.
+        $this->refreshTwoFxRates();
 
         $this->output .= $this->displayConfirmation($this->l('General settings are updated.'));
     }


### PR DESCRIPTION
## What

PrestaShop has no scheduler for FX rates. The only refresh point is the checkout media hook (`twopayment.php:2976-2979`), which calls `refreshTwoFxRates()` synchronously — so on a fresh install the *first shopper to reach checkout* paid the `/refdata/v1/fx-rates` round-trip, and if it failed, every conversion in that request failed closed because no table had ever been stored.

`saveTwoGeneralFormValues()` now warms the cache after persisting settings. That is the earliest moment a fetch can authenticate (it is where `PS_TWO_MERCHANT_API_KEY` is written), and it is a merchant's admin request rather than a shopper's checkout.

`refreshTwoFxRates()` itself is untouched: still TTL-gated, still bumps its clock before the wire call (anti-stampede), still rolls back to `FX_RATES_RETRY_BACKOFF` and serves last-known-good on failure, still a no-op without an API key. A merchant mashing Save against a dead endpoint cannot hammer it; a save inside the TTL is not a cache-buster.

A merchant-identity change additionally resets `CONFIG_FX_RATES_TS`, mirroring the `invalidateMerchantAvailableTerms()` precedent immediately above it — otherwise a clock still inside its 6h TTL would suppress the warm-up fetch for hours after an API-key swap into another environment. The last-known-good rate **table** is deliberately kept: rates are merchant-independent and the table is the gate's only fallback.

Deliberately **no** fetch in `install()` — no API key exists there, and a wire call would put the install at the mercy of the endpoint.

## Placement note

The ticket suggested wiring this in `getContent()`. It went one level down, into `saveTwoGeneralFormValues()`, for two reasons: it runs only on an actually-successful save (`getContent()` would need the same `!count($this->errors)` guard duplicated), and it is reachable from the existing test harness, so the behaviour is covered rather than asserted by eye. Same moment, same trigger.

## Staleness audit that preceded this

Verified on `staging` before writing code: age is knowable via `CONFIG_FX_RATES_TS` (`:80`) checked against `FX_RATES_TTL` in `refreshTwoFxRates()` (`:7335-7336`); a failed refresh rolls back to `FX_RATES_RETRY_BACKOFF` 300s (`:7369-7372`) and keeps serving last-known-good; the on-demand miss path `getTwoFxRatesForPair()` (`:7260-7278`) allows one gated refresh. So the fall-through posture was already correct — this PR is cold-start warm-up only.

One nit noted, not changed here: the stored table has no `fetched_at` of its own, so `CONFIG_FX_RATES_TS` doubles as an *attempt* clock and backoff state. "How old are the rates I just served" is only answerable via the endpoint's `as_of` floor. Observability for that is Linear TWO-25176.

## Gates

```
$ php tests/run.php
PASS FxRatesSpec::runAll
...
All tests passed.

$ (make phpstan, with the pinned 1.7.6.0 core clone + generated aliases mounted)
/tmp/phpstan.phar: OK
 [OK] No errors
```

New specs were confirmed load-bearing — with the warm call disabled: `FAIL FxRatesSpec::runAll: a settings save on a cold cache must warm it`.

## Ticket

Linear TWO-25184 (parent Linear TWO-25181). Related: Linear TWO-25176 (always-on FX/gate logging), Linear TWO-25175 (the `/refdata` allowlist gap that made all FX paths silently inert for ~6 weeks — this warm-up is only observable once that ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)