### PR TITLE
TWO-25209/docs: refer to the overlay repo generically, not by name

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,4 +1,5 @@
-# tag/push deliberately off (mirrors magento-abn-plugin's bumpver.toml fix) —
+# tag/push deliberately off (mirrors the same bumpver.toml fix in the sibling
+# Magento overlay repo) —
 # a human runs `git push --follow-tags` explicitly when actually cutting a
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.


### PR DESCRIPTION
## Why

This is a **PUBLIC** repository. The private sibling overlay repo must not be named here — public repos are indexed by GitHub code search, and the repo name alone discloses the partner.

Filed as [TWO-25209](https://linear.app/two-inc/issue/TWO-25209) under [TWO-24739](https://linear.app/two-inc/issue/TWO-24739), which covers the same sweep across all four public plugin repos.

## What changed

One comment in `bumpver.toml` that referenced a private repo by name as the origin of this file's tag/push settings. Reworded to "the sibling Magento overlay repo". The explanation of *why* tag/push are off is unchanged.

**Comment only. No behaviour or configuration changes** — `[tool.bumpver]` and every setting under it are untouched.

## Scope note

This was the only hit in the entire repo, on `staging` only (`main` had 0). One unrelated match was checked and dismissed: `tests/TwoInvoiceRetrievalSpec.php` matches the pattern only because the substring appears inside the ordinary English word "Reinstalled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
