### PR TITLE
fix(company-search): stop autofill blanking buyer input, correct cache-key docs

### DIFF
--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -80,10 +80,12 @@ cache:
 - organisation-number extraction across the payload shapes different registries use.
 - the cache: outlives the instance that filled it, keys on the country so two countries
   never share results, expires after five minutes, and evicts oldest-first at fifty
-  entries. Two tests record that `buildCacheKey`'s docblock is wrong about the
-  unselected-country case — `getCurrentCountry()` never returns empty, it falls through to
-  a `navigator.language` guess and then to a literal `'GB'`, both of which are pinned
-  (the second by stubbing the locale, since jsdom's `en-US` default hides it).
+  entries. The key/wire invariant is asserted directly as well as through each fallback
+  case: `getCurrentCountry()` never returns empty — it falls through to a
+  `navigator.language` guess and then to a literal `'GB'` — and whichever of those wins
+  reaches both the cache key and the `country` parameter, so neither can believe in a
+  country the other does not. (The `'GB'` last resort needs the locale stubbed, since
+  jsdom's `en-US` default hides it.)
 
 `company-search-rerender.test.js` — what happens when PrestaShop re-renders the address
 form (which it does for something as ordinary as a country change):
@@ -121,6 +123,10 @@ form (which it does for something as ordinary as a country change):
   BUSINESS/REGISTERED/VISITING address wins over an untyped or mailing one whatever the
   order, four address key-variant spellings normalise, a partial address writes the parts
   it has, and a failed detail lookup leaves the selection intact.
+- which values a partial address is allowed to clear: a field the buyer typed survives, a
+  field a *previous* company's fill wrote is cleared (and announces the clear to the
+  theme), a buyer edit on top of an autofill turns it back into buyer input, and a value
+  two successive companies happen to share is still recognised as autofilled by the third.
 - the custom fallback used when jQuery UI is absent: its own spinner clears on failure,
   survives a superseded request, and repeated setup leaves exactly one dropdown rather
   than orphan containers listening on the shared field.
@@ -137,13 +143,6 @@ re-render safety rather than every behaviour in the file: the order-intent reche
 closure re-hides only the list it was created with, and that node is already detached by
 the time a leaked handler could fire, so removing the unbind changes nothing any test can
 see. The `input`-listener unbind beside it is covered (via the duplicate-search count).
-
-`autoFillAddress()`'s `typeof value === 'undefined' || value === null` write guard is
-unreachable: `street`/`postal`/`city` each coalesce to `''` a few lines above, so the guard
-never sees either value. Its observable consequence *is* pinned — an address missing a key
-blanks the corresponding field even when the buyer had filled it — as a characterisation
-test rather than an endorsement. Worth a production decision separately; changing it here
-would be a behaviour change in a test-only PR.
 
 Two branches of `clearStaleOrganizationSelection()` are redundant rather than untested —
 removing either changes no observable outcome for any reachable input: the absent-marker

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -85,7 +85,9 @@ cache:
   `navigator.language` guess and then to a literal `'GB'` — and whichever of those wins
   reaches both the cache key and the `country` parameter, so neither can believe in a
   country the other does not. (The `'GB'` last resort needs the locale stubbed, since
-  jsdom's `en-US` default hides it.)
+  jsdom's `en-US` default hides it.) The one place they could still fork is a country
+  change *during* a request, since the key is built before the request and closed over —
+  pinned too: the entry stays filed under the country the request actually carried.
 
 `company-search-rerender.test.js` — what happens when PrestaShop re-renders the address
 form (which it does for something as ordinary as a country change):
@@ -127,6 +129,10 @@ form (which it does for something as ordinary as a country change):
   field a *previous* company's fill wrote is cleared (and announces the clear to the
   theme), a buyer edit on top of an autofill turns it back into buyer input, and a value
   two successive companies happen to share is still recognised as autofilled by the third.
+  The load-bearing one is a company *confirming* a value the buyer had already typed:
+  there is no write to do, but the marker still has to be recorded, or the next company
+  that lacks that field reads it as untouched buyer input and one company's address sticks
+  to another for the rest of checkout.
 - the custom fallback used when jQuery UI is absent: its own spinner clears on failure,
   survives a superseded request, and repeated setup leaves exactly one dropdown rather
   than orphan containers listening on the shared field.

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -782,6 +782,33 @@ describe('the company-detail fill', () => {
         expect($("input[name='city']").val()).toBe('');
     });
 
+    test('a company confirming a value the buyer typed still claims it', async () => {
+        // The load-bearing case for recording the marker OUTSIDE the write
+        // branch: there is nothing to write, because the company's city is the
+        // one the buyer already typed. Record it anyway - the fill has claimed
+        // that value for this company, so the next company that lacks a city
+        // must be able to clear it. With the marker recorded only on write, this
+        // reads as untouched buyer input and the city sticks to the wrong
+        // company for the rest of checkout.
+        $("input[name='city']").val('Exampleton');
+
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', city: 'Exampleton' }] });
+        await flushPromises();
+        expect($("input[name='city']").val()).toBe('Exampleton');
+
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', street_address: '2 Second Street' }] });
+        await flushPromises();
+
+        expect($("input[name='city']").val()).toBe('');
+    });
+
     test('clearing a stale autofill notifies the theme', async () => {
         const search = makeInstance();
         search.onCompanySelected(null, {

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -686,19 +686,123 @@ describe('the company-detail fill', () => {
         expect($("input[name='postcode']").val()).toBe('');
     });
 
-    test('a partial address blanks a field the buyer had already filled', async () => {
+    test('a partial address leaves a field the buyer had already filled alone', async () => {
         $("input[name='city']").val('Buyerton');
 
         await fillFrom({
             addresses: [{ type: 'BUSINESS', street_address: '1 Example Street' }]
         });
 
-        // CHARACTERISATION, not endorsement. The missing keys coalesce to '' well
-        // before the write guard sees them, so the guard's undefined/null arms are
-        // unreachable and an absent city overwrites one the buyer typed. Pinned so
-        // the behaviour cannot change silently; see Known gaps in the README for
-        // why it is recorded rather than fixed here.
+        // A company record missing a key is not evidence the buyer's own answer
+        // is wrong. The key variants all coalesce to '' before the write, so
+        // "absent" and "empty string" are the same thing here - which is why
+        // this used to blank the field and why the fix keys off whether WE wrote
+        // the current value rather than off the incoming shape.
+        expect($("input[name='city']").val()).toBe('Buyerton');
+        expect($("input[name='address1']").val()).toBe('1 Example Street');
+    });
+
+    test('a second company clears an address part the first one filled', async () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', street_address: '1 Example Street', city: 'Exampleton' }]
+        });
+        await flushPromises();
+        expect($("input[name='city']").val()).toBe('Exampleton');
+
+        // Same instance, second selection: the new company has no city. Leaving
+        // the previous company's city behind is just as wrong as blanking the
+        // buyer's own - it silently attributes one company's address to another.
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', street_address: '2 Second Street' }]
+        });
+        await flushPromises();
+
+        expect($("input[name='address1']").val()).toBe('2 Second Street');
         expect($("input[name='city']").val()).toBe('');
+    });
+
+    test('a buyer edit after an autofill survives the next company selection', async () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', street_address: '1 Example Street', city: 'Exampleton' }]
+        });
+        await flushPromises();
+
+        // The buyer corrects the autofilled city by hand. That makes it buyer
+        // input, so the marker recorded at fill time no longer matches and the
+        // clearing arm above must not claim it.
+        $("input[name='city']").val('Buyerton');
+
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', street_address: '2 Second Street' }]
+        });
+        await flushPromises();
+
+        expect($("input[name='city']").val()).toBe('Buyerton');
+    });
+
+    test('an autofilled value that the company repeats is still recognised as ours', async () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', city: 'Exampleton' }]
+        });
+        await flushPromises();
+
+        // Second company repeats the same city, so there is no write to do. The
+        // marker still has to be refreshed, or a third company without a city
+        // would read the value as buyer-typed and keep it forever.
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', city: 'Exampleton' }] });
+        await flushPromises();
+
+        search.onCompanySelected(null, {
+            item: { value: 'Third Trading Ltd', lookup_id: 'lookup-ghi-789' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', street_address: '3 Third Street' }] });
+        await flushPromises();
+
+        expect($("input[name='city']").val()).toBe('');
+    });
+
+    test('clearing a stale autofill notifies the theme', async () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', city: 'Exampleton' }] });
+        await flushPromises();
+
+        const events = [];
+        $("input[name='city']").on('input change', (e) => events.push(e.type));
+
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+        ajax.last().succeed({ addresses: [{ type: 'BUSINESS', street_address: '2 Second Street' }] });
+        await flushPromises();
+
+        // Themes bind validation and their own state to these; a cleared field
+        // that never announced itself leaves the theme showing the old value as
+        // still valid.
+        expect(events).toEqual(['input', 'change']);
     });
 
     test('a filled address field notifies the theme', async () => {

--- a/tests/js/company-search-resilience.test.js
+++ b/tests/js/company-search-resilience.test.js
@@ -447,10 +447,11 @@ describe('class-static result cache', () => {
         const search = makeInstance();
         document.querySelector("select[name='id_country']").innerHTML = '';
 
-        // NOTE: getCurrentCountry() never returns empty, so buildCacheKey()'s
-        // docblock is wrong about an empty segment for the unselected case — that
-        // path is unreachable. Strategy 4 is a navigator.language guess, which
-        // under jsdom is en-US.
+        // There is no "no country selected" key: getCurrentCountry() never
+        // returns empty, it guesses from navigator.language (en-US under jsdom).
+        // What matters is that the guess reaches the KEY and the WIRE as the same
+        // value — a country the key believes in but the request does not is how
+        // one country's results end up answering another's search.
         expect(search.getCurrentCountry()).toBe('US');
         expect(search.buildCacheKey('exa')).toBe('exa|US');
         search.searchCompanies('exa', callbackRecorder().fn);
@@ -496,9 +497,36 @@ describe('class-static result cache', () => {
             // reads getCurrentCountry() back cannot fail if it changes.
             expect(search.getCurrentCountry()).toBe('GB');
             expect(search.buildCacheKey('exa')).toBe('exa|GB');
+            // And the same 'GB' goes on the wire, so the entry filed under it
+            // really is a GB search rather than a server-default one wearing a
+            // GB label.
+            search.searchCompanies('exa', callbackRecorder().fn);
+            expect(new URL(ajax.last().url).searchParams.get('country')).toBe('GB');
         } finally {
             language.mockRestore();
         }
+    });
+
+    test('the key and the wire never disagree about the country', () => {
+        // The invariant both halves of the fix rest on, asserted directly rather
+        // than inferred from the individual fallback cases: whatever
+        // getCurrentCountry() resolves, the request carries it and the key
+        // records it. Give either side its own fallback and the cache starts
+        // answering one country's search with another's results.
+        [
+            ['GB', 'gb'],
+            ['NO', 'NO'],
+            ['DE', 'de']
+        ].forEach(([expected, markup]) => {
+            document.body.innerHTML = '';
+            buildAddressForm({ country: markup });
+            const search = makeInstance();
+            search.searchCompanies('exa', callbackRecorder().fn);
+
+            const onTheWire = new URL(ajax.last().url).searchParams.get('country');
+            expect(onTheWire).toBe(expected);
+            expect(search.buildCacheKey('exa')).toBe('exa|' + onTheWire);
+        });
     });
 
     test('an entry expires after five minutes, and drops on read', () => {

--- a/tests/js/company-search-resilience.test.js
+++ b/tests/js/company-search-resilience.test.js
@@ -529,6 +529,27 @@ describe('class-static result cache', () => {
         });
     });
 
+    test('a country change mid-request does not re-file the response', () => {
+        // The one way key and wire could still fork: the key is built before the
+        // request and closed over, so if the buyer changes country while the
+        // response is in flight, the entry must stay filed under the country the
+        // REQUEST carried, not the one now selected. It does, because both are
+        // resolved in the same synchronous tick before the request goes out.
+        const search = makeInstance();
+        search.companyField.autocomplete('instance').search('exa');
+        expect(new URL(ajax.last().url).searchParams.get('country')).toBe('GB');
+
+        const inFlight = ajax.last();
+        document.querySelector("select[name='id_country']").innerHTML =
+            '<option value="44" data-iso-code="NO" selected>Norge</option>';
+        expect(search.getCurrentCountry()).toBe('NO');
+
+        inFlight.succeed(SEARCH_RESPONSE);
+
+        expect(TwoCompanySearch.cacheGet('exa|GB')).not.toBeNull();
+        expect(TwoCompanySearch.cacheGet('exa|NO')).toBeNull();
+    });
+
     test('an entry expires after five minutes, and drops on read', () => {
         // Hard-coded rather than read off the class: the boundary logic and the
         // VALUE are separate decisions, and a five-minute window is the one that

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -6,6 +6,12 @@
 class TwoCompanySearch {
     static DEFAULT_COMPANY_SEARCH_LIMIT = 50;
 
+    // Records the exact value an address autofill wrote into a field, so a
+    // later fill can tell "we put this here" from "the buyer typed this". The
+    // buyer editing the field leaves the attribute stale rather than matching,
+    // which is the signal we need - see autoFillAddress().
+    static AUTOFILL_MARKER_ATTR = 'data-two-autofilled-value';
+
     /**
      * Company-search result cache, held on the CLASS rather than inside
      * setupAutocomplete().
@@ -493,18 +499,26 @@ class TwoCompanySearch {
     /**
      * Cache key for a search term.
      *
-     * The country half must be exactly what searchCompanies() puts on the wire.
-     * It omits the `country` parameter entirely when no country is selected, so
-     * keying an unselected country as 'GB' filed server-default results under
-     * GB and then served them once the buyer actually picked GB. An empty
-     * segment keeps the two cases distinct - and matters more now the cache
-     * outlives the widget instead of dying at the next address-form re-render.
+     * The country half must be exactly what searchCompanies() puts on the wire,
+     * or one country's results get served for another's search - and that
+     * matters more now the cache outlives the widget instead of dying at the
+     * next address-form re-render.
+     *
+     * That invariant is structural, not a coincidence to be re-checked: both
+     * this and searchCompanies() take the value from getCurrentCountry(), which
+     * never returns empty - it resolves the selected option, then guesses from
+     * `navigator.language`, then falls back to a literal 'GB'. So there is no
+     * "no country selected" case to key separately: whatever the fallback
+     * chain produces is also what goes on the wire, so a search filed under it
+     * is genuinely a search for that country. Do not give either side its own
+     * fallback - a country the key believes in but the request does not is
+     * exactly how one country's results end up answering another's search.
      *
      * @param {string} term
      * @returns {string}
      */
     buildCacheKey(term) {
-        return term + '|' + (this.getCurrentCountry() || '');
+        return term + '|' + this.getCurrentCountry();
     }
 
     /**
@@ -796,7 +810,11 @@ class TwoCompanySearch {
             return;
         }
 
-        // Get country ISO from the selected option if available; otherwise omit
+        // Country ISO for the search. getCurrentCountry() always resolves to
+        // something (selected option, then locale guess, then 'GB'), so this is
+        // always on the wire - and buildCacheKey() files the response under the
+        // same value, which is what stops one country's results answering
+        // another country's search.
         const country = this.getCurrentCountry();
 
         // Build URL with correct API parameters. `limit`/`offset` mirror the
@@ -807,8 +825,7 @@ class TwoCompanySearch {
         // platforms.
         const limit = Number(this.config.companySearchLimit)
             || TwoCompanySearch.DEFAULT_COMPANY_SEARCH_LIMIT;
-        const params = new URLSearchParams({ q: term, limit: limit, offset: 0 });
-        if (country) params.set('country', country);
+        const params = new URLSearchParams({ q: term, limit: limit, offset: 0, country: country });
         // Direct Two API call from frontend as required
         const searchUrl = `${this.config.checkoutHost}/companies/v2/company?${params}`;
 
@@ -1149,16 +1166,43 @@ class TwoCompanySearch {
             'city': city
         };
         Object.entries(fieldMappings).forEach(([fieldName, value]) => {
-            if (typeof value === 'undefined' || value === null) {
+            const field = $(`input[name='${fieldName}']`);
+            if (field.length === 0) {
                 return;
             }
-            const field = $(`input[name='${fieldName}']`);
-            if (field.length > 0) {
-                if (field.val() !== String(value)) {
-                    field.val(value);
+
+            const incoming = String(value == null ? '' : value);
+            const current = String(field.val() == null ? '' : field.val());
+            // What a previous fill wrote here, if it was us. The key variants
+            // above all coalesce to '', so an address simply missing a key is
+            // indistinguishable from one carrying an empty string by the time we
+            // get here - which is why the old undefined/null guard never fired
+            // and an absent city blanked a city the buyer had typed.
+            const written = field.attr(TwoCompanySearch.AUTOFILL_MARKER_ATTR);
+
+            if (incoming === '') {
+                // Nothing to fill. Clear only what we ourselves put here and
+                // the buyer has not since changed - otherwise selecting company
+                // B would leave company A's street sitting in the form. Any
+                // other value is buyer input and is left alone: a company
+                // record missing a field is not evidence the buyer's own answer
+                // is wrong.
+                if (typeof written !== 'undefined' && written === current && current !== '') {
+                    field.removeAttr(TwoCompanySearch.AUTOFILL_MARKER_ATTR);
+                    field.val('');
                     field.trigger('input');
                     field.trigger('change');
                 }
+                return;
+            }
+
+            // Record the value as ours even when it already matches, so a later
+            // fill can still recognise it as autofilled rather than typed.
+            field.attr(TwoCompanySearch.AUTOFILL_MARKER_ATTR, incoming);
+            if (current !== incoming) {
+                field.val(incoming);
+                field.trigger('input');
+                field.trigger('change');
             }
         });
     }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -10,6 +10,13 @@ class TwoCompanySearch {
     // later fill can tell "we put this here" from "the buyer typed this". The
     // buyer editing the field leaves the attribute stale rather than matching,
     // which is the signal we need - see autoFillAddress().
+    //
+    // It lives on the DOM node, so PrestaShop replacing the address form on
+    // `updatedAddressForm` takes it with the node. A value that survives that
+    // re-render therefore reads as buyer input to the next fill and is left
+    // alone. That is the residual case, and it errs the right way: the cost is
+    // one company's city outliving its selection across a re-render, against
+    // blanking an answer the buyer gave us.
     static AUTOFILL_MARKER_ATTR = 'data-two-autofilled-value';
 
     /**


### PR DESCRIPTION
TWO-25247 (child of TWO-25239). Fixes the two defects the JS test-harness PR deliberately left pinned by characterisation tests, in `views/js/modules/TwoCompanySearch.js`.

## 1. `autoFillAddress()` blanked fields the buyer had already filled — real bug, fixed

When the selected company's address lacked a key, the fill wrote an empty value over whatever the buyer had typed. The `typeof value === 'undefined' || value === null` guard could never stop it: `street`/`postal`/`city` each coalesce to `''` a few lines above, so "absent key" and "empty string" are the same value by the time the guard runs.

Simply never clearing would be wrong too: buyer picks company A, its address fills, then they pick company B whose address lacks that field — leaving A's value silently attributes A's address to B.

So the fill records the exact value it wrote in a `data-two-autofilled-value` attribute, and clears a field only when the current value is still that recording. A buyer edit makes the recording stale, which is exactly the "buyer typed this" signal; buyer input is never touched. The marker is refreshed even when the incoming value already matches, otherwise two companies sharing a value would make a third read it as buyer-typed forever.

Residual case, stated explicitly: a buyer who types a value that happens to be character-identical to what a previous autofill wrote will have it cleared by the next company that omits that field. Distinguishing those needs real input-event tracking, and the outcome is the same string either way.

## 2. `buildCacheKey()` country segment — docs defect, not a live bug

The docblock claimed `searchCompanies()` omits the `country` parameter when no country is selected, and that an empty country segment keeps that case distinct from a real `GB` selection. **Neither is true, and the cross-country poisoning it claims to have fixed is not reachable.**

`getCurrentCountry()` never returns empty — selected option, then a `navigator.language` guess, then a literal `'GB'`. So the parameter is *always* on the wire, and the key always records the same value the request carried. An entry filed under the fallback country genuinely *is* a search for that country, so serving it back for a later explicit selection of that same country is correct. Attempted reproduction on the en-GB / nothing-selected path: search files `exa|GB` after a real `country=GB` request; selecting GB hits it correctly, selecting DE keys `exa|DE` and misses. Key and wire are resolved in the same synchronous tick from the same call, so they cannot fork.

Fix is therefore to make code and docs agree in the direction that is true, and to make the invariant structural rather than coincidental: the docblock now describes the fallback chain, the vestigial `if (country)` omission guard that made the old claim plausible is gone, and a test asserts key-equals-wire directly rather than only inferring it from the individual fallback cases.

**Separate finding, not fixed here (out of scope):** the fallback chain itself is a wart. A shop whose country `<select>` carries no `data-iso-code`, whose option text is not in `extractCountryFromText()`'s map, and whose country id is not in the 10-entry id map falls through to a `navigator.language` guess and then to `'GB'` — so such a shop silently searches GB companies. That is a wrong-results bug in `getCurrentCountry()`, not a cache bug, and worth its own ticket.

## Tests

Both characterisation assertions become correctness assertions, four new cases cover the clear-vs-preserve semantics, and the characterisation framing is out of `tests/js/README.md`.

`npm run test:js` — 132 passed (was 127).
`php tests/run.php` — All tests passed.

Mutation-checked in three directions against the committed fix:
- revert the autofill guard → `a partial address leaves a field the buyer had already filled alone`, `a buyer edit after an autofill survives the next company selection` go red (2 failed)
- naive never-clear → `a second company clears an address part the first one filled`, `an autofilled value that the company repeats is still recognised as ours`, `clearing a stale autofill notifies the theme` go red (3 failed)
- fork the cache key from the wire → `the key and the wire never disagree about the country`, `the key carries the country, so two countries do not share results` go red (2 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)