### PR TITLE
TWO-24739/refactor: drop dead PS_TWO_ENABLE_B2B_B2C configuration key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now validates the emitted amounts and also asserts `gross == net + tax` exactly
 
 ### Removed
+- **Dead `PS_TWO_ENABLE_B2B_B2C` configuration key removed** (TWO-24739)
+  - The key was never a rendered admin field and was never read for a behavioural decision. Its only two references were the advanced-settings form's value hydration and a matching `Configuration::updateValue()` in the save handler, so saving advanced settings wrote a blank value into the row on every submit while nothing ever consulted it. Two is B2B-only - there is no B2B/B2C mode to switch
+  - The 2.6.4 upgrade script deletes the stored row on existing installs (any shop whose merchant has ever saved advanced settings holds one), and uninstall clears it for shops that never ran the upgrade
+  - Module version bumped to `2.6.4`
+
 - **`PS_TWO_ENABLE_SOLE_TRADER` admin setting retired - sole trader is gated on country only** (TWO-25166, umbrella TWO-25163)
   - The "Enable sole trader checkout" switch is removed from the module configuration page. Whether a buyer can check out as a sole trader is Two's registry answer for their billing country (`GET /registry/v1/supported-company-types/<ISO>`, TWO-24753 - the UK and US currently), never a merchant preference; this matches Magento's toggle-less behaviour, the cross-plugin target state
   - `TwoSoleTrader::isEnabled()` is gone and `isAvailable()` now consults the registry alone. The registry country check was already the barrier the order-intent controller enforced before minting delegated-authority tokens, so removing the toggle does not widen access to that endpoint - the country gate is unchanged and still fails closed on a cart with no invoice address

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -3,7 +3,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.6.3"
+current_version = "2.6.4"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.3]]></version>
+    <version><![CDATA[2.6.4]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/twopayment.php
+++ b/twopayment.php
@@ -196,7 +196,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.3';
+        $this->version = '2.6.4';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -614,6 +614,10 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_ENABLE_DEPARTMENT');
         Configuration::deleteByName('PS_TWO_ENABLE_PROJECT');
         Configuration::deleteByName('PS_TWO_ENABLE_TAX_SUBTOTALS');
+        // Never an admin field and never read for a behavioural decision - the
+        // advanced-settings save wrote it blindly on every submit (TWO-24739).
+        // upgrade-2.6.4 deletes the row; this covers uninstall-without-upgrade.
+        Configuration::deleteByName('PS_TWO_ENABLE_B2B_B2C');
         Configuration::deleteByName('PS_TWO_FINALIZE_PURCHASE');
         // Retired admin toggle (TWO-25166) - sole trader is gated on the
         // registry's country answer alone now. Shops upgraded from <=2.6.2
@@ -1470,7 +1474,6 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
         $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
-        $fields_values['PS_TWO_ENABLE_B2B_B2C'] = Tools::getValue('PS_TWO_ENABLE_B2B_B2C', Configuration::get('PS_TWO_ENABLE_B2B_B2C'));
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         return $fields_values;
@@ -1485,7 +1488,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
-        Configuration::updateValue('PS_TWO_ENABLE_B2B_B2C', Tools::getValue('PS_TWO_ENABLE_B2B_B2C'));
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
 

--- a/upgrade/upgrade-2.6.4.php
+++ b/upgrade/upgrade-2.6.4.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.4
+ *
+ * PS_TWO_ENABLE_B2B_B2C is removed from the module entirely (TWO-24739
+ * plugin-parity cleanup). It was never a rendered admin field and was
+ * never read for a behavioural decision - the only two references were
+ * the advanced-settings form's value hydration and a matching
+ * updateValue() in the save handler, so saving advanced settings wrote a
+ * blank value into the row on every submit and nothing ever consulted it.
+ * Two is B2B-only; there is no B2B/B2C mode to switch.
+ *
+ * Existing installs therefore carry a stored row for the key (any shop
+ * whose merchant has ever saved advanced settings). Nothing reads it, so
+ * this deletes it rather than leaving a dead row that a future reader
+ * could mistake for live configuration.
+ *
+ * Created: 2026-07-27
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_4($module)
+{
+    if (Configuration::hasKey('PS_TWO_ENABLE_B2B_B2C')) {
+        Configuration::deleteByName('PS_TWO_ENABLE_B2B_B2C');
+
+        PrestaShopLogger::addLog(
+            'Two Payment v2.6.4 upgrade: removed dead PS_TWO_ENABLE_B2B_B2C configuration row - never rendered, never read (TWO-24739)',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}


### PR DESCRIPTION
## What

Removes the dead `PS_TWO_ENABLE_B2B_B2C` configuration key. Parent context: Linear TWO-24739 (plugin parity umbrella) — no new ticket, approved directly.

## Proof it is dead

A repo-wide grep for `PS_TWO_ENABLE_B2B_B2C` returned exactly two hits, both in `twopayment.php`:

- `getTwoOtherFormValues()` — hydrated `$fields_values['PS_TWO_ENABLE_B2B_B2C']` for a form field that does not exist (no `renderTwoOtherForm` input declares this name, nothing in `views/` references it).
- `saveTwoOtherFormValues()` — `Configuration::updateValue('PS_TWO_ENABLE_B2B_B2C', Tools::getValue(...))`. With no field posted, `Tools::getValue()` returns `false`, so every advanced-settings save wrote a blank value into the row.

No install default, no uninstall cleanup, and no behavioural reader anywhere — not in `twopayment.php`, `classes/`, `controllers/`, `override/`, `views/`, or `tests/`. Two is B2B-only; there is no B2B/B2C mode to switch.

## What changed

Mirrors the `PS_TWO_ENABLE_SOLE_TRADER` retirement in TWO-25166 (commit `f1f39c1`):

- Both plumbing lines removed.
- `upgrade/upgrade-2.6.4.php` deletes the stored row, guarded on `Configuration::hasKey()` so it is idempotent. Existing installs *do* carry a row — any shop whose merchant has ever saved advanced settings — which is why an upgrade script is warranted rather than a bare code deletion.
- `Configuration::deleteByName('PS_TWO_ENABLE_B2B_B2C')` added to `uninstall()`, annotated, covering shops that uninstall without ever running the upgrade. This is the same belt-and-braces pattern already used for `PS_TWO_ENABLE_SOLE_TRADER` and `PS_TWO_USE_OWN_INVOICES`.
- Version bumped `2.6.3` → `2.6.4` (`twopayment.php`, `config.xml`, `bumpver.toml`). Not folded into `upgrade-2.6.3.php`: 2.6.3 is already merged to staging and may already be the installed version on the staging shops, so a 2.6.3-named script would never fire there.
- `CHANGELOG.md` Unreleased → Removed entry added. Grepped `README.md`, `AI_CONTEXT.md`, `AGENTS.md` and `.ai/*.md` for the key and for any B2B/B2C mode description — nothing documents this setting, so no other doc needs updating.

## Verification

Run the way `.github/workflows/tests.yml` does:

- `php -l twopayment.php` and `php -l upgrade/upgrade-2.6.4.php` — no syntax errors.
- `php tests/run.php` — `All tests passed.`
- phpstan 2.2.5 (pinned, checksum-verified) against the pinned PrestaShop 1.7.6.0 core checkout with generated class aliases — `[OK] No errors`.

No live shop or database touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
