### PR TITLE
TWO-25194/fix: resolve deployed commit from .git gitlink first, sidecar last

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -53,7 +53,9 @@ cd "${MODULE_DIR}"
 
 # Stamp the deployed commit into a sidecar file INSIDE the module source dir so
 # it is picked up by the copy below and ships inside the packaged module.
-# getTwoDeployedCommitHash() reads this first (no .git in the artifact).
+# getTwoDeployedCommitHash() reads this LAST (TWO-25194) — a live `.git` gitlink or
+# directory always wins, because this stamp is frozen at build time. The stamp is what
+# resolves the sha in a packaged artifact, which ships no .git at all.
 SIDECAR_FILE="${MODULE_DIR}/.two-deployed-commit"
 SIDECAR_PREEXISTING=0
 if [ -f "${SIDECAR_FILE}" ]; then

--- a/tests/DeployVersionInfoSpec.php
+++ b/tests/DeployVersionInfoSpec.php
@@ -18,11 +18,14 @@ final class DeployVersionInfoSpec
         self::testDetachedHeadReturnsShortSha();
         self::testGarbageHeadReturnsNull();
         self::testMissingRefAndPackedRefsReturnsNull();
-        self::testSidecarFileTakesPrecedenceOverGitDir();
+        self::testGitDirTakesPrecedenceOverSidecar();
         self::testInvalidSidecarFallsBackToGitDir();
         self::testGitlinkFileReturnsShortSha();
+        self::testGitlinkTakesPrecedenceOverValidSidecar();
         self::testEmptySidecarFallsBackToGitlinkFile();
         self::testGarbageSidecarFallsBackToGitlinkFile();
+        self::testMalformedGitlinkFallsBackToValidSidecar();
+        self::testUnreadableGitlinkFallsBackToValidSidecar();
         self::testNeitherSidecarNorGitReturnsNull();
         self::testGitlinkFileWithoutShaReturnsNull();
         self::testDeployedAtLabelMatchesModuleFileMtime();
@@ -136,10 +139,11 @@ final class DeployVersionInfoSpec
         self::removeDir(dirname($git));
     }
 
-    private static function testSidecarFileTakesPrecedenceOverGitDir(): void
+    private static function testGitDirTakesPrecedenceOverSidecar(): void
     {
-        // Deploy-time sidecar file (written by the git-sync materialise loop) must win
-        // over a co-located .git directory when both exist.
+        // TWO-25194: live git state wins over the build-time sidecar stamp. The stamp is
+        // frozen when package-release.sh runs, so a stamped tree that is later checked
+        // out over would otherwise keep reporting the stale build sha forever.
         $git = self::makeTempGitDir();
         file_put_contents($git . '/HEAD', "ref: refs/heads/staging\n");
         mkdir($git . '/refs/heads', 0777, true);
@@ -147,7 +151,7 @@ final class DeployVersionInfoSpec
         $sidecar = dirname($git) . '/.two-deployed-commit';
         file_put_contents($sidecar, "1234abc\n");
 
-        TinyAssert::same('1234abc', self::callCommitHash($git, $sidecar));
+        TinyAssert::same('abcdef0', self::callCommitHash($git, $sidecar));
         self::removeDir(dirname($git));
     }
 
@@ -183,6 +187,57 @@ final class DeployVersionInfoSpec
         file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
 
         TinyAssert::same('fbdc80b', self::callCommitHash($gitlink));
+        self::removeDir($dir);
+    }
+
+    private static function testGitlinkTakesPrecedenceOverValidSidecar(): void
+    {
+        // TWO-25194: the gitlink reflects what the git-sync loop has checked out RIGHT
+        // NOW, so it must beat a perfectly well-formed build-time stamp. package-release.sh
+        // only removes its stamp via an EXIT trap, so an interrupted run leaves a stale
+        // (but syntactically valid) sidecar behind that must never win.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
+        $sidecar = $dir . '/.two-deployed-commit';
+        file_put_contents($sidecar, "1234abc\n");
+
+        TinyAssert::same('fbdc80b', self::callCommitHash($gitlink, $sidecar));
+        self::removeDir($dir);
+    }
+
+    private static function testMalformedGitlinkFallsBackToValidSidecar(): void
+    {
+        // The gitlink exists and is readable but carries no worktree sha (plain gitdir
+        // pointer). That must FALL THROUGH to the sidecar, not return null — the bug the
+        // pre-TWO-25194 early `return null` introduced once gitlink moved to first place.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: /srv/repos/prestashop-plugin/.git\n");
+        $sidecar = $dir . '/.two-deployed-commit';
+        file_put_contents($sidecar, "1234abc\n");
+
+        TinyAssert::same('1234abc', self::callCommitHash($gitlink, $sidecar));
+        self::removeDir($dir);
+    }
+
+    private static function testUnreadableGitlinkFallsBackToValidSidecar(): void
+    {
+        // An unreadable gitlink file must also fall through rather than hard-null.
+        $dir = self::makeTempModuleDir();
+        $gitlink = $dir . '/.git';
+        file_put_contents($gitlink, "gitdir: ../../.git/worktrees/fbdc80b92070eded9a2acbef222da0d55ac4af48\n");
+        $sidecar = $dir . '/.two-deployed-commit';
+        file_put_contents($sidecar, "1234abc\n");
+        @chmod($gitlink, 0000);
+
+        // Skip the assertion when running as a user that bypasses mode bits (e.g. root
+        // in CI containers), where the file stays readable no matter the chmod.
+        if (!is_readable($gitlink)) {
+            TinyAssert::same('1234abc', self::callCommitHash($gitlink, $sidecar));
+        }
+
+        @chmod($gitlink, 0644);
         self::removeDir($dir);
     }
 
@@ -222,7 +277,8 @@ final class DeployVersionInfoSpec
 
     private static function testGitlinkFileWithoutShaReturnsNull(): void
     {
-        // A gitlink pointing at a plain (non-worktree) gitdir carries no sha.
+        // A gitlink pointing at a plain (non-worktree) gitdir carries no sha, and with no
+        // sidecar to fall through to there is nothing left to resolve.
         $dir = self::makeTempModuleDir();
         $gitlink = $dir . '/.git';
         file_put_contents($gitlink, "gitdir: /srv/repos/prestashop-plugin/.git\n");

--- a/twopayment.php
+++ b/twopayment.php
@@ -1592,9 +1592,16 @@ class Twopayment extends PaymentModule
 
     /**
      * Best-effort short commit hash of the deployed module code.
-     * Checks a flat sidecar file first (written at deploy time by the git-sync
-     * materialise loop, where .git is a worktree gitlink file this method can't
-     * read), then falls back to a co-located .git directory (local dev).
+     *
+     * Resolution order — live state first, build-time stamp last (TWO-25194):
+     *   1. `.git` gitlink FILE (git-synced shops: reflects what is checked out RIGHT NOW)
+     *   2. `.git` DIRECTORY (local dev checkout)
+     *   3. `.two-deployed-commit` sidecar (frozen at package-release.sh build time,
+     *      so it goes stale if an artifact tree is later checked out over, and an
+     *      interrupted release run can leave one behind in the working tree)
+     *
+     * Each source falls THROUGH to the next when it cannot produce a valid sha;
+     * null is only returned when all three fail.
      * Plain file reads only — no exec. Returns null (never throws/fatals) if unavailable.
      *
      * @param string|null $git_dir Overridable for tests; defaults to this module's .git
@@ -1604,9 +1611,31 @@ class Twopayment extends PaymentModule
      */
     protected function getTwoDeployedCommitHash($git_dir = null, $sidecar_file = null)
     {
+        if ($git_dir === null) {
+            $git_dir = __DIR__ . '/.git';
+        }
         if ($sidecar_file === null) {
             $sidecar_file = __DIR__ . '/.two-deployed-commit';
         }
+
+        // 1. Git-synced staging shops materialise the module as a linked worktree, so
+        // `.git` is a gitlink FILE, not a directory:
+        //   gitdir: ../../.git/worktrees/<40-hex-sha>
+        // The last path segment is the commit the sync loop checked out.
+        if (is_file($git_dir) && is_readable($git_dir)) {
+            $gitlink_contents = (string) @file_get_contents($git_dir);
+            if (preg_match('#gitdir:\s*.*/([0-9a-f]{7,40})\s*$#i', $gitlink_contents, $gitlink_match)) {
+                return substr($gitlink_match[1], 0, 7);
+            }
+        }
+
+        // 2. Plain `.git` directory (local dev checkout).
+        $git_dir_sha = $this->readShaFromGitDirectory($git_dir);
+        if ($git_dir_sha !== null) {
+            return $git_dir_sha;
+        }
+
+        // 3. Deploy-time sidecar stamp, last because it is frozen at build time.
         if (is_file($sidecar_file) && is_readable($sidecar_file)) {
             $sidecar_contents = trim((string) @file_get_contents($sidecar_file));
             if ($sidecar_contents !== '' && preg_match('/^[0-9a-f]{7,40}$/i', $sidecar_contents)) {
@@ -1614,26 +1643,19 @@ class Twopayment extends PaymentModule
             }
         }
 
-        if ($git_dir === null) {
-            $git_dir = __DIR__ . '/.git';
-        }
+        return null;
+    }
 
-        // Git-synced staging shops materialise the module as a linked worktree, so
-        // `.git` is a gitlink FILE, not a directory:
-        //   gitdir: ../../.git/worktrees/<40-hex-sha>
-        // The last path segment is the commit the sync loop checked out.
-        if (is_file($git_dir)) {
-            if (!is_readable($git_dir)) {
-                return null;
-            }
-            $gitlink_contents = (string) @file_get_contents($git_dir);
-            if (preg_match('#gitdir:\s*.*/([0-9a-f]{7,40})\s*$#i', $gitlink_contents, $gitlink_match)) {
-                return substr($gitlink_match[1], 0, 7);
-            }
-
-            return null;
-        }
-
+    /**
+     * Resolve the short HEAD sha from a plain `.git` DIRECTORY.
+     * Plain file reads only — no exec. Returns null when it cannot be resolved.
+     *
+     * @param string $git_dir
+     *
+     * @return string|null
+     */
+    private function readShaFromGitDirectory($git_dir)
+    {
         if (!is_dir($git_dir) || !is_readable($git_dir)) {
             return null;
         }


### PR DESCRIPTION
Linear: **TWO-25194**

Follows up two-inc/prestashop-plugin PR #91, which shipped `getTwoDeployedCommitHash()` and the `.two-deployed-commit` build stamp with the precedence backwards.

## The precedence flip

Resolution order is now, in order, with each source falling **through** to the next on failure:

| # | Source | Why here |
|---|---|---|
| 1 | `.git` gitlink **FILE** | Git-synced shops materialise the module as a linked worktree; the gitlink names the commit checked out **right now**. Live state. |
| 2 | `.git` **DIRECTORY** | Local dev checkout. Also live state. |
| 3 | `.two-deployed-commit` sidecar | Frozen at build time. Last resort. |

Previously the sidecar won. That is wrong for two reasons:

1. The stamp is written when `package-release.sh` runs and never updated again, so it reports a stale sha the moment a stamped tree is checked out over.
2. `package-release.sh` writes the stamp **into the working tree** and only removes it via an `EXIT` trap. An interrupted run therefore leaves a stale-but-syntactically-valid stamp behind — which, under the old order, would have won forever on that shop.

The sidecar is still the thing that resolves the sha inside a packaged artifact, which ships no `.git` at all. It just no longer outranks live git state.

## Latent bug the reorder would have made load-bearing

The gitlink branch used to `return null` when `.git` was a readable file whose contents did not match the worktree-sha pattern (e.g. a plain `gitdir: /srv/repos/....git` pointer). Harmless while gitlink was checked *second-to-last*; as the **first** source that early return would have swallowed both remaining fallbacks and reported no commit at all.

Fixed: every source falls through on failure and `null` is returned only when all three fail. The `.git`-directory reader moved into a `readShaFromGitDirectory()` helper so the fall-through chain reads flat. All existing guards (`is_file` / `is_dir` / `is_readable`, `@`-suppressed reads, sha regex validation, packed-refs exact-match) are unchanged, as are the `$git_dir` / `$sidecar_file` test override params.

## Tests

`tests/DeployVersionInfoSpec.php`:

- **inverted** `testSidecarFileTakesPrecedenceOverGitDir` -> `testGitDirTakesPrecedenceOverSidecar`
- **added** `testGitlinkTakesPrecedenceOverValidSidecar` — a well-formed stale stamp must not beat the gitlink
- **added** `testMalformedGitlinkFallsBackToValidSidecar` — the fall-through fix; fails with `Expected '1234abc', got NULL` if the early `return null` is reintroduced
- **added** `testUnreadableGitlinkFallsBackToValidSidecar` (self-skips where mode bits are bypassed, e.g. root in a container)
- **kept** the graceful-absence case: nothing resolvable -> bare version, no trailing `+`

Also corrected the now-wrong `package-release.sh` comment that claimed `getTwoDeployedCommitHash()` reads the stamp *first*.

## Gates (run locally exactly as `.github/workflows/tests.yml` does)

- `php -l` over all 19 listed files — `No syntax errors detected` on each
- `php tests/run.php` — `All tests passed.` (`PASS DeployVersionInfoSpec::runAll`)
- phpstan 2.2.5 (checksum-verified) + pinned PrestaShop 1.7.6.0 core stubs + generated aliases — `[OK] No errors`

Negative-control check: reintroducing the removed `return null` makes the suite fail as expected, then passes again once restored.

Not merging — repo disallows squash and this is left open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)