### PR TITLE
TWO-25206: Remove the redundant org-number pre-verification at checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Redundant organisation-number pre-verification on the checkout path** (TWO-25206, umbrella TWO-24739)
+  - When a logged-in buyer checked out against a saved billing address, the module pulled an organisation number out of that address (`dni`, `vat_number`, `companyid`) and then made its own blocking, unauthenticated `GET /companies/v2/company?q=<orgnum>&country=<iso>` call - a 30-second timeout budget on the buyer-blocking order-intent AJAX - before it would let the buyer pay with Two. Neither the WooCommerce nor the Magento plugin has an equivalent step
+  - The call was redundant. Two validates the organisation number's format and checksum per country and resolves it against the company registry synchronously on the same `/v1/order_intent` request this handler builds the payload for, rejecting the intent before it is created when it does not resolve. It also overwrites the company name from the registry, so any name the module resolved locally was discarded and re-derived anyway. The module's own payload path has always sent this organisation number unverified, so the pre-check never guarded the payload - only its own prompt
+  - It was also actively harmful. The pre-check used the **fuzzy** company-search endpoint while order intent uses the **exact** by-organisation-number one, so a company Two resolves fine could fail the pre-check and the buyer was hard-blocked with "go back to your billing address and search for your company name". A slow or unreachable provider was indistinguishable from "this company does not exist" - both blocked. And when the fuzzy search returned no exact match but exactly one result, the module accepted **that** company, whose organisation number differed from the one searched, and cached it as the buyer's verified identity
+  - The organisation number found on the address is now handed to Two as-is, and Two is the only thing that verifies it. It is deliberately not treated as search-verified anywhere it was not before
+  - Removed with it: `verifyCompanyByOrgNumber()`, the `getTwoVerifiedCompanyForOrgNumber()` wrapper and its `two_company_verify_miss` cookie memo (added by TWO-24799 to make the miss path survivable), `extractOrganizationNumber()`, and the `COMPANY_VERIFY_MISS_CACHE_TTL` constant. `extractOrgNumberFromAddress()` is untouched - it is still how a saved-address organisation number reaches Two
+  - No configuration key was removed, so this release needs no upgrade script
+  - Module version bumped to `2.6.7`
+
 ### Added
 - **Merchant toggle for the checkout address lookup** (TWO-25203, umbrella TWO-24739)
   - The company address lookup on the checkout address step was unconditional: picking a company from the company search always overwrote the address fields (street, postcode, city) and the organisation-number fields (DNI, VAT number). The other plugins each let the merchant turn that off; this one did not
@@ -17,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Module version bumped to `2.6.6`
 
 ### Fixed
+- **A rejected order intent now tells the buyer what to fix** (TWO-25206)
+  - The browser calls `/v1/order_intent` directly and the error handler read only jQuery's status text ("Bad Request"), never the JSON body. Every 4xx therefore collapsed into the generic "cannot be approved at this time, please select an alternative payment method" - including `COMPANY_NOT_FOUND`, which is the response to an organisation number that does not resolve against the company registry and is precisely the case the removed pre-check used to catch locally
+  - `error_code` and `error_message` are now carried out of the response body, and `COMPANY_NOT_FOUND` maps to the same instruction the pre-check used to show: go back to the billing address and search for the company. The message is the existing translated `select_company_to_use_two` string, matched ahead of the broader keyword branches so the wording cannot drift into a vaguer one
 - **Company search now bounds its result set** (TWO-25192)
   - The request to `GET /companies/v2/company` sent only `q` and `country`, so the API's own default page size decided how many rows came back. A common company name in a large country returned an unbounded list into the autocomplete dropdown
   - The request now carries `limit` (50, matching the Magento and WooCommerce plugins) and `offset` (always 0). As on both of those platforms there is no load-more or next-page control - the first page is the whole result set - so the dropdown is capped rather than paged, and the existing scroll containers handle the rest

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -4,7 +4,7 @@
 # release. Without this, `make patch/minor/major` on any branch would push a
 # version-bump commit + tag straight to origin.
 [tool.bumpver]
-current_version = "2.6.6"
+current_version = "2.6.7"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/classes/TwoSoleTrader.php
+++ b/classes/TwoSoleTrader.php
@@ -27,9 +27,9 @@
  * organization number (TWO:ST…) their registration minted carries the
  * semantics, and the backend derives the company type from it
  * (TWO-24749 spike). There is no account-type security gate on the
- * order-intent path either - a company name plus a verified org number
- * is the business guard, and both a registered business and an enrolled
- * sole trader arrive with that pair.
+ * order-intent path either - an org number is the business guard, and
+ * both a registered business and an enrolled sole trader arrive with
+ * one.
  */
 
 if (!defined('_PS_VERSION_')) {

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>twopayment</name>
     <displayName><![CDATA[Two - BNPL for businesses]]></displayName>
-    <version><![CDATA[2.6.6]]></version>
+    <version><![CDATA[2.6.7]]></version>
     <description><![CDATA[This module allows any merchant to accept payments with Two payment gateway.]]></description>
     <author><![CDATA[Two]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/controllers/front/orderintent.php
+++ b/controllers/front/orderintent.php
@@ -381,19 +381,24 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
         // ENHANCED VALIDATION: Provide clear status codes for different company data scenarios
         // This allows frontend to show specific guidance to users
         
-        // Case 1: No company name at all - user hasn't entered company details
-        if (empty($companyName)) {
-            PrestaShopLogger::addLog('TwoPayment: No company name provided - prompting user', 2);
-            $this->sendJsonResponse(json_encode([
-                'success' => false,
-                'status' => 'no_company',
-                'error' => $this->module->l('To pay with Two, go back to your billing address and enter your company name in the Company field.')
-            ]));
-            return;
-        }
-        
-        // Case 2: Has company name but no org number - common with existing addresses
+        // An org number is the business identity Two resolves against the
+        // company registry, and it resolves the company NAME from that registry
+        // too - overwriting whatever the plugin sent. So an org number without a
+        // local company name is a complete, usable identity and must not be
+        // blocked here (TWO-25206); the payload path has always sent it that way.
         if (empty($companyId)) {
+            // Case 1: No company name and no org number - user hasn't entered company details
+            if (empty($companyName)) {
+                PrestaShopLogger::addLog('TwoPayment: No company name provided - prompting user', 2);
+                $this->sendJsonResponse(json_encode([
+                    'success' => false,
+                    'status' => 'no_company',
+                    'error' => $this->module->l('To pay with Two, go back to your billing address and enter your company name in the Company field.')
+                ]));
+                return;
+            }
+
+            // Case 2: Has company name but no org number - common with existing addresses
             PrestaShopLogger::addLog('TwoPayment: Company name exists but no org number - prompting user to search', 2);
             $this->sendJsonResponse(json_encode([
                 'success' => false,
@@ -403,11 +408,12 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             return;
         }
 
-        // A company name plus a verified org number is the business guard
-        // (TWO-24755): registered businesses search/select their company,
-        // and enrolled sole traders carry the synthetic org number their
-        // Two registration minted, so both arrive here as a valid
-        // business - there is no account-type selector to also check.
+        // An org number is the business guard (TWO-24755): registered
+        // businesses search/select their company, and enrolled sole traders
+        // carry the synthetic org number their Two registration minted, so both
+        // arrive here as a valid business - there is no account-type selector to
+        // also check. Whether the org number is real is Two's call, made on the
+        // order-intent request itself (TWO-25206).
 
         try {
             // Set address with validated form data for API call (form-first approach)
@@ -629,14 +635,14 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
     }
 
     /**
-     * Get company data using PrestaShop-native fallback chain with smart auto-resolution
-     * Priority: Form data → Session → Address fields (with org number verification via Two API)
-     * 
-     * CRITICAL FIX: When a logged-in user uses an existing address, we check for organization
-     * numbers stored in address fields (dni, vat_number) and verify them via Two's API.
-     * This is MORE RELIABLE than searching by company name because org numbers give exact matches.
-     * 
-     * Example: https://api.two.inc/companies/v2/company?q=A81304487&country=ES returns exact match
+     * Get company data using PrestaShop-native fallback chain
+     * Priority: Form data → Session → Address fields → Partial session → Partial form
+     *
+     * When a logged-in user checks out against an existing address, an organization
+     * number stored in that address (dni, vat_number, companyid) is taken as-is and
+     * handed to Two, which validates its format and resolves it against the company
+     * registry on the order-intent request (TWO-25206). This module makes no company
+     * lookup of its own on this path.
      */
     private function getCompanyDataWithFallbacks()
     {
@@ -698,68 +704,53 @@ class TwopaymentOrderintentModuleFrontController extends ModuleFrontController
             ];
         }
         
-        // Priority 3: Customer's address with ORG NUMBER VERIFICATION via Two API
-        // This is the KEY FIX - we look for org numbers in address fields and verify them
+        // Priority 3: Org number stored on the customer's saved address, used AS-IS.
+        //
+        // TWO-25206: the plugin used to pre-verify this org number against
+        // /companies/v2/company before letting it through. That call was
+        // redundant and could block buyers Two accepts:
+        //  - Two verifies the org number synchronously on the very same
+        //    /v1/order_intent request this handler builds the payload for -
+        //    per-country format and checksum validation, then an exact
+        //    by-org-number registry lookup - and rejects the intent with
+        //    COMPANY_NOT_FOUND when it does not resolve.
+        //  - Two also overwrites the company name from the registry, so any
+        //    name resolved here was discarded and re-derived anyway.
+        //  - The pre-check used the FUZZY search endpoint while order intent
+        //    uses the exact one, so a resolvable company could fail the
+        //    pre-check and hard-block the buyer; a slow provider was
+        //    indistinguishable from "company does not exist"; and a single
+        //    fuzzy hit was accepted even when its org number differed from the
+        //    one searched, caching another company as the buyer's identity.
+        //
+        // The payload path (Twopayment::getCompanyDataWithFallbacks()) has
+        // always sent this org number unverified, so the pre-check never
+        // guarded the payload - only its own prompt.
         $address = new Address($selectedAddressId);
         if (Validate::isLoadedObject($address)) {
             $countryIso = Country::getIsoById($address->id_country);
-            
+
             if ($countryIso && is_string($countryIso)) {
-                // STEP 1: Try to extract organization number from address fields
-                // This checks dni, vat_number, companyid fields
+                // Look for an organization number in dni, vat_number, companyid.
                 $existingOrgNumber = $this->module->extractOrgNumberFromAddress($address, $countryIso);
-                
+
                 if (!empty($existingOrgNumber)) {
-                    // STEP 2: Verify the org number via Two's API to get company name
-                    // This gives us an EXACT match - no vagueness like name-based search
                     PrestaShopLogger::addLog(
-                        'TwoPayment: Found org number in address (' . $existingOrgNumber . '), verifying via Two API',
+                        'TwoPayment: Using org number from address for ' . $countryIso .
+                        ' unverified - Two verifies it on order intent',
                         1
                     );
-                    
-                    // TWO-24799: memoises both outcomes for the session. The
-                    // success path was already cached below via the
-                    // two_company_* cookie; this also stops an unresolvable org
-                    // number re-paying a blocking company lookup on every
-                    // checkout update.
-                    $verifiedCompany = $this->module->getTwoVerifiedCompanyForOrgNumber(
-                        $existingOrgNumber,
-                        $countryIso,
-                        $selectedAddressId
-                    );
-                    
-                    if ($verifiedCompany && !empty($verifiedCompany['organization_number'])) {
-                        // SUCCESS! We have verified company data from existing address
-                        $resolvedCompany = $verifiedCompany['name'];
-                        $resolvedOrgNumber = $verifiedCompany['organization_number'];
-                        
-                        // Cache in session for future requests
-                        $this->context->cookie->two_company_name = $resolvedCompany;
-                        $this->context->cookie->two_company_id = $resolvedOrgNumber;
-                        $this->context->cookie->two_company_country = $countryIso;
-                        $this->context->cookie->setExpire(time() + Twopayment::COOKIE_EXPIRY_ONE_HOUR);
-                        
-                        PrestaShopLogger::addLog(
-                            'TwoPayment: ✓ Company VERIFIED from address org number - ' . 
-                            $existingOrgNumber . ' => ' . $resolvedCompany . ' (cached in session)',
-                            1
-                        );
-                        
-                        return [
-                            'company' => $resolvedCompany,
-                            'companyid' => $resolvedOrgNumber
-                        ];
-                    } else {
-                        // Org number couldn't be verified - might be invalid or Two API issue
-                        PrestaShopLogger::addLog(
-                            'TwoPayment: Org number from address could not be verified: ' . $existingOrgNumber . 
-                            ' in ' . $countryIso . ' - user will need to search manually',
-                            2
-                        );
-                    }
+
+                    // Deliberately NOT cached in the two_company_* cookie: that
+                    // cookie holds company data verified by the company search,
+                    // and this org number has not been verified by anything yet.
+                    return [
+                        'company' => trim((string) $address->company),
+                        'companyid' => $existingOrgNumber
+                    ];
                 }
-                
-                // FALLBACK: Address has company name but no verifiable org number
+
+                // FALLBACK: Address has company name but no org number in any field
                 // User will need to use company search to select their company
                 if (!empty($address->company)) {
                     PrestaShopLogger::addLog(

--- a/tests/CheckoutLatencySpec.php
+++ b/tests/CheckoutLatencySpec.php
@@ -3,17 +3,13 @@
 declare(strict_types=1);
 
 /**
- * TWO-24799 - checkout-path latency: the nested company lookup and the
- * order-intent snapshot dedupe. Contract under test:
+ * TWO-24799 - checkout-path latency: the order-intent snapshot dedupe.
+ * Contract under test:
  *
- *  - Nested company lookup. An org number found on a saved address is verified
- *    against /companies/v2/company on the buyer-blocking path. The SUCCESS path
- *    was already memoised (the caller writes the resolved company into the
- *    two_company_* cookie); the MISS path was not, so an unresolvable org number
- *    re-paid that blocking round trip on every checkout update, forever
- *    returning the same null. getTwoVerifiedCompanyForOrgNumber() memoises both,
- *    keyed on org number + country + address ID so editing any of the three
- *    re-verifies instead of inheriting the miss.
+ *  - Nested company lookup. Removed outright by TWO-25206 rather than kept
+ *    memoised: the lookup duplicated one Two already makes on the same
+ *    order-intent request. Its specs moved to OrgNumberPreVerificationSpec,
+ *    which asserts the removal and the unverified pass-through that replaced it.
  *
  *  - Order-intent snapshot dedupe. Every checkout update re-runs the intent
  *    handler and the browser then pays a 2.5-3s /v1/order_intent round trip even
@@ -36,15 +32,6 @@ final class CheckoutLatencySpec
 {
     public static function runAll(): void
     {
-        // Nested company lookup
-        self::testRepeatedUnverifiableOrgNumberIsLookedUpOnlyOnce();
-        self::testVerifiedOrgNumberIsLookedUpOnlyOnce();
-        self::testCountryChangeBustsTheVerificationMiss();
-        self::testOrgNumberChangeBustsTheVerificationMiss();
-        self::testAddressSwitchBustsTheVerificationMiss();
-        self::testVerificationMissExpiresAfterTtl();
-        self::testSuccessfulVerificationForgetsAnEarlierMiss();
-
         // Order-intent snapshot dedupe
         self::testUnchangedSnapshotIsServedFromCache();
         self::testCachedDecisionPreservesDeclineAsWellAsApproval();
@@ -67,148 +54,6 @@ final class CheckoutLatencySpec
         Tools::resetTestValues();
         PrestaShopLogger::reset();
         Context::getContext()->cookie = new Cookie();
-    }
-
-    // -----------------------------------------------------------------
-    // Nested company lookup
-    // -----------------------------------------------------------------
-
-    /**
-     * Module that counts /companies/v2/company round trips instead of making
-     * them. $resolvable maps "ORGNUMBER|COUNTRY" to a verified company.
-     */
-    private static function countingModule(array $resolvable = []): TwopaymentTestHarness
-    {
-        return new class($resolvable) extends TwopaymentTestHarness {
-            public int $companyLookups = 0;
-            /** @var array<string,array{name:string,organization_number:string}> */
-            private array $resolvable;
-
-            public function __construct(array $resolvable)
-            {
-                parent::__construct();
-                $this->resolvable = $resolvable;
-            }
-
-            public function verifyCompanyByOrgNumber($orgNumber, $countryIso)
-            {
-                ++$this->companyLookups;
-                $key = strtoupper(trim((string) $orgNumber)) . '|' . strtoupper(trim((string) $countryIso));
-
-                return $this->resolvable[$key] ?? null;
-            }
-        };
-    }
-
-    /**
-     * The measured regression: six checkout updates against an address whose org
-     * number Two cannot resolve used to cost six blocking lookups. One now.
-     */
-    private static function testRepeatedUnverifiableOrgNumberIsLookedUpOnlyOnce(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        for ($i = 0; $i < 6; ++$i) {
-            $result = $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-            TinyAssert::same(null, $result, 'An unresolvable org number must keep resolving to null');
-        }
-
-        TinyAssert::same(1, $module->companyLookups, 'Six identical checkout updates must cost one company lookup');
-    }
-
-    private static function testVerifiedOrgNumberIsLookedUpOnlyOnce(): void
-    {
-        self::reset();
-        $module = self::countingModule([
-            'B12345678|ES' => ['name' => 'ACME S.L.', 'organization_number' => 'B12345678'],
-        ]);
-
-        // The success path is memoised by the caller's two_company_* cookie, so
-        // assert the resolved value is stable rather than re-deriving it here.
-        for ($i = 0; $i < 4; ++$i) {
-            $result = $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-            TinyAssert::same('ACME S.L.', $result['name']);
-        }
-
-        TinyAssert::same(4, $module->companyLookups, 'A verified org number is cached by the caller, not by the miss marker');
-    }
-
-    private static function testCountryChangeBustsTheVerificationMiss(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        TinyAssert::same(1, $module->companyLookups);
-
-        // Country switch: must NOT inherit the ES miss (TWO-24867 bug class).
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'GB', 1901);
-        TinyAssert::same(2, $module->companyLookups, 'A country switch must re-verify the org number');
-    }
-
-    private static function testOrgNumberChangeBustsTheVerificationMiss(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        $module->getTwoVerifiedCompanyForOrgNumber('B87654321', 'ES', 1901);
-
-        TinyAssert::same(2, $module->companyLookups, 'A corrected org number must re-verify');
-    }
-
-    private static function testAddressSwitchBustsTheVerificationMiss(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1902);
-
-        TinyAssert::same(2, $module->companyLookups, 'Switching billing address must re-verify');
-    }
-
-    /**
-     * The miss is a latency guard, not a verdict: a provider hiccup must
-     * self-heal inside the same checkout session.
-     */
-    private static function testVerificationMissExpiresAfterTtl(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        TinyAssert::same(1, $module->companyLookups);
-
-        // Age the marker past its TTL.
-        $encoded = (string) Context::getContext()->cookie->two_company_verify_miss;
-        $decoded = json_decode($encoded, true);
-        $decoded['at'] = time() - (Twopayment::COMPANY_VERIFY_MISS_CACHE_TTL + 1);
-        Context::getContext()->cookie->two_company_verify_miss = json_encode($decoded);
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        TinyAssert::same(2, $module->companyLookups, 'An expired miss must re-verify');
-    }
-
-    private static function testSuccessfulVerificationForgetsAnEarlierMiss(): void
-    {
-        self::reset();
-        $module = self::countingModule();
-
-        $module->getTwoVerifiedCompanyForOrgNumber('B12345678', 'ES', 1901);
-        TinyAssert::true(!Tools::isEmpty((string) Context::getContext()->cookie->two_company_verify_miss));
-
-        // A different, resolvable org number on the same address.
-        $resolving = self::countingModule([
-            'B87654321|ES' => ['name' => 'ACME S.L.', 'organization_number' => 'B87654321'],
-        ]);
-        $resolving->getTwoVerifiedCompanyForOrgNumber('B87654321', 'ES', 1901);
-
-        TinyAssert::true(
-            Tools::isEmpty((string) (Context::getContext()->cookie->two_company_verify_miss ?? '')),
-            'A successful verification must clear the stale miss marker'
-        );
     }
 
     // -----------------------------------------------------------------

--- a/tests/OrgNumberPreVerificationSpec.php
+++ b/tests/OrgNumberPreVerificationSpec.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../controllers/front/orderintent.php';
+
+/**
+ * TWO-25206: the plugin no longer pre-verifies an organization number found on
+ * the buyer's saved address.
+ *
+ * It used to call GET /companies/v2/company?q=<orgnum> on the buyer-blocking
+ * order-intent path and block checkout when that lookup came back empty. The
+ * call was redundant - Two validates the org number's format and resolves it
+ * against the company registry on the very same /v1/order_intent request, and
+ * overwrites the company name from the registry, so anything resolved locally
+ * was discarded - and it was worse than redundant: it used the FUZZY search
+ * endpoint while order intent uses the exact by-org-number one, so a company
+ * Two resolves fine could fail the pre-check and hard-block the buyer; a slow
+ * provider was indistinguishable from "no such company"; and a lone fuzzy hit
+ * was accepted even when its org number differed from the one searched.
+ *
+ * Contract under test:
+ *  - An org number on the address is handed to Two AS-IS, with no local lookup.
+ *  - The only company identity that can end up cached for the buyer is the one
+ *    their own address carries - the old lookup could cache a DIFFERENT company
+ *    when the fuzzy search returned a single non-matching hit.
+ *  - An org number with no company name beside it is a complete identity and
+ *    must not be blocked - Two supplies the name.
+ *  - The two existing prompts are unchanged for the cases that still warrant
+ *    them: a company name with no org number, and neither.
+ *  - The removed helpers stay removed (a direct guard against reverting this).
+ */
+final class OrgNumberPreVerificationSpec
+{
+    private const CART_ID = 9701;
+    private const CUSTOMER_ID = 9702;
+    private const ADDRESS_ID = 9703;
+    private const ES_COUNTRY_ID = 724;
+
+    private const SEARCH_PROMPT = 'To pay with Two, go back to your billing address and search for your ' .
+        'company name. Select your company from the results to verify your business.';
+    private const NAME_PROMPT = 'To pay with Two, go back to your billing address and enter your company ' .
+        'name in the Company field.';
+
+    public static function runAll(): void
+    {
+        self::testAddressOrgNumberIsSentUnverified();
+        self::testAddressOrgNumberWithoutCompanyNameIsNotBlocked();
+        self::testOnlyTheAddressOwnCompanyCanBeCached();
+        self::testCompanyNameWithoutOrgNumberStillPromptsForSearch();
+        self::testNoCompanyDataAtAllStillPromptsForCompanyName();
+        self::testCompanySearchSelectionStillShortCircuits();
+        self::testPreVerificationHelpersAreGone();
+    }
+
+    /**
+     * The removal itself. Reverting any part of it - the helper, its memo
+     * cookie, or the caller - puts these methods back on the module.
+     */
+    private static function testPreVerificationHelpersAreGone(): void
+    {
+        foreach (
+            [
+                'verifyCompanyByOrgNumber',
+                'getTwoVerifiedCompanyForOrgNumber',
+                'buildTwoCompanyVerifyCacheKey',
+                'hasTwoCompanyVerifyMiss',
+                'recordTwoCompanyVerifyMiss',
+                'clearTwoCompanyVerifyMiss',
+                'extractOrganizationNumber',
+            ] as $method
+        ) {
+            TinyAssert::false(
+                method_exists('Twopayment', $method),
+                'Twopayment::' . $method . '() is the removed org-number pre-verification (TWO-25206) ' .
+                'and must not come back - Two verifies the org number on the order-intent request'
+            );
+        }
+
+        TinyAssert::false(
+            defined('Twopayment::COMPANY_VERIFY_MISS_CACHE_TTL'),
+            'the pre-verification miss-cache TTL existed only to serve the removed lookup'
+        );
+
+        // extractOrgNumberFromAddress() is deliberately NOT removed: it is how a
+        // saved-address org number reaches Two, on this path and on the payload
+        // path (Twopayment::getCompanyDataWithFallbacks()).
+        TinyAssert::true(
+            method_exists('Twopayment', 'extractOrgNumberFromAddress'),
+            'the address org-number extraction is still the source of the org number'
+        );
+    }
+
+    /**
+     * A saved address carrying an org number resolves without any company
+     * lookup, and the org number reaches the payload exactly as stored.
+     */
+    private static function testAddressOrgNumberIsSentUnverified(): void
+    {
+        $controller = self::makeController(['company' => 'Tienda Ejemplo SL', 'dni' => 'B12345678']);
+
+        self::runHandler($controller);
+
+        self::assertPayloadWasBuilt($controller, 'a resolvable address must not be answered with a prompt');
+        TinyAssert::same('B12345678', $controller->module->seenCompanyId);
+        TinyAssert::same('Tienda Ejemplo SL', $controller->module->seenCompanyName);
+        TinyAssert::same(0, $controller->module->outboundCalls, 'the handler must reach no Two endpoint on this path');
+    }
+
+    /**
+     * The regression the old gate would have introduced. Two resolves the
+     * company NAME from the registry and overwrites whatever the plugin sent,
+     * so an org number on its own is a usable identity. Blocking it here would
+     * strand a buyer whose saved address has a fiscal number but no company.
+     */
+    private static function testAddressOrgNumberWithoutCompanyNameIsNotBlocked(): void
+    {
+        $controller = self::makeController(['company' => '', 'dni' => 'B12345678']);
+
+        self::runHandler($controller);
+
+        self::assertPayloadWasBuilt(
+            $controller,
+            'an org number with no local company name must reach Two, not a prompt'
+        );
+        TinyAssert::same('B12345678', $controller->module->seenCompanyId);
+        TinyAssert::same('', $controller->module->seenCompanyName);
+    }
+
+    /**
+     * The old pre-check's worst defect: when the fuzzy search returned no exact
+     * match but exactly one result, it returned THAT company - a different
+     * organization number from the one searched - and the caller cached it in
+     * the two_company_* session cookie as the buyer's verified identity. With no
+     * lookup left, the only company identity that can be cached is the one the
+     * buyer's own address carries.
+     */
+    private static function testOnlyTheAddressOwnCompanyCanBeCached(): void
+    {
+        $controller = self::makeController(['company' => 'Tienda Ejemplo SL', 'dni' => 'B12345678']);
+
+        self::runHandler($controller);
+
+        $cookie = Context::getContext()->cookie;
+        TinyAssert::same(
+            'B12345678',
+            (string) ($cookie->two_company_id ?? ''),
+            'no org number other than the address\'s own may be cached for this buyer'
+        );
+        TinyAssert::same(
+            'Tienda Ejemplo SL',
+            (string) ($cookie->two_company_name ?? ''),
+            'no company name other than the address\'s own may be cached for this buyer'
+        );
+        TinyAssert::same('ES', (string) ($cookie->two_company_country ?? ''));
+    }
+
+    /**
+     * Unchanged prompt #1: the address names a company but no field holds an org
+     * number, so there is nothing for Two to resolve. This branch never made an
+     * HTTP call and still does not.
+     */
+    private static function testCompanyNameWithoutOrgNumberStillPromptsForSearch(): void
+    {
+        $controller = self::makeController(['company' => 'Tienda Ejemplo SL', 'dni' => '']);
+
+        self::runHandler($controller);
+
+        TinyAssert::count(1, $controller->emitted);
+        TinyAssert::same('incomplete_company', $controller->emitted[0]['status']);
+        TinyAssert::same(self::SEARCH_PROMPT, $controller->emitted[0]['error']);
+        TinyAssert::same(0, $controller->module->outboundCalls, 'this branch must stay HTTP-free');
+    }
+
+    /** Unchanged prompt #2: no company identity of any kind on the address. */
+    private static function testNoCompanyDataAtAllStillPromptsForCompanyName(): void
+    {
+        $controller = self::makeController(['company' => '', 'dni' => '']);
+
+        self::runHandler($controller);
+
+        TinyAssert::count(1, $controller->emitted);
+        TinyAssert::same('no_company', $controller->emitted[0]['status']);
+        TinyAssert::same(self::NAME_PROMPT, $controller->emitted[0]['error']);
+    }
+
+    /**
+     * The company-search path is untouched: a buyer who picked a company posts
+     * company + companyid and short-circuits before the address is consulted.
+     */
+    private static function testCompanySearchSelectionStillShortCircuits(): void
+    {
+        $controller = self::makeController(['company' => '', 'dni' => '']);
+        Tools::setTestValue('company', 'Tienda Ejemplo SL');
+        Tools::setTestValue('companyid', 'B87654321');
+
+        self::runHandler($controller);
+
+        self::assertPayloadWasBuilt($controller, 'a company selected from the search must not be re-prompted');
+        TinyAssert::same('B87654321', $controller->module->seenCompanyId);
+        TinyAssert::same('Tienda Ejemplo SL', $controller->module->seenCompanyName);
+    }
+
+    /* ---- fixtures ---- */
+
+    /**
+     * The handler answered with an order-intent payload rather than one of the
+     * company prompts.
+     */
+    private static function assertPayloadWasBuilt($controller, string $message): void
+    {
+        TinyAssert::count(1, $controller->emitted, $message);
+        TinyAssert::true($controller->emitted[0]['success'], $message);
+        TinyAssert::false(
+            isset($controller->emitted[0]['status']),
+            $message . ' (a company prompt carries a status, a payload does not)'
+        );
+        TinyAssert::true(
+            isset($controller->emitted[0]['payload']['buyer']['company']['organization_number']),
+            $message
+        );
+    }
+
+    private static function runHandler($controller): void
+    {
+        try {
+            $controller->ajaxProcessCheckOrderIntent();
+        } catch (StubOrderIntentResponded $responded) {
+            // Stands in for the production exit.
+        }
+
+    }
+
+    /**
+     * @param array{company:string,dni:string} $addressFields
+     */
+    private static function makeController(array $addressFields)
+    {
+        StubStore::reset();
+        PrestaShopLogger::reset();
+        Tools::resetTestValues();
+        Context::getContext()->cookie = new Cookie();
+        Tools::setTestValue('token', Tools::getToken(false));
+        Tools::setTestValue('id_address_invoice', self::ADDRESS_ID);
+        // The handler only serves POSTs.
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        StubStore::$currencies[978] = ['iso_code' => 'EUR', 'loaded' => true];
+        StubStore::$countries[self::ES_COUNTRY_ID] = 'ES';
+        StubStore::$addresses[self::ADDRESS_ID] = [
+            'id_country' => self::ES_COUNTRY_ID,
+            'company' => $addressFields['company'],
+            'dni' => $addressFields['dni'],
+            'address1' => 'Calle Mayor 1',
+            'city' => 'Madrid',
+            'postcode' => '28001',
+            'phone' => '+34600000000',
+            'loaded' => true,
+        ];
+        StubStore::$customers[self::CUSTOMER_ID] = [
+            'email' => 'buyer@example.com',
+            'firstname' => 'Ana',
+            'lastname' => 'Ruiz',
+            'secure_key' => 'secure-key-9702',
+            'loaded' => true,
+        ];
+        StubStore::$carts[self::CART_ID] = [
+            'id_customer' => self::CUSTOMER_ID,
+            'id_currency' => 978,
+            'id_address_invoice' => self::ADDRESS_ID,
+            'id_address_delivery' => self::ADDRESS_ID,
+            'id_carrier' => 0,
+            'id_lang' => 1,
+        ];
+
+        Context::getContext()->cart = new Cart(self::CART_ID);
+
+        $controller = new class extends TwopaymentOrderintentModuleFrontController {
+            /** @var array<int,array> */
+            public array $emitted = [];
+
+            public function sendJsonResponse($content)
+            {
+                $decoded = json_decode((string) $content, true);
+                $this->emitted[] = is_array($decoded) ? $decoded : ['raw' => $content];
+
+                throw new StubOrderIntentResponded('order intent response sent');
+            }
+        };
+        $controller->module = self::makeModule();
+
+        return $controller;
+    }
+
+    /**
+     * Module double that counts company lookups instead of making them and
+     * records the company identity the payload build was handed.
+     */
+    private static function makeModule()
+    {
+        return new class extends TwopaymentTestHarness {
+            public int $outboundCalls = 0;
+            public string $seenCompanyId = '';
+            public string $seenCompanyName = '';
+
+            public function getTwoIntentOrderData($cart, $customer, $currency, $address)
+            {
+                $this->seenCompanyId = (string) $address->companyid;
+                $this->seenCompanyName = (string) $address->company;
+
+                return [
+                    'gross_amount' => '121.00',
+                    'net_amount' => '100.00',
+                    'tax_amount' => '21.00',
+                    'discount_amount' => '0.00',
+                    'currency' => 'EUR',
+                    'invoice_type' => 'FUNDED_INVOICE',
+                    'buyer' => [
+                        'company' => [
+                            'company_name' => $this->seenCompanyName,
+                            'country_prefix' => 'ES',
+                            'organization_number' => $this->seenCompanyId,
+                            'website' => '',
+                        ],
+                    ],
+                    'billing_address' => ['country' => 'ES', 'city' => 'Madrid'],
+                    'shipping_address' => ['country' => 'ES', 'city' => 'Madrid'],
+                    'line_items' => [],
+                ];
+            }
+
+            /**
+             * Tripwire. Every outbound call the module makes builds its URL from
+             * this, including the removed /companies/v2/company pre-verification.
+             * Nothing on the order-intent controller path is supposed to reach
+             * the network, so asking for the host at all is the regression.
+             */
+            public function getTwoCheckoutHostUrl()
+            {
+                ++$this->outboundCalls;
+
+                throw new RuntimeException(
+                    'The order-intent handler must make no outbound call (TWO-25206)'
+                );
+            }
+        };
+    }
+}
+
+if (!class_exists('StubOrderIntentResponded')) {
+    /**
+     * Deliberately an Error, not an Exception: the handler wraps its payload
+     * build in catch (Exception), so an Exception here would be swallowed and
+     * re-emitted as a build failure instead of standing in for the exit.
+     */
+    class StubOrderIntentResponded extends Error
+    {
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -5533,6 +5533,7 @@ require __DIR__ . '/AjaxCheckoutFailureSpec.php';
 require __DIR__ . '/CheckoutLatencySpec.php';
 require __DIR__ . '/FulfilledStatusMappingSpec.php';
 require __DIR__ . '/AddressLookupConfigSpec.php';
+require __DIR__ . '/OrgNumberPreVerificationSpec.php';
 
 $tests = [
     'OrderBuilderSpec::runAll' => [OrderBuilderSpec::class, 'runAll'],
@@ -5556,6 +5557,7 @@ $tests = [
     'CheckoutLatencySpec::runAll' => [CheckoutLatencySpec::class, 'runAll'],
     'FulfilledStatusMappingSpec::runAll' => [FulfilledStatusMappingSpec::class, 'runAll'],
     'AddressLookupConfigSpec::runAll' => [AddressLookupConfigSpec::class, 'runAll'],
+    'OrgNumberPreVerificationSpec::runAll' => [OrgNumberPreVerificationSpec::class, 'runAll'],
 ];
 
 $failed = 0;

--- a/twopayment.php
+++ b/twopayment.php
@@ -143,11 +143,6 @@ class Twopayment extends PaymentModule
     // the authoritative check at payment submit
     // (checkTwoOrderIntentApprovalAtPayment) is never served from this cache.
     const ORDER_INTENT_DECISION_CACHE_TTL = 300; // 5 minutes
-    // TWO-24799: how long an unverifiable org number stays remembered as a miss.
-    // The success path is already cached indefinitely (for the cookie's lifetime)
-    // by the two_company_* company cookie, so only the miss needs its own TTL -
-    // short enough that a provider blip self-heals inside one checkout session.
-    const COMPANY_VERIFY_MISS_CACHE_TTL = 300; // 5 minutes
     // Cross-request cache for the buyer fee-share quote (POST /v1/pricing/order/fee).
     // fetchTwoTermFee() already request-scopes the quote via $this->twoFeeCache, but
     // that array is rebuilt from scratch on every HTTP request (e.g. each order-intent
@@ -196,7 +191,7 @@ class Twopayment extends PaymentModule
     {
         $this->name = 'twopayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.6.6';
+        $this->version = '2.6.7';
         $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
         $this->author = 'Two';
         $this->bootstrap = true;
@@ -11179,131 +11174,6 @@ class Twopayment extends PaymentModule
     }
 
     /**
-     * Verify an org number found on a saved address, memoising BOTH outcomes for
-     * the checkout session (TWO-24799).
-     *
-     * The success path was already cached: verifyCompanyByOrgNumber()'s caller
-     * writes the resolved company into the two_company_* cookie, so a verified
-     * org number costs one lookup per session. The MISS path was not cached at
-     * all, so an address carrying an org number Two cannot resolve (a typo, a
-     * deregistered company, or a provider hiccup) paid a fresh blocking
-     * /companies/v2/company round trip on every single checkout update, at the
-     * 30s API_TIMEOUT_SHORT budget, forever returning the same null.
-     *
-     * The miss marker is keyed on org number + country + address ID, so editing
-     * any of the three re-verifies immediately instead of inheriting the miss.
-     *
-     * @param string $orgNumber
-     * @param string $countryIso
-     * @param int $addressId
-     * @return array{name:string,organization_number:string}|null
-     */
-    public function getTwoVerifiedCompanyForOrgNumber($orgNumber, $countryIso, $addressId)
-    {
-        $key = $this->buildTwoCompanyVerifyCacheKey($orgNumber, $countryIso, $addressId);
-
-        if ($key !== '' && $this->hasTwoCompanyVerifyMiss($key)) {
-            PrestaShopLogger::addLog(
-                'TwoPayment: Skipped org-number verification - cached miss for country=' .
-                strtoupper(trim((string)$countryIso)) . ', address=' . (int)$addressId,
-                1
-            );
-            return null;
-        }
-
-        $verified = $this->verifyCompanyByOrgNumber($orgNumber, $countryIso);
-
-        if ($verified && !empty($verified['organization_number'])) {
-            // Success: forget any stale miss so a later re-check is not blocked.
-            $this->clearTwoCompanyVerifyMiss();
-            return $verified;
-        }
-
-        if ($key !== '') {
-            $this->recordTwoCompanyVerifyMiss($key);
-        }
-
-        return null;
-    }
-
-    /**
-     * Cache key for an org-number verification attempt (TWO-24799).
-     *
-     * @param string $orgNumber
-     * @param string $countryIso
-     * @param int $addressId
-     * @return string '' when the inputs cannot form a usable key
-     */
-    private function buildTwoCompanyVerifyCacheKey($orgNumber, $countryIso, $addressId)
-    {
-        $orgNumber = strtoupper(preg_replace('/[\s\-]/', '', trim((string)$orgNumber)));
-        $countryIso = strtoupper(trim((string)$countryIso));
-        if (Tools::isEmpty($orgNumber) || Tools::isEmpty($countryIso)) {
-            return '';
-        }
-
-        return hash('sha256', 'company_verify|' . $orgNumber . '|' . $countryIso . '|' . (int)$addressId);
-    }
-
-    /**
-     * Whether this exact verification attempt is a remembered, unexpired miss.
-     *
-     * @param string $key
-     * @return bool
-     */
-    private function hasTwoCompanyVerifyMiss($key)
-    {
-        $encoded = isset($this->context->cookie->two_company_verify_miss)
-            ? (string)$this->context->cookie->two_company_verify_miss
-            : '';
-        if (Tools::isEmpty($encoded)) {
-            return false;
-        }
-
-        $decoded = json_decode($encoded, true);
-        if (!is_array($decoded) || !isset($decoded['key'], $decoded['at'])) {
-            return false;
-        }
-
-        if (!hash_equals((string)$decoded['key'], (string)$key)) {
-            return false;
-        }
-
-        $age = time() - (int)$decoded['at'];
-
-        return $age >= 0 && $age <= self::COMPANY_VERIFY_MISS_CACHE_TTL;
-    }
-
-    /**
-     * Remember an org number that Two could not resolve.
-     *
-     * Single-slot by design: the buyer has one billing address in play at a
-     * time, so one marker keeps the cookie bounded while still covering the
-     * repeat-update case this exists for.
-     *
-     * @param string $key
-     * @return void
-     */
-    private function recordTwoCompanyVerifyMiss($key)
-    {
-        $this->context->cookie->two_company_verify_miss = json_encode(array(
-            'key' => (string)$key,
-            'at' => time(),
-        ));
-        $this->context->cookie->setExpire(time() + self::COOKIE_EXPIRY_ONE_HOUR);
-    }
-
-    /**
-     * Forget the remembered verification miss (TWO-24799).
-     *
-     * @return void
-     */
-    public function clearTwoCompanyVerifyMiss()
-    {
-        unset($this->context->cookie->two_company_verify_miss);
-    }
-
-    /**
      * Build normalized checkout snapshot with stable ordering.
      *
      * @param Cart $cart
@@ -12616,131 +12486,6 @@ class Twopayment extends PaymentModule
     }
     
     /**
-     * Verify and resolve company data using organization number via Two's company search API
-     * 
-     * CRITICAL: This enables smart UX for logged-in users with existing addresses.
-     * Instead of searching by company name, we search by organization 
-     * number which gives an EXACT match.
-     * 
-     * Two's API supports searching by org number: /companies/v2/company?q={org_number}&country={iso}
-     * Example: https://api.two.inc/companies/v2/company?q=A81304487&country=ES
-     * 
-     * @param string $orgNumber The organization number to search for (CIF, NIF, company number, etc.)
-     * @param string $countryIso Two-letter country ISO code (e.g., 'GB', 'NO', 'SE', 'ES')
-     * @return array|null Returns ['name' => string, 'organization_number' => string] on success, null on failure
-     */
-    public function verifyCompanyByOrgNumber($orgNumber, $countryIso)
-    {
-        if (empty($orgNumber) || empty($countryIso)) {
-            return null;
-        }
-        
-        // Normalize inputs
-        $orgNumber = trim($orgNumber);
-        $countryIso = strtoupper(trim($countryIso));
-        
-        // Build the search URL - search by organization number for exact match
-        // This is the key insight: Two's API accepts org numbers in the 'q' parameter
-        $searchUrl = $this->getTwoCheckoutHostUrl() . '/companies/v2/company';
-        $searchUrl .= '?' . http_build_query([
-            'q' => $orgNumber,
-            'country' => $countryIso
-        ]);
-        
-        PrestaShopLogger::addLog(
-            'TwoPayment: Verifying company by org number: ' . $orgNumber . ' in ' . $countryIso,
-            1
-        );
-        
-        // Make the request (no API key required for company search)
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $searchUrl);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, self::API_TIMEOUT_SHORT);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Accept: application/json'
-        ]);
-        
-        // Configure SSL verification
-        $this->configureSslVerification($ch);
-        
-        $response_body = curl_exec($ch);
-        $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $curl_error = curl_error($ch);
-        curl_close($ch);
-        
-        // Handle errors
-        if ($response_body === false || !empty($curl_error) || $http_status !== 200) {
-            PrestaShopLogger::addLog(
-                'TwoPayment: Company verification failed - HTTP ' . $http_status . 
-                ', Error: ' . ($curl_error ?: 'Unknown') . 
-                ', OrgNumber: ' . $orgNumber . ', Country: ' . $countryIso,
-                2
-            );
-            return null;
-        }
-        
-        $response = json_decode($response_body, true);
-        
-        if (!isset($response['items']) || !is_array($response['items']) || empty($response['items'])) {
-            PrestaShopLogger::addLog(
-                'TwoPayment: Company verification - no results for org number: ' . $orgNumber . ' in ' . $countryIso,
-                1
-            );
-            return null;
-        }
-        
-        $companies = $response['items'];
-        
-        // When searching by org number, we expect an exact match
-        // The API should return the company with matching organization number
-        foreach ($companies as $company) {
-            $foundOrgNumber = $this->extractOrganizationNumber($company);
-            
-            // Normalize both for comparison (remove spaces, dashes, make uppercase)
-            $normalizedSearch = strtoupper(preg_replace('/[\s\-]/', '', $orgNumber));
-            $normalizedFound = strtoupper(preg_replace('/[\s\-]/', '', $foundOrgNumber));
-            
-            if ($normalizedSearch === $normalizedFound) {
-                PrestaShopLogger::addLog(
-                    'TwoPayment: ✓ Company verified by org number - ' . $orgNumber . 
-                    ' => ' . $company['name'] . ' in ' . $countryIso,
-                    1
-                );
-                return [
-                    'name' => $company['name'],
-                    'organization_number' => $foundOrgNumber
-                ];
-            }
-        }
-        
-        // If no exact org number match, but we got a single result, it might be valid
-        // (API might have found it via partial match)
-        if (count($companies) === 1) {
-            $company = $companies[0];
-            $foundOrgNumber = $this->extractOrganizationNumber($company);
-            if (!empty($foundOrgNumber)) {
-                PrestaShopLogger::addLog(
-                    'TwoPayment: ✓ Company resolved (single result) - searched: ' . $orgNumber . 
-                    ' => ' . $company['name'] . ' (' . $foundOrgNumber . ') in ' . $countryIso,
-                    1
-                );
-                return [
-                    'name' => $company['name'],
-                    'organization_number' => $foundOrgNumber
-                ];
-            }
-        }
-        
-        PrestaShopLogger::addLog(
-            'TwoPayment: Company verification - org number not matched: ' . $orgNumber . 
-            ' in ' . $countryIso . ' (found ' . count($companies) . ' companies)',
-            2
-        );
-        return null;
-    }
-    
-    /**
      * Extract organization number from address fields
      * Checks various PrestaShop address fields where org numbers might be stored
      * 
@@ -12795,37 +12540,6 @@ class Twopayment extends PaymentModule
                 1
             );
             return trim($address->companyid);
-        }
-        
-        return '';
-    }
-    
-    /**
-     * Extract organization number from Two company search result
-     * Handles various field naming conventions across different countries
-     * 
-     * @param array $company Company data from Two API
-     * @return string Organization number or empty string
-     */
-    private function extractOrganizationNumber($company)
-    {
-        // Primary: national_identifier object (most countries)
-        if (isset($company['national_identifier']) && is_array($company['national_identifier'])) {
-            $ni = $company['national_identifier'];
-            $orgNumber = $ni['id'] ?? $ni['value'] ?? $ni['organisationNumber'] ?? 
-                        $ni['organizationNumber'] ?? $ni['registration_number'] ?? 
-                        $ni['company_number'] ?? '';
-            if (!empty($orgNumber)) {
-                return trim($orgNumber);
-            }
-        }
-        
-        // Fallback: Direct fields (commonly used in GB)
-        $directFields = ['registration_number', 'company_number', 'organization_number', 'organisation_number'];
-        foreach ($directFields as $field) {
-            if (isset($company[$field]) && !empty($company[$field])) {
-                return trim($company[$field]);
-            }
         }
         
         return '';

--- a/views/js/modules/TwoOrderIntent.js
+++ b/views/js/modules/TwoOrderIntent.js
@@ -338,10 +338,50 @@ class TwoOrderIntent {
                     }
                 },
                 error: (xhr, status, error) => {
-                    reject(new Error(`Two order intent failed: ${error}`));
+                    // TWO-25206: Two is the only thing that verifies the buyer's
+                    // organization number now, so its rejection reason has to reach
+                    // getErrorMessage() - jQuery's statusText alone ("Bad Request")
+                    // carries none of it and every 4xx collapsed into the generic
+                    // "pick another payment method" decline. Carry error_code and
+                    // error_message through so COMPANY_NOT_FOUND (the response to an
+                    // org number that does not resolve against the company registry)
+                    // maps to the actionable company-search prompt instead.
+                    reject(new Error(`Two order intent failed: ${TwoOrderIntent.describeApiError(xhr, error)}`));
                 }
             });
         });
+    }
+
+    /**
+     * Flatten an order-intent error response into a matchable string.
+     * Reads the JSON body first (error_code / error_message), and falls back to
+     * jQuery's statusText when the body is absent or not JSON.
+     */
+    static describeApiError(xhr, statusText) {
+        let body = xhr && xhr.responseJSON ? xhr.responseJSON : null;
+
+        if (!body && xhr && typeof xhr.responseText === 'string' && xhr.responseText !== '') {
+            try {
+                body = JSON.parse(xhr.responseText);
+            } catch (e) {
+                body = null;
+            }
+        }
+
+        const parts = [];
+        if (body && typeof body === 'object') {
+            if (body.error_code) {
+                parts.push('' + body.error_code);
+            }
+            if (body.error_message) {
+                parts.push('' + body.error_message);
+            }
+        }
+        if (parts.length === 0 && statusText) {
+            parts.push('' + statusText);
+        }
+
+        return parts.join(' ');
     }
 
     processResult(response) {
@@ -394,6 +434,19 @@ class TwoOrderIntent {
         // field that's actually blocking them.
         if (error.includes('select your company') || error.includes('search for your company')) {
             return errorString;
+        }
+
+        // TWO-25206: Two rejects the order intent with COMPANY_NOT_FOUND when the
+        // organization number does not resolve against the company registry. This
+        // is the case the plugin's own pre-verification used to catch locally, so
+        // show the buyer the same instruction it used to show - matched before the
+        // generic keyword branches below so the wording cannot drift into a vaguer
+        // one. Kept ahead of 'not found' too, which is a broader catch-all.
+        if (error.includes('company_not_found') || error.includes('company not found')) {
+            return this.t(
+                'select_company_to_use_two',
+                'To pay with Two, go back to your billing address and search for your company name. Select your company from the results to verify your business.'
+            );
         }
 
         // Phone number validation errors (priority - specific error type)


### PR DESCRIPTION
## TWO-25206 — remove the redundant org-number pre-verification

Umbrella: TWO-24739 (plugin parity). Related: TWO-24799, which added the miss-memoisation that made the call below survivable.

### What it did

When a logged-in buyer reached the payment step against a **saved billing address**, `getCompanyDataWithFallbacks()` in the order-intent controller pulled an organisation number out of that address (`dni`, `vat_number`, `companyid`) and then made the module's own blocking, unauthenticated `GET /companies/v2/company?q=<orgnum>&country=<iso>` call — `CURLOPT_TIMEOUT = 30` — on the buyer-blocking checkout AJAX, before it would let the buyer pay. Neither the WooCommerce nor the Magento plugin has an equivalent step.

### Why it goes

**Redundant.** Two validates the organisation number's format and checksum per country, and resolves it against the company registry, **synchronously on the same `/v1/order_intent` request this handler builds the payload for** — rejecting the intent before it is created when it does not resolve. It also overwrites `company_name` from the registry, so any name the module resolved locally was discarded and re-derived anyway.

**And the pre-check never guarded the payload.** The module's own payload path (`Twopayment::getCompanyDataWithFallbacks()`, Priority 2) has always taken `extractOrgNumberFromAddress()` output raw and sent it, with the in-code comment *"Two's order API will accept org number and resolve company name"*. The pre-check gated only its own prompt.

**Worse than redundant — three failure modes it created:**

1. **False block.** The pre-check used the **fuzzy** search endpoint (`?q=`) while order intent uses the **exact** by-organisation-number endpoint with `include_inactive`. The search path also drops rows with a null national identifier. A company Two resolves fine could therefore fail the pre-check, and the buyer was hard-blocked with *"go back to your billing address and search for your company name"*.
2. **Timeout = block.** Provider slow or unreachable and "this company does not exist" both returned `null`, and `null` blocked.
3. **Wrong company cached.** When the fuzzy search returned no exact match but exactly one result, the module returned **that** company — whose organisation number differed from the one searched — and cached it in the `two_company_*` session cookie as the buyer's verified identity.

### What changed

- The organisation number on the address is handed to Two **as-is**. Two is the only thing that verifies it.
- The local gate now keys on the **organisation number alone**. An organisation number with no company name beside it used to be blocked with *"enter your company name"* whenever the lookup could not supply one; it is now let through, because Two resolves the name from the registry. Both existing prompts are unchanged for the cases that still warrant them (name but no number → `incomplete_company`; neither → `no_company`).
- Removed: `verifyCompanyByOrgNumber()`, the `getTwoVerifiedCompanyForOrgNumber()` wrapper and its `two_company_verify_miss` cookie memo, `extractOrganizationNumber()`, and `COMPANY_VERIFY_MISS_CACHE_TTL`. Grepped for live readers first; there were none outside the removed set and its specs. **`extractOrgNumberFromAddress()` is untouched** — it is still how a saved-address organisation number reaches Two, here and on the payload path.
- No configuration key was removed, so **no upgrade script** is needed. Nothing was added to `uninstall()` for the same reason. The orphaned `two_company_verify_miss` cookie key expires on its own (1h).

### The bad-organisation-number case still gets a clear prompt — this needed wiring

The browser calls `/v1/order_intent` directly, so the rejection arrives client-side. `TwoOrderIntent.callTwoOrderIntent()` read **only jQuery's status text** ("Bad Request") and never touched the response body — `grep` for `error_code` / `error_message` / `responseJSON` across `views/` returned zero hits. Every 4xx therefore collapsed into the generic *"cannot be approved at this time, please select an alternative payment method"*, which is exactly the wrong advice for a fixable company field.

`error_code` and `error_message` are now carried out of the body, and `COMPANY_NOT_FOUND` maps to the same instruction the pre-check used to show, via the existing translated `select_company_to_use_two` string. It is matched **ahead of** the broader `not found` keyword branch so the wording cannot drift into the vaguer one.

### Buyer experience, before → after

| Scenario | Before | After |
| -- | -- | -- |
| Saved address, **valid** organisation number Two resolves | Works, after one blocking lookup per session | Works, no lookup |
| Saved address, **valid** organisation number the fuzzy search misses or drops | **Blocked** — "search for your company name" | Works — Two resolves it via the exact endpoint |
| Saved address, valid organisation number, **provider slow/down** | **Blocked** after up to a 30s budget | Works — the intent call is the only round trip |
| Saved address, **bogus** organisation number | "search for your company name", after the round trip | Same message, from Two's `COMPANY_NOT_FOUND`, no extra round trip |
| Saved address, valid organisation number, **no company name** on the address | Worked only if the lookup supplied a name, else "enter your company name" | Works — Two supplies the name |
| Address has a company name, **no** organisation number anywhere | "search for your company name" (no HTTP call) | Unchanged |
| Address has neither | "enter your company name" | Unchanged |
| Buyer used the JS company search and selected a company | Short-circuits before the address is consulted | Unchanged |

Same message text, same rendering path (`handleError` → `showOrderIntentError`), in every case where the buyer is prompted. Nobody who can check out today loses the ability to check out.

### Tests

New `tests/OrgNumberPreVerificationSpec.php` drives the real controller over the stub core: the unverified pass-through, the no-company-name case not being blocked, both prompts intact, the company-search short-circuit intact, only-the-address's-own-company can be cached, and a `method_exists` guard that fails if any removed helper comes back. The module double's `getTwoCheckoutHostUrl()` throws, so any outbound call re-added to this path fails the suite.

`tests/CheckoutLatencySpec.php` loses its nested-company-lookup section — those specs covered the memo that no longer exists. Its TWO-24799 order-intent snapshot-dedupe half is untouched.

**Mutation-checked** — each of these was applied and the suite failed:

| Mutation | Caught by |
| -- | -- |
| Restore the name-first gate (block when the company name is empty) | `a resolvable address must not be answered with a prompt` |
| Return `companyid => ''` from the address branch instead of the organisation number | same |
| Re-add `verifyCompanyByOrgNumber()` to the module | `...is the removed org-number pre-verification (TWO-25206) and must not come back` |

### Gates run locally, as CI runs them

- `php -l` on every changed PHP file — clean
- `php tests/run.php` — **All tests passed.** (37 PASS lines)
- phpstan 2.2.5 against a pinned PS 1.7.6.0 core checkout, `--configuration=phpstan.neon` — **`[OK] No errors`**
- `node --check` on the changed JS — clean

Not run here: the PS 8 / PS 9 e2e suites and the live checkout scenarios in the ticket's VALIDATE section (registered buyer with a real organisation number on `dni`, the bogus-number prompt, the GB→ES country switch, and the artificially-slow-provider latency comparison). Those need the staging shop.

Version bumped to `2.6.7`.

---

*Implemented by Claude.*
