### PR TITLE
fix(TWO-25253): stop the company search guessing which country to search

### DIFF
--- a/tests/CompanySearchCountrySourcingSpec.php
+++ b/tests/CompanySearchCountrySourcingSpec.php
@@ -14,25 +14,28 @@ declare(strict_types=1);
  * The fix has a PHP half and a JS half, and these tests pin the seam between
  * them - the part no Jest test can see:
  *
- *  - the module still injects `countries`, the complete id_country -> ISO map
- *    built from this shop's own country table. That map is now the search's
+ *  - the media hook still builds `countries`, the complete id_country -> ISO
+ *    map from this shop's own country table, AND still injects it in the same
+ *    method that registers the search script. That map is now the search's
  *    authoritative source, not a nice-to-have for the order-intent module, so
- *    dropping it from the addJsDef payload would silently return the search to
- *    guessing;
+ *    moving it to a method nothing calls, or dropping it from the addJsDef
+ *    payload, would silently return the search to guessing;
  *  - the i18n key the JS reads for the "pick a country" row exists in the
  *    payload under exactly that name. A rename on either side is invisible at
  *    runtime: the JS falls back to hardcoded English, so a merchant's
  *    translated checkout quietly stops being translated;
- *  - the two guesses are gone from the JS for good. Asserted against the
- *    source rather than through behaviour, because the reachable-in-jsdom
- *    behaviour is only a subset - a re-added `'GB'` on a path no test builds a
- *    DOM for would pass every Jest case and still ship the defect.
+ *  - the two guesses are gone from getCurrentCountry() for good. Asserted
+ *    against the source rather than through behaviour, because the
+ *    reachable-in-jsdom behaviour is only a subset - a re-added GB literal on
+ *    a path no test builds a DOM for would pass every Jest case and still ship
+ *    the defect. The source check is textual, so it catches a re-added literal
+ *    whatever quoting style it uses, but not a value assembled at runtime.
  */
 final class CompanySearchCountrySourcingSpec
 {
     public static function runAll(): void
     {
-        self::testCountryIsoMapIsInjected();
+        self::testCountryIsoMapIsInjectedByTheMediaHook();
         self::testSelectCountryCopyKeyMatchesTheKeyTheJsReads();
         self::testJsNoLongerGuessesTheCountry();
     }
@@ -55,36 +58,128 @@ final class CompanySearchCountrySourcingSpec
     }
 
     /**
-     * Strip comment lines so a prose explanation of a removed guess does not
-     * read as the guess itself - the WHY comments deliberately name both.
+     * Strip comments so a prose explanation of a removed guess does not read as
+     * the guess itself - the WHY comments deliberately name both. Handles `//`
+     * lines, docblock continuations and multi-line `/* ... *\/` blocks whose
+     * continuation lines start with an ordinary word.
+     *
+     * Keys are 1-based source line numbers and survive the stripping, so a
+     * failure message can point at the real line.
+     *
+     * @return array<int, string>
      */
     private static function codeLines(string $source): array
     {
         $kept = array();
-        foreach (explode("\n", $source) as $number => $line) {
-            if (preg_match('#^\s*(//|\*|/\*)#', $line) === 1) {
+        $in_block_comment = false;
+
+        foreach (explode("\n", $source) as $index => $line) {
+            $number = $index + 1;
+
+            if ($in_block_comment) {
+                $close = strpos($line, '*/');
+                if ($close === false) {
+                    continue;
+                }
+                $in_block_comment = false;
+                $line = substr($line, $close + 2);
+            }
+
+            $trimmed = ltrim($line);
+            if ($trimmed === '' || strpos($trimmed, '//') === 0 || strpos($trimmed, '*') === 0) {
                 continue;
             }
-            $kept[$number + 1] = $line;
+
+            $line = (string) preg_replace('#/\*.*?\*/#', '', $line);
+            $open = strpos($line, '/*');
+            if ($open !== false) {
+                $in_block_comment = true;
+                $line = substr($line, 0, $open);
+            }
+
+            if (trim($line) === '') {
+                continue;
+            }
+            $kept[$number] = $line;
         }
 
         return $kept;
     }
 
-    private static function testCountryIsoMapIsInjected(): void
+    /**
+     * Slice one function body out of already-comment-stripped lines.
+     *
+     * The body ends at the first following line that is nothing but the closing
+     * brace at the declaration's own indentation. Anchoring on the declaration's
+     * own brace rather than on whatever member happens to come next keeps the
+     * slice stable when members are reordered - a no-op edit must not fail a
+     * spec.
+     *
+     * @param array<int, string> $lines
+     *
+     * @return array<int, string> body lines, keyed by source line number
+     */
+    private static function functionBody(array $lines, string $signature, string $where): array
     {
-        $source = self::moduleSource();
+        $indent = null;
+        $body = array();
+
+        foreach ($lines as $number => $line) {
+            if ($indent === null) {
+                if (strpos($line, $signature) === false) {
+                    continue;
+                }
+                $indent = substr($line, 0, strlen($line) - strlen(ltrim($line)));
+                continue;
+            }
+            if (rtrim($line) === $indent . '}') {
+                return $body;
+            }
+            $body[$number] = $line;
+        }
+
+        TinyAssert::true(
+            false,
+            'Could not slice ' . $signature . ' out of ' . $where
+            . ' - this test has drifted from the source it guards'
+        );
+
+        return $body;
+    }
+
+    private static function testCountryIsoMapIsInjectedByTheMediaHook(): void
+    {
+        $hook = 'hookActionFrontControllerSetMedia';
+        $body = self::functionBody(
+            self::codeLines(self::moduleSource()),
+            'public function ' . $hook . '()',
+            'twopayment.php'
+        );
+        $body_text = implode("\n", $body);
 
         // Built from Country::getCountries() for THIS install, so it covers
         // every country the shop has rather than a handful of ids guessed at
         // in JavaScript. PrestaShop country ids are table rows, not constants.
+        // Matched loosely: a cast, a row-variable rename or a line wrap is not
+        // a regression, so only the two column names are pinned.
         TinyAssert::true(
-            strpos($source, "\$param_countries[\$country['id_country']] = Tools::strtolower(\$country['iso_code']);") !== false,
-            'The id_country -> ISO map is no longer built from the shop country table'
+            preg_match('#\$param_countries\b.{0,160}id_country.{0,160}iso_code#s', $body_text) === 1,
+            'The id_country -> ISO map is no longer built from the shop country table inside ' . $hook . '()'
+        );
+
+        // Presence anywhere in the file proves nothing: the map is only alive
+        // if it is injected by the hook the front controller actually calls,
+        // behind the same early-return gate as the script that consumes it.
+        TinyAssert::true(
+            strpos($body_text, 'Media::addJsDef(') !== false
+            && strpos($body_text, "'countries' => \$param_countries") !== false,
+            'The countries map is no longer injected by ' . $hook
+            . '() - moved or dropped, the company search falls back to guessing'
         );
         TinyAssert::true(
-            strpos($source, "'countries' => \$param_countries,") !== false,
-            'The countries map is no longer injected; the company search would fall back to guessing'
+            strpos($body_text, "registerJavascript('two-company-search'") !== false,
+            'The company search script is no longer registered by ' . $hook
+            . '(), so it no longer shares the gate that injects its country map'
         );
     }
 
@@ -104,6 +199,7 @@ final class CompanySearchCountrySourcingSpec
 
     private static function testJsNoLongerGuessesTheCountry(): void
     {
+        $path = 'views/js/modules/TwoCompanySearch.js';
         $lines = self::codeLines(self::searchJsSource());
 
         // The browser locale is never a legitimate source for this anywhere in
@@ -114,38 +210,21 @@ final class CompanySearchCountrySourcingSpec
                 strpos($line, 'navigator.language') === false
                 && strpos($line, 'navigator.userLanguage') === false,
                 'The company search guesses the country from the browser locale again, at '
-                . 'views/js/modules/TwoCompanySearch.js:' . $number . ' - ' . trim($line)
+                . $path . ':' . $number . ' - ' . trim($line)
             );
         }
 
-        // A hardcoded 'GB' is checked only inside getCurrentCountry(), because
-        // it is legitimate below that: extractCountryFromText() maps the country
+        // A hardcoded GB is checked only inside getCurrentCountry(), because it
+        // is legitimate below that: extractCountryFromText() maps the country
         // NAME "United Kingdom" to it, which is a resolution, not a default.
-        $start = null;
-        $end = null;
-        foreach ($lines as $number => $line) {
-            if ($start === null && strpos($line, 'getCurrentCountry() {') !== false) {
-                $start = $number;
-                continue;
-            }
-            if ($start !== null && strpos($line, 'extractCountryFromText(text) {') !== false) {
-                $end = $number;
-                break;
-            }
-        }
-        TinyAssert::true(
-            $start !== null && $end !== null,
-            'Could not locate getCurrentCountry() - this test has drifted from the source it guards'
-        );
-
-        foreach ($lines as $number => $line) {
-            if ($number <= $start || $number >= $end) {
-                continue;
-            }
+        // Quote style is not assumed - a backtick template literal is the same
+        // defect as a single-quoted one.
+        $body = self::functionBody($lines, 'getCurrentCountry() {', $path);
+        foreach ($body as $number => $line) {
             TinyAssert::true(
-                strpos($line, "'GB'") === false && strpos($line, '"GB"') === false,
+                preg_match('#\bGB\b#', $line) !== 1,
                 'A hardcoded GB default is back in getCurrentCountry(), at '
-                . 'views/js/modules/TwoCompanySearch.js:' . $number . ' - ' . trim($line)
+                . $path . ':' . $number . ' - ' . trim($line)
             );
         }
     }

--- a/tests/CompanySearchCountrySourcingSpec.php
+++ b/tests/CompanySearchCountrySourcingSpec.php
@@ -37,10 +37,15 @@ declare(strict_types=1);
  *    file (extractCountryFromText() maps country NAMES to 'GB' in a plain map
  *    entry, which is a resolution and not a return). Whole-file shape checks
  *    cost nothing in precision here and cannot be defeated by gutting,
- *    reordering or re-indenting a method. They are textual, so they catch a
- *    re-added literal in any quoting style but not a value assembled at
- *    runtime; a gutted getCurrentCountry() is caught separately, by asserting
- *    that the two real resolution sources it reads are still read at all.
+ *    reordering or re-indenting a method. They are textual, so what they catch
+ *    is a country literal in the RETURN EXPRESSION itself, in any quoting
+ *    style. A literal reached through a variable or a method call is NOT
+ *    caught - `const FALLBACK = 'GB'; return FALLBACK;` walks through, and so
+ *    does `return this.defaultCountry()`. The guard is narrower than the
+ *    defect space on purpose: it pins the shape the defect actually had, and
+ *    the behaviour itself is pinned by Jest. A gutted getCurrentCountry() is
+ *    caught separately, by asserting that the two real resolution sources it
+ *    reads are still read at all.
  */
 final class CompanySearchCountrySourcingSpec
 {
@@ -75,11 +80,15 @@ final class CompanySearchCountrySourcingSpec
      * that start with `*`, and multi-line `/* ... *\/` blocks whose
      * continuation lines start with an ordinary word.
      *
-     * A trailing `//` comment on a code line is NOT stripped, so a
-     * `// ... GB ...` tacked onto the end of real code would false-fail. None
-     * exist in either guarded file; if one is ever added, strip it here rather
-     * than renaming the guess. Trailing `/* ... *\/` blocks and a trailing
-     * `/*` opener ARE stripped, below.
+     * A trailing `//` comment on a code line is NOT stripped. That only matters
+     * for the `navigator.language` sweep, which is a plain substring match: a
+     * `// ... navigator.language ...` tacked onto the end of real code would
+     * false-fail there. It does NOT affect the GB check, which needs a quoted
+     * country code inside a `return` with no intervening `;`, so both
+     * `return ''; // no GB fallback` and `// used to be 'GB'` pass. None of
+     * either exist in the guarded files today; if one is ever added, strip it
+     * here rather than renaming the guess. Trailing `/* ... *\/` blocks and a
+     * trailing `/*` opener ARE stripped, below.
      *
      * Keys are 1-based source line numbers and survive the stripping, so a
      * failure message can point at the real line.

--- a/tests/CompanySearchCountrySourcingSpec.php
+++ b/tests/CompanySearchCountrySourcingSpec.php
@@ -18,8 +18,11 @@ declare(strict_types=1);
  *    map from this shop's own country table, AND still injects it in the same
  *    method that registers the search script. That map is now the search's
  *    authoritative source, not a nice-to-have for the order-intent module, so
- *    moving it to a method nothing calls, or dropping it from the addJsDef
- *    payload, would silently return the search to guessing;
+ *    moving it OUT OF THIS METHOD, or dropping it from the addJsDef payload,
+ *    would silently return the search to guessing. The assertion is that
+ *    tight on purpose: it fails even for a behaviour-preserving extraction
+ *    into a helper the hook still calls, because whether the map survives the
+ *    hook's early-return gate is exactly what it guards;
  *  - the i18n key the JS reads for the "pick a country" row exists in the
  *    payload under exactly that name. A rename on either side is invisible at
  *    runtime: the JS falls back to hardcoded English, so a merchant's
@@ -58,10 +61,16 @@ final class CompanySearchCountrySourcingSpec
     }
 
     /**
-     * Strip comments so a prose explanation of a removed guess does not read as
-     * the guess itself - the WHY comments deliberately name both. Handles `//`
-     * lines, docblock continuations and multi-line `/* ... *\/` blocks whose
+     * Strip LEADING comment lines so a prose explanation of a removed guess
+     * does not read as the guess itself - the WHY comments deliberately name
+     * both. Handles lines that START with `//`, docblock continuation lines
+     * that start with `*`, and multi-line `/* ... *\/` blocks whose
      * continuation lines start with an ordinary word.
+     *
+     * A trailing comment on a code line is NOT stripped, so a `// ... GB ...`
+     * tacked onto the end of real code would false-fail. None exist in either
+     * guarded file; if one is ever added, strip it here rather than renaming
+     * the guess.
      *
      * Keys are 1-based source line numbers and survive the stripping, so a
      * failure message can point at the real line.
@@ -115,6 +124,9 @@ final class CompanySearchCountrySourcingSpec
      * slice stable when members are reordered - a no-op edit must not fail a
      * spec.
      *
+     * An EMPTY slice is never returned: a gutted method would otherwise make
+     * every per-line assertion over its body pass by iterating nothing.
+     *
      * @param array<int, string> $lines
      *
      * @return array<int, string> body lines, keyed by source line number
@@ -133,6 +145,12 @@ final class CompanySearchCountrySourcingSpec
                 continue;
             }
             if (rtrim($line) === $indent . '}') {
+                TinyAssert::true(
+                    $body !== array(),
+                    'Sliced an EMPTY body for ' . $signature . ' out of ' . $where
+                    . ' - the method was gutted, so anything asserted over its body asserts nothing'
+                );
+
                 return $body;
             }
             $body[$number] = $line;
@@ -160,10 +178,14 @@ final class CompanySearchCountrySourcingSpec
         // Built from Country::getCountries() for THIS install, so it covers
         // every country the shop has rather than a handful of ids guessed at
         // in JavaScript. PrestaShop country ids are table rows, not constants.
-        // Matched loosely: a cast, a row-variable rename or a line wrap is not
-        // a regression, so only the two column names are pinned.
+        // Anchored on the SUBSCRIPT - `$param_countries[<...id_country...>] =
+        // <...iso_code...>` - so that building the map into some other
+        // variable, leaving $param_countries an empty array, fails here. A
+        // co-occurrence check would not: the dead-map build still mentions
+        // both column names. Still tolerant of a cast, a row-variable rename
+        // or a line wrap, which are not regressions.
         TinyAssert::true(
-            preg_match('#\$param_countries\b.{0,160}id_country.{0,160}iso_code#s', $body_text) === 1,
+            preg_match('#\$param_countries\[[^\]]*id_country[^\]]*\][^;]{0,120}iso_code#s', $body_text) === 1,
             'The id_country -> ISO map is no longer built from the shop country table inside ' . $hook . '()'
         );
 

--- a/tests/CompanySearchCountrySourcingSpec.php
+++ b/tests/CompanySearchCountrySourcingSpec.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for how the company search establishes which country to search.
+ *
+ * The register searched is decided entirely by one value, and until now
+ * TwoCompanySearch.getCurrentCountry() would invent it: a chain of hardcoded
+ * maps ending in navigator.language and then a literal 'GB'. Any shop that
+ * missed every map searched GB companies for every buyer, on every keystroke,
+ * with nothing on screen saying so.
+ *
+ * The fix has a PHP half and a JS half, and these tests pin the seam between
+ * them - the part no Jest test can see:
+ *
+ *  - the module still injects `countries`, the complete id_country -> ISO map
+ *    built from this shop's own country table. That map is now the search's
+ *    authoritative source, not a nice-to-have for the order-intent module, so
+ *    dropping it from the addJsDef payload would silently return the search to
+ *    guessing;
+ *  - the i18n key the JS reads for the "pick a country" row exists in the
+ *    payload under exactly that name. A rename on either side is invisible at
+ *    runtime: the JS falls back to hardcoded English, so a merchant's
+ *    translated checkout quietly stops being translated;
+ *  - the two guesses are gone from the JS for good. Asserted against the
+ *    source rather than through behaviour, because the reachable-in-jsdom
+ *    behaviour is only a subset - a re-added `'GB'` on a path no test builds a
+ *    DOM for would pass every Jest case and still ship the defect.
+ */
+final class CompanySearchCountrySourcingSpec
+{
+    public static function runAll(): void
+    {
+        self::testCountryIsoMapIsInjected();
+        self::testSelectCountryCopyKeyMatchesTheKeyTheJsReads();
+        self::testJsNoLongerGuessesTheCountry();
+    }
+
+    private static function moduleSource(): string
+    {
+        $source = file_get_contents(dirname(__DIR__) . '/twopayment.php');
+        TinyAssert::true(is_string($source), 'Unreadable twopayment.php');
+
+        return (string) $source;
+    }
+
+    private static function searchJsSource(): string
+    {
+        $path = dirname(__DIR__) . '/views/js/modules/TwoCompanySearch.js';
+        $source = file_get_contents($path);
+        TinyAssert::true(is_string($source), 'Unreadable ' . $path);
+
+        return (string) $source;
+    }
+
+    /**
+     * Strip comment lines so a prose explanation of a removed guess does not
+     * read as the guess itself - the WHY comments deliberately name both.
+     */
+    private static function codeLines(string $source): array
+    {
+        $kept = array();
+        foreach (explode("\n", $source) as $number => $line) {
+            if (preg_match('#^\s*(//|\*|/\*)#', $line) === 1) {
+                continue;
+            }
+            $kept[$number + 1] = $line;
+        }
+
+        return $kept;
+    }
+
+    private static function testCountryIsoMapIsInjected(): void
+    {
+        $source = self::moduleSource();
+
+        // Built from Country::getCountries() for THIS install, so it covers
+        // every country the shop has rather than a handful of ids guessed at
+        // in JavaScript. PrestaShop country ids are table rows, not constants.
+        TinyAssert::true(
+            strpos($source, "\$param_countries[\$country['id_country']] = Tools::strtolower(\$country['iso_code']);") !== false,
+            'The id_country -> ISO map is no longer built from the shop country table'
+        );
+        TinyAssert::true(
+            strpos($source, "'countries' => \$param_countries,") !== false,
+            'The countries map is no longer injected; the company search would fall back to guessing'
+        );
+    }
+
+    private static function testSelectCountryCopyKeyMatchesTheKeyTheJsReads(): void
+    {
+        $key = 'company_search_select_country';
+
+        TinyAssert::true(
+            strpos(self::moduleSource(), "'" . $key . "' => \$this->l(") !== false,
+            'Missing translatable copy for the "pick a country" row: ' . $key
+        );
+        TinyAssert::true(
+            strpos(self::searchJsSource(), 'window.twopayment.i18n.' . $key) !== false,
+            'The search JS no longer reads ' . $key . '; the PHP copy is dead and the row is untranslated'
+        );
+    }
+
+    private static function testJsNoLongerGuessesTheCountry(): void
+    {
+        $lines = self::codeLines(self::searchJsSource());
+
+        // The browser locale is never a legitimate source for this anywhere in
+        // the file: it describes the buyer's laptop, not the shop's country or
+        // the company's.
+        foreach ($lines as $number => $line) {
+            TinyAssert::true(
+                strpos($line, 'navigator.language') === false
+                && strpos($line, 'navigator.userLanguage') === false,
+                'The company search guesses the country from the browser locale again, at '
+                . 'views/js/modules/TwoCompanySearch.js:' . $number . ' - ' . trim($line)
+            );
+        }
+
+        // A hardcoded 'GB' is checked only inside getCurrentCountry(), because
+        // it is legitimate below that: extractCountryFromText() maps the country
+        // NAME "United Kingdom" to it, which is a resolution, not a default.
+        $start = null;
+        $end = null;
+        foreach ($lines as $number => $line) {
+            if ($start === null && strpos($line, 'getCurrentCountry() {') !== false) {
+                $start = $number;
+                continue;
+            }
+            if ($start !== null && strpos($line, 'extractCountryFromText(text) {') !== false) {
+                $end = $number;
+                break;
+            }
+        }
+        TinyAssert::true(
+            $start !== null && $end !== null,
+            'Could not locate getCurrentCountry() - this test has drifted from the source it guards'
+        );
+
+        foreach ($lines as $number => $line) {
+            if ($number <= $start || $number >= $end) {
+                continue;
+            }
+            TinyAssert::true(
+                strpos($line, "'GB'") === false && strpos($line, '"GB"') === false,
+                'A hardcoded GB default is back in getCurrentCountry(), at '
+                . 'views/js/modules/TwoCompanySearch.js:' . $number . ' - ' . trim($line)
+            );
+        }
+    }
+}

--- a/tests/CompanySearchCountrySourcingSpec.php
+++ b/tests/CompanySearchCountrySourcingSpec.php
@@ -27,12 +27,20 @@ declare(strict_types=1);
  *    payload under exactly that name. A rename on either side is invisible at
  *    runtime: the JS falls back to hardcoded English, so a merchant's
  *    translated checkout quietly stops being translated;
- *  - the two guesses are gone from getCurrentCountry() for good. Asserted
- *    against the source rather than through behaviour, because the
- *    reachable-in-jsdom behaviour is only a subset - a re-added GB literal on
- *    a path no test builds a DOM for would pass every Jest case and still ship
- *    the defect. The source check is textual, so it catches a re-added literal
- *    whatever quoting style it uses, but not a value assembled at runtime.
+ *  - the two guesses are gone for good. Asserted against the source rather
+ *    than through behaviour, because the reachable-in-jsdom behaviour is only a
+ *    subset - a re-added GB literal on a path no test builds a DOM for would
+ *    pass every Jest case and still ship the defect. Both defects are asserted
+ *    as SHAPES over the whole comment-stripped file rather than over a sliced
+ *    method body: the defect is a RETURN of a hardcoded country, and no
+ *    legitimate `return '<literal>'` of a country code exists anywhere in the
+ *    file (extractCountryFromText() maps country NAMES to 'GB' in a plain map
+ *    entry, which is a resolution and not a return). Whole-file shape checks
+ *    cost nothing in precision here and cannot be defeated by gutting,
+ *    reordering or re-indenting a method. They are textual, so they catch a
+ *    re-added literal in any quoting style but not a value assembled at
+ *    runtime; a gutted getCurrentCountry() is caught separately, by asserting
+ *    that the two real resolution sources it reads are still read at all.
  */
 final class CompanySearchCountrySourcingSpec
 {
@@ -67,10 +75,11 @@ final class CompanySearchCountrySourcingSpec
      * that start with `*`, and multi-line `/* ... *\/` blocks whose
      * continuation lines start with an ordinary word.
      *
-     * A trailing comment on a code line is NOT stripped, so a `// ... GB ...`
-     * tacked onto the end of real code would false-fail. None exist in either
-     * guarded file; if one is ever added, strip it here rather than renaming
-     * the guess.
+     * A trailing `//` comment on a code line is NOT stripped, so a
+     * `// ... GB ...` tacked onto the end of real code would false-fail. None
+     * exist in either guarded file; if one is ever added, strip it here rather
+     * than renaming the guess. Trailing `/* ... *\/` blocks and a trailing
+     * `/*` opener ARE stripped, below.
      *
      * Keys are 1-based source line numbers and survive the stripping, so a
      * failure message can point at the real line.
@@ -116,7 +125,10 @@ final class CompanySearchCountrySourcingSpec
     }
 
     /**
-     * Slice one function body out of already-comment-stripped lines.
+     * Slice one PHP method body out of already-comment-stripped lines.
+     *
+     * PHP-only by design: the JS assertions deliberately do not slice, so this
+     * only ever has to cope with PSR-12 brace-on-its-own-next-line style.
      *
      * The body ends at the first following line that is nothing but the closing
      * brace at the declaration's own indentation. Anchoring on the declaration's
@@ -124,8 +136,12 @@ final class CompanySearchCountrySourcingSpec
      * slice stable when members are reordered - a no-op edit must not fail a
      * spec.
      *
-     * An EMPTY slice is never returned: a gutted method would otherwise make
-     * every per-line assertion over its body pass by iterating nothing.
+     * There is deliberately NO empty-slice guard. Brace-on-next-line style puts
+     * the opening `{` into the collected body, so the slice is never empty and
+     * such a guard could never fire. A gutted hook is caught instead by the
+     * caller's own map and injection assertions, which fail on a body that no
+     * longer contains them - those two assertions are the only thing protecting
+     * this slice, and that is enough for what it guards.
      *
      * @param array<int, string> $lines
      *
@@ -145,12 +161,6 @@ final class CompanySearchCountrySourcingSpec
                 continue;
             }
             if (rtrim($line) === $indent . '}') {
-                TinyAssert::true(
-                    $body !== array(),
-                    'Sliced an EMPTY body for ' . $signature . ' out of ' . $where
-                    . ' - the method was gutted, so anything asserted over its body asserts nothing'
-                );
-
                 return $body;
             }
             $body[$number] = $line;
@@ -183,9 +193,10 @@ final class CompanySearchCountrySourcingSpec
         // variable, leaving $param_countries an empty array, fails here. A
         // co-occurrence check would not: the dead-map build still mentions
         // both column names. Still tolerant of a cast, a row-variable rename
-        // or a line wrap, which are not regressions.
+        // or a line wrap, which are not regressions - the line-wrap tolerance
+        // comes from the negated character classes, which match newlines.
         TinyAssert::true(
-            preg_match('#\$param_countries\[[^\]]*id_country[^\]]*\][^;]{0,120}iso_code#s', $body_text) === 1,
+            preg_match('#\$param_countries\[[^\]]*id_country[^\]]*\][^;]{0,120}iso_code#', $body_text) === 1,
             'The id_country -> ISO map is no longer built from the shop country table inside ' . $hook . '()'
         );
 
@@ -236,18 +247,39 @@ final class CompanySearchCountrySourcingSpec
             );
         }
 
-        // A hardcoded GB is checked only inside getCurrentCountry(), because it
-        // is legitimate below that: extractCountryFromText() maps the country
-        // NAME "United Kingdom" to it, which is a resolution, not a default.
-        // Quote style is not assumed - a backtick template literal is the same
-        // defect as a single-quoted one.
-        $body = self::functionBody($lines, 'getCurrentCountry() {', $path);
-        foreach ($body as $number => $line) {
-            TinyAssert::true(
-                preg_match('#\bGB\b#', $line) !== 1,
-                'A hardcoded GB default is back in getCurrentCountry(), at '
-                . $path . ':' . $number . ' - ' . trim($line)
-            );
-        }
+        // The defect being guarded is a RETURN of a hardcoded country, so that
+        // is the shape asserted, over the whole file. No method slicing: the
+        // one legitimate GB in this file is a map entry in
+        // extractCountryFromText() ('united kingdom' => 'GB'), which resolves a
+        // country NAME and is not a return, so it needs no carved-out range.
+        // Checking the shape instead of a line range makes this immune to the
+        // whole class of slicing bug - a gutted, re-indented, one-line-brace or
+        // reordered method cannot make it pass by accident. Quote style is not
+        // assumed: a backtick template literal is the same defect as a
+        // single-quoted one. Line wraps between `return` and the literal are
+        // tolerated because the negated class matches newlines.
+        $code = implode("\n", $lines);
+        $found = array();
+        TinyAssert::true(
+            preg_match('#\breturn\b[^;]*([\'"`])GB\1#', $code, $found) !== 1,
+            'A hardcoded GB default is returned again in ' . $path
+            . ' - ' . trim((string) (isset($found[0]) ? $found[0] : ''))
+        );
+
+        // Gutting getCurrentCountry() would satisfy every assertion above by
+        // containing nothing at all, so assert that the two authoritative
+        // sources it resolves from are still read. Both strings appear only
+        // inside that method, so losing either means the resolution chain is
+        // gone - which is the same defect as guessing, arrived at differently.
+        TinyAssert::true(
+            strpos($code, "getAttribute('data-iso-code')") !== false,
+            'The country select\'s own ISO code is no longer read in ' . $path
+            . ' - getCurrentCountry() has lost its first-choice resolution source'
+        );
+        TinyAssert::true(
+            strpos($code, 'window.twopayment.countries[') !== false,
+            'The server-injected id_country -> ISO map is no longer read in ' . $path
+            . ' - getCurrentCountry() has lost its authoritative resolution source'
+        );
     }
 }

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -80,14 +80,29 @@ cache:
 - organisation-number extraction across the payload shapes different registries use.
 - the cache: outlives the instance that filled it, keys on the country so two countries
   never share results, expires after five minutes, and evicts oldest-first at fifty
-  entries. The key/wire invariant is asserted directly as well as through each fallback
-  case: `getCurrentCountry()` never returns empty — it falls through to a
-  `navigator.language` guess and then to a literal `'GB'` — and whichever of those wins
-  reaches both the cache key and the `country` parameter, so neither can believe in a
-  country the other does not. (The `'GB'` last resort needs the locale stubbed, since
-  jsdom's `en-US` default hides it.) The one place they could still fork is a country
-  change *during* a request, since the key is built before the request and closed over —
-  pinned too: the entry stays filed under the country the request actually carried.
+  entries. The key/wire invariant is asserted directly as well as through each resolution
+  case: whatever `getCurrentCountry()` returns reaches both the cache key and the `country`
+  parameter, so neither can believe in a country the other does not. The one place they
+  could still fork is a country change *during* a request, since the key is built before
+  the request and closed over — pinned too: the entry stays filed under the country the
+  request actually carried.
+- country resolution, which decides which register is searched: the `data-iso-code`
+  attribute, then the server-supplied `window.twopayment.countries` id-to-ISO map (built
+  from this shop's own country table), then an exact match on the option's visible text.
+  When none resolves, `getCurrentCountry()` returns `''` and **no search is made** —
+  reported as `{ countryUnresolved: true }`, rendered as a "pick a country" row rather
+  than an empty list, and never cached. It used to guess instead: `navigator.language`
+  and then a literal `'GB'`, so a shop the chain could not read searched GB companies for
+  every buyer, silently, forever. Both guesses are pinned as gone, the locale one with a
+  stub since jsdom's `en-US` default would otherwise hide it. Omitting the parameter is
+  not an alternative — `country` is required on `GET /companies/v2/company`, so an
+  omitted one is a 422.
+
+  The source-level half of that lives in the PHP suite
+  (`tests/CompanySearchCountrySourcingSpec.php`): that the map is still injected, that the
+  i18n key the JS reads still exists under that name, and that neither guess has come
+  back. Reachable-in-jsdom behaviour is only a subset — a re-added `'GB'` on a path no
+  test builds a DOM for would pass every Jest case here.
 
 `company-search-rerender.test.js` — what happens when PrestaShop re-renders the address
 form (which it does for something as ordinary as a country change):

--- a/tests/js/company-search-resilience.test.js
+++ b/tests/js/company-search-resilience.test.js
@@ -443,67 +443,138 @@ describe('class-static result cache', () => {
         expect(new URL(ajax.last().url).searchParams.get('country')).toBe('NO');
     });
 
-    test('with nothing selected the key falls back to the browser locale', () => {
+    test('with nothing selected there is no key to answer from, and no search', () => {
         const search = makeInstance();
         document.querySelector("select[name='id_country']").innerHTML = '';
+        const rec = callbackRecorder();
 
-        // There is no "no country selected" key: getCurrentCountry() never
-        // returns empty, it guesses from navigator.language (en-US under jsdom).
-        // What matters is that the guess reaches the KEY and the WIRE as the same
-        // value — a country the key believes in but the request does not is how
-        // one country's results end up answering another's search.
-        expect(search.getCurrentCountry()).toBe('US');
-        expect(search.buildCacheKey('exa')).toBe('exa|US');
-        search.searchCompanies('exa', callbackRecorder().fn);
-        expect(new URL(ajax.last().url).searchParams.get('country')).toBe('US');
+        // getCurrentCountry() used to guess here — navigator.language, then a
+        // literal 'GB' — so a shop whose select the resolution chain could not
+        // read searched the GB register for every buyer, silently. It now
+        // resolves or returns empty, and an empty country means no request.
+        expect(search.getCurrentCountry()).toBe('');
+        expect(search.buildCacheKey('exa')).toBe('exa|');
+
+        search.searchCompanies('exa', rec.fn);
+
+        expect(ajax.calls).toHaveLength(0);
+        expect(rec.calls).toHaveLength(1);
+        expect(rec.calls[0].results).toEqual([]);
+        expect(rec.calls[0].meta).toEqual({ countryUnresolved: true });
     });
 
-    test('a browser locale region is upper-cased, and only a 2-letter one is used', () => {
-        const language = jest
-            .spyOn(window.navigator, 'language', 'get')
-            .mockReturnValue('en-no');
+    test('the browser locale is not consulted, whatever it says', () => {
+        // The worst of the removed guesses: the buyer's browser locale has no
+        // relationship to the shop's country or the company's, so a laptop set
+        // to en-US searched the US register for a Dutch company.
+        const language = jest.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-no');
         try {
             const search = makeInstance();
             document.querySelector("select[name='id_country']").innerHTML = '';
-            expect(search.getCurrentCountry()).toBe('NO');
+            expect(search.getCurrentCountry()).toBe('');
         } finally {
             language.mockRestore();
         }
-
-        const longRegion = jest
-            .spyOn(window.navigator, 'language', 'get')
-            .mockReturnValue('zh-Hans');
-        try {
-            const search = makeInstance();
-            document.querySelector("select[name='id_country']").innerHTML = '';
-            // A script subtag is not a country. Passed through it would put
-            // `country=HANS` on the wire.
-            expect(search.getCurrentCountry()).toBe('GB');
-        } finally {
-            longRegion.mockRestore();
-        }
     });
 
-    test('with no locale to guess from either, the key falls back to GB', () => {
-        const language = jest
-            .spyOn(window.navigator, 'language', 'get')
-            .mockReturnValue('xx');
+    test('the authoritative id-to-ISO map resolves a select with no ISO attribute', () => {
+        // The real fix, not a fallback: window.twopayment.countries is built
+        // server-side from THIS shop's country table (Country::getCountries() in
+        // twopayment.php) and injected via Media::addJsDef, so it covers every
+        // country the shop has rather than the ten ids that used to be hardcoded
+        // here. Lower-cased there, upper-cased on the wire.
+        document.body.innerHTML = '';
+        buildAddressForm({ country: null, countryId: '44', countryText: 'Nederland' });
+        window.twopayment = { countries: { 44: 'nl' } };
         try {
             const search = makeInstance();
-            document.querySelector("select[name='id_country']").innerHTML = '';
 
-            // The last resort is a literal 'GB'. Pinned explicitly because the
-            // jsdom default locale hides it, and because a test that merely
-            // reads getCurrentCountry() back cannot fail if it changes.
-            expect(search.getCurrentCountry()).toBe('GB');
-            expect(search.buildCacheKey('exa')).toBe('exa|GB');
-            // And the same 'GB' goes on the wire, so the entry filed under it
-            // really is a GB search rather than a server-default one wearing a
-            // GB label.
+            expect(search.getCurrentCountry()).toBe('NL');
+            expect(search.buildCacheKey('exa')).toBe('exa|NL');
             search.searchCompanies('exa', callbackRecorder().fn);
-            expect(new URL(ajax.last().url).searchParams.get('country')).toBe('GB');
+            expect(new URL(ajax.last().url).searchParams.get('country')).toBe('NL');
         } finally {
-            language.mockRestore();
+            delete window.twopayment;
+        }
+    });
+
+    test('an id the map does not cover resolves to nothing rather than to GB', () => {
+        // PrestaShop country ids are per-installation table rows, not constants.
+        // The hardcoded map this replaces was therefore wrong on any shop whose
+        // country table had been edited — and wrong SILENTLY, because a miss fell
+        // straight through to the 'GB' default.
+        document.body.innerHTML = '';
+        buildAddressForm({ country: null, countryId: '999', countryText: 'Somewhere' });
+        window.twopayment = { countries: { 44: 'nl' } };
+        try {
+            const search = makeInstance();
+            const rec = callbackRecorder();
+
+            expect(search.getCurrentCountry()).toBe('');
+            search.searchCompanies('exa', rec.fn);
+
+            expect(ajax.calls).toHaveLength(0);
+            expect(rec.calls[0].meta).toEqual({ countryUnresolved: true });
+        } finally {
+            delete window.twopayment;
+        }
+    });
+
+    test('the option text still resolves when there is no map to read', () => {
+        // Kept as the last strategy for a theme that renders its own select and
+        // loads the search without the module's JS defs. It is an exact
+        // full-name match, so it fails closed rather than guessing.
+        document.body.innerHTML = '';
+        buildAddressForm({ country: null, countryId: '44', countryText: 'Netherlands' });
+        const search = makeInstance();
+
+        expect(search.getCurrentCountry()).toBe('NL');
+    });
+
+    test('nothing is cached for an unresolved country', () => {
+        // The cache is class-static and outlives the widget, so an entry filed
+        // under the empty key would be served to every later search for the same
+        // term. There must be no entry to serve.
+        document.body.innerHTML = '';
+        buildAddressForm({ country: null, countryId: '999' });
+        const search = makeInstance();
+        search.companyField.autocomplete('instance').search('exa');
+
+        expect(ajax.calls).toHaveLength(0);
+        expect(TwoCompanySearch.cacheGet('exa|')).toBeNull();
+    });
+
+    test('the buyer is told to pick a country rather than shown an empty list', () => {
+        // An empty dropdown reads as "your company is not registered", which is a
+        // reason to abandon checkout. It is also not the `unavailable` copy:
+        // nothing is broken and retrying changes nothing.
+        document.body.innerHTML = '';
+        buildAddressForm({ country: null, countryId: '999' });
+        window.twopayment = {
+            i18n: { company_search_select_country: 'Pick a country first.' }
+        };
+        try {
+            const search = makeInstance();
+            const rendered = [];
+            search.companyField.autocomplete('option', 'response', (event, ui) => {
+                ui.content.forEach((item) => rendered.push(item));
+            });
+            search.companyField.autocomplete('instance').search('exa');
+
+            // `value` is the MESSAGE, not the '' the item was built with:
+            // jQuery UI's _normalize() rewrites it as `value || label`. So the
+            // `two_unavailable` flag is the only thing keeping this row out of
+            // the company field — same trap as buildUnavailableItem() documents.
+            expect(rendered).toEqual([
+                {
+                    label: 'Pick a country first.',
+                    value: 'Pick a country first.',
+                    two_unavailable: true
+                }
+            ]);
+            expect(rendered[0].label).not.toBe(search.getSearchUnavailableText());
+        } finally {
+            delete window.twopayment;
         }
     });
 

--- a/tests/js/ps-harness.js
+++ b/tests/js/ps-harness.js
@@ -140,17 +140,24 @@ function loadCompanySearch() {
  * The subset of the PrestaShop address form the module reads and writes.
  *
  * `id_country` carries `data-iso-code`, which is the first of getCurrentCountry()'s
- * four resolution strategies and the only deterministic one — after it come the
- * option's text, an id-to-iso map, a `navigator.language` guess and finally a
- * literal `'GB'`.
+ * three resolution strategies — after it come the server-supplied
+ * `window.twopayment.countries` id-to-ISO map and then the option's visible text.
+ * Pass `country: null` to build the select WITHOUT the attribute, which is how a
+ * test reaches the later strategies and the unresolvable case.
  *
  * @param {Object} [options]
- * @param {string} [options.country] ISO code for the selected option
+ * @param {?string} [options.country] ISO code for the selected option; null omits
+ *        the `data-iso-code` attribute entirely
+ * @param {string} [options.countryId] `id_country` value, default '17'
+ * @param {string} [options.countryText] option text, default 'Selected country'
  * @returns {void}
  */
 function buildAddressForm(options) {
     const opts = options || {};
-    const country = opts.country || 'GB';
+    const country = 'country' in opts ? opts.country : 'GB';
+    const countryId = opts.countryId || '17';
+    const countryText = opts.countryText || 'Selected country';
+    const isoAttr = country ? ' data-iso-code="' + country + '"' : '';
     document.body.innerHTML = [
         '<div class="js-address-form">',
         '  <form data-id-address="7">',
@@ -161,7 +168,7 @@ function buildAddressForm(options) {
         "    <input type='text' name='postcode' value='' />",
         "    <input type='text' name='city' value='' />",
         "    <select name='id_country'>",
-        '      <option value="17" data-iso-code="' + country + '" selected>Selected country</option>',
+        '      <option value="' + countryId + '"' + isoAttr + ' selected>' + countryText + '</option>',
         '    </select>',
         '  </form>',
         '</div>'

--- a/tests/run.php
+++ b/tests/run.php
@@ -5536,6 +5536,7 @@ require __DIR__ . '/AddressLookupConfigSpec.php';
 require __DIR__ . '/OrgNumberPreVerificationSpec.php';
 require __DIR__ . '/IntentApprovedNoticeSpec.php';
 require __DIR__ . '/UpgradeScriptVersionSpec.php';
+require __DIR__ . '/CompanySearchCountrySourcingSpec.php';
 // LAST, deliberately: DefaultShippingTaxCodeSpec defines
 // _TWO_ENABLE_DEFAULT_SHIPPING_TAX_CODE_ partway through its own run, and a
 // PHP constant cannot be undefined again. ShippingCostSourcingSpec asserts the
@@ -5568,6 +5569,7 @@ $tests = [
     'OrgNumberPreVerificationSpec::runAll' => [OrgNumberPreVerificationSpec::class, 'runAll'],
     'IntentApprovedNoticeSpec::runAll' => [IntentApprovedNoticeSpec::class, 'runAll'],
     'UpgradeScriptVersionSpec::runAll' => [UpgradeScriptVersionSpec::class, 'runAll'],
+    'CompanySearchCountrySourcingSpec::runAll' => [CompanySearchCountrySourcingSpec::class, 'runAll'],
     // Keep last - see the require above.
     'DefaultShippingTaxCodeSpec::runAll' => [DefaultShippingTaxCodeSpec::class, 'runAll'],
 ];

--- a/twopayment.php
+++ b/twopayment.php
@@ -3314,6 +3314,11 @@ class Twopayment extends PaymentModule
             'end_of_month_plus_days' => $this->l('End of Month + %s days'),
             'company_search_searching' => $this->l('Searching...'),
             'company_search_unavailable' => $this->l('Company search is temporarily unavailable. Please try again.'),
+            // Distinct from company_search_unavailable on purpose: nothing is
+            // broken and retrying will not help. The search could not establish
+            // which country's company register to query, and the only action
+            // that resolves it is the buyer selecting a country.
+            'company_search_select_country' => $this->l('Select your country above to search for your company.'),
             'sole_trader_registered_business' => $this->l('Registered business'),
             'sole_trader_label' => $this->l('Sole trader'),
         );

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1533,12 +1533,19 @@ class TwoCompanySearch {
                     token: window.twopayment.ajax_token,
                     company: data.company,
                     companyid: data.companyid,
-                    // Deliberately relayed even when unresolved: '' makes the
+                    // Deliberately relayed even when unresolved. '' makes the
                     // controller's `if (!empty($country))` skip the country
-                    // write and keep whatever it already had, which is the
-                    // wanted outcome. The order payload's country_iso comes
-                    // from the address, never from this cookie, so an empty
-                    // value here can never reach the API as a guess.
+                    // write, so with no prior marker the cookie ends up
+                    // company + id and an EMPTY country - and twopayment.php
+                    // then DISCARDS the whole session company on the next
+                    // read, because a value with no country marker cannot be
+                    // safely reused across countries. The outcome is discard,
+                    // not keep: an unresolved country loses the prefill, it
+                    // does not preserve it. Safe either way for the order
+                    // payload, whose country_iso comes from the address
+                    // server-side (Country::getIsoById), never from this
+                    // cookie, so an empty value here can never reach the API
+                    // as a guess.
                     country: this.getCurrentCountry(),
                     id_address: this.getCurrentAddressId()
                 },

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -414,6 +414,13 @@ class TwoCompanySearch {
                             response([]);
                             return;
                         }
+                        if (meta && meta.countryUnresolved) {
+                            // Not cached, and not an empty dropdown: an empty
+                            // list here would read as "your company is not
+                            // registered" when in fact no search was made.
+                            response([this.buildSelectCountryItem()]);
+                            return;
+                        }
                         if (meta && meta.unavailable) {
                             // Not cached: the service may well be healthy again
                             // by the buyer's next keystroke.
@@ -512,14 +519,17 @@ class TwoCompanySearch {
      * next address-form re-render.
      *
      * That invariant is structural, not a coincidence to be re-checked: both
-     * this and searchCompanies() take the value from getCurrentCountry(), which
-     * never returns empty - it resolves the selected option, then guesses from
-     * `navigator.language`, then falls back to a literal 'GB'. So there is no
-     * "no country selected" case to key separately: whatever the fallback
-     * chain produces is also what goes on the wire, so a search filed under it
-     * is genuinely a search for that country. Do not give either side its own
-     * fallback - a country the key believes in but the request does not is
-     * exactly how one country's results end up answering another's search.
+     * this and searchCompanies() take the value from getCurrentCountry() and
+     * neither adds a fallback of its own. A country the key believes in but the
+     * request does not is exactly how one country's results end up answering
+     * another's search, so do not add one here.
+     *
+     * getCurrentCountry() CAN now return '' (it stopped guessing - see there),
+     * which makes the key `term|`. Nothing is ever filed under it, because
+     * searchCompanies() declines to search at all in that case, so the read is
+     * a guaranteed miss rather than a bucket where unrelated countries pool.
+     * The empty half is still carried rather than special-cased: giving this
+     * side its own substitute for "unknown" is the exact mistake above.
      *
      * @param {string} term
      * @returns {string}
@@ -558,6 +568,38 @@ class TwoCompanySearch {
             // text. The `two_unavailable` checks in those three handlers are the
             // only thing keeping it out of the company field - do not remove one
             // on the assumption that an empty value makes it harmless.
+            value: '',
+            two_unavailable: true
+        };
+    }
+
+    /**
+     * Message shown when the search cannot tell which country to search.
+     *
+     * Deliberately not the `unavailable` copy: nothing is broken and retrying
+     * changes nothing. The one action that helps is the buyer picking a country
+     * on the address form, so say that instead of blaming the service.
+     *
+     * @returns {string}
+     */
+    getSelectCountryText() {
+        return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_select_country)
+            || 'Select your country above to search for your company.';
+    }
+
+    /**
+     * Pseudo-result carrying the select-a-country message through jQuery UI.
+     *
+     * Reuses `two_unavailable` rather than adding a second flag: that flag is
+     * what the select / focus / _renderItem handlers check to keep a message row
+     * out of the company field, and this row needs exactly the same treatment.
+     * It means "not a company", not "the service is down".
+     *
+     * @returns {Object}
+     */
+    buildSelectCountryItem() {
+        return {
+            label: this.getSelectCountryText(),
             value: '',
             two_unavailable: true
         };
@@ -657,6 +699,20 @@ class TwoCompanySearch {
             list.style.display = 'block';
         };
 
+        // Same reasoning, different cause: no search was made because the
+        // country is unknown, so point at the fix the buyer can apply.
+        const renderSelectCountry = () => {
+            setLoadingState(false);
+            list.innerHTML = '';
+            const row = document.createElement('div');
+            row.className = 'two-autocomplete-item two-autocomplete-select-country';
+            row.style.padding = '6px 10px';
+            row.style.color = '#888';
+            row.textContent = this.getSelectCountryText();
+            list.appendChild(row);
+            list.style.display = 'block';
+        };
+
         // Debounced input. Held in a named ref so teardown can unbind it: the
         // listener is on the shared company field, not on the container, so
         // dropping the container would leave it firing.
@@ -704,6 +760,10 @@ class TwoCompanySearch {
                     // input event, so nothing else would ever clear it.
                     if ((inputEl.value || '') !== term) {
                         setLoadingState(false);
+                        return;
+                    }
+                    if (meta && meta.countryUnresolved) {
+                        renderSelectCountry();
                         return;
                     }
                     if (meta && meta.unavailable) {
@@ -817,12 +877,30 @@ class TwoCompanySearch {
             return;
         }
 
-        // Country ISO for the search. getCurrentCountry() always resolves to
-        // something (selected option, then locale guess, then 'GB'), so this is
-        // always on the wire - and buildCacheKey() files the response under the
-        // same value, which is what stops one country's results answering
+        // Country ISO for the search. Whatever getCurrentCountry() resolves
+        // goes on the wire, and buildCacheKey() files the response under that
+        // same value - which is what stops one country's results answering
         // another country's search.
         const country = this.getCurrentCountry();
+
+        if (!country) {
+            // No country, no search. The alternative - send the request without
+            // the parameter and let the API pick - is not available: `country`
+            // is REQUIRED on GET /companies/v2/company, so an omitted one is a
+            // 422 the buyer would read as "search is broken". And the guess this
+            // replaces was worse than either, because a GB register searched for
+            // a Dutch buyer looks like a working search returning no match.
+            //
+            // Reported distinctly from `unavailable` because the remedy is the
+            // buyer's, not ours: pick a country on the address form. Treated
+            // like the short-term branch above for sequencing, so a pending
+            // request for the previous country cannot land afterwards and
+            // repaint the list.
+            this._companySearchSeq += 1;
+            this._abortPendingCompanySearch();
+            responseCallback([], { countryUnresolved: true });
+            return;
+        }
 
         // Build URL with correct API parameters. `limit`/`offset` mirror the
         // Magento and WooCommerce plugins: bound the response to one page so
@@ -934,51 +1012,76 @@ class TwoCompanySearch {
     }
     
     /**
-     * Get current country from checkout form - SIMPLIFIED
+     * ISO 3166-1 alpha-2 country the company search should query, or `''` when
+     * it cannot be established.
+     *
+     * The company register searched is decided entirely by this value, so a
+     * wrong answer here is worse than no answer: the buyer is shown companies
+     * from a register their company is not in, and there is nothing on screen
+     * saying which register was used. This function therefore resolves or
+     * returns empty. It does not guess.
+     *
+     * Two guesses used to sit at the bottom of this chain and both are gone:
+     *
+     * - `navigator.language`. The buyer's browser locale has no relationship to
+     *   either the shop's country or the company's. A Dutch company bought for
+     *   by someone whose laptop is set to en-US searched the US register.
+     * - a literal `'GB'`. Any shop that missed every map above searched GB
+     *   companies for every buyer, on every keystroke, silently and forever.
+     *
+     * What replaces them is an authoritative source the module already ships:
+     * `window.twopayment.countries`, the complete `id_country` -> ISO map built
+     * server-side from `Country::getCountries()` in twopayment.php and injected
+     * via `Media::addJsDef`. It supersedes the ten-entry hardcoded id map that
+     * used to be strategy three - PrestaShop's country ids are per-installation
+     * table rows, not constants, so hardcoding them was wrong on any shop whose
+     * country table had been edited, and wrong SILENTLY because a mismatched id
+     * simply fell through to the guesses below. TwoOrderIntent.js already reads
+     * this same map.
+     *
+     * The remaining two strategies are both exact matches rather than guesses:
+     * `data-iso-code` is the ISO code itself, and the option-text map only
+     * resolves on a full country-name match. Either fails closed.
+     *
+     * @returns {string} uppercase ISO code, or '' when unresolvable
      */
     getCurrentCountry() {
-        // Method 1: Check if country option has data attribute with ISO code
         const countryField = document.querySelector("select[name='id_country']");
         if (countryField && countryField.selectedOptions.length > 0) {
             const selectedOption = countryField.selectedOptions[0];
-            
-            // Check for data-iso attribute
+
+            // 1. The ISO code, stated outright. Themes that render the country
+            // select from PrestaShop's own template carry it.
             const isoCode = selectedOption.getAttribute('data-iso-code') || selectedOption.getAttribute('data-iso');
             if (isoCode) {
                 return isoCode.toUpperCase();
             }
-            
-            // Method 2: Extract from option text
+
+            // 2. The server-built id -> ISO map for THIS shop's country table.
+            // Values are lower-cased by twopayment.php; the API wants upper.
+            const countryId = countryField.value;
+            const isoFromConfig = (window.twopayment && window.twopayment.countries)
+                ? window.twopayment.countries[countryId]
+                : null;
+            if (isoFromConfig) {
+                return String(isoFromConfig).toUpperCase();
+            }
+
+            // 3. The option's visible text, for a theme that renders its own
+            // select AND loads the search without the module's JS defs.
             const optionText = selectedOption.textContent.trim();
             const countryFromText = this.extractCountryFromText(optionText);
             if (countryFromText) {
                 return countryFromText;
             }
-            
-            // Method 3: Simple ID-based mapping for common countries
-            const countryId = countryField.value;
-            const commonCountries = {
-                '17': 'GB', '6': 'ES', '8': 'FR', '1': 'DE', '10': 'IT',
-                '13': 'NL', '3': 'BE', '21': 'US', '4': 'CA', '24': 'AU'
-            };
-            
-            if (commonCountries[countryId]) {
-                return commonCountries[countryId];
-            }
         }
-        
-        // Method 4: Browser locale fallback
-        const browserLang = navigator.language || navigator.userLanguage;
-        if (browserLang && browserLang.includes('-')) {
-            const countryCode = browserLang.split('-')[1];
-            if (countryCode && countryCode.length === 2) {
-                return countryCode.toUpperCase();
-            }
-        }
-        
-        return 'GB'; // Safe default
+
+        // Unresolvable. searchCompanies() declines to search rather than
+        // sending a country it invented - see the countryUnresolved branch
+        // there for why omitting the parameter is not an option either.
+        return '';
     }
-    
+
     /**
      * Extract country code from country name text
      */

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1059,7 +1059,7 @@ class TwoCompanySearch {
 
             // 2. The server-built id -> ISO map for THIS shop's country table.
             // Values are lower-cased by twopayment.php; the API wants upper.
-            const countryId = countryField.value;
+            const countryId = selectedOption.value;
             const isoFromConfig = (window.twopayment && window.twopayment.countries)
                 ? window.twopayment.countries[countryId]
                 : null;
@@ -1533,6 +1533,12 @@ class TwoCompanySearch {
                     token: window.twopayment.ajax_token,
                     company: data.company,
                     companyid: data.companyid,
+                    // Deliberately relayed even when unresolved: '' makes the
+                    // controller's `if (!empty($country))` skip the country
+                    // write and keep whatever it already had, which is the
+                    // wanted outcome. The order payload's country_iso comes
+                    // from the address, never from this cookie, so an empty
+                    // value here can never reach the API as a guess.
                     country: this.getCurrentCountry(),
                     id_address: this.getCurrentAddressId()
                 },

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1536,16 +1536,18 @@ class TwoCompanySearch {
                     // Deliberately relayed even when unresolved. '' makes the
                     // controller's `if (!empty($country))` skip the country
                     // write, so with no prior marker the cookie ends up
-                    // company + id and an EMPTY country - and twopayment.php
-                    // then DISCARDS the whole session company on the next
-                    // read, because a value with no country marker cannot be
-                    // safely reused across countries. The outcome is discard,
-                    // not keep: an unresolved country loses the prefill, it
-                    // does not preserve it. Safe either way for the order
-                    // payload, whose country_iso comes from the address
-                    // server-side (Country::getIsoById), never from this
-                    // cookie, so an empty value here can never reach the API
-                    // as a guess.
+                    // company + id and an EMPTY country. What happens to that
+                    // half-record on the next read depends on the reader:
+                    // twopayment.php's legacy-marker discard is gated on
+                    // `!Tools::isEmpty($country_iso)`, so it DISCARDS the whole
+                    // session company when the read path has an address country
+                    // to compare against, and REUSES it when the read path has
+                    // none - which is exactly the case orderintent.php hits
+                    // when no checkout address is selected yet and it passes
+                    // ''. Safe either way for the order payload, whose
+                    // country_iso comes from the address server-side
+                    // (Country::getIsoById), never from this cookie, so an
+                    // empty value here can never reach the API as a guess.
                     country: this.getCurrentCountry(),
                     id_address: this.getCurrentAddressId()
                 },


### PR DESCRIPTION
Linear: [TWO-25253](https://linear.app/two-inc/issue/TWO-25253)

## The defect

`getCurrentCountry()` in `views/js/modules/TwoCompanySearch.js` ended its resolution chain in two guesses: the buyer's browser locale, then a literal `'GB'`.

A shop whose country `<select>` carries no `data-iso-code`, whose option text falls outside a ~20-entry name map, and whose country id falls outside a ~10-entry hardcoded id map fell through both. **That shop searched the GB company register for every buyer, on every keystroke, silently** — with nothing on screen saying which register had been used, so the buyer reads it as "my company is not registered".

`navigator.language` is a particularly bad source here: the buyer's browser locale has no relationship to the shop's country or the company's. A Dutch company bought for from a laptop set to `en-US` searched the US register.

## The fix

The register searched is decided entirely by this one value, so a wrong answer is worse than no answer. Resolve it properly, or decline to search.

**Resolve properly** using a source the module already ships: `window.twopayment.countries`, the complete `id_country` → ISO map built server-side from *this shop's own* country table (`Country::getCountries()` in `twopayment.php`) and injected via `Media::addJsDef`. `TwoOrderIntent.js` already reads it.

That supersedes the hardcoded id map entirely. PrestaShop country ids are per-installation table rows, not constants, so hardcoding ten of them was wrong on any shop whose country table had been edited — and wrong *silently*, because a miss fell straight through to `'GB'`.

The two remaining strategies are resolutions rather than guesses and both fail closed: `data-iso-code` is the ISO code itself, and the option-text map only resolves on an exact full country-name match. It is kept last for a theme that renders its own select and loads the search without the module's JS defs.

**Decline to search** when nothing resolves: no request at all, reported as `{ countryUnresolved: true }`, rendered as a "select your country above" row on both the jQuery UI and custom-fallback paths.

Three alternatives considered and rejected:

- **an empty dropdown** — reads as "your company is not registered", which is a reason to abandon checkout.
- **the existing `unavailable` copy** — nothing is broken and retrying changes nothing. The only action that helps is the buyer's, so the copy says so. New i18n key `company_search_select_country`.
- **omitting the `country` parameter and letting the API decide** — not available. `country` is a **required** field on `GET /companies/v2/company`, so an omitted one is a 422 the buyer reads as a broken search.

The shop's own default country was also rejected as a fallback: the merchant's country is not the buyer's company's country, so it would just reintroduce a silent wrong register with a different constant.

## Keeps the TWO-25247 key-equals-wire invariant

Preserved rather than worked around. `buildCacheKey()` still carries exactly what `getCurrentCountry()` returned — empty included — and adds no fallback of its own. Because no request is made in the unresolved case, nothing is ever filed under the empty key, so the read is a guaranteed miss rather than a bucket where unrelated countries pool. Pinned by a test.

## Verification

Jest: **138 passed**, 2 suites.
PHP: **41 PASS, 0 FAIL** (`php tests/run.php`).

Test coverage added:
- the authoritative map resolving a select with no ISO attribute (and lower→upper casing)
- an id the map does not cover resolving to nothing rather than to GB
- the browser locale not being consulted whatever it says
- nothing cached under the unresolved key
- the "pick a country" row rendered instead of an empty list, flagged non-selectable
- option-text resolution still working with no map present

Plus `tests/CompanySearchCountrySourcingSpec.php` for the PHP↔JS seam no Jest test can see: the map is built and injected **inside the same hook that registers the search script** (so "same hook, same early-return gate" is the property asserted, not merely that the text exists somewhere in the file), the i18n key the JS reads still exists under that name, and neither guess has come back. Source-level on purpose — reachable-in-jsdom behaviour is only a subset, and a re-added `'GB'` on a path no test builds a DOM for would pass every Jest case.

Mutations, each caught:

| Mutation | Result |
|---|---|
| restore the literal `'GB'` default | 5 Jest failures + PHP `A hardcoded GB default is returned again in views/js/modules/TwoCompanySearch.js` |
| restore the `navigator.language` guess | 5 Jest failures + PHP `guesses the country from the browser locale again` |
| drop the authoritative countries map | 1 Jest failure + PHP `no longer built from the shop country table inside hookActionFrontControllerSetMedia()` |
| drop the `countryUnresolved` guard in `searchCompanies()` | 4 Jest failures |
| drop the PHP i18n key | PHP `Missing translatable copy for the "pick a country" row` |

The last one caught a real mistake during this work: restoring `twopayment.php` after a mutation reverted the i18n addition along with it, and the spec failed rather than the key silently going missing.

## Review history

Four adversarial rounds, every finding in the new PHP spec rather than in the behaviour fix. Round 1 passed the behaviour design and found every issue in the new PHP spec; round 2 found that round 1's own fix had **untied the map assertion from its subscript** — mutating the build to write a different variable left the map dead at runtime and the spec green, the exact regression it claims to catch. Round 3 fixed that plus an empty-slice silent pass, but its own guard still let a one-line `getCurrentCountry() {}` gut pass silently. Round 4 therefore deleted the JS line-range slicing altogether: the GB check is now a whole-file assertion that no hardcoded `GB` is ever *returned* (quote-agnostic), plus assertions that both real resolution sources are still read, which cannot silently pass on a gutted method. Round 3 also corrected a comment that described the unresolved-country cookie outcome as "keep what it had"; round 4 found that correction equally overstated — the next read discards only when it has an address country to compare against.

## Found and deliberately left for its own ticket

When the country is unresolved, `persistCompanyToCookie()` still writes company + id with an empty country marker. What happens to that half-record on the next read depends on the reader, because the clearing branch in `twopayment.php:7126` is gated on `!Tools::isEmpty($country_iso)`: it unsets all four cookie keys when the read path has an address country to compare against ("Cleared legacy session company without country marker"), and leaves the half-record in place — reused as-is — when it does not. `controllers/front/orderintent.php:672-682` hits the second case, passing `''` whenever no checkout address resolves. The order-payload reader at `twopayment.php:7240` always has a real ISO, so it always clears. The gate is correct in intent — a marker-less value cannot safely be reused across countries — but the split means the loss lands in the case where a country IS known server-side, i.e. the one where a fresh search would immediately resolve it anyway, while the no-country case silently keeps an unvalidated record. Either way it is small, and the clean fix is to not write a half-record at all, which is a change to the cookie path rather than to country resolution.
