### PR TITLE
TWO-25190/refactor: drop dead PS_TWO_ENABLE_COMPANY_ID admin toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tax rate precision raised to PrestaShop-native 6dp (rates still capped at 2 decimals of percent per e-invoicing rules); per-line validation now validates the emitted amounts and also asserts `gross == net + tax` exactly
 
 ### Removed
+- **Dead "Activate company org.id auto-complete" admin toggle removed** (TWO-25190, umbrella TWO-24739)
+  - `PS_TWO_ENABLE_COMPANY_ID` was a rendered switch on the advanced-settings page whose only consumer was the `company_id_search` entry in the `Media::addJsDef()` `twopayment` payload - and no JavaScript ever read that entry. Checkout company lookup is driven solely by `company_name_search` (`views/js/twopayment.js`), which is untouched, so the switch advertised a setting that did nothing whichever way a merchant set it
+  - The 2.6.5 upgrade script deletes the stored row on existing installs (install seeded it to `1`), and uninstall clears it for shops that never ran the upgrade
+  - Module version bumped to `2.6.5`
+
 - **Dead `PS_TWO_ENABLE_B2B_B2C` configuration key removed** (TWO-24739)
   - The key was never a rendered admin field and was never read for a behavioural decision. Its only two references were the advanced-settings form's value hydration and a matching `Configuration::updateValue()` in the save handler, so saving advanced settings wrote a blank value into the row on every submit while nothing ever consulted it. Two is B2B-only - there is no B2B/B2C mode to switch
   - The 2.6.4 upgrade script deletes the stored row on existing installs (any shop whose merchant has ever saved advanced settings holds one), and uninstall clears it for shops that never ran the upgrade

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -3,7 +3,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.6.4"
+current_version = "2.6.5"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.4]]></version>
+    <version><![CDATA[2.6.5]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/twopayment.php
+++ b/twopayment.php
@@ -182,8 +182,6 @@ class Twopayment extends PaymentModule
     /** @var string|false */
     public $enable_company_name;
     /** @var string|false */
-    public $enable_company_id;
-    /** @var string|false */
     public $enable_department;
     /** @var string|false */
     public $enable_project;
@@ -196,7 +194,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.4';
+        $this->version = '2.6.5';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -209,7 +207,6 @@ class Twopayment extends PaymentModule
         $this->merchant_short_name = Configuration::get('PS_TWO_MERCHANT_SHORT_NAME');
         $this->api_key = Configuration::get('PS_TWO_MERCHANT_API_KEY');
         $this->enable_company_name = Configuration::get('PS_TWO_ENABLE_COMPANY_NAME');
-        $this->enable_company_id = Configuration::get('PS_TWO_ENABLE_COMPANY_ID');
         $this->enable_department = Configuration::get('PS_TWO_ENABLE_DEPARTMENT');
         $this->enable_project = Configuration::get('PS_TWO_ENABLE_PROJECT');
         // Order intent pre-check is mandatory for all checkouts.
@@ -377,7 +374,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_API_KEY_VERIFIED', 0);
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 0); // Default: SSL verification enabled (secure)
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', 1);
-        Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', 1);
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
@@ -610,6 +606,10 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_API_KEY_VERIFIED');
         Configuration::deleteByName('PS_TWO_DISABLE_SSL_VERIFY');
         Configuration::deleteByName('PS_TWO_ENABLE_COMPANY_NAME');
+        // Retired admin toggle (TWO-25190) - the org.id auto-complete switch
+        // was rendered and stored but no JavaScript ever read the
+        // `company_id_search` variable it fed. upgrade-2.6.5 deletes the row;
+        // this covers uninstall-without-upgrade.
         Configuration::deleteByName('PS_TWO_ENABLE_COMPANY_ID');
         Configuration::deleteByName('PS_TWO_ENABLE_DEPARTMENT');
         Configuration::deleteByName('PS_TWO_ENABLE_PROJECT');
@@ -1380,26 +1380,6 @@ class Twopayment extends PaymentModule
                     ),
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Activate company org.id auto-complete'),
-                        'name' => 'PS_TWO_ENABLE_COMPANY_ID',
-                        'is_bool' => true,
-                        'desc' => $this->l('If you choose YES then customers to use search api to fins their company id (number) automatically.'),
-                        'required' => true,
-                        'values' => array(
-                            array(
-                                'id' => 'PS_TWO_ENABLE_COMPANY_ID_ON',
-                                'value' => 1,
-                                'label' => $this->l('Yes')
-                            ),
-                            array(
-                                'id' => 'PS_TWO_ENABLE_COMPANY_ID_OFF',
-                                'value' => 0,
-                                'label' => $this->l('No')
-                            ),
-                        ),
-                    ),
-                    array(
-                        'type' => 'switch',
                         'label' => $this->l('Automatically fulfill orders with Two'),
                         'name' => 'PS_TWO_FINALIZE_PURCHASE',
                         'is_bool' => true,
@@ -1472,7 +1452,6 @@ class Twopayment extends PaymentModule
     {
         $fields_values = array();
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
-        $fields_values['PS_TWO_ENABLE_COMPANY_ID'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_ID', Configuration::get('PS_TWO_ENABLE_COMPANY_ID'));
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
@@ -1486,7 +1465,6 @@ class Twopayment extends PaymentModule
     protected function saveTwoOtherFormValues()
     {
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
-        Configuration::updateValue('PS_TWO_ENABLE_COMPANY_ID', Tools::getValue('PS_TWO_ENABLE_COMPANY_ID'));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
@@ -2982,7 +2960,6 @@ class Twopayment extends PaymentModule
                 'search_empty_text' => $this->l('No result found'),
                 'checkout_host' => $this->getTwoCheckoutHostUrl(),
                 'company_name_search' => $this->enable_company_name,
-                'company_id_search' => $this->enable_company_id,
                 'enable_department' => $this->enable_department,
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,

--- a/upgrade/upgrade-2.6.5.php
+++ b/upgrade/upgrade-2.6.5.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.5
+ *
+ * PS_TWO_ENABLE_COMPANY_ID is removed from the module entirely (TWO-25190
+ * plugin-parity cleanup). It was a rendered admin switch ("Activate company
+ * org.id auto-complete") whose only consumer was the `company_id_search`
+ * entry in the Media::addJsDef() `twopayment` payload - and no JavaScript
+ * ever read that entry. Company lookup on the checkout is driven solely by
+ * `company_name_search` (views/js/twopayment.js), which is unchanged. The
+ * switch therefore advertised a setting that did nothing.
+ *
+ * Existing installs carry a stored row for the key (install() seeded it to 1
+ * and every advanced-settings save rewrote it). Nothing reads it, so this
+ * deletes it rather than leaving a dead row that a future reader could
+ * mistake for live configuration.
+ *
+ * Created: 2026-07-27
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_5($module)
+{
+    if (Configuration::hasKey('PS_TWO_ENABLE_COMPANY_ID')) {
+        Configuration::deleteByName('PS_TWO_ENABLE_COMPANY_ID');
+
+        PrestaShopLogger::addLog(
+            'Two Payment v2.6.5 upgrade: removed dead PS_TWO_ENABLE_COMPANY_ID configuration row - the org.id auto-complete switch was never read by any consumer (TWO-25190)',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}


### PR DESCRIPTION
## What

Removes the `PS_TWO_ENABLE_COMPANY_ID` admin toggle ("Activate company org.id auto-complete") — Linear TWO-25190, umbrella Linear TWO-24739.

## Why it is dead

- The toggle was rendered on the advanced-settings page, seeded to `1` in `install()`, hydrated in `getTwoOtherFormValues()` and rewritten in `saveTwoOtherFormValues()`.
- Its **only** downstream reference was `'company_id_search' => $this->enable_company_id` in the `Media::addJsDef()` `twopayment` payload.
- Repo-wide grep for `company_id_search` finds **no reader**. The only company-search flag any JavaScript consumes is `company_name_search`, at `views/js/twopayment.js:110` and `:156`. That toggle is deliberately untouched.

So the switch advertised a setting that did nothing whichever way a merchant set it.

## Shape

Follows the pattern used to retire `PS_TWO_ENABLE_B2B_B2C` in prestashop-plugin PR #88:

- plumbing removed (property, constructor read, install seed, admin field, form hydration, save handler, JS var)
- `upgrade/upgrade-2.6.5.php` deletes the stored row, `Configuration::hasKey()`-guarded and idempotent
- `uninstall()` keeps its `Configuration::deleteByName('PS_TWO_ENABLE_COMPANY_ID')` (now commented) for shops that never run the upgrade
- version bumped `2.6.4` → `2.6.5` in `twopayment.php`, `config.xml`, `bumpver.toml`. Not folded into 2.6.4: that version is already on staging and may already be installed on the staging shops, where a 2.6.4-named script would never fire
- CHANGELOG entry under Removed

## Gates run locally

- `php -l` over every file the Module Tests workflow lints, plus the new upgrade script — no syntax errors
- `php tests/run.php` — `All tests passed.`
- `php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G` against a pinned 1.7.6.0 core checkout — ` [OK] No errors`

Docker-dependent install/upgrade smoke left to CI.

## Merge

Do **not** squash-merge — the repo's history convention is merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)