### PR TITLE
TWO-25194/feat: resolve deployed commit from git worktree gitlink and report it in client_v

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
           php -l tests/CheckoutLatencySpec.php
           php -l tests/ShippingCostSourcingSpec.php
           php -l tests/FulfilledStatusMappingSpec.php
+          php -l tests/DeployVersionInfoSpec.php
           php -l tests/run.php
 
       - name: Run offline test suite

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ Thumbs.db
 # Playwright e2e (TWO-25110)
 tests/e2e/test-results/
 tests/e2e/playwright-report/
+
+# Deploy-time commit stamp (written by package-release.sh / git-sync, never committed)
+.two-deployed-commit

--- a/package-release.sh
+++ b/package-release.sh
@@ -51,6 +51,32 @@ echo "Creating temporary package directory..."
 mkdir -p "${TEMP_DIR}/${MODULE_NAME}"
 cd "${MODULE_DIR}"
 
+# Stamp the deployed commit into a sidecar file INSIDE the module source dir so
+# it is picked up by the copy below and ships inside the packaged module.
+# getTwoDeployedCommitHash() reads this first (no .git in the artifact).
+SIDECAR_FILE="${MODULE_DIR}/.two-deployed-commit"
+SIDECAR_PREEXISTING=0
+if [ -f "${SIDECAR_FILE}" ]; then
+    SIDECAR_PREEXISTING=1
+fi
+if COMMIT_SHA=$(git -C "${MODULE_DIR}" rev-parse --short HEAD 2>/dev/null) && [ -n "${COMMIT_SHA}" ]; then
+    printf '%s\n' "${COMMIT_SHA}" > "${SIDECAR_FILE}"
+    echo "✓ Stamped deployed commit: ${COMMIT_SHA}"
+else
+    echo "ERROR: Unable to resolve git commit for .two-deployed-commit stamp"
+    exit 1
+fi
+
+# Remove the stamp again on exit unless it was already tracked in the source tree,
+# so packaging never leaves the working tree dirty.
+cleanup_sidecar() {
+    if [ "${SIDECAR_PREEXISTING}" -eq 0 ]; then
+        rm -f "${SIDECAR_FILE}"
+    fi
+    rm -rf "${TEMP_DIR}"
+}
+trap cleanup_sidecar EXIT
+
 # Copy files, excluding unnecessary ones
 echo "Copying module files (excluding dev files)..."
 
@@ -111,6 +137,15 @@ echo ""
 
 # Remove any .DS_Store files that might have been copied
 find "${TEMP_DIR}" -name ".DS_Store" -delete 2>/dev/null || true
+
+# Fail loudly if the commit stamp did not make it into the built artifact -
+# a silently missing sidecar means the shop reports no commit hash at all.
+if [ ! -s "${TEMP_DIR}/${MODULE_NAME}/.two-deployed-commit" ]; then
+    echo "ERROR: .two-deployed-commit missing (or empty) in the packaged module."
+    echo "       Check the copy exclude-lists in this script."
+    exit 1
+fi
+echo "✓ Commit stamp present in artifact: $(cat "${TEMP_DIR}/${MODULE_NAME}/.two-deployed-commit")"
 
 # Create ZIP file
 echo "Creating ZIP archive..."

--- a/tests/DeployVersionInfoSpec.php
+++ b/tests/DeployVersionInfoSpec.php
@@ -20,7 +20,15 @@ final class DeployVersionInfoSpec
         self::testMissingRefAndPackedRefsReturnsNull();
         self::testSidecarFileTakesPrecedenceOverGitDir();
         self::testInvalidSidecarFallsBackToGitDir();
+        self::testGitlinkFileReturnsShortSha();
+        self::testEmptySidecarFallsBackToGitlinkFile();
+        self::testGarbageSidecarFallsBackToGitlinkFile();
+        self::testNeitherSidecarNorGitReturnsNull();
+        self::testGitlinkFileWithoutShaReturnsNull();
         self::testDeployedAtLabelMatchesModuleFileMtime();
+        self::testClientVersionHasNoTrailingPlusWithoutSha();
+        self::testClientVersionAppendsShaWhenResolved();
+        self::testClientParamsAreUrlEncodedWithPercent2B();
     }
 
     private static function callCommitHash(?string $gitDir, ?string $sidecarFile = null): ?string
@@ -158,6 +166,101 @@ final class DeployVersionInfoSpec
         self::removeDir(dirname($git));
     }
 
+    private static function makeTempModuleDir(): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'two-deploy-spec-' . uniqid('', true);
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+
+    private static function testGitlinkFileReturnsShortSha(): void
+    {
+        // Git-synced staging shops materialise the module as a LINKED WORKTREE:
+        // `.git` is a file containing `gitdir: ../../.git/worktrees/<sha>`.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
+
+        TinyAssert::same('fbdc80b', self::callCommitHash($gitlink));
+        self::removeDir($dir);
+    }
+
+    private static function testEmptySidecarFallsBackToGitlinkFile(): void
+    {
+        // The staging sidecar is currently written as a 0-byte file by broken deploy
+        // infra; that must NOT short-circuit into an empty/absent hash.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
+        $sidecar = $dir . '/.two-deployed-commit';
+        file_put_contents($sidecar, '');
+
+        TinyAssert::same('fbdc80b', self::callCommitHash($gitlink, $sidecar));
+        self::removeDir($dir);
+    }
+
+    private static function testGarbageSidecarFallsBackToGitlinkFile(): void
+    {
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
+        $sidecar = $dir . '/.two-deployed-commit';
+        file_put_contents($sidecar, "<html>404 not found</html>\n");
+
+        TinyAssert::same('fbdc80b', self::callCommitHash($gitlink, $sidecar));
+        self::removeDir($dir);
+    }
+
+    private static function testNeitherSidecarNorGitReturnsNull(): void
+    {
+        $dir = self::makeTempModuleDir();
+
+        TinyAssert::same(null, self::callCommitHash($dir . '/.git', $dir . '/.two-deployed-commit'));
+        self::removeDir($dir);
+    }
+
+    private static function testGitlinkFileWithoutShaReturnsNull(): void
+    {
+        // A gitlink pointing at a plain (non-worktree) gitdir carries no sha.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: /srv/repos/prestashop-plugin/.git\n");
+
+        TinyAssert::same(null, self::callCommitHash($gitlink));
+        self::removeDir($dir);
+    }
+
+    private static function testClientVersionHasNoTrailingPlusWithoutSha(): void
+    {
+        $module = new TwopaymentClientVersionNoShaHarness();
+        TinyAssert::same('2.4.0', $module->getTwoClientVersion());
+        TinyAssert::same(
+            array('client' => 'PS', 'client_v' => '2.4.0'),
+            $module->getTwoClientParams()
+        );
+    }
+
+    private static function testClientVersionAppendsShaWhenResolved(): void
+    {
+        $module = new TwopaymentClientVersionWithShaHarness();
+        TinyAssert::same('2.4.0+fbdc80b', $module->getTwoClientVersion());
+    }
+
+    private static function testClientParamsAreUrlEncodedWithPercent2B(): void
+    {
+        // `+` is a literal SPACE in an application/x-www-form-urlencoded query value,
+        // so the build MUST percent-encode it as %2B or the API sees "2.4.0 fbdc80b".
+        $module = new TwopaymentClientVersionWithShaHarness();
+        $query = http_build_query($module->getTwoClientParams());
+
+        TinyAssert::same('client=PS&client_v=2.4.0%2Bfbdc80b', $query);
+
+        $parsed = [];
+        parse_str($query, $parsed);
+        TinyAssert::same('2.4.0+fbdc80b', $parsed['client_v']);
+    }
+
     private static function testDeployedAtLabelMatchesModuleFileMtime(): void
     {
         $module = new TwopaymentTestHarness();
@@ -166,5 +269,27 @@ final class DeployVersionInfoSpec
 
         $mtime = filemtime(dirname(__DIR__) . '/twopayment.php');
         TinyAssert::same(date('Y-m-d H:i:s', $mtime), $label);
+    }
+}
+
+/**
+ * Harness where no deployed commit can be resolved (no sidecar, no .git).
+ */
+final class TwopaymentClientVersionNoShaHarness extends TwopaymentTestHarness
+{
+    protected function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
+    {
+        return null;
+    }
+}
+
+/**
+ * Harness where the deployed commit resolves to a known short sha.
+ */
+final class TwopaymentClientVersionWithShaHarness extends TwopaymentTestHarness
+{
+    protected function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
+    {
+        return 'fbdc80b';
     }
 }

--- a/twopayment.php
+++ b/twopayment.php
@@ -162,6 +162,8 @@ class Twopayment extends PaymentModule
     protected $errors = array();
     protected $verifiedMerchantId = null;
     protected $verifiedMerchantShortName = null;
+    /** @var string|null Memoised `client_v` value (version + optional +<sha7>) */
+    protected $two_client_version_cache = null;
 
     // Module metadata fields ModuleCore does not declare on all supported
     // PrestaShop versions ($bootstrap was only added to ModuleCore in PS 8;
@@ -1622,7 +1624,7 @@ class Twopayment extends PaymentModule
      *
      * @return string|null
      */
-    private function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
+    protected function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
     {
         if ($sidecar_file === null) {
             $sidecar_file = __DIR__ . '/.two-deployed-commit';
@@ -1637,6 +1639,23 @@ class Twopayment extends PaymentModule
         if ($git_dir === null) {
             $git_dir = __DIR__ . '/.git';
         }
+
+        // Git-synced staging shops materialise the module as a linked worktree, so
+        // `.git` is a gitlink FILE, not a directory:
+        //   gitdir: ../../.git/worktrees/<40-hex-sha>
+        // The last path segment is the commit the sync loop checked out.
+        if (is_file($git_dir)) {
+            if (!is_readable($git_dir)) {
+                return null;
+            }
+            $gitlink_contents = (string) @file_get_contents($git_dir);
+            if (preg_match('#gitdir:\s*.*/([0-9a-f]{7,40})\s*$#i', $gitlink_contents, $gitlink_match)) {
+                return substr($gitlink_match[1], 0, 7);
+            }
+
+            return null;
+        }
+
         if (!is_dir($git_dir) || !is_readable($git_dir)) {
             return null;
         }
@@ -6793,7 +6812,7 @@ class Twopayment extends PaymentModule
     private function verifyTwoApiKey($apiKey, $environment)
     {
         $base = $this->getTwoCheckoutHostUrlForEnvironment($environment);
-        $url = $base . '/v1/merchant/verify_api_key?client=PS&client_v=' . $this->version;
+        $url = $base . '/v1/merchant/verify_api_key?' . http_build_query($this->getTwoClientParams());
         $headers = [
             'Content-Type: application/json; charset=utf-8',
             'X-API-Key:' . $apiKey,
@@ -6908,7 +6927,7 @@ class Twopayment extends PaymentModule
     {
         $url = $this->getTwoCheckoutHostUrl() . '/v1/invoice/' . urlencode($two_order_id) . '/pdf';
         $query = array_merge(
-            array('client' => 'PS', 'client_v' => $this->version),
+            $this->getTwoClientParams(),
             is_array($params) ? $params : array()
         );
         $url .= '?' . http_build_query($query);
@@ -10206,7 +10225,7 @@ class Twopayment extends PaymentModule
         $request_timeout = $timeout !== null ? max(1, (int)$timeout) : self::API_TIMEOUT_LONG;
         if ($method == "POST" || $method == "PUT") {
             $url = sprintf('%s%s', $this->getTwoCheckoutHostUrl(), $endpoint);
-            $url = $url . '?client=PS&client_v=' . $this->version;
+            $url = $url . '?' . http_build_query($this->getTwoClientParams());
             $params = empty($payload) ? '' : json_encode($payload);
             $headers = $this->getTwoRequestHeaders($endpoint, $additional_headers);
             
@@ -10259,7 +10278,7 @@ class Twopayment extends PaymentModule
             ], is_array($response_data) ? $response_data : []);
         } else {
             $url = sprintf('%s%s', $this->getTwoCheckoutHostUrl(), $endpoint);
-            $url = $url . '?client=PS&client_v=' . $this->version;
+            $url = $url . '?' . http_build_query($this->getTwoClientParams());
             $headers = $this->getTwoRequestHeaders($endpoint, $additional_headers);
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_URL, $url);
@@ -10317,6 +10336,42 @@ class Twopayment extends PaymentModule
      * @param array $additional_headers
      * @return array
      */
+    /**
+     * Client version string reported to the Two API as `client_v`.
+     *
+     * Semver from $this->version, suffixed with `+<short-sha>` when the deployed
+     * commit can be resolved (sidecar file or .git gitlink/directory). Never emits
+     * a bare trailing `+`.
+     *
+     * NOTE: callers MUST url-encode this — `+` decodes to a space in a query string.
+     * Use getTwoClientParams() with http_build_query() rather than concatenating.
+     *
+     * @return string
+     */
+    public function getTwoClientVersion()
+    {
+        if ($this->two_client_version_cache === null) {
+            $client_version = (string) $this->version;
+            $sha = $this->getTwoDeployedCommitHash();
+            if (is_string($sha) && $sha !== '') {
+                $client_version .= '+' . $sha;
+            }
+            $this->two_client_version_cache = $client_version;
+        }
+
+        return $this->two_client_version_cache;
+    }
+
+    /**
+     * Standard client identification query params for Two API calls.
+     *
+     * @return array<string, string>
+     */
+    public function getTwoClientParams()
+    {
+        return array('client' => 'PS', 'client_v' => $this->getTwoClientVersion());
+    }
+
     public function getTwoRequestHeaders($endpoint, $additional_headers = [])
     {
         $headers = [


### PR DESCRIPTION
## TWO-25194

PrestaShop currently shows **no** deployed commit hash anywhere, on any git-synced staging shop.

Two independent reasons:

1. Git-sync materialises the module as a **linked git worktree**, so `/var/www/html/modules/twopayment/.git` is a FILE containing `gitdir: ../../.git/worktrees/<40-hex-sha>` — not a directory. `getTwoDeployedCommitHash()` was `is_dir()`-only and bailed immediately.
2. The `.two-deployed-commit` sidecar on staging is **0 bytes** (broken deploy infra — separate ticket), so the sidecar path yields nothing either.

## Changes

**`twopayment.php` — `getTwoDeployedCommitHash()`**

Read order is now:
1. sidecar `.two-deployed-commit`, validated against `/^[0-9a-f]{7,40}$/i` — an **empty or garbage** file falls through rather than short-circuiting;
2. **NEW:** `.git` as a FILE — parses the worktree gitlink's trailing sha;
3. existing `.git` DIRECTORY branch (HEAD / loose refs / packed-refs).

Still plain file reads only (no `exec`), still fail-soft to `null`, never warns on unreadable files. Visibility relaxed `private` → `protected` so the tests can stub it.

**`package-release.sh`**

Stamps `git rev-parse --short HEAD` into `<module dir>/.two-deployed-commit` *before* the copy block so it lands inside the packaged module, then **asserts the file exists and is non-empty in the built artifact before zipping** and fails loudly if not. An `EXIT` trap removes the stamp again so packaging never leaves the source tree dirty. `.two-deployed-commit` is not matched by any entry in either copy deny-list — verified by actually running the script both with and without `rsync` on `PATH`; both artifacts contained the stamp.

**`client_v` carries the sha**

New `getTwoClientVersion()` (memoised) / `getTwoClientParams()` next to `getTwoRequestHeaders()`. Value is `$this->version`, plus `'+' . $sha7` **only** when a sha resolves — never a bare trailing `+`. All four hand-rolled sites replaced:

- `verifyTwoApiKey()` (`/v1/merchant/verify_api_key`)
- `getTwoInvoicePdf()`
- `setTwoPaymentRequest()` × 2 (POST/PUT and GET/other branches)

All four now build the query with `http_build_query`, so the `+` is percent-encoded:

```
https://api.two.inc/v1/order?client=PS&client_v=2.6.4%2Bfbdc80b
```

Unencoded, `+` decodes to a **space** in a query value and the API would see `2.6.4 fbdc80b`. There is a test asserting the exact encoded string and the `parse_str` round-trip.

Smarty template vars `client` / `client_version` (~`twopayment.php:3013`) are deliberately untouched — different surface.

## Tests

`tests/DeployVersionInfoSpec.php` gains: gitlink FILE resolves; empty sidecar falls through to gitlink; garbage sidecar falls through to gitlink; neither present returns `null`; gitlink without a sha returns `null`; `client_v` has no trailing `+` when no sha resolves; `client_v` appends `+<sha7>` when one does; query encoding is `%2B`.

The spec was also missing from the `php -l` list in `tests.yml`; added.

## CI gates, run locally the way CI runs them

```
$ php tests/run.php
PASS DeployVersionInfoSpec::runAll
...
All tests passed.

$ php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G
 [OK] No errors
```

(phpstan 2.2.5, checksum-verified, against a pinned `1.7.6.0` core checkout — same as the workflow.)

## Note for the merger

**This repo DISALLOWS squash merges** — merge with a merge commit, do not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)