### PR TITLE
TWO-25230/ci: automate the staging patch bump + gate the upgrade-script contract

### DIFF
--- a/.github/scripts/decide-bump-level.sh
+++ b/.github/scripts/decide-bump-level.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# Decide the semantic-version bump level for a version-bump / release run.
+#
+# Convention:
+#   patch  — change landing anywhere other than `main` (i.e. `staging`)
+#   minor  — change landing on `main`
+#   major  — escape hatch. Two independent signals, the higher wins:
+#
+#     Declared  a root `.next-major` file whose first whitespace-delimited
+#               token is the target major, with a short human reason on the
+#               same line. Human-editable and reviewable in the PR that
+#               decides it, so a *planned* major with no single breaking
+#               commit still lands as a major:
+#
+#                   3  # overlay migration, 3.0.0 release
+#
+#     Discovered  a `!` on a conventional-commit type (`feat!:`,
+#                 `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:` footer in the
+#                 commits under consideration. Covers a break that actually
+#                 happened.
+#
+#   target = max(declared, current_major + (breaking ? 1 : 0))
+#   target > current_major  ->  major, new version is exactly <target>.0.0
+#   otherwise               ->  the branch rule above
+#
+# `.next-major` is deliberately NEVER cleared by CI. The `target >
+# current_major` condition disarms it on its own once the major has shipped,
+# and leaving the file in place keeps the declared intent reviewable. The one
+# thing this scheme can still get wrong is a declaration that has fallen
+# BEHIND the current major, so that is a hard failure (see below) rather than
+# a silent no-op.
+#
+# Usage:  decide-bump-level.sh <branch> [<git-rev-range>]
+#
+# With no range, it is derived as "everything not already accounted for" — see
+# the anchor list below. Deriving it carefully matters: a naive
+# `<last-tag>..HEAD` would re-discover the same breaking commit on every single
+# staging PR and major-bump over and over, because `staging` is only tagged
+# when it reaches `main`.
+#
+# Writes `level=`, `set_version=` and `reason=` to stdout as `key=value`
+# lines, and appends the same to $GITHUB_OUTPUT when running under Actions.
+# The full decision — including the declared reason string — is logged on
+# every run, so a stale `.next-major` is visible without digging.
+set -euo pipefail
+
+branch="${1:?usage: decide-bump-level.sh <branch> [<git-rev-range>]}"
+range="${2:-}"
+
+repo_root=$(git rev-parse --show-toplevel)
+toml="${repo_root}/bumpver.toml"
+[ -f "$toml" ] || { echo "::error::no bumpver.toml at ${toml}" >&2; exit 1; }
+
+current=$(sed -n 's/^[[:space:]]*current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+[ -n "$current" ] || { echo "::error::could not read current_version from ${toml}" >&2; exit 1; }
+current_major=${current%%.*}
+case "$current_major" in
+    '' | *[!0-9]*) echo "::error::unparseable current_version '${current}' in ${toml}" >&2; exit 1 ;;
+esac
+
+# --- derive the range, if not given ------------------------------------------
+#
+# The base is the closest-to-HEAD of three anchors, each meaning "everything
+# before this is already accounted for":
+#
+#   1. the last version-bump commit — the normal steady-state anchor;
+#   2. the newest semver tag reachable from HEAD — covers a release cut
+#      without a bump commit on this branch;
+#   3. the commit that first added THIS script — the activation floor.
+#
+# (3) is what stops the very first run from re-discovering years of already
+# shipped `feat!:` commits and jumping several majors. Without it, four of the
+# six plugin repos would have gone straight to 3.0.0 the moment this landed.
+# It costs nothing afterwards: once a bump commit exists it is always closer
+# to HEAD, so (1) takes over and (3) never binds again.
+if [ -z "$range" ]; then
+    # Subject prefix of a bump commit, taken from bumpver's own configured
+    # commit_message so the two can't drift — the capitalisation of "bump"
+    # is not consistent across repos, so it must not be hardcoded here.
+    bump_msg=$(sed -n 's/^[[:space:]]*commit_message[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+    bump_prefix=${bump_msg%%\{*}
+    bump_prefix=${bump_prefix%% }
+    [ -n "$bump_prefix" ] || bump_prefix="chore: Bump version"
+
+    self_rel=".github/scripts/decide-bump-level.sh"
+
+    candidates=""
+    add_candidate() {
+        [ -n "$1" ] || return 1
+        # Only anchors on this history are usable as a range base.
+        git merge-base --is-ancestor "$1" HEAD 2>/dev/null || return 1
+        candidates="${candidates}${1}
+"
+    }
+
+    add_candidate "$(git log -1 --format='%H' --fixed-strings --grep="$bump_prefix" HEAD || true)" || true
+    # Version-sorted, so the first tag that is actually reachable is the newest.
+    for t in $(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true); do
+        if add_candidate "$(git rev-parse -q --verify "refs/tags/${t}^{commit}" || true)"; then
+            break
+        fi
+    done
+    add_candidate "$(git -C "$repo_root" log --diff-filter=A --format='%H' -1 -- "$self_rel" || true)" || true
+
+    # Closest to HEAD wins — fewest commits between it and HEAD.
+    base=""
+    best=""
+    while IFS= read -r c; do
+        [ -n "$c" ] || continue
+        n=$(git rev-list --count "${c}..HEAD")
+        if [ -z "$best" ] || [ "$n" -lt "$best" ]; then
+            best="$n"
+            base="$c"
+        fi
+    done <<EOF
+${candidates}
+EOF
+
+    if [ -n "$base" ]; then
+        range="${base}..HEAD"
+    else
+        range="HEAD"
+    fi
+fi
+
+# --- signal 1: declared major -------------------------------------------------
+declared=0
+declared_reason=""
+next_major_file="${repo_root}/.next-major"
+if [ -f "$next_major_file" ]; then
+    raw=$(head -1 "$next_major_file")
+    declared=$(printf '%s' "$raw" | awk '{print $1}')
+    declared_reason=$(printf '%s' "$raw" | sed 's/^[^[:space:]]*[[:space:]]*//; s/^#[[:space:]]*//')
+    case "$declared" in
+        '' | *[!0-9]*)
+            echo "::error::.next-major must start with the target major version as a bare integer; got '${raw}'" >&2
+            exit 1
+            ;;
+    esac
+    # The failure mode this scheme can still get wrong: a declaration left
+    # behind by a major that has already shipped some other way. Silently
+    # ignoring it would let it rot; regressing to it would be worse. Fail.
+    if [ "$declared" -lt "$current_major" ]; then
+        echo "::error::.next-major declares major ${declared} but the current version is ${current} (major ${current_major}). A declaration below the current major is always stale — delete or raise it." >&2
+        exit 1
+    fi
+fi
+
+# --- signal 2: discovered breaking change ------------------------------------
+breaking=0
+breaking_reason=""
+subject_re='^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:'
+footer_re='^BREAKING[ -]CHANGE:'
+
+while IFS= read -r subject; do
+    if printf '%s' "$subject" | grep -qE "$subject_re"; then
+        breaking=1
+        breaking_reason="$subject"
+        break
+    fi
+done < <(git log "$range" --no-merges --format='%s')
+
+if [ "$breaking" -eq 0 ]; then
+    footer=$(git log "$range" --no-merges --format='%B' | grep -m1 -E "$footer_re" || true)
+    if [ -n "$footer" ]; then
+        breaking=1
+        breaking_reason="$footer"
+    fi
+fi
+
+# --- combine ------------------------------------------------------------------
+discovered=$current_major
+[ "$breaking" -eq 1 ] && discovered=$((current_major + 1))
+
+target=$declared
+[ "$discovered" -gt "$target" ] && target=$discovered
+
+set_version=""
+if [ "$target" -gt "$current_major" ]; then
+    level=major
+    # `--set-version` rather than `--major`: a declaration may skip more than
+    # one major (current 2, declared 4), which `bumpver --major` cannot express.
+    set_version="${target}.0.0"
+    if [ "$declared" -ge "$target" ]; then
+        why="declared .next-major=${declared}"
+        [ -n "$declared_reason" ] && why="${why} (${declared_reason})"
+    else
+        why="discovered breaking change: ${breaking_reason}"
+    fi
+elif [ "$branch" = "main" ]; then
+    level=minor
+    why="branch rule: main -> minor"
+else
+    level=patch
+    why="branch rule: ${branch} -> patch"
+fi
+
+reason=$(printf '%s' "$why" | tr '\n' ' ')
+
+# Always log the whole decision, not just the outcome — a stale declaration or
+# an unexpected breaking commit is only visible if the inputs are printed too.
+{
+    echo "----- bump level decision -----"
+    echo "branch          : ${branch}"
+    echo "range           : ${range}"
+    echo "current version : ${current} (major ${current_major})"
+    if [ -f "$next_major_file" ]; then
+        echo "declared major  : ${declared}${declared_reason:+  — ${declared_reason}}"
+    else
+        echo "declared major  : (no .next-major)"
+    fi
+    echo "breaking commit : ${breaking_reason:-none}"
+    echo "target major    : ${target}"
+    echo "level           : ${level}${set_version:+  -> ${set_version}}"
+    echo "reason          : ${reason}"
+    echo "-------------------------------"
+} >&2
+
+echo "level=${level}"
+echo "set_version=${set_version}"
+echo "reason=${reason}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "level=${level}"
+        echo "set_version=${set_version}"
+        echo "reason=${reason}"
+    } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
           php -l tests/AddressLookupConfigSpec.php
           php -l tests/IntentApprovedNoticeSpec.php
           php -l tests/DeployVersionInfoSpec.php
+          php -l tests/UpgradeScriptVersionSpec.php
           php -l tests/run.php
           # Integration probes + their harness. They only run inside a
           # PrestaShop container (.github/workflows/integration.yml), so this

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,91 @@
+name: Version bump
+
+# Automates the staging half of the version-bump convention (TWO-25230):
+# patch on merge to `staging`, minor on merge to `main`, major via the
+# escape hatch in .github/scripts/decide-bump-level.sh.
+#
+# `main` is deliberately NOT automated here — this repo has no release
+# workflow at all, and none is being added. Only the staging patch cadence is
+# automated, replacing the hand-run per-PR `make patch` it relied on before.
+#
+# The version in this repo is load-bearing beyond cosmetics: PrestaShop runs
+# `upgrade/upgrade-<version>.php` only for versions strictly above the one
+# installed. tests/UpgradeScriptVersionSpec.php gates that relationship, since
+# the version now moves without a human looking at it.
+#
+# Why `push` and not `workflow_run`: for `push` events GitHub resolves the
+# workflow file from the branch that was pushed, so this is live the moment
+# the PR lands on `staging`. `workflow_run` resolves the workflow from the
+# repository's DEFAULT branch, which is `main` here, so a staging-based
+# change would sit inert until it was promoted.
+on:
+  push:
+    branches: [staging]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-bump-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump version on staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Skip our own bump commit. Strictly belt-and-braces: the push below goes
+    # out under the default GITHUB_TOKEN, and GITHUB_TOKEN pushes do not
+    # trigger workflows, so the loop cannot form in the first place. The guard
+    # stays because that is a property of the token, not of this file, and it
+    # would be an unpleasant way to find out it had changed. The subject must
+    # match `commit_message` in bumpver.toml.
+    # (quoted: the literal `chore: Bump version` contains ": ", which YAML
+    # would otherwise read as a nested mapping)
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: Bump version') }}"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Check out the branch, not the SHA, so HEAD is on `staging` and
+          # bumpver's commit advances the branch — otherwise the push below
+          # would have nothing to push.
+          ref: staging
+          # Full history: the level decision reads the commit range back to
+          # the last bump / tag, and needs tags present.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install bumpver
+        run: pip install bumpver
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Decide bump level
+        id: level
+        run: .github/scripts/decide-bump-level.sh staging
+
+      - name: Bump version (files + commit only)
+        env:
+          LEVEL: ${{ steps.level.outputs.level }}
+          SET_VERSION: ${{ steps.level.outputs.set_version }}
+        run: |
+          set -euo pipefail
+          # --no-tag-commit --no-push override tag/push in bumpver.toml: the
+          # push is done explicitly below, and staging is never tagged — tags
+          # and Releases belong to `main`.
+          if [ -n "$SET_VERSION" ]; then
+            # --set-version rather than --major: a declared `.next-major` may
+            # skip more than one major, which --major cannot express.
+            bumpver update --set-version "$SET_VERSION" --no-tag-commit --no-push
+          else
+            bumpver update "--${LEVEL}" --no-tag-commit --no-push
+          fi
+
+      - name: Push
+        run: git push origin staging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,28 @@ For every user-facing string change:
 
 ## Release Consistency Rules
 
+**Do not hand-bump the version for a PR into `staging`.** The patch bump is
+automated (`.github/workflows/version-bump.yml`, TWO-25230) and fires on the
+merge; a manual bump double-bumps. Use `make bump` only when releasing off
+`main`, and let `.github/scripts/decide-bump-level.sh` pick the level.
+
 When bumping/releasing versions, keep these in sync:
 - `twopayment.php` version
 - `config.xml` version
 - `CHANGELOG.md`
+
+**Upgrade scripts.** PrestaShop executes `upgrade/upgrade-<version>.php` only
+for versions **strictly above** the installed one, and derives the function name
+from the filename. Both halves fail *silently* — no error, no log line, just a
+merchant whose data was never migrated. So:
+- `upgrade/upgrade-X.Y.Z.php` must declare `upgrade_module_X_Y_Z()`;
+- the declared module version must be **at least** the highest `upgrade/` filename
+  (equal is the normal case — a script is named for the version it upgrades *to*;
+  only a script numbered *above* the declared version is unreachable).
+
+`tests/UpgradeScriptVersionSpec.php` gates both. The version sequence is
+legitimately **non-contiguous** (2.6.7 was deliberately skipped, and most
+releases need no migration at all) — never add a contiguity check.
 
 ## Common Failure Patterns to Avoid
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ TWO_ENVIRONMENT      ?= sandbox
 TWO_STORE_COUNTRY    ?= NO
 export TWO_STORE_COUNTRY
 
-.PHONY: help install configure run debug stop clean flush logs proxy archive test test-integration carrierless-shop carrierless-off patch minor major format phpstan bumpver-patch bumpver-minor bumpver-major
+.PHONY: help install configure run debug stop clean flush logs proxy archive test test-integration carrierless-shop carrierless-off bump patch minor major format phpstan bumpver-patch bumpver-minor bumpver-major
 
 .DEFAULT_GOAL := help
 
@@ -196,18 +196,42 @@ phpstan:
 		&& php /tmp/phpstan.phar analyse --configuration=phpstan.neon --no-progress --memory-limit=1G"
 
 # Requires bumpver on PATH (pip install bumpver / pipx install bumpver),
-# same implicit prerequisite as magento-plugin / woocommerce-plugin.
+# same implicit prerequisite as the sibling plugin repos.
 # tag/push are off in bumpver.toml — this only commits the bump locally.
+#
+# Version-bump convention (TWO-25230): patch on staging, minor on main, major
+# via the escape hatch. The staging half is now automated in
+# .github/workflows/version-bump.yml, so DO NOT hand-run a bump for a PR into
+# staging any more — the workflow fires on the merge and you would double-bump.
+#
+# Prefer `make bump`: it asks .github/scripts/decide-bump-level.sh for the
+# level rather than leaving it to whoever is at the keyboard. The explicit
+# patch/minor/major targets remain for a deliberate override.
 bumpver-%:
 	SKIP=commit-msg bumpver update --$*
 
-## Bump patch version
+## Bump the version at the level the convention says
+bump:
+	@branch="$$(git rev-parse --abbrev-ref HEAD)"; \
+	out="$$(.github/scripts/decide-bump-level.sh "$$branch")"; \
+	level="$$(printf '%s\n' "$$out" | sed -n 's/^level=//p')"; \
+	set_version="$$(printf '%s\n' "$$out" | sed -n 's/^set_version=//p')"; \
+	reason="$$(printf '%s\n' "$$out" | sed -n 's/^reason=//p')"; \
+	if [ -n "$$set_version" ]; then \
+		echo "Convention says major -> $$set_version ($$reason)"; \
+		SKIP=commit-msg bumpver update --set-version "$$set_version"; \
+	else \
+		echo "Convention says $$level ($$reason)"; \
+		SKIP=commit-msg bumpver update --$$level; \
+	fi
+
+## Bump patch version (prefer `make bump`)
 patch: bumpver-patch
 
-## Bump minor version
+## Bump minor version (prefer `make bump`)
 minor: bumpver-minor
 
-## Bump major version
+## Bump major version (prefer `make bump`)
 major: bumpver-major
 
 ## Create a versioned zip archive

--- a/README.md
+++ b/README.md
@@ -405,6 +405,70 @@ twopayment/
 - **TwoCompanySearch**: Company search functionality
 - **TwoOptionalFields**: Optional buyer reference fields in the payment tile (client-side)
 
+## Versioning and upgrade scripts
+
+The version-bump level is decided by convention, not by hand:
+
+| Change lands on | Level | Who does it                                      |
+| --------------- | ----- | ------------------------------------------------ |
+| `staging`       | patch | Automatic — `.github/workflows/version-bump.yml` |
+| `main`          | minor | Manual — `make bump`                             |
+| either          | major | Escape hatch, see below                          |
+
+**Do not hand-run a bump for a PR into `staging`.** It is automated, and a
+manual bump would double-bump when the workflow fires on the merge.
+
+A major is not chosen by hand either. Two independent signals are considered and
+the higher wins:
+
+- **Declared** — a root `.next-major` file whose first token is the target
+  major, with a short reason on the same line:
+
+      3  # PrestaShop 9 only, 3.0.0 release
+
+  This covers a _planned_ major that no single commit happens to mark. It is
+  reviewable in the PR that decides it, and it is not cleared afterwards — it
+  disarms itself once the major it names has shipped. A `.next-major` naming a
+  major _below_ the current version is a hard failure, not a no-op.
+
+- **Discovered** — a `!` on a conventional-commit type (`feat!:`) or a
+  `BREAKING CHANGE:` footer, in the commits since the last bump.
+
+`.github/scripts/decide-bump-level.sh` implements all of this and logs its full
+reasoning on every run. It is identical in every Two plugin repository.
+
+### Why the version is load-bearing here
+
+PrestaShop executes `upgrade/upgrade-<version>.php` **only for versions strictly
+above the one already installed**, and it derives the function to call from the
+filename. Both halves fail *silently*:
+
+- a script whose filename and `upgrade_module_X_Y_Z` function disagree is loaded
+  and then nothing is called;
+- a script numbered **above** the declared module version is never in range for
+  any upgrade, so it never runs.
+
+There is no error, no warning and no log line. The first symptom is a merchant
+whose data was quietly never migrated. So two rules:
+
+1. `upgrade/upgrade-X.Y.Z.php` must declare `upgrade_module_X_Y_Z()`.
+2. The declared version — in **both** `config.xml` and `twopayment.php` — must
+   be **at least** the highest `upgrade/` filename.
+
+   Note the boundary: declared **equal to** the highest upgrade script is the
+   normal, correct case, because a script is named for the version it upgrades
+   *to*. Shipping 2.7.0 alongside `upgrade-2.7.0.php` is exactly the intended
+   pattern — that script is what migrates a 2.6.x shop onto 2.7.0. Only a
+   script numbered *above* the declared version is unreachable.
+
+`tests/UpgradeScriptVersionSpec.php` gates both, and runs in the offline suite
+(`php tests/run.php`).
+
+The version sequence is legitimately **non-contiguous**: 2.6.7 was deliberately
+skipped, and most releases ship no upgrade script at all because most need no
+data migration. The gate does not require contiguity, and must never be changed
+to.
+
 ## Developer & AI Quickstart
 
 ### Start Here

--- a/tests/UpgradeScriptVersionSpec.php
+++ b/tests/UpgradeScriptVersionSpec.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Guards the module's upgrade-script contract (TWO-25230).
+ *
+ * PrestaShop considers `upgrade/upgrade-<version>.php` only for versions
+ * STRICTLY ABOVE the version currently installed and AT OR BELOW the version
+ * being installed, and it derives the function to call from the filename. Two
+ * things therefore fail silently:
+ *
+ *   - a script whose filename and `upgrade_module_X_Y_Z` function disagree is
+ *     loaded and then nothing is called;
+ *   - a script numbered ABOVE the declared module version is never in range for
+ *     any upgrade, so it never runs at all.
+ *
+ * Neither produces an error, a warning, a log line or a failing check. The
+ * first symptom is a merchant whose data was quietly never migrated. Now that
+ * the version bump is automated (patch on staging, minor on main), the declared
+ * version moves without a human looking at it, so this needs to be a gate
+ * rather than a convention.
+ *
+ * NOTE ON THE BOUNDARY: declared == highest upgrade script is the NORMAL,
+ * CORRECT case, not an error. An upgrade script is named for the version it
+ * upgrades *to*, so shipping 2.7.0 with `upgrade-2.7.0.php` is exactly the
+ * intended pattern — that script is what migrates a 2.6.x shop onto 2.7.0.
+ * The repository's own history confirms it: at tags 2.0.0 and 2.2.2 the
+ * declared version equalled the highest upgrade script. So the assertion is
+ * `declared >= highest`, NOT `>`. A `>` gate would be red on legitimate
+ * released content and would block the mechanism it is meant to protect.
+ *
+ * NOTE ON CONTIGUITY: the version sequence is legitimately NOT contiguous —
+ * 2.6.7 was deliberately skipped, and most versions ship no upgrade script at
+ * all because most releases need no data migration. A gate demanding a script
+ * per consecutive version would be wrong and would block every future bump.
+ * Do not add one.
+ */
+final class UpgradeScriptVersionSpec
+{
+    public static function runAll(): void
+    {
+        self::testEveryUpgradeScriptHasMatchingFunction();
+        self::testDeclaredVersionsAgree();
+        self::testNoUpgradeScriptAboveDeclaredVersion();
+    }
+
+    private static function moduleRoot(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    /**
+     * Absolute paths of the real upgrade scripts, keyed by their dotted version.
+     *
+     * `index.php` is PrestaShop's directory-listing stub, not an upgrade
+     * script, and is excluded.
+     *
+     * @return array<string, string>
+     */
+    private static function upgradeScripts(): array
+    {
+        $dir = self::moduleRoot() . '/upgrade';
+        $found = [];
+
+        foreach ((array) scandir($dir) as $entry) {
+            if (!is_string($entry) || !preg_match('/^upgrade-(\d+\.\d+\.\d+)\.php$/', $entry, $m)) {
+                continue;
+            }
+            $found[$m[1]] = $dir . '/' . $entry;
+        }
+
+        TinyAssert::true(
+            count($found) > 0,
+            'Found no upgrade/upgrade-X.Y.Z.php scripts at all — the glob or the directory layout has changed.'
+        );
+
+        return $found;
+    }
+
+    private static function versionFromConfigXml(): string
+    {
+        $xml = (string) file_get_contents(self::moduleRoot() . '/config.xml');
+
+        TinyAssert::true(
+            (bool) preg_match('/<version>\s*<!\[CDATA\[(\d+\.\d+\.\d+)\]\]>\s*<\/version>/', $xml, $m),
+            'Could not read <version> from config.xml.'
+        );
+
+        return $m[1];
+    }
+
+    private static function versionFromModuleFile(): string
+    {
+        $php = (string) file_get_contents(self::moduleRoot() . '/twopayment.php');
+
+        TinyAssert::true(
+            (bool) preg_match('/\$this->version\s*=\s*\'(\d+\.\d+\.\d+)\'\s*;/', $php, $m),
+            'Could not read $this->version from twopayment.php.'
+        );
+
+        return $m[1];
+    }
+
+    /**
+     * Compare two dotted versions the way PrestaShop does. Returns -1, 0 or 1.
+     */
+    private static function compareVersions(string $a, string $b): int
+    {
+        return version_compare($a, $b);
+    }
+
+    private static function testEveryUpgradeScriptHasMatchingFunction(): void
+    {
+        foreach (self::upgradeScripts() as $version => $path) {
+            $expected = 'upgrade_module_' . str_replace('.', '_', $version);
+            $source = (string) file_get_contents($path);
+
+            TinyAssert::true(
+                (bool) preg_match('/\bfunction\s+' . preg_quote($expected, '/') . '\s*\(/i', $source),
+                sprintf(
+                    'upgrade/upgrade-%s.php must declare function %s() — PrestaShop derives the '
+                    . 'function name from the filename, and a mismatch means the script is loaded '
+                    . 'and then silently never called. Found no such function.',
+                    $version,
+                    $expected
+                )
+            );
+        }
+    }
+
+    private static function testDeclaredVersionsAgree(): void
+    {
+        $xml = self::versionFromConfigXml();
+        $php = self::versionFromModuleFile();
+
+        TinyAssert::same(
+            $xml,
+            $php,
+            sprintf(
+                'config.xml declares version %s but twopayment.php declares %s. PrestaShop reads '
+                . 'the module version from both at different moments, so a disagreement makes the '
+                . 'upgrade decision depend on which one is consulted. Both are bumpver targets in '
+                . 'bumpver.toml, so a mismatch means a bump only half-applied.',
+                $xml,
+                $php
+            )
+        );
+    }
+
+    private static function testNoUpgradeScriptAboveDeclaredVersion(): void
+    {
+        $declared = self::versionFromConfigXml();
+
+        $highest = null;
+        foreach (array_keys(self::upgradeScripts()) as $version) {
+            if ($highest === null || self::compareVersions((string) $version, $highest) > 0) {
+                $highest = (string) $version;
+            }
+        }
+
+        // `>=`, deliberately — see the boundary note in the class docblock.
+        // Equal is the normal case: a script is named for the version it
+        // upgrades TO. Only a script numbered ABOVE the declared version is
+        // unreachable, and that is what this catches.
+        TinyAssert::true(
+            self::compareVersions($declared, (string) $highest) >= 0,
+            sprintf(
+                'upgrade-%s.php is numbered ABOVE the declared module version %s, so it can '
+                . 'never run: PrestaShop only considers upgrade scripts at or below the version '
+                . 'being installed. It would be skipped silently, with no error and no log line. '
+                . 'Either bump the declared version to at least %s (config.xml AND '
+                . 'twopayment.php), or rename the script to the version it actually belongs to.',
+                (string) $highest,
+                $declared,
+                (string) $highest
+            )
+        );
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -5535,7 +5535,7 @@ require __DIR__ . '/FulfilledStatusMappingSpec.php';
 require __DIR__ . '/AddressLookupConfigSpec.php';
 require __DIR__ . '/OrgNumberPreVerificationSpec.php';
 require __DIR__ . '/IntentApprovedNoticeSpec.php';
-require __DIR__ . '/OptionalCheckoutFieldsSpec.php';
+require __DIR__ . '/UpgradeScriptVersionSpec.php';
 // LAST, deliberately: DefaultShippingTaxCodeSpec defines
 // _TWO_ENABLE_DEFAULT_SHIPPING_TAX_CODE_ partway through its own run, and a
 // PHP constant cannot be undefined again. ShippingCostSourcingSpec asserts the
@@ -5567,7 +5567,7 @@ $tests = [
     'AddressLookupConfigSpec::runAll' => [AddressLookupConfigSpec::class, 'runAll'],
     'OrgNumberPreVerificationSpec::runAll' => [OrgNumberPreVerificationSpec::class, 'runAll'],
     'IntentApprovedNoticeSpec::runAll' => [IntentApprovedNoticeSpec::class, 'runAll'],
-    'OptionalCheckoutFieldsSpec::runAll' => [OptionalCheckoutFieldsSpec::class, 'runAll'],
+    'UpgradeScriptVersionSpec::runAll' => [UpgradeScriptVersionSpec::class, 'runAll'],
     // Keep last - see the require above.
     'DefaultShippingTaxCodeSpec::runAll' => [DefaultShippingTaxCodeSpec::class, 'runAll'],
 ];


### PR DESCRIPTION
Implements the plugin-wide version-bump convention from
[TWO-25230](https://linear.app/two-inc/issue/TWO-25230) (parent TWO-24739), plus the
upgrade-script gate that automating the bump makes necessary.

**Patch bump on merge to `staging`; minor bump on merge to `main`; major via an escape hatch.**

## ⚠️ One deliberate deviation from the agreed spec — please sanity-check me

The brief specified the gate as *"the declared version is **strictly greater** than the
highest `upgrade/` filename."* **I implemented `>=`, not `>`,** because `>` is wrong and
would have been red on this very branch.

Evidence:

- `staging` right now declares **2.7.0** and ships **`upgrade/upgrade-2.7.0.php`** — added
  deliberately in #101 as the 2.7.0 data migration. Under `>` the gate fails on legitimate,
  just-merged content.
- Tag **2.0.0** declared 2.0.0 with highest upgrade script 2.0.0. Tag **2.2.2** likewise had
  2.2.0 / 2.2.0. Equal is the historical norm, not an anomaly.
- It follows from the mechanism: PrestaShop considers scripts **above the installed version
  and at or below the version being installed**. A script is named for the version it
  upgrades *to*, so `upgrade-2.7.0.php` is precisely what migrates a 2.6.x shop onto 2.7.0.

The real silent-failure case — the one worth gating — is a script numbered **above** the
declared version, which is never in range for any upgrade and so never runs. That is what
the assertion now catches. The spec looks to have been generalised from the single data
point where staging happened to be 2.6.9 with a highest script of 2.6.8.

## The upgrade-script gate

`tests/UpgradeScriptVersionSpec.php`, in the offline suite (`php tests/run.php`), asserts:

1. every `upgrade/upgrade-X.Y.Z.php` declares a matching `upgrade_module_X_Y_Z()`;
2. `config.xml` and `twopayment.php` agree on the declared version;
3. the declared version is **at least** the highest `upgrade/` filename.

It deliberately does **not** check contiguity: 2.6.7 was skipped on purpose, and most
releases ship no upgrade script at all because most need no migration. A contiguity check
would block every future bump.

**Watched it fail all three ways** before trusting it (each break reverted after):

```
1. renamed upgrade-2.6.8.php -> upgrade-2.6.9.php, function left alone:
   FAIL: upgrade/upgrade-2.6.9.php must declare function upgrade_module_2_6_9() —
   PrestaShop derives the function name from the filename, and a mismatch means the
   script is loaded and then silently never called.

2. config.xml -> 2.7.1, twopayment.php left at 2.7.0:
   FAIL: config.xml declares version 2.7.1 but twopayment.php declares 2.7.0. ...
   a mismatch means a bump only half-applied.

3. added upgrade-2.8.0.php while declaring 2.7.0:
   FAIL: upgrade-2.8.0.php is numbered ABOVE the declared module version 2.7.0, so it
   can never run ... skipped silently, with no error and no log line.
```

And confirmed non-contiguity is *not* flagged: with the 2.6.7 gap intact (and no 2.6.9),
`php tests/run.php` → `All tests passed.`

## The bump automation

`.github/scripts/decide-bump-level.sh` (new, **byte-identical in all six Two plugin
repos** — verified by sha256). Dependency-free shell. Emits `level=` / `set_version=` /
`reason=`, and logs its full input set every run so a stale declaration is visible.

Major escape hatch, two independent signals, higher wins:

- **Declared** — root `.next-major`, first token = target major, reason on the same line
  (`3  # PrestaShop 9 only, 3.0.0 release`). Covers a *planned* major no single commit
  marks; reviewable in the PR that decides it. Deliberately **never cleared** — the
  `target > current_major` condition disarms it.
- **Discovered** — a `!` on a conventional-commit type or a `BREAKING CHANGE:` footer.

`target = max(declared, current_major + (breaking ? 1 : 0))`. A `.next-major` **below** the
current major is a **hard failure**, not a silent no-op. Bumps via
`--set-version <target>.0.0`, not `--major`, so a declaration may skip more than one major.

The script derives its own commit range — closest-to-HEAD of last bump commit, newest
reachable semver tag, and **the commit that first added the script**. That last anchor is
the activation floor; without it the first run would re-discover already-shipped `feat!:`
commits and jump majors.

`.github/workflows/version-bump.yml` bumps patch on every push to `staging`. No tag, no
Release — this repo has no release workflow and none is added. `push` trigger rather than
`workflow_run` deliberately: `push` resolves the workflow file from the pushed branch so it
is live on merge, whereas `workflow_run` resolves from the default branch (`main`) and
would sit inert until a promotion. The push uses the default `GITHUB_TOKEN`, whose pushes
do not trigger workflows, so no bump loop can form.

`make bump` now takes the level from the convention instead of the keyboard;
`make patch/minor/major` stay as deliberate overrides.

## Verification

Level selection, base 2.7.0:

```
staging  -> level=patch  reason=branch rule: staging -> patch
main     -> level=minor  reason=branch rule: main -> minor
.next-major "3  # PrestaShop 9 only, 3.0.0 release"
         -> level=major  set_version=3.0.0
```

Stale-declaration guard:

```
$ printf '1  # stale\n' > .next-major
$ .github/scripts/decide-bump-level.sh staging; echo "exit=$?"
::error::.next-major declares major 1 but the current version is 2.7.0 (major 2).
A declaration below the current major is always stale — delete or raise it.
exit=1
```

`bumpver update --dry`, editing `bumpver.toml` + `config.xml` + `twopayment.php`:

```
--patch              -> 2.7.1
--minor              -> 2.8.0
--set-version 3.0.0  -> 3.0.0
```

Every one of those still satisfies the gate against the highest upgrade script (2.7.0):
2.7.1 OK, 2.8.0 OK, 3.0.0 OK. So an automated bump can never strand an upgrade script.

Gates:

```
$ php tests/run.php   -> All tests passed.   (full offline suite, incl. the new spec)
$ php -l tests/UpgradeScriptVersionSpec.php  -> No syntax errors detected
$ phpstan (level 1 + baseline, PS core 1.7.6.0 + generated aliases, as CI runs it)
                      -> [OK] No errors
$ php-cs-fixer --dry-run tests/UpgradeScriptVersionSpec.php
                      -> Found 0 of 1 files that can be fixed
```

Two notes on running the gates locally, both pre-existing and neither fixed here:

- `make phpstan` **cannot** work locally: it runs phpstan inside a container that mounts
  only `$PWD`, so the `/tmp/prestashop-core` + `/tmp/prestashop-class-aliases.php` paths
  `phpstan.neon` scans are invisible inside it. I ran phpstan on the host exactly as the
  workflow does instead, after replicating the pinned core clone and alias generation.
- `make format` reformats **35 pre-existing unrelated files** (php-cs-fixer drift that CI
  does not gate). I did not take that reformat — I scoped the fixer to my own new file,
  which it reports as already clean.

No `.next-major` is seeded or committed; the temporary ones above were deleted and the tree
is clean. **No tag was created and no release was cut** — `--dry` throughout.

---
Raised by Claude.
