### PR TITLE
TWO-25203: Add a merchant toggle for the checkout address lookup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
           php -l tests/CheckoutLatencySpec.php
           php -l tests/ShippingCostSourcingSpec.php
           php -l tests/FulfilledStatusMappingSpec.php
+          php -l tests/AddressLookupConfigSpec.php
           php -l tests/DeployVersionInfoSpec.php
           php -l tests/run.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Merchant toggle for the checkout address lookup** (TWO-25203, umbrella TWO-24739)
+  - The company address lookup on the checkout address step was unconditional: picking a company from the company search always overwrote the address fields (street, postcode, city) and the organisation-number fields (DNI, VAT number). The other plugins each let the merchant turn that off; this one did not
+  - New `PS_TWO_ADDRESS_LOOKUP` switch on the advanced-settings page, **enabled by default**. With it off the company search still runs and still records the company name and organisation number - the Two flow needs those - but nothing is written into the address or identifier fields
+  - The fill semantics are unchanged and remain deliberate: with the toggle on, re-searching and picking a different company overwrites both the address and the organisation number with the new company's values
+  - Separate from the existing "Activate company name auto-complete" switch (`PS_TWO_ENABLE_COMPANY_NAME`), which gates the search widget itself. Neither key was reused or widened
+  - Existing installs are behaving as "on", so the 2.6.6 upgrade script seeds the key to `1` - only when absent, so a merchant's saved opt-out survives a re-run - and every reader resolves an absent or empty row to enabled, meaning an install whose upgrade has not run yet cannot silently lose the fill
+  - Module version bumped to `2.6.6`
+
 ### Fixed
 - **Company search now bounds its result set** (TWO-25192)
   - The request to `GET /companies/v2/company` sent only `q` and `country`, so the API's own default page size decided how many rows came back. A common company name in a large country returned an unbounded list into the autocomplete dropdown

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Payment is due at the **end of the current month (at fulfillment) plus X days**.
 - Module searches Two's Company API v2 (frontend call)
 - Customer selects a company from search results
 - Module stores organization number in hidden `companyid` field
-- Address fields auto-fill when available from Two's data
+- Address fields, DNI and VAT number auto-fill from Two's data when available, and a re-search overwrites them with the newly selected company's values. Merchant-configurable (Advanced Settings -> "Auto-fill the address from the selected company", enabled by default); with it off, the company search still records the company name and organisation number but writes nothing into the address step
 - Selection persists in cookie to survive checkout step changes
 
 #### 2. Payment Step

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -3,7 +3,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.6.5"
+current_version = "2.6.6"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.5]]></version>
+    <version><![CDATA[2.6.6]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/tests/AddressLookupConfigSpec.php
+++ b/tests/AddressLookupConfigSpec.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for the address-lookup toggle PS_TWO_ADDRESS_LOOKUP - TWO-25203.
+ *
+ * The company address lookup on the checkout address step (picking a company
+ * overwrites the address fields and the DNI / VAT number fields) used to be
+ * ungated. The behaviour is unchanged and is deliberate - a re-search must
+ * overwrite - so the only requirement of the new key is that it can never
+ * silently turn an existing shop's lookup off. These tests pin:
+ *
+ *  - a fresh install seeds the key to 1;
+ *  - the 2.6.6 upgrade seeds an absent key to 1 (the pre-toggle behaviour was
+ *    always-on), and leaves a merchant's deliberate 0 alone even if it runs
+ *    again;
+ *  - an absent key resolves to enabled everywhere it is read - the value
+ *    handed to the checkout JS and the admin switch's rendered position - so
+ *    an install whose upgrade has not run yet still fills;
+ *  - the admin save round-trips both positions, and the value the checkout JS
+ *    receives is the '1'/'0' string it compares against, not a bool or an int.
+ */
+final class AddressLookupConfigSpec
+{
+    public static function runAll(): void
+    {
+        self::testFreshInstallSeedsEnabled();
+        self::testUpgrade266SeedsAbsentKeyToEnabled();
+        self::testUpgrade266LeavesDeliberateOptOutAlone();
+        self::testAbsentKeyResolvesToEnabled();
+        self::testSaveRoundTripsBothPositions();
+        self::testResolvedValueIsTheStringTheJsCompares();
+    }
+
+    private static function reset(): void
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+        Tools::resetTestValues();
+    }
+
+    private static function resolve(TwopaymentTestHarness $module): string
+    {
+        $method = new ReflectionMethod(Twopayment::class, 'getAddressLookupEnabled');
+
+        return $method->invoke($module);
+    }
+
+    /** @return array<string,mixed> */
+    private static function formValues(TwopaymentTestHarness $module): array
+    {
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoOtherFormValues');
+
+        return $method->invoke($module);
+    }
+
+    private static function save(TwopaymentTestHarness $module, $posted): void
+    {
+        Tools::setTestValue('PS_TWO_ADDRESS_LOOKUP', $posted);
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoOtherFormValues');
+        $method->invoke($module);
+    }
+
+    private static function upgrade(TwopaymentTestHarness $module): void
+    {
+        require_once dirname(__DIR__) . '/upgrade/upgrade-2.6.6.php';
+        TinyAssert::true(upgrade_module_2_6_6($module));
+    }
+
+    private static function testFreshInstallSeedsEnabled(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        $method = new ReflectionMethod(Twopayment::class, 'installTwoSettings');
+        TinyAssert::true($method->invoke($module));
+
+        TinyAssert::true(Configuration::hasKey('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same(1, Configuration::get('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same('1', self::resolve($module));
+    }
+
+    private static function testUpgrade266SeedsAbsentKeyToEnabled(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // An install from before the toggle existed: no row, always-on behaviour.
+        TinyAssert::false(Configuration::hasKey('PS_TWO_ADDRESS_LOOKUP'));
+
+        self::upgrade($module);
+
+        TinyAssert::same(1, Configuration::get('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same('1', self::resolve($module));
+        // The seed is a behavioural decision worth a trail in the shop log.
+        TinyAssert::count(1, PrestaShopLogger::$logs);
+    }
+
+    private static function testUpgrade266LeavesDeliberateOptOutAlone(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // Merchant has already switched the lookup off. A re-run of the
+        // upgrade must not resurrect it.
+        Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', 0);
+
+        self::upgrade($module);
+
+        TinyAssert::same(0, Configuration::get('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same('0', self::resolve($module));
+        TinyAssert::count(0, PrestaShopLogger::$logs);
+    }
+
+    private static function testAbsentKeyResolvesToEnabled(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // Upgrade script not run yet - the shop is still behaving as always-on,
+        // and both readers must agree with that rather than fail closed.
+        TinyAssert::same('1', self::resolve($module));
+        TinyAssert::same('1', self::formValues($module)['PS_TWO_ADDRESS_LOOKUP']);
+
+        // An empty stored value is the same case, not a deliberate "off".
+        Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', '');
+        TinyAssert::same('1', self::resolve($module));
+    }
+
+    private static function testSaveRoundTripsBothPositions(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // Switches post strings.
+        self::save($module, '0');
+        TinyAssert::same(0, Configuration::get('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same('0', self::resolve($module));
+        TinyAssert::same('0', self::formValues($module)['PS_TWO_ADDRESS_LOOKUP']);
+
+        Tools::resetTestValues();
+        self::save($module, '1');
+        TinyAssert::same(1, Configuration::get('PS_TWO_ADDRESS_LOOKUP'));
+        TinyAssert::same('1', self::resolve($module));
+        TinyAssert::same('1', self::formValues($module)['PS_TWO_ADDRESS_LOOKUP']);
+    }
+
+    private static function testResolvedValueIsTheStringTheJsCompares(): void
+    {
+        self::reset();
+        $module = new TwopaymentTestHarness();
+
+        // views/js/twopayment.js reads `twopayment.address_lookup !== '0'`, so
+        // the payload value has to be a '1'/'0' string whichever shape the
+        // configuration row happens to hold (int from install, string from a
+        // database read).
+        foreach ([1, '1', true] as $enabled) {
+            Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', $enabled);
+            TinyAssert::same('1', self::resolve($module));
+        }
+
+        // Not `false`: that is what a real Configuration::get() returns for an
+        // absent row, so it is the absent case (enabled), not a stored "off".
+        foreach ([0, '0'] as $disabled) {
+            Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', $disabled);
+            TinyAssert::same('0', self::resolve($module));
+        }
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -5532,6 +5532,7 @@ require __DIR__ . '/ShippingCostSourcingSpec.php';
 require __DIR__ . '/AjaxCheckoutFailureSpec.php';
 require __DIR__ . '/CheckoutLatencySpec.php';
 require __DIR__ . '/FulfilledStatusMappingSpec.php';
+require __DIR__ . '/AddressLookupConfigSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5554,6 +5555,7 @@ $tests = [
     'AjaxCheckoutFailureSpec::runAll' => [AjaxCheckoutFailureSpec::class, 'runAll'],
     'CheckoutLatencySpec::runAll' => [CheckoutLatencySpec::class, 'runAll'],
     'FulfilledStatusMappingSpec::runAll' => [FulfilledStatusMappingSpec::class, 'runAll'],
+    'AddressLookupConfigSpec::runAll' => [AddressLookupConfigSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -196,7 +196,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.5';
+        $this->version = '2.6.6';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -376,6 +376,7 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_API_KEY_VERIFIED', 0);
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 0); // Default: SSL verification enabled (secure)
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', 1);
+        Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', 1); // Default: address lookup fills the address step, matching every other plugin
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', 1);
         Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', 'STANDARD'); // Default: Standard payment terms (not EOM)
         Configuration::updateValue('PS_TWO_PAYMENT_TERMS_30', 1); // Default: 30 days enabled
@@ -608,6 +609,7 @@ class Twopayment extends PaymentModule
         Configuration::deleteByName('PS_TWO_API_KEY_VERIFIED');
         Configuration::deleteByName('PS_TWO_DISABLE_SSL_VERIFY');
         Configuration::deleteByName('PS_TWO_ENABLE_COMPANY_NAME');
+        Configuration::deleteByName('PS_TWO_ADDRESS_LOOKUP');
         // Retired admin toggle (TWO-25190) - the org.id auto-complete switch
         // was rendered and stored but no JavaScript ever read the
         // `company_id_search` variable it fed. upgrade-2.6.5 deletes the row;
@@ -1382,6 +1384,26 @@ class Twopayment extends PaymentModule
                     ),
                     array(
                         'type' => 'switch',
+                        'label' => $this->l('Auto-fill the address from the selected company'),
+                        'name' => 'PS_TWO_ADDRESS_LOOKUP',
+                        'is_bool' => true,
+                        'desc' => $this->l('Governs the company address lookup on the checkout ADDRESS step only. When enabled, picking a company from the company search overwrites the address fields (street, postcode, city) and the organisation-number fields (DNI / VAT number) with the registry data for that company - including on a re-search, where picking a different company replaces the previous company\'s values. When disabled, the company search still works and still records the company name and organisation number, but nothing is written into the address or identifier fields and the customer fills them in themselves. This does not turn the company search itself off - use "Activate company name auto-complete" for that.'),
+                        'required' => true,
+                        'values' => array(
+                            array(
+                                'id' => 'PS_TWO_ADDRESS_LOOKUP_ON',
+                                'value' => 1,
+                                'label' => $this->l('Yes')
+                            ),
+                            array(
+                                'id' => 'PS_TWO_ADDRESS_LOOKUP_OFF',
+                                'value' => 0,
+                                'label' => $this->l('No')
+                            ),
+                        ),
+                    ),
+                    array(
+                        'type' => 'switch',
                         'label' => $this->l('Automatically fulfill orders with Two'),
                         'name' => 'PS_TWO_FINALIZE_PURCHASE',
                         'is_bool' => true,
@@ -1450,10 +1472,35 @@ class Twopayment extends PaymentModule
         return $fields_form;
     }
 
+    /**
+     * Effective value of the address-lookup toggle (TWO-25203), as the '1'/'0'
+     * string the checkout JS compares against.
+     *
+     * An absent row means an install carrying the pre-toggle behaviour whose
+     * upgrade script has not run yet. That behaviour was always-on, so absent
+     * resolves to enabled - a missing row must never silently disable the fill.
+     *
+     * @return string
+     */
+    protected function getAddressLookupEnabled()
+    {
+        $value = Configuration::get('PS_TWO_ADDRESS_LOOKUP');
+
+        if ($value === false || $value === null || $value === '') {
+            return '1';
+        }
+
+        return ((int) $value) === 1 ? '1' : '0';
+    }
+
     protected function getTwoOtherFormValues()
     {
         $fields_values = array();
         $fields_values['PS_TWO_ENABLE_COMPANY_NAME'] = Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME', Configuration::get('PS_TWO_ENABLE_COMPANY_NAME'));
+        // Read through the same default-on resolver the checkout uses, so an
+        // install whose upgrade script has not run yet renders the switch in
+        // the position it is actually behaving in.
+        $fields_values['PS_TWO_ADDRESS_LOOKUP'] = Tools::getValue('PS_TWO_ADDRESS_LOOKUP', $this->getAddressLookupEnabled());
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
@@ -1467,6 +1514,7 @@ class Twopayment extends PaymentModule
     protected function saveTwoOtherFormValues()
     {
         Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
+        Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', (int) Tools::getValue('PS_TWO_ADDRESS_LOOKUP', 1));
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
@@ -2979,6 +3027,10 @@ class Twopayment extends PaymentModule
                 'search_empty_text' => $this->l('No result found'),
                 'checkout_host' => $this->getTwoCheckoutHostUrl(),
                 'company_name_search' => $this->enable_company_name,
+                // Separate from company_name_search: that gates the search
+                // widget itself, this gates only what a selection writes into
+                // the address step (TWO-25203).
+                'address_lookup' => $this->getAddressLookupEnabled(),
                 'enable_department' => $this->enable_department,
                 'enable_project' => $this->enable_project,
                 'enable_order_intent' => $this->enable_order_intent,

--- a/upgrade/upgrade-2.6.6.php
+++ b/upgrade/upgrade-2.6.6.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * UPGRADE SCRIPT: Version 2.6.6
+ *
+ * PS_TWO_ADDRESS_LOOKUP is a new merchant toggle (TWO-25203, umbrella
+ * TWO-24739) for the company address lookup on the checkout address step -
+ * whether picking a company overwrites the address fields and the
+ * DNI / VAT number fields. The behaviour is unchanged; it was previously
+ * ungated, with no way for a merchant to turn it off.
+ *
+ * Existing installs are therefore behaving as "on". Seed the key to 1 so no
+ * shop's effective behaviour flips on upgrade. Only when the key is absent -
+ * a merchant who has already saved a deliberate 0 must keep it, and this
+ * script may run again on a shop that has one.
+ *
+ * Created: 2026-07-28
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_6_6($module)
+{
+    if (!Configuration::hasKey('PS_TWO_ADDRESS_LOOKUP')) {
+        Configuration::updateValue('PS_TWO_ADDRESS_LOOKUP', 1);
+
+        PrestaShopLogger::addLog(
+            'Two Payment v2.6.6 upgrade: seeded PS_TWO_ADDRESS_LOOKUP to 1 - the company address lookup was previously ungated, so enabled preserves this shop\'s existing behaviour (TWO-25203)',
+            1,
+            null,
+            'Module',
+            $module->id
+        );
+    }
+
+    return true;
+}

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -6,6 +6,10 @@ class TwoCheckoutManager {
     constructor(config) {
         this.config = {
             companySearchEnabled: false,
+            // Default-on, mirroring the server-side resolver: the address
+            // lookup was unconditional before the toggle existed (TWO-25203),
+            // so an omitted value must not turn it off.
+            addressLookupEnabled: true,
             orderIntentEnabled: false,
             checkoutHost: '',
             orderIntentUrl: '',
@@ -1883,7 +1887,8 @@ class TwoCheckoutManager {
     initializeCompanySearch() {
         if (!this.companySearch && window.TwoCompanySearch) {
             this.companySearch = new TwoCompanySearch({
-                checkoutHost: this.config.checkoutHost
+                checkoutHost: this.config.checkoutHost,
+                addressLookupEnabled: this.config.addressLookupEnabled !== false
             });
         }
     }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -18,6 +18,10 @@ class TwoCompanySearch {
             // buyer an unbounded list. Like both of those plugins there is
             // no load-more UI - the first page is the whole result set.
             companySearchLimit: TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT,
+            // Merchant toggle for the address lookup (TWO-25203). Default-on,
+            // mirroring the server-side resolver: the fill was unconditional
+            // before the toggle existed, so an omitted value keeps it on.
+            addressLookupEnabled: true,
             ...config
         };
         
@@ -156,12 +160,12 @@ class TwoCompanySearch {
 
         let orgNumber = String(this.organizationField.val() || '').trim();
         const dniField = $("input[name='dni']");
-        const vatField = $("input[name='vat_number']");
-
         const dniValue = dniField.length > 0 ? String(dniField.val() || '').trim() : '';
-        const vatValue = vatField.length > 0 ? String(vatField.val() || '').trim() : '';
 
-        // If user already filled DNI manually, reuse it as fallback org number for Two flow.
+        // If user already filled DNI manually, reuse it as fallback org number
+        // for Two flow. This direction is the customer's own input flowing
+        // *into* the Two flow, not the lookup writing out, so it is not gated
+        // by the address-lookup toggle.
         if (!orgNumber && dniValue) {
             orgNumber = dniValue;
             this.organizationField.val(orgNumber);
@@ -174,15 +178,51 @@ class TwoCompanySearch {
             return;
         }
 
-        if (dniField.length > 0 && !dniValue) {
-            dniField.val(orgNumber);
+        this.writeOrganizationToAddressIdentifiers(orgNumber, true);
+    }
+
+    /**
+     * Whether the merchant has the address lookup switched on
+     * (PS_TWO_ADDRESS_LOOKUP, TWO-25203).
+     *
+     * This gates only what a company selection *writes* into the address step.
+     * Company search itself, and the hidden organisation-number field the Two
+     * flow needs, are governed by companySearchEnabled and stay live either
+     * way.
+     */
+    isAddressLookupEnabled() {
+        return this.config.addressLookupEnabled !== false;
+    }
+
+    /**
+     * Single gate for the DNI / vat_number writes the lookup performs - the
+     * selection handler, the company-details refinement, and the pre-submit
+     * sync all go through here rather than each carrying its own condition.
+     *
+     * @param {string} orgNumber
+     * @param {boolean} [onlyIfEmpty] Leave a value the customer typed alone.
+     */
+    writeOrganizationToAddressIdentifiers(orgNumber, onlyIfEmpty) {
+        if (!this.isAddressLookupEnabled()) {
+            return;
         }
 
-        if (vatField.length > 0 && !vatValue) {
-            vatField.val(orgNumber);
+        const value = String(orgNumber || '').trim();
+        if (!value) {
+            return;
         }
+
+        [$("input[name='dni']"), $("input[name='vat_number']")].forEach(field => {
+            if (field.length === 0) {
+                return;
+            }
+            if (onlyIfEmpty && String(field.val() || '').trim() !== '') {
+                return;
+            }
+            field.val(value);
+        });
     }
-    
+
     /**
      * Setup jQuery UI Autocomplete for company search
      */
@@ -555,16 +595,10 @@ class TwoCompanySearch {
                 companyid: ui.item.organization_number
             });
             
-            // Also sync to DNI field if it exists
-            const dniField = $("input[name='dni']");
-            if (dniField.length > 0) {
-                dniField.val(ui.item.organization_number);
-            }
-
-            const vatField = $("input[name='vat_number']");
-            if (vatField.length > 0) {
-                vatField.val(ui.item.organization_number);
-            }
+            // Also sync to the DNI / VAT fields - gated on the address-lookup
+            // toggle inside the writer (TWO-25203). Unconditional overwrite so
+            // a re-search replaces the previous company's number.
+            this.writeOrganizationToAddressIdentifiers(ui.item.organization_number);
         }
 
         // For some countries (e.g. GB), org number may only be present in company details.
@@ -641,14 +675,7 @@ class TwoCompanySearch {
                 if (!currentOrgNumber || currentOrgNumber !== natIdVal) {
                     this.organizationField.val(natIdVal);
                     this.organizationField.attr('data-two-company-name', this.companyField ? this.companyField.val() : '');
-                    const dniField = $("input[name='dni']");
-                    if (dniField.length > 0) {
-                        dniField.val(natIdVal);
-                    }
-                    const vatField = $("input[name='vat_number']");
-                    if (vatField.length > 0) {
-                        vatField.val(natIdVal);
-                    }
+                    this.writeOrganizationToAddressIdentifiers(natIdVal);
                     // Persist to cookie so backend can use it during order placement
                     this.persistCompanyToCookie({
                         company: this.companyField ? this.companyField.val() : '',
@@ -671,6 +698,12 @@ class TwoCompanySearch {
      * Auto-fill address fields with company address data
      */
     autoFillAddress(addresses) {
+        // Single gate for the address-field writes (TWO-25203). Both call
+        // paths into the fill land here.
+        if (!this.isAddressLookupEnabled()) {
+            return;
+        }
+
         // Prefer business/registered/visiting; fallback to first
         const address = addresses.find(addr => (addr.type && (
             String(addr.type).toUpperCase().includes('BUSINESS') ||

--- a/views/js/twopayment.js
+++ b/views/js/twopayment.js
@@ -108,6 +108,11 @@
             // Initialize the checkout manager with configuration
             const checkoutManager = new TwoCheckoutManager({
                 companySearchEnabled: twopayment.company_name_search === '1',
+                // Separate toggle from companySearchEnabled (TWO-25203): the
+                // search widget can be on while the address / DNI / VAT fill
+                // is off. Absent reads as enabled, matching the server-side
+                // default-on resolver.
+                addressLookupEnabled: twopayment.address_lookup !== '0',
                 orderIntentEnabled: true,
                 checkoutHost: twopayment.checkout_host,
                 orderIntentUrl: twopayment.order_intent_url,
@@ -154,6 +159,8 @@
 
                         const checkoutManager = new TwoCheckoutManager({
                             companySearchEnabled: twopayment.company_name_search === '1',
+                            // Keep in step with the primary config object above (TWO-25203).
+                            addressLookupEnabled: twopayment.address_lookup !== '0',
                             orderIntentEnabled: true,
                             checkoutHost: twopayment.checkout_host,
                             orderIntentUrl: twopayment.order_intent_url,


### PR DESCRIPTION
## Problem

The company address lookup on the checkout **address** step is unconditional. Picking a company from the company search always overwrites the address fields (street, postcode, city) and the organisation-number fields (`dni`, `vat_number`). Magento and WooCommerce each let the merchant turn that off; this module has no such switch.

The *behaviour* is correct and is the cross-plugin reference — re-searching and picking a different company **should** overwrite address and VAT. Only the missing config surface is the defect.

## Change

One new merchant toggle, `PS_TWO_ADDRESS_LOOKUP`, **default enabled**, mirroring WooCommerce's `enable_address_lookup`. Nothing about the fill semantics changes.

Kept separate from `PS_TWO_ENABLE_COMPANY_NAME` ("Activate company name auto-complete"), which gates the search widget itself — neither key is reused or widened.

With the toggle **off**: company search still runs, the company name and hidden organisation number are still recorded (the Two flow needs them), and nothing is written into the address or identifier fields.

### Upgrade safety

Existing installs are behaving as "on". `upgrade/upgrade-2.6.6.php` seeds the key to `1`, **only when absent**, so a merchant's saved opt-out survives a re-run. Independently, every reader resolves an absent or empty row to enabled, so an install whose upgrade script has not run yet cannot silently lose the fill.

## Implementation notes for the reviewer

- `twopayment.php`: install default `1`, uninstall `deleteByName`, advanced-settings switch (same shape as `PS_TWO_FINALIZE_PURCHASE`), form-values read, save path, and a single `getAddressLookupEnabled()` resolver that returns the `'1'`/`'0'` string the checkout JS compares against.
- `views/js/twopayment.js`: the front-end config object is built in **two** places — the primary path and the retry-after-failure fallback. Both carry `addressLookupEnabled`.
- `views/js/modules/TwoCompanySearch.js`: the three `dni` / `vat_number` write sites now go through one gated writer (`writeOrganizationToAddressIdentifiers()`) instead of each carrying its own condition, and the address-field fill is gated at its single entry point (`autoFillAddress()`). The reverse direction — a customer-typed DNI being reused as the org number for the Two flow — is deliberately **not** gated; it is the customer's own input flowing in, not the lookup writing out.
- Module version `2.6.5` → `2.6.6` (`twopayment.php`, `config.xml`, `bumpver.toml`).

### Note on the payment step

PrestaShop has no company-search surface on the payment-method step — `TwoCheckoutManager` only constructs `TwoCompanySearch` when `currentStep === 'address'`. The help text therefore names the address step explicitly, and this toggle has no payment-step scope.

## Tests

`tests/AddressLookupConfigSpec.php` (style of `FulfilledStatusMappingSpec.php`) pins the install / upgrade / save round-trip: fresh-install seeds `1`; the upgrade seeds an absent key to `1` and leaves a deliberate `0` alone on a re-run; absent and empty rows resolve to enabled for both the checkout payload and the rendered switch position; both switch positions round-trip; and the resolved value is the `'1'`/`'0'` string regardless of the shape the configuration row holds.

Gates run locally:

```
$ php tests/run.php
...
PASS AddressLookupConfigSpec::runAll
All tests passed.

$ php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G
 [OK] No errors
```

Still owed: manual verification on the staging shop in both toggle positions.

## Docs

`README.md`'s checkout-flow section described the auto-fill as unconditional; updated. CHANGELOG entry added.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)