### PR TITLE
TWO-25256/ci: compute the version from the PR's commits, on the PR

### DIFF
--- a/.github/scripts/check-upgrade-script-version.sh
+++ b/.github/scripts/check-upgrade-script-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Reject a pull request whose NEW upgrade script is not named for the version
+# this PR is computing (.github/scripts/decide-bump-level.sh).
+#
+# PrestaShop discovers upgrade scripts BY FILENAME: it runs
+# `upgrade/upgrade-<version>.php` only for versions strictly above the one
+# installed and at or below the one being installed, and derives the function
+# name from the filename. Two consequences, both silent:
+#
+#   - appending a second migration to an already-installed version's script
+#     means that migration NEVER RUNS on a shop that already reached that
+#     version. Proven by experiment: `number_upgraded=0`, no error, no log line.
+#   - a script named for a version the module never declares is never in range
+#     for any upgrade, so it never runs at all.
+#
+# tests/UpgradeScriptVersionSpec.php already gates the static half of this
+# (declared >= highest script, filename agrees with its function name). This
+# check is the dynamic half that spec cannot see: it compares the ADDED
+# filenames against the version this PR will actually land with. The two compose
+# — do not duplicate either one in the other.
+#
+# Usage:  check-upgrade-script-version.sh <expected-version> [<base-ref>] [<head-ref>]
+set -euo pipefail
+
+expected="${1:?usage: check-upgrade-script-version.sh <expected-version> [<base-ref>] [<head-ref>]}"
+base_ref="${2:-origin/staging}"
+head_ref="${3:-HEAD}"
+
+added=$(git diff --diff-filter=A --name-only "${base_ref}...${head_ref}" -- 'upgrade/upgrade-*.php' || true)
+
+if [ -z "$added" ]; then
+    echo "No new upgrade scripts in this PR — nothing to check."
+    exit 0
+fi
+
+rc=0
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    v=${path##*/upgrade-}
+    v=${v%.php}
+    if [ "$v" = "$expected" ]; then
+        echo "OK  ${path} matches the version this PR lands with (${expected})."
+    else
+        echo "::error file=${path}::this PR lands version ${expected}, so a new upgrade script must be named upgrade/upgrade-${expected}.php — ${path} declares ${v}. PrestaShop finds upgrade scripts by filename, so a mismatched name runs at the wrong time or never runs at all. Rename the file AND its upgrade_module_* function."
+        rc=1
+    fi
+done <<<"$added"
+
+exit "$rc"

--- a/.github/scripts/decide-bump-level.sh
+++ b/.github/scripts/decide-bump-level.sh
@@ -1,163 +1,174 @@
 #!/usr/bin/env bash
 #
-# Decide the semantic-version bump level for a version-bump / release run.
+# Compute the version this pull request should land on `staging` with.
 #
-# Convention:
-#   patch  — change landing anywhere other than `main` (i.e. `staging`)
-#   minor  — change landing on `main`
-#   major  — escape hatch. Two independent signals, the higher wins:
+# The version describes the CHANGE, not the branch it is landing on. It is
+# derived from the conventional-commit types of the commits this PR adds, which
+# is what semver actually asks for. The previous scheme ("patch on staging,
+# minor on main") made the number describe the branch rule instead, so the same
+# change got a different version depending on where it merged.
 #
-#     Declared  a root `.next-major` file whose first whitespace-delimited
-#               token is the target major, with a short human reason on the
-#               same line. Human-editable and reviewable in the PR that
-#               decides it, so a *planned* major with no single breaking
-#               commit still lands as a major:
+#   M = version on `origin/main`          - the last released version
+#   C = version on this PR's head         - what the tree currently declares
+#   L = conventional-commit classification of `<base>..<head> --no-merges`
 #
-#                   3  # overlay migration, 3.0.0 release
+#   breaking  ->  candidate = (M.major + 1).0.0
+#   feat      ->  candidate = M.major.(M.minor + 1).0
+#   otherwise ->  candidate = M.major.M.minor.(M.patch + 1)
 #
-#     Discovered  a `!` on a conventional-commit type (`feat!:`,
-#                 `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:` footer in the
-#                 commits under consideration. Covers a break that actually
-#                 happened.
+#   new = max(C, candidate)            # version_compare semantics
+#   new == C  ->  nothing to do
 #
-#   target = max(declared, current_major + (breaking ? 1 : 0))
-#   target > current_major  ->  major, new version is exactly <target>.0.0
-#   otherwise               ->  the branch rule above
+# Four properties this shape has deliberately, none of them incidental:
 #
-# `.next-major` is deliberately NEVER cleared by CI. The `target >
-# current_major` condition disarms it on its own once the major has shipped,
-# and leaving the file in place keeps the declared intent reviewable. The one
-# thing this scheme can still get wrong is a declaration that has fallen
-# BEHIND the current major, so that is a hard failure (see below) rather than
-# a silent no-op.
+#  1. THE RANGE IS THIS PR'S COMMITS ONLY (`origin/staging..HEAD`), never the
+#     cumulative `main..staging`. The cumulative range currently contains
+#     `feat!:` commits in several of these repos, so every PR would keep
+#     re-discovering the same break and re-proposing a major.
 #
-# Usage:  decide-bump-level.sh <branch> [<git-rev-range>]
+#  2. THE `max()` CLAMP, not "bump by one from C". This makes the computation
+#     idempotent by construction - re-running on the same head is a no-op, a
+#     second fix commit on the same PR is a no-op, and the version can NEVER
+#     REGRESS. That last part is load-bearing because `main` sits behind
+#     `staging` in these repos: with a stale main the raw candidate can compute
+#     BELOW the version already on staging, and on PrestaShop that would
+#     resurrect an already-run `upgrade/upgrade-<version>.php` filename.
 #
-# With no range, it is derived as "everything not already accounted for" — see
-# the anchor list below. Deriving it carefully matters: a naive
-# `<last-tag>..HEAD` would re-discover the same breaking commit on every single
-# staging PR and major-bump over and over, because `staging` is only tagged
-# when it reaches `main`.
+#  3. ONLY `feat` EARNS A MINOR. `chore`, `docs`, `ci`, `test`, `refactor`,
+#     `build`, `perf`, `style` all take a patch. The obvious-looking "minor
+#     unless every commit is a fix" rule would send a docs-only PR to a minor.
 #
-# Writes `level=`, `set_version=` and `reason=` to stdout as `key=value`
+#  4. `.next-major` IS COMPARED AGAINST MAIN'S MAJOR, not the head's. A
+#     declaration below the released major is always stale, and is a hard error
+#     rather than a silent no-op:
+#
+#         target_major = max(declared, M.major + breaking)
+#
+# PrestaShop-only clause: PrestaShop discovers upgrade scripts BY FILENAME and
+# runs `upgrade/upgrade-<version>.php` only for versions strictly above the
+# installed one. Appending a second migration to an already-installed version's
+# script therefore never runs on a shop that already reached that version -
+# silently, `number_upgraded=0`. So if this PR ADDS a new upgrade script and the
+# rule above produced no version change, force a patch bump so the script gets a
+# filename of its own. Editing an EXISTING script does not trigger this. The
+# clause is inert in the repos that have no `upgrade/upgrade-*.php` at all.
+#
+# Usage:  decide-bump-level.sh [<base-ref>] [<head-ref>]
+#         defaults: origin/staging HEAD
+#         MAIN_REF overrides the released-version ref (default origin/main).
+#
+# Writes `set_version=`, `changed=` and `reason=` to stdout as `key=value`
 # lines, and appends the same to $GITHUB_OUTPUT when running under Actions.
-# The full decision — including the declared reason string — is logged on
-# every run, so a stale `.next-major` is visible without digging.
+# `set_version` is ABSOLUTE and always populated; consumers pass it straight to
+# `bumpver update --set-version`. There is no bump "level" any more - a level
+# cannot express "clamp to what the tree already has".
 set -euo pipefail
 
-branch="${1:?usage: decide-bump-level.sh <branch> [<git-rev-range>]}"
-range="${2:-}"
+base_ref="${1:-origin/staging}"
+head_ref="${2:-HEAD}"
+main_ref="${MAIN_REF:-origin/main}"
 
 repo_root=$(git rev-parse --show-toplevel)
-toml="${repo_root}/bumpver.toml"
-[ -f "$toml" ] || { echo "::error::no bumpver.toml at ${toml}" >&2; exit 1; }
 
-current=$(sed -n 's/^[[:space:]]*current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
-[ -n "$current" ] || { echo "::error::could not read current_version from ${toml}" >&2; exit 1; }
-current_major=${current%%.*}
-case "$current_major" in
-    '' | *[!0-9]*) echo "::error::unparseable current_version '${current}' in ${toml}" >&2; exit 1 ;;
-esac
+die() {
+    echo "::error::$*" >&2
+    exit 1
+}
 
-# --- derive the range, if not given ------------------------------------------
+# --- reading a version out of a ref ------------------------------------------
 #
-# The base is the closest-to-HEAD of three anchors, each meaning "everything
-# before this is already accounted for":
-#
-#   1. the last version-bump commit — the normal steady-state anchor;
-#   2. the newest semver tag reachable from HEAD — covers a release cut
-#      without a bump commit on this branch;
-#   3. the commit that first added THIS script — the activation floor.
-#
-# (3) is what stops the very first run from re-discovering years of already
-# shipped `feat!:` commits and jumping several majors. Without it, four of the
-# six plugin repos would have gone straight to 3.0.0 the moment this landed.
-# It costs nothing afterwards: once a bump commit exists it is always closer
-# to HEAD, so (1) takes over and (3) never binds again.
-if [ -z "$range" ]; then
-    # Subject prefix of a bump commit, taken from bumpver's own configured
-    # commit_message so the two can't drift — the capitalisation of "bump"
-    # is not consistent across repos, so it must not be hardcoded here.
-    bump_msg=$(sed -n 's/^[[:space:]]*commit_message[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
-    bump_prefix=${bump_msg%%\{*}
-    bump_prefix=${bump_prefix%% }
-    [ -n "$bump_prefix" ] || bump_prefix="chore: Bump version"
+# bumpver.toml is the source of truth everywhere it exists. It does NOT exist on
+# `main` in the PrestaShop repo (it was only ever added on `staging`), so fall
+# back to the module's own declarations rather than crashing - reading M is not
+# optional, it is the base of every candidate below.
+read_version() {
+    local ref="$1" v=""
 
-    self_rel=".github/scripts/decide-bump-level.sh"
-
-    candidates=""
-    add_candidate() {
-        [ -n "$1" ] || return 1
-        # Only anchors on this history are usable as a range base.
-        git merge-base --is-ancestor "$1" HEAD 2>/dev/null || return 1
-        candidates="${candidates}${1}
-"
+    v=$(git show "${ref}:bumpver.toml" 2>/dev/null |
+        sed -n 's/^[[:space:]]*current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' | head -1) || true
+    [ -n "$v" ] && {
+        printf '%s' "$v"
+        return 0
     }
 
-    add_candidate "$(git log -1 --format='%H' --fixed-strings --grep="$bump_prefix" HEAD || true)" || true
-    # Version-sorted, so the first tag that is actually reachable is the newest.
-    for t in $(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true); do
-        if add_candidate "$(git rev-parse -q --verify "refs/tags/${t}^{commit}" || true)"; then
-            break
-        fi
-    done
-    add_candidate "$(git -C "$repo_root" log --diff-filter=A --format='%H' -1 -- "$self_rel" || true)" || true
+    v=$(git show "${ref}:config.xml" 2>/dev/null |
+        sed -n 's/.*<version><!\[CDATA\[\([^]]*\)\]\]><\/version>.*/\1/p' | head -1) || true
+    [ -n "$v" ] && {
+        printf '%s' "$v"
+        return 0
+    }
 
-    # Closest to HEAD wins — fewest commits between it and HEAD.
-    base=""
-    best=""
-    while IFS= read -r c; do
-        [ -n "$c" ] || continue
-        n=$(git rev-list --count "${c}..HEAD")
-        if [ -z "$best" ] || [ "$n" -lt "$best" ]; then
-            best="$n"
-            base="$c"
-        fi
-    done <<EOF
-${candidates}
-EOF
+    v=$(git show "${ref}:twopayment.php" 2>/dev/null |
+        sed -n "s/.*this->version[[:space:]]*=[[:space:]]*'\([^']*\)'.*/\1/p" | head -1) || true
+    [ -n "$v" ] && {
+        printf '%s' "$v"
+        return 0
+    }
 
-    if [ -n "$base" ]; then
-        range="${base}..HEAD"
-    else
-        range="HEAD"
+    return 1
+}
+
+# MAJOR MINOR PATCH out of a version string, ignoring any -TAGNUM suffix.
+split_version() {
+    local v="${1%%-*}"
+    [[ $v =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || return 1
+    printf '%s %s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+}
+
+# `version_compare` semantics: echo the greater of the two versions. Ties echo
+# the first argument, which is why callers pass the head version first - a tie
+# means "the tree already has it" and must not read as a change.
+version_max() {
+    local am ai ap bm bi bp
+    read -r am ai ap <<<"$(split_version "$1")"
+    read -r bm bi bp <<<"$(split_version "$2")"
+    if [ "$am" -ne "$bm" ]; then
+        if [ "$am" -gt "$bm" ]; then printf '%s' "$1"; else printf '%s' "$2"; fi
+        return
     fi
-fi
-
-# --- signal 1: declared major -------------------------------------------------
-declared=0
-declared_reason=""
-next_major_file="${repo_root}/.next-major"
-if [ -f "$next_major_file" ]; then
-    raw=$(head -1 "$next_major_file")
-    declared=$(printf '%s' "$raw" | awk '{print $1}')
-    declared_reason=$(printf '%s' "$raw" | sed 's/^[^[:space:]]*[[:space:]]*//; s/^#[[:space:]]*//')
-    case "$declared" in
-        '' | *[!0-9]*)
-            echo "::error::.next-major must start with the target major version as a bare integer; got '${raw}'" >&2
-            exit 1
-            ;;
-    esac
-    # The failure mode this scheme can still get wrong: a declaration left
-    # behind by a major that has already shipped some other way. Silently
-    # ignoring it would let it rot; regressing to it would be worse. Fail.
-    if [ "$declared" -lt "$current_major" ]; then
-        echo "::error::.next-major declares major ${declared} but the current version is ${current} (major ${current_major}). A declaration below the current major is always stale — delete or raise it." >&2
-        exit 1
+    if [ "$ai" -ne "$bi" ]; then
+        if [ "$ai" -gt "$bi" ]; then printf '%s' "$1"; else printf '%s' "$2"; fi
+        return
     fi
-fi
+    if [ "$ap" -ne "$bp" ]; then
+        if [ "$ap" -gt "$bp" ]; then printf '%s' "$1"; else printf '%s' "$2"; fi
+        return
+    fi
+    printf '%s' "$1"
+}
 
-# --- signal 2: discovered breaking change ------------------------------------
-breaking=0
-breaking_reason=""
+main_version=$(read_version "$main_ref") ||
+    die "could not read a version from ${main_ref} (tried bumpver.toml, config.xml, twopayment.php)"
+head_version=$(read_version "$head_ref") ||
+    die "could not read a version from ${head_ref} (tried bumpver.toml, config.xml, twopayment.php)"
+
+main_parts=$(split_version "$main_version") ||
+    die "unparseable version '${main_version}' on ${main_ref}"
+read -r M_major M_minor M_patch <<<"$main_parts"
+split_version "$head_version" >/dev/null ||
+    die "unparseable version '${head_version}' on ${head_ref}"
+
+# --- classify this PR's commits ----------------------------------------------
+range="${base_ref}..${head_ref}"
 subject_re='^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:'
 footer_re='^BREAKING[ -]CHANGE:'
+feat_re='^([A-Z]+-[0-9]+/)?feat(\([^)]+\))?:'
+
+breaking=0
+breaking_reason=""
+feat=0
+feat_reason=""
 
 while IFS= read -r subject; do
+    [ -n "$subject" ] || continue
     if printf '%s' "$subject" | grep -qE "$subject_re"; then
         breaking=1
         breaking_reason="$subject"
         break
+    fi
+    if [ "$feat" -eq 0 ] && printf '%s' "$subject" | grep -qE "$feat_re"; then
+        feat=1
+        feat_reason="$subject"
     fi
 done < <(git log "$range" --no-merges --format='%s')
 
@@ -169,62 +180,116 @@ if [ "$breaking" -eq 0 ]; then
     fi
 fi
 
-# --- combine ------------------------------------------------------------------
-discovered=$current_major
-[ "$breaking" -eq 1 ] && discovered=$((current_major + 1))
+# --- declared major (`.next-major`) ------------------------------------------
+declared=0
+declared_reason=""
+next_major_file="${repo_root}/.next-major"
+if [ -f "$next_major_file" ]; then
+    raw=$(head -1 "$next_major_file")
+    declared=$(printf '%s' "$raw" | awk '{print $1}')
+    declared_reason=$(printf '%s' "$raw" | sed 's/^[^[:space:]]*[[:space:]]*//; s/^#[[:space:]]*//')
+    case "$declared" in
+        '' | *[!0-9]*)
+            die ".next-major must start with the target major version as a bare integer; got '${raw}'"
+            ;;
+    esac
+    # A declaration that has fallen behind the RELEASED major is always stale -
+    # the major it declared has already shipped some other way. Ignoring it
+    # silently lets it rot; honouring it would regress. Fail.
+    if [ "$declared" -lt "$M_major" ]; then
+        die ".next-major declares major ${declared} but ${main_ref} is at ${main_version} (major ${M_major}). A declaration below the released major is always stale - delete or raise it."
+    fi
+fi
 
-target=$declared
-[ "$discovered" -gt "$target" ] && target=$discovered
+target_major=$declared
+discovered_major=$((M_major + breaking))
+[ "$discovered_major" -gt "$target_major" ] && target_major=$discovered_major
 
-set_version=""
-if [ "$target" -gt "$current_major" ]; then
-    level=major
-    # `--set-version` rather than `--major`: a declaration may skip more than
-    # one major (current 2, declared 4), which `bumpver --major` cannot express.
-    set_version="${target}.0.0"
-    if [ "$declared" -ge "$target" ]; then
+# --- candidate ---------------------------------------------------------------
+if [ "$target_major" -gt "$M_major" ]; then
+    candidate="${target_major}.0.0"
+    if [ "$declared" -ge "$target_major" ]; then
         why="declared .next-major=${declared}"
         [ -n "$declared_reason" ] && why="${why} (${declared_reason})"
     else
-        why="discovered breaking change: ${breaking_reason}"
+        why="breaking change: ${breaking_reason}"
     fi
-elif [ "$branch" = "main" ]; then
-    level=minor
-    why="branch rule: main -> minor"
+elif [ "$feat" -eq 1 ]; then
+    candidate="${M_major}.$((M_minor + 1)).0"
+    why="feature: ${feat_reason}"
 else
-    level=patch
-    why="branch rule: ${branch} -> patch"
+    candidate="${M_major}.${M_minor}.$((M_patch + 1))"
+    why="no feature or breaking commit in this PR -> patch"
 fi
+
+new=$(version_max "$head_version" "$candidate")
+if [ "$new" != "$candidate" ]; then
+    why="${why}; clamped to the version already on the head (${head_version} >= candidate ${candidate})"
+fi
+
+# --- PrestaShop-only: a NEW upgrade script needs a filename of its own -------
+#
+# `--diff-filter=A` against the merge base, so an EDIT to an existing script
+# never triggers this - only a genuinely new file does.
+added_upgrade_scripts=""
+if git rev-parse -q --verify "$base_ref" >/dev/null 2>&1; then
+    added_upgrade_scripts=$(git diff --diff-filter=A --name-only \
+        "${base_ref}...${head_ref}" -- 'upgrade/upgrade-*.php' 2>/dev/null || true)
+fi
+
+if [ -n "$added_upgrade_scripts" ] && [ "$new" = "$head_version" ]; then
+    # ...unless one of the added scripts is ALREADY named for the head version.
+    # That is the converged state: the script has a filename of its own and
+    # forcing again on the next `synchronize` would bump forever.
+    owns_its_filename=0
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        v=${path##*/upgrade-}
+        v=${v%.php}
+        [ "$v" = "$head_version" ] && owns_its_filename=1
+    done <<<"$added_upgrade_scripts"
+
+    if [ "$owns_its_filename" -eq 0 ]; then
+        read -r n_major n_minor n_patch <<<"$(split_version "$new")"
+        new="${n_major}.${n_minor}.$((n_patch + 1))"
+        why="${why}; forced a patch because this PR adds a new upgrade script and PrestaShop discovers upgrade scripts by filename"
+    else
+        why="${why}; the new upgrade script is already named for this version"
+    fi
+fi
+
+changed=false
+[ "$new" != "$head_version" ] && changed=true
 
 reason=$(printf '%s' "$why" | tr '\n' ' ')
 
-# Always log the whole decision, not just the outcome — a stale declaration or
-# an unexpected breaking commit is only visible if the inputs are printed too.
 {
-    echo "----- bump level decision -----"
-    echo "branch          : ${branch}"
-    echo "range           : ${range}"
-    echo "current version : ${current} (major ${current_major})"
+    echo "----- version decision -----"
+    echo "main (${main_ref})     : ${main_version}"
+    echo "head (${head_ref})     : ${head_version}"
+    echo "range                  : ${range}"
     if [ -f "$next_major_file" ]; then
-        echo "declared major  : ${declared}${declared_reason:+  — ${declared_reason}}"
+        echo "declared major         : ${declared}${declared_reason:+  - ${declared_reason}}"
     else
-        echo "declared major  : (no .next-major)"
+        echo "declared major         : (no .next-major)"
     fi
-    echo "breaking commit : ${breaking_reason:-none}"
-    echo "target major    : ${target}"
-    echo "level           : ${level}${set_version:+  -> ${set_version}}"
-    echo "reason          : ${reason}"
-    echo "-------------------------------"
+    echo "breaking commit        : ${breaking_reason:-none}"
+    echo "feature commit         : ${feat_reason:-none}"
+    echo "added upgrade scripts  : $(printf '%s' "${added_upgrade_scripts:-none}" | tr '\n' ' ')"
+    echo "candidate              : ${candidate}"
+    echo "set_version            : ${new}  (changed=${changed})"
+    echo "reason                 : ${reason}"
+    echo "----------------------------"
 } >&2
 
-echo "level=${level}"
-echo "set_version=${set_version}"
+echo "set_version=${new}"
+echo "changed=${changed}"
 echo "reason=${reason}"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
     {
-        echo "level=${level}"
-        echo "set_version=${set_version}"
+        echo "set_version=${new}"
+        echo "changed=${changed}"
         echo "reason=${reason}"
-    } >> "$GITHUB_OUTPUT"
+    } >>"$GITHUB_OUTPUT"
 fi

--- a/.github/scripts/test-decide-bump-level.sh
+++ b/.github/scripts/test-decide-bump-level.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+#
+# Unit tests for decide-bump-level.sh.
+#
+# Each case builds a throwaway git repo with a real `origin/main` and
+# `origin/staging` (as remote-tracking refs, so `git show origin/main:...` and
+# `origin/staging..HEAD` behave exactly as they do in CI), lays the PR's commits
+# on top of staging, runs the script and asserts `set_version` / `changed`.
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/decide-bump-level.sh"
+CHECKER="$(cd "$(dirname "$0")" && pwd)/check-upgrade-script-version.sh"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+
+# write_version <version>  — bumpver.toml as the repos have it
+write_version() {
+    cat >bumpver.toml <<EOF
+[tool.bumpver]
+current_version = "$1"
+version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
+commit_message = "chore: Bump version {old_version} -> {new_version}"
+EOF
+}
+
+# new_repo <name> <main-version> <staging-version> [next-major] [--no-main-bumpver]
+new_repo() {
+    local name=$1 mainv=$2 stagingv=$3 nextmajor=${4:-2} nomain=${5:-}
+    local d="$TMPROOT/$name"
+    mkdir -p "$d"
+    cd "$d" || exit 1
+    git init -q -b main .
+    git config user.email t@t.t
+    git config user.name t
+    git config commit.gpgsign false
+
+    if [ "$nomain" = "--no-main-bumpver" ]; then
+        # PrestaShop's `main`: no bumpver.toml, version only in the module files.
+        cat >config.xml <<EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+    <version><![CDATA[${mainv}]]></version>
+</module>
+EOF
+    else
+        write_version "$mainv"
+    fi
+    [ -n "$nextmajor" ] && echo "$nextmajor  # declared" >.next-major
+    git add -A
+    git commit -qm "chore: initial main at ${mainv}"
+    git update-ref refs/remotes/origin/main HEAD
+
+    # staging carries bumpver.toml in every repo.
+    write_version "$stagingv"
+    git add -A
+    git commit -q --allow-empty -m "chore: Bump version ${mainv} -> ${stagingv}"
+    git update-ref refs/remotes/origin/staging HEAD
+}
+
+# commit <subject> [body]
+commit() {
+    echo "$RANDOM$RANDOM" >>"work-$(date +%s%N).txt"
+    git add -A
+    if [ -n "${2:-}" ]; then
+        git commit -qm "$1" -m "$2"
+    else
+        git commit -qm "$1"
+    fi
+}
+
+# set_head_version <version> — simulates a bump commit already on the PR head
+set_head_version() {
+    write_version "$1"
+    git add -A
+    git commit -qm "chore: Bump version x -> $1"
+}
+
+check() {
+    local label=$1 want_version=$2 want_changed=$3
+    local out
+    out=$("$SCRIPT" 2>/dev/null)
+    local got_v got_c
+    got_v=$(printf '%s\n' "$out" | sed -n 's/^set_version=//p')
+    got_c=$(printf '%s\n' "$out" | sed -n 's/^changed=//p')
+    if [ "$got_v" = "$want_version" ] && [ "$got_c" = "$want_changed" ]; then
+        printf 'PASS  %-58s set_version=%s changed=%s\n' "$label" "$got_v" "$got_c"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL  %-58s want set_version=%s changed=%s / got set_version=%s changed=%s\n' \
+            "$label" "$want_version" "$want_changed" "$got_v" "$got_c"
+        fail=$((fail + 1))
+    fi
+}
+
+check_fails() {
+    local label=$1 want_substr=$2
+    local out rc
+    out=$("$SCRIPT" 2>&1)
+    rc=$?
+    if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qF "$want_substr"; then
+        printf 'PASS  %-58s exit=%s (errored as expected)\n' "$label" "$rc"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL  %-58s wanted non-zero exit mentioning "%s"; got exit=%s: %s\n' \
+            "$label" "$want_substr" "$rc" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+# check_upgrade <label> <expected-version> ok|reject
+check_upgrade() {
+    local label=$1 expected=$2 want=$3
+    local out rc
+    # check-upgrade-script-version.sh only exists in the PrestaShop repo — the
+    # filename-based upgrade mechanism it guards is PrestaShop's alone.
+    if [ ! -x "$CHECKER" ]; then
+        printf 'SKIP  %-58s (no check-upgrade-script-version.sh in this repo)\n' "$label"
+        return 0
+    fi
+    out=$("$CHECKER" "$expected" 2>&1)
+    rc=$?
+    if { [ "$want" = ok ] && [ "$rc" -eq 0 ]; } || { [ "$want" = reject ] && [ "$rc" -ne 0 ]; }; then
+        printf 'PASS  %-58s exit=%s\n' "$label" "$rc"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL  %-58s wanted %s, got exit=%s: %s\n' "$label" "$want" "$rc" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "=============================================================================="
+echo " decide-bump-level.sh — unit tests"
+echo "=============================================================================="
+echo
+
+echo "--- classification (main 2.1.2, staging == main) -----------------------------"
+new_repo cls-fix 2.1.2 2.1.2
+commit "TWO-1/fix: correct the thing"
+check "fix only -> patch" 2.1.3 true
+
+new_repo cls-feat 2.1.2 2.1.2
+commit "TWO-1/feat: add the thing"
+check "feat -> minor" 2.2.0 true
+
+new_repo cls-breaking 2.1.2 2.1.2
+commit "TWO-1/feat!: drop the old thing"
+check "feat! -> major" 3.0.0 true
+
+new_repo cls-footer 2.1.2 2.1.2
+commit "TWO-1/refactor: rework internals" "BREAKING CHANGE: config key renamed"
+check "BREAKING CHANGE footer -> major" 3.0.0 true
+
+new_repo cls-chore 2.1.2 2.1.2
+commit "chore: tidy up"
+commit "docs: rewrite the readme"
+commit "ci: pin an action"
+check "chore/docs/ci only -> patch (NOT minor)" 2.1.3 true
+
+new_repo cls-mixed 2.1.2 2.1.2
+commit "docs: note the flag"
+commit "TWO-1/feat(checkout): new term selector"
+commit "chore: lint"
+check "one feat among chores -> minor" 2.2.0 true
+
+echo
+echo "--- idempotence / no-op re-runs ---------------------------------------------"
+new_repo idem 2.1.2 2.1.2
+commit "TWO-1/fix: correct the thing"
+set_head_version 2.1.3
+check "re-run after its own bump -> no change" 2.1.3 false
+
+new_repo idem2 2.1.2 2.1.2
+commit "TWO-1/fix: first fix"
+set_head_version 2.1.3
+commit "TWO-1/fix: second fix on the same PR"
+check "second fix commit on the same PR -> no change" 2.1.3 false
+
+new_repo fixafterfeat 2.1.2 2.1.2
+commit "TWO-1/feat: new thing"
+set_head_version 2.2.0
+commit "TWO-1/fix: fix the new thing"
+check "fix after feat stays at the minor" 2.2.0 false
+
+new_repo breakafterfeat 2.1.2 2.1.2
+commit "TWO-1/feat: new thing"
+set_head_version 2.2.0
+commit "TWO-1/feat!: and now it breaks"
+check "breaking after feat escalates to major" 3.0.0 true
+
+echo
+echo "--- stale main: the clamp (PrestaShop's real shape) --------------------------"
+new_repo stale 2.5.1 2.7.0
+commit "TWO-1/fix: correct the thing"
+check "stale main 2.5.1 vs staging 2.7.0, fix -> clamp holds at 2.7.0" 2.7.0 false
+
+new_repo stale-feat 2.5.1 2.7.0
+commit "TWO-1/feat: add the thing"
+check "stale main, feat -> candidate 2.6.0 clamped, no regression" 2.7.0 false
+
+new_repo caughtup 2.7.0 2.7.0
+commit "TWO-1/fix: correct the thing"
+check "once main catches up (2.7.0) the patch cadence resumes" 2.7.1 true
+
+new_repo stale-break 2.5.1 2.7.0
+commit "TWO-1/feat!: break the thing"
+check "stale main, breaking -> 3.0.0 beats the clamp" 3.0.0 true
+
+new_repo stale-nomain 2.5.1 2.7.0 2 --no-main-bumpver
+commit "TWO-1/fix: correct the thing"
+check "main has no bumpver.toml (config.xml fallback reads 2.5.1)" 2.7.0 false
+
+echo
+echo "--- .next-major -------------------------------------------------------------"
+new_repo nm-armed 2.1.2 2.1.2 3
+commit "chore: prepare the migration"
+check ".next-major=3 with no breaking commit -> 3.0.0" 3.0.0 true
+
+new_repo nm-disarmed 3.0.1 3.0.1 3
+commit "TWO-1/fix: correct the thing"
+check ".next-major=3 already shipped -> disarms itself" 3.0.2 true
+
+new_repo nm-skip 2.1.2 2.1.2 5
+commit "chore: prepare"
+check ".next-major may skip majors -> 5.0.0" 5.0.0 true
+
+new_repo nm-stale 3.0.1 3.0.1 2
+commit "TWO-1/fix: correct the thing"
+check_fails ".next-major below main's major -> hard error" "always stale"
+
+echo
+echo "--- PrestaShop upgrade-script clause ----------------------------------------"
+# staging already carries upgrade-2.7.0.php, matching its declared 2.7.0. This is
+# the shape the real repo is in.
+seed_ps() {
+    new_repo "$1" 2.5.1 2.7.0
+    mkdir -p upgrade
+    echo "<?php // upgrade" >upgrade/upgrade-2.7.0.php
+    git add -A
+    git commit -qm "chore: seed the existing upgrade script"
+    git update-ref refs/remotes/origin/staging HEAD
+}
+
+seed_ps ps-force
+commit "TWO-1/fix: correct the thing"
+echo "<?php // new migration" >upgrade/upgrade-2.7.1.php
+git add -A
+git commit -qm "TWO-1/fix: migrate the column"
+check "adds a NEW upgrade script, rule says no change -> forced patch" 2.7.1 true
+check_upgrade "  filename matches the computed version -> accepted" 2.7.1 ok
+
+seed_ps ps-converged
+commit "TWO-1/fix: correct the thing"
+echo "<?php // new migration" >upgrade/upgrade-2.7.1.php
+git add -A
+git commit -qm "TWO-1/fix: migrate the column"
+set_head_version 2.7.1
+check "re-run after the forced bump -> no second force" 2.7.1 false
+
+seed_ps ps-edit
+commit "TWO-1/fix: correct the thing"
+echo "<?php // edited in place" >upgrade/upgrade-2.7.0.php
+git add -A
+git commit -qm "TWO-1/fix: tweak the existing migration"
+check "EDITS an existing upgrade script -> no forced bump" 2.7.0 false
+
+seed_ps ps-misnamed
+commit "TWO-1/fix: correct the thing"
+echo "<?php // new migration" >upgrade/upgrade-2.9.9.php
+git add -A
+git commit -qm "TWO-1/fix: migrate the column"
+check "misnamed new script does not steer the version" 2.7.1 true
+check_upgrade "  filename does NOT match -> PR rejected" 2.7.1 reject
+
+seed_ps ps-with-feat
+commit "TWO-1/feat: new capability"
+echo "<?php // new migration" >upgrade/upgrade-2.7.1.php
+git add -A
+git commit -qm "TWO-1/feat: migrate the column"
+check "feat + new script: rule already bumps, no double bump" 2.7.1 true
+
+seed_ps ps-noscript
+commit "TWO-1/fix: correct the thing"
+check_upgrade "  no new upgrade script -> nothing to check" 2.7.1 ok
+
+echo
+echo "--- range hygiene -----------------------------------------------------------"
+# A `feat!:` already merged to staging must NOT be re-discovered by later PRs.
+new_repo range 2.1.2 2.1.2
+commit "TWO-0/feat!: the break that already landed"
+git update-ref refs/remotes/origin/staging HEAD
+commit "chore: unrelated tidy-up"
+check "breaking commit already on staging is not re-discovered" 2.1.3 true
+
+new_repo empty 2.1.2 2.1.2
+check "no commits in range -> still proposes the patch floor" 2.1.3 true
+
+echo
+echo "=============================================================================="
+printf ' %d passed, %d failed\n' "$pass" "$fail"
+echo "=============================================================================="
+[ "$fail" -eq 0 ]

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,91 +1,162 @@
 name: Version bump
 
-# Automates the staging half of the version-bump convention (TWO-25230):
-# patch on merge to `staging`, minor on merge to `main`, major via the
-# escape hatch in .github/scripts/decide-bump-level.sh.
+# Computes the version a pull request should land on `staging` with, and commits
+# it onto the PR's own head branch.
 #
-# `main` is deliberately NOT automated here — this repo has no release
-# workflow at all, and none is being added. Only the staging patch cadence is
-# automated, replacing the hand-run per-PR `make patch` it relied on before.
+# The version now describes the CHANGE, derived from the conventional-commit
+# types of the commits the PR adds, which is what semver actually asks for. The
+# previous scheme bumped by branch rule (patch on `staging`, minor on `main`),
+# so the same change got a different version depending on where it merged. That
+# is not semver, and the number carried no information.
 #
-# The version in this repo is load-bearing beyond cosmetics: PrestaShop runs
-# `upgrade/upgrade-<version>.php` only for versions strictly above the one
-# installed. tests/UpgradeScriptVersionSpec.php gates that relationship, since
-# the version now moves without a human looking at it.
+# Trigger is `pull_request` to `staging` ONLY. In particular:
 #
-# Why `push` and not `workflow_run`: for `push` events GitHub resolves the
-# workflow file from the branch that was pushed, so this is live the moment
-# the PR lands on `staging`. `workflow_run` resolves the workflow from the
-# repository's DEFAULT branch, which is `main` here, so a staging-based
-# change would sit inert until it was promoted.
+#   - NEVER on a `staging -> main` PR. Promotion to `main` does not invent a new
+#     version; it releases the version already in the tree. The `main` side only
+#     tags what is there and cuts the Release.
+#   - No longer on `push:` to `staging`. Bumping after the merge meant the
+#     version that reviewers saw was never the version that shipped, and it also
+#     needed a push to a protected branch (see the token note below).
+#
+# The whole decision lives in .github/scripts/decide-bump-level.sh, which emits
+# an ABSOLUTE `set_version`. It is idempotent by construction (`max()` against
+# the version already on the head), so a re-run, a synchronize triggered by this
+# workflow's own bump commit, or a second fix commit on the same PR all compute
+# the same answer and commit nothing.
+#
+# TOKEN: the org App, not the default GITHUB_TOKEN. Two reasons, both hard
+# requirements rather than preferences:
+#
+#   1. Pushes made with GITHUB_TOKEN do not trigger workflows, so CI would never
+#      re-run on the bump commit and the PR's checks would refer to a SHA that
+#      is no longer the head.
+#   2. The App (id 2603046) holds `bypass_mode: always` on the branch-protection
+#      ruleset in each of these repos.
+#
+# On (2): this scheme also sidesteps the GH013 failure that the old
+# push-to-staging workflow hits, because the bump is now a commit on the PR's
+# own head branch, and `terraform-managed-branch-protection` only targets
+# refs/heads/{main,release,staging}. A feature branch is outside its conditions
+# entirely.
 on:
-  push:
+  pull_request:
     branches: [staging]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
 
+# Never cancel in flight: a cancelled run could be killed between the bump
+# commit and the push.
 concurrency:
-  group: version-bump-${{ github.ref }}
+  group: version-bump-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
+  self-test:
+    # The version arithmetic is unit-tested against throwaway git repos (no
+    # network, no docker, a couple of seconds). It gates the bump below rather
+    # than living in the main CI workflow, so the logic can never write a commit
+    # it cannot pass its own tests on.
+    name: Test the version computation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - run: .github/scripts/test-decide-bump-level.sh
+
   bump:
-    name: Bump version on staging
+    name: Compute version for this PR
+    needs: self-test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip our own bump commit. Strictly belt-and-braces: the push below goes
-    # out under the default GITHUB_TOKEN, and GITHUB_TOKEN pushes do not
-    # trigger workflows, so the loop cannot form in the first place. The guard
-    # stays because that is a property of the token, not of this file, and it
-    # would be an unpleasant way to find out it had changed. The subject must
-    # match `commit_message` in bumpver.toml.
-    # (quoted: the literal `chore: Bump version` contains ": ", which YAML
-    # would otherwise read as a nested mapping)
-    if: "${{ !startsWith(github.event.head_commit.message, 'chore: Bump version') }}"
+    # Fork PRs cannot be pushed to. Nothing here is secret-dependent for a fork
+    # to abuse; it simply has nowhere to write, so skip rather than fail red.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
-          # Check out the branch, not the SHA, so HEAD is on `staging` and
-          # bumpver's commit advances the branch — otherwise the push below
-          # would have nothing to push.
-          ref: staging
-          # Full history: the level decision reads the commit range back to
-          # the last bump / tag, and needs tags present.
-          fetch-depth: 0
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+        with:
+          # The PR's head BRANCH, not the merge ref: the bump commit has to land
+          # on the contributor's branch, so HEAD must be the branch tip and not
+          # a detached merge commit.
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Fetch main and staging
+        # The decision reads the released version off `origin/main` and the PR's
+        # commit range off `origin/staging`. Explicit refspecs because
+        # actions/checkout only guarantees the ref it was asked for.
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/staging:refs/remotes/origin/staging"
+
+      - name: Compute the version
+        id: decide
+        run: .github/scripts/decide-bump-level.sh origin/staging HEAD
+
+      - name: A new upgrade script must be named for this version
+        # PrestaShop finds upgrade scripts BY FILENAME, so a new migration
+        # appended to an already-installed version's script silently never runs
+        # (`number_upgraded=0`, no error, no log line — verified by experiment).
+        # Reject the PR here rather than discover it on a merchant's shop.
+        # Composes with tests/UpgradeScriptVersionSpec.php, which gates the
+        # static side (declared >= highest script, filename agrees with its
+        # function name); this is the part that spec cannot see — the filename
+        # against the version the PR is about to land with.
+        run: .github/scripts/check-upgrade-script-version.sh "${{ steps.decide.outputs.set_version }}" origin/staging HEAD
+
+      - uses: actions/setup-python@v6
+        if: steps.decide.outputs.changed == 'true'
         with:
           python-version: "3.12"
 
       - name: Install bumpver
+        if: steps.decide.outputs.changed == 'true'
         run: pip install bumpver
 
       - name: Configure git identity
+        if: steps.decide.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "two-inc-app[bot]"
+          git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
 
-      - name: Decide bump level
-        id: level
-        run: .github/scripts/decide-bump-level.sh staging
-
-      - name: Bump version (files + commit only)
+      - name: Write the version (files + commit only)
+        if: steps.decide.outputs.changed == 'true'
         env:
-          LEVEL: ${{ steps.level.outputs.level }}
-          SET_VERSION: ${{ steps.level.outputs.set_version }}
+          SET_VERSION: ${{ steps.decide.outputs.set_version }}
         run: |
           set -euo pipefail
-          # --no-tag-commit --no-push override tag/push in bumpver.toml: the
-          # push is done explicitly below, and staging is never tagged — tags
-          # and Releases belong to `main`.
-          if [ -n "$SET_VERSION" ]; then
-            # --set-version rather than --major: a declared `.next-major` may
-            # skip more than one major, which --major cannot express.
-            bumpver update --set-version "$SET_VERSION" --no-tag-commit --no-push
-          else
-            bumpver update "--${LEVEL}" --no-tag-commit --no-push
-          fi
+          # bumpver.toml is the single source of truth for which files carry the
+          # version. --set-version because the script hands over an absolute
+          # version, not a level: no level can express "clamp to the version the
+          # tree already has". --no-tag-commit --no-push because tags belong to
+          # `main` and the push is done explicitly below.
+          bumpver update --set-version "$SET_VERSION" --no-tag-commit --no-push
 
-      - name: Push
-        run: git push origin staging
+      - name: Push onto the PR branch
+        if: steps.decide.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: git push origin "HEAD:refs/heads/${HEAD_REF}"
+
+      - name: Summary
+        env:
+          SET_VERSION: ${{ steps.decide.outputs.set_version }}
+          CHANGED: ${{ steps.decide.outputs.changed }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          if [ "$CHANGED" = "true" ]; then
+            echo "Version set to ${SET_VERSION} — ${REASON}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Version already correct at ${SET_VERSION} — ${REASON}" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,12 @@ For every user-facing string change:
 
 ## Release Consistency Rules
 
-**Do not hand-bump the version for a PR into `staging`.** The patch bump is
-automated (`.github/workflows/version-bump.yml`, TWO-25230) and fires on the
-merge; a manual bump double-bumps. Use `make bump` only when releasing off
-`main`, and let `.github/scripts/decide-bump-level.sh` pick the level.
+**Do not hand-bump the version for a PR into `staging`.** The bump is automated
+(`.github/workflows/version-bump.yml`, TWO-25256): the version is computed from
+this PR's own conventional-commit subjects and committed onto the PR's branch, so
+by review time the tree already declares the version it will ship as. `make bump`
+previews that decision and writes nothing. `main` computes nothing at all - it
+tags the version already in the tree.
 
 When bumping/releasing versions, keep these in sync:
 - `twopayment.php` version
@@ -88,6 +90,17 @@ merchant whose data was never migrated. So:
 - the declared module version must be **at least** the highest `upgrade/` filename
   (equal is the normal case — a script is named for the version it upgrades *to*;
   only a script numbered *above* the declared version is unreachable).
+
+**A new upgrade script must be named for the version the PR lands with.** That is
+why the version computation has a PrestaShop-only clause: a PR that adds a new
+`upgrade/upgrade-<version>.php` forces a patch bump even when nothing else in the
+PR earns one, so the script gets a filename of its own.
+`.github/scripts/check-upgrade-script-version.sh` rejects the PR if an added
+script's filename does not match the computed version. This exists because
+appending a migration to an already-installed version's script was verified by
+experiment to never run at all on a shop that already reached that version
+(`number_upgraded=0`, silent). It composes with the static gate below - do not
+duplicate either in the other.
 
 `tests/UpgradeScriptVersionSpec.php` gates both. The version sequence is
 legitimately **non-contiguous** (2.6.7 was deliberately skipped, and most

--- a/Makefile
+++ b/Makefile
@@ -212,31 +212,20 @@ phpstan:
 # same implicit prerequisite as the sibling plugin repos.
 # tag/push are off in bumpver.toml — this only commits the bump locally.
 #
-# Version-bump convention (TWO-25230): patch on staging, minor on main, major
-# via the escape hatch. The staging half is now automated in
-# .github/workflows/version-bump.yml, so DO NOT hand-run a bump for a PR into
-# staging any more — the workflow fires on the merge and you would double-bump.
+# Version-bump convention (TWO-25256): the version is computed from the
+# conventional-commit types of a PR's own commits and committed onto that PR's
+# branch by .github/workflows/version-bump.yml, so it describes the change
+# rather than the branch it merges into. DO NOT hand-run a bump for a PR into
+# `staging` - CI owns it, and a hand-run one is at best redundant.
 #
-# Prefer `make bump`: it asks .github/scripts/decide-bump-level.sh for the
-# level rather than leaving it to whoever is at the keyboard. The explicit
-# patch/minor/major targets remain for a deliberate override.
+# `make bump` is now a PREVIEW of that decision (it writes nothing). The
+# explicit patch/minor/major targets remain for a deliberate manual override.
 bumpver-%:
 	SKIP=commit-msg bumpver update --$*
 
-## Bump the version at the level the convention says
+## Preview the version this branch's PR will land with (writes nothing)
 bump:
-	@branch="$$(git rev-parse --abbrev-ref HEAD)"; \
-	out="$$(.github/scripts/decide-bump-level.sh "$$branch")"; \
-	level="$$(printf '%s\n' "$$out" | sed -n 's/^level=//p')"; \
-	set_version="$$(printf '%s\n' "$$out" | sed -n 's/^set_version=//p')"; \
-	reason="$$(printf '%s\n' "$$out" | sed -n 's/^reason=//p')"; \
-	if [ -n "$$set_version" ]; then \
-		echo "Convention says major -> $$set_version ($$reason)"; \
-		SKIP=commit-msg bumpver update --set-version "$$set_version"; \
-	else \
-		echo "Convention says $$level ($$reason)"; \
-		SKIP=commit-msg bumpver update --$$level; \
-	fi
+	@.github/scripts/decide-bump-level.sh origin/staging HEAD >/dev/null
 
 ## Bump patch version (prefer `make bump`)
 patch: bumpver-patch

--- a/README.md
+++ b/README.md
@@ -426,16 +426,32 @@ twopayment/
 
 ## Versioning and upgrade scripts
 
-The version-bump level is decided by convention, not by hand:
+The version is computed from the change itself, not from the branch it lands on:
 
-| Change lands on | Level | Who does it                                      |
-| --------------- | ----- | ------------------------------------------------ |
-| `staging`       | patch | Automatic — `.github/workflows/version-bump.yml` |
-| `main`          | minor | Manual — `make bump`                             |
-| either          | major | Escape hatch, see below                          |
+| Change                | What happens                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------- |
+| PR into `staging`     | The version is computed and committed onto the PR's own branch — `.github/workflows/version-bump.yml` |
+| merge into `staging`  | Nothing. The merge brings in the version its PR already computed.                                 |
+| `staging` into `main` | Nothing is computed. `main` tags the version already in the tree and cuts the Release.             |
 
-**Do not hand-run a bump for a PR into `staging`.** It is automated, and a
-manual bump would double-bump when the workflow fires on the merge.
+With `M` the version on `origin/main` and `C` the version on the PR head, the
+PR's own commits (`origin/staging..HEAD`, `--no-merges`) are classified by
+conventional-commit type:
+
+- a `!` on the type (`feat!:`, `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:`
+  footer → `(M.major + 1).0.0`
+- a `feat:` → `M.major.(M.minor + 1).0`
+- anything else — `fix`, and `chore` / `docs` / `ci` / `test` / `refactor`
+  alike → `M.major.M.minor.(M.patch + 1)`
+
+The candidate is then clamped with `max(C, candidate)`. That clamp is what makes
+the whole thing idempotent: a re-run, the `synchronize` event fired by the bump
+commit itself, and a second fix commit on the same PR all compute the same
+answer and write nothing. It also means the version can never regress while
+`main` is behind `staging`.
+
+**Do not hand-run a bump for a PR into `staging`.** CI owns it. `make bump`
+previews the decision and writes nothing.
 
 A major is not chosen by hand either. Two independent signals are considered and
 the higher wins:
@@ -448,13 +464,16 @@ the higher wins:
   This covers a _planned_ major that no single commit happens to mark. It is
   reviewable in the PR that decides it, and it is not cleared afterwards — it
   disarms itself once the major it names has shipped. A `.next-major` naming a
-  major _below_ the current version is a hard failure, not a no-op.
+  major _below the major on `main`_ is a hard failure, not a no-op.
 
-- **Discovered** — a `!` on a conventional-commit type (`feat!:`) or a
-  `BREAKING CHANGE:` footer, in the commits since the last bump.
+- **Discovered** — a `!` on a conventional-commit type or a `BREAKING CHANGE:`
+  footer, in **this PR's own commits** only. Deliberately not the cumulative
+  `main..staging` range: a break that already landed on `staging` must not be
+  re-discovered by every later PR.
 
-`.github/scripts/decide-bump-level.sh` implements all of this and logs its full
-reasoning on every run. It is identical in every Two plugin repository.
+`.github/scripts/decide-bump-level.sh` implements all of this, is unit-tested by
+`.github/scripts/test-decide-bump-level.sh`, and logs its full reasoning on every
+run. It is identical in every Two plugin repository.
 
 ### Why the version is load-bearing here
 


### PR DESCRIPTION
## What

The version is no longer decided by the branch a change merges into. It is computed from the conventional-commit types of the pull request's own commits, on the pull request, and committed onto the PR's own branch.

Reviewer feedback on the previous scheme was that bumping by branch rule (patch on `staging`, minor on `main`) is not semver — the same change got a different version depending on where it landed, and the number said nothing about what changed. That is the objection this fixes.

## The algorithm

With `M` the version on `origin/main` and `C` the version on the PR head, and the PR's own commits classified over `origin/staging..HEAD --no-merges`:

| classification | candidate |
|---|---|
| `!` on the type, or a `BREAKING CHANGE:` footer | `(M.major + 1).0.0` |
| `feat:` | `M.major.(M.minor + 1).0` |
| anything else (`fix`, `chore`, `docs`, `ci`, `test`, `refactor`, …) | `M.major.M.minor.(M.patch + 1)` |

```
new = max(C, candidate)        # version_compare semantics
new == C  ->  no commit
```

Four things in there are deliberate, and each fixes a specific hazard:

1. **This PR's commits only** (`origin/staging..HEAD`), never the cumulative `main..staging`. The cumulative range currently contains `feat!:` commits in several of these repos, so it would re-discover the same break on every PR and keep proposing a major.
2. **The `max()` clamp**, not "bump by one". That makes it idempotent by construction: a re-run, the `synchronize` event fired by its own bump commit, and a second fix commit on the same PR all compute the same answer and write nothing. It also cannot regress, which matters because `main` sits behind `staging` in most of these repos — a raw candidate can compute *below* the version already on `staging`.
3. **Only `feat` earns a minor.** The obvious-looking "minor unless everything is a fix" rule would send a docs-only PR to a minor.
4. **`.next-major` is compared against main's major**, not the head's; a declaration below it is a hard error rather than a silent no-op.

## What changed on `main`

Merges to `main` compute nothing. They tag the version already in the tree and cut the Release. The old bump-on-push-to-`staging` and bump-on-`main` behaviour is removed.

## Token, and the GH013 failure

The push uses the org GitHub App token rather than the default `GITHUB_TOKEN`. Two reasons: a `GITHUB_TOKEN` push fires no workflows, so CI would never re-run on the bump SHA and the PR's checks would refer to a stale head; and the App holds the ruleset bypass.

This shape also sidesteps the `GH013` rejection that currently breaks the bump workflow, because the bump is now a commit on the PR's own head branch, and `terraform-managed-branch-protection` targets only `refs/heads/{main,release,staging}` — a feature branch is outside its conditions entirely.

## PrestaShop-only clause

PrestaShop discovers upgrade scripts **by filename**: it runs `upgrade/upgrade-<version>.php` only for versions strictly above the one installed, and derives the function name from the filename. Appending a second migration to an already-installed version's script therefore never runs on a shop that already reached that version — verified by experiment: `number_upgraded=0`, no error, no log line, no symptom until a merchant's data turns out never to have been migrated.

So: a PR that **adds** a new upgrade script forces a patch bump even when nothing else in it earns one, so the script gets a filename of its own. Editing an **existing** script does not. And `.github/scripts/check-upgrade-script-version.sh` rejects the PR if an added script's filename does not match the version the PR lands with — that check is what actually prevents the failure, rather than trusting the convention.

It composes with `tests/UpgradeScriptVersionSpec.php`, which gates the static half (declared version >= highest script, filename agrees with its `upgrade_module_*` function). Neither duplicates the other.

## Tests

`.github/scripts/test-decide-bump-level.sh` builds throwaway git repos with real `origin/main` / `origin/staging` refs and asserts the computed version: classification (breaking / feat / fix / chore-only / mixed), idempotence (re-run, second fix commit, fix-after-feat, breaking-after-feat), the stale-`main` clamp, `.next-major` armed / disarmed / skipping / stale-and-fatal, and range hygiene (a break already on `staging` is not re-discovered). The version-bump workflow runs those tests before it is allowed to write anything.

## Not to be merged yet

This is up for approval of the approach before any of the six repos merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
