### PR TITLE
TWO-25192: bound company search with limit/offset (parity with Magento/WooCommerce)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Company search now bounds its result set** (TWO-25192)
+  - The request to `GET /companies/v2/company` sent only `q` and `country`, so the API's own default page size decided how many rows came back. A common company name in a large country returned an unbounded list into the autocomplete dropdown
+  - The request now carries `limit` (50, matching the Magento and WooCommerce plugins) and `offset` (always 0). As on both of those platforms there is no load-more or next-page control - the first page is the whole result set - so the dropdown is capped rather than paged, and the existing scroll containers handle the rest
+  - The limit is overridable through the module's JS config (`companySearchLimit`); the default lives on `TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT`
 - **Checkout failures now reach AJAX checkout front-ends instead of vanishing** (TWO-24768)
   - The payment controller's only failure signal was a 302 back to the order page with the message flashed into the session. A checkout that posts the payment form over XHR rather than navigating (PrestaShop's own checkout module does) follows that redirect, receives the order page HTML with HTTP 200, cannot distinguish it from success, and leaves the buyer on a checkout that never moves
   - AJAX callers (identified by `X-Requested-With: XMLHttpRequest`, or an `Accept` that asks for JSON and does not accept HTML) now receive `HTTP 400` with a JSON body carrying `error`, `message` and `redirect_url`. Ordinary browser form posts keep the existing redirect-with-notification behaviour unchanged

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -3,11 +3,21 @@
  * Handles company autocomplete, organization number persistence, and address saving
  */
 class TwoCompanySearch {
+    static DEFAULT_COMPANY_SEARCH_LIMIT = 50;
+
     constructor(config) {
         this.config = {
             companyFieldSelector: "input[name='company']",
             checkoutHost: '',
             saveCompanyUrl: '',
+            // Page size for GET /companies/v2/company. Matches the Magento
+            // (`companySearchLimit` in Model/Ui/ConfigProvider.php) and
+            // WooCommerce (`twoincSearchLimit` in assets/js/twoinc.js)
+            // plugins. Without it the API's own default decides how many
+            // rows come back, so a common name in a large country gives the
+            // buyer an unbounded list. Like both of those plugins there is
+            // no load-more UI - the first page is the whole result set.
+            companySearchLimit: TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT,
             ...config
         };
         
@@ -371,8 +381,15 @@ class TwoCompanySearch {
         // Get country ISO from the selected option if available; otherwise omit
         const country = this.getCurrentCountry();
 
-        // Build URL with correct API parameters
-        const params = new URLSearchParams({ q: term });
+        // Build URL with correct API parameters. `limit`/`offset` mirror the
+        // Magento and WooCommerce plugins: bound the response to one page so
+        // a common name in a large country can't return an unbounded list.
+        // Offset is always 0 - there is no load-more/next-page UI here, same
+        // as select2's `pagination: { more: false }` on the other two
+        // platforms.
+        const limit = Number(this.config.companySearchLimit)
+            || TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT;
+        const params = new URLSearchParams({ q: term, limit: limit, offset: 0 });
         if (country) params.set('country', country);
         // Direct Two API call from frontend as required
         const searchUrl = `${this.config.checkoutHost}/companies/v2/company?${params}`;


### PR DESCRIPTION
Linear [TWO-25192](https://linear.app/two-inc/issue/TWO-25192) (parent [TWO-24739](https://linear.app/two-inc/issue/TWO-24739) plugin feature parity)

## Problem

`TwoCompanySearch.searchCompanies()` sent only `q` and `country` to `GET /companies/v2/company`. With no `limit`/`offset`, the API's own default page size decided the response size — a common company name in a large country gives the buyer an unbounded wall of results in the autocomplete dropdown.

## What the reference plugins do

Both paginate the request, and both then **cap** rather than page:

| | params | limit | debounce | load-more |
| -- | -- | -- | -- | -- |
| WooCommerce `assets/js/twoinc.js` | `country,limit,offset,q` | 50 (`twoincSearchLimit`) | 200 ms | no — select2 `pagination: { more: false }` |
| Magento `view/frontend/web/js/view/address-autocomplete.js` | `country,limit,offset,q` | 50 (`companySearchLimit`, `Model/Ui/ConfigProvider.php`) | 400 ms | no — same |

They wire `offset` off select2's `params.page`, but since `more` is hard-coded `false` select2 never requests page 2. The effective behaviour on both platforms is "first 50, scroll the dropdown".

## Change

- Request now carries `limit=50` and `offset=0`.
- Limit is overridable via the module's JS config (`companySearchLimit`); default on `TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT`, matching Magento's value.
- **No new UI.** Cap, not load-more — matching the other two. PrestaShop's two dropdown renderers are already scroll-capped (`.ui-autocomplete { max-height: 200px; overflow-y: auto }` in `views/css/two.css`; `maxHeight: 240px` on the custom-fallback list), so 50 rows scroll inside the existing idiom.
- CHANGELOG entry.

## Debounce

PrestaShop debounces at **300 ms** — on both code paths (jQuery UI `delay: 300`, and the custom fallback's `setTimeout(..., 300)`). That sits between WooCommerce's 200 ms and Magento's 400 ms, so it is not a material divergence and is left alone. Reporting it rather than churning it.

## Verification

```
$ php tests/run.php
...
All tests passed.
$ node --check views/js/modules/TwoCompanySearch.js
JS_SYNTAX_OK
```

phpstan not run locally: the diff touches one JS file and CHANGELOG.md, no PHP. CI runs it.

Not manually exercised against a staging shop — the request-shape change is the whole diff and is visible in devtools as `limit=50&offset=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)