### PR TITLE
TWO-25243 docs: explain company-search result-cache staleness

### DIFF
--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -24,6 +24,11 @@ class TwoCompanySearch {
      * render. Only the cache is preserved, not the pending request.
      */
     static _resultCache = new Map();
+    // A company registered mid-session stays absent from an already-searched
+    // term until its entry expires. That staleness is deliberate: buyers search
+    // for their own company, which is already registered, so nothing here busts
+    // the cache on registration - the TTL below is the only thing that clears
+    // it, and a page reload starts cold.
     static _CACHE_TTL_MS = 5 * 60 * 1000;
     // Bounds the cache. It now lives for the whole page session rather than
     // until the next address-form re-render, so it needs an eviction policy it


### PR DESCRIPTION
Comment-only. No behaviour change.

The class-static company-search result cache is not busted when a company is registered, so a company registered mid-session stays absent from an already-searched term until its 5-minute TTL expires (or the page reloads). That is intentional — buyers search for their own, already-registered company, so tighter invalidation would spend API calls on a case that essentially never happens.

Part of the parity epic; companion PR adds the equivalent note to Magento. WooCommerce has no company-search result cache, so nothing to document there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)