### PR TITLE
fix(i18n): standardise the PO field label on "PO Number" (TWO-25278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The purchase-order field is now called "PO Number" everywhere** (TWO-25278, umbrella TWO-24739, reverses TWO-25271)
+  - The admin toggle said `Show Purchase order number field` and the checkout field said `Purchase order number`, while the Magento plugin's checkout tile said `PO Number`. The same field therefore had two names depending on which plugin, and which pane, a merchant was looking at. All four plugins now use the single phrase `PO Number`
+  - **Why the short phrase rather than the long one**: it leaves no stale translation key behind to maintain, carries no cosmetic-breakage risk for a shop upgrading, and renders better in the field. TWO-25271 had briefly gone the other way, standardising on the longer phrase; that is reversed here
+  - Surfaces: the admin switch label, its help text, and the checkout tile's field label, plus the two README references. The switch keeps the `Show <x> field` pattern shared with the invoice email, project and department switches, which are unchanged
+  - **Display copy only.** `PS_TWO_ENABLE_PO_NUMBER`, the `two_purchase_order_number` input name, the `purchase_order_number` internal key and the `buyer_purchase_order_number` payload field are all untouched, so no stored configuration and no request shape changes
+  - **No migration**, and therefore no new upgrade script: nothing is persisted and no configuration key is added or renamed
+  - `translations/es.php` carries no entry for any of the three changed strings, so no translation is orphaned by the new source hashes. The gap for Spanish predates this change and is unaffected by it
+
 ### Fixed
 - **A buyer surcharge that could not be priced in the cart currency was silently not charged at all** (TWO-25269, umbrella TWO-24739)
   - **This was believed to be safe and was not.** The previous reasoning was that PrestaShop was "already fail-closed because the quote is omitted". Both halves of that were wrong. `hookPaymentOptions()` never consulted the surcharge, the fee quote or FX at all - between the minimum-order gate and the return there was nothing but an unconditional "payment option shown" log. And `applyTwoSurchargeCartLineSync()` treated "quote unavailable" as equivalent to "surcharge deselected", removing the hidden surcharge cart line and returning **success**

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Two is a B2B payment method that lets your business customers pay by invoice wit
    - Enable/disable organization number field requirement
    - Enable/disable the optional buyer reference fields shown in the Two
      payment section at checkout, in this order: invoice email address,
-     purchase order number, project, department (all enabled by default on a
-     fresh install)
+     PO Number, project, department (all enabled by default on a fresh
+     install)
    - Enable/disable Order Intent check (Required for use)
    - Enable/disable account type selection
    - Enable automatic invoice upload to Two
@@ -92,7 +92,7 @@ Two is a B2B payment method that lets your business customers pay by invoice wit
 | Company Name | Require company name field | Enabled |
 | Organization Number | Require organization number | Enabled |
 | Invoice email Field | Show invoice email address field in the Two payment section | Enabled |
-| Purchase order number Field | Show purchase order number field in the Two payment section | Enabled |
+| PO Number Field | Show PO Number field in the Two payment section | Enabled |
 | Project Field | Show project field in the Two payment section | Enabled |
 | Department Field | Show department field in the Two payment section | Enabled |
 | Order Intent | Enable Order Intent check | Enabled |
@@ -110,7 +110,7 @@ used by both the admin switches and the checkout fields so the configuration
 pane reads like the thing it configures:
 
 1. Invoice email address — sent as `invoice_details.invoice_emails`
-2. Purchase order number — sent as `buyer_purchase_order_number`
+2. PO Number — sent as `buyer_purchase_order_number`
 3. Project — sent as `buyer_project`
 4. Department — sent as `buyer_department`
 5. Order note — **PrestaShop core's field, not one of ours** (see below); sent

--- a/twopayment.php
+++ b/twopayment.php
@@ -1208,10 +1208,10 @@ class Twopayment extends PaymentModule
 
         $inputs[] = array(
             'type' => 'switch',
-            'label' => $this->l('Show Purchase order number field'),
+            'label' => $this->l('Show PO Number field'),
             'name' => 'PS_TWO_ENABLE_PO_NUMBER',
             'is_bool' => true,
-            'desc' => $this->l('If you choose YES then customers will see a purchase order number field in the Two payment section at checkout.'),
+            'desc' => $this->l('If you choose YES then customers will see a PO Number field in the Two payment section at checkout.'),
             'required' => true,
             'values' => array(
                 array(
@@ -3597,7 +3597,7 @@ class Twopayment extends PaymentModule
         $labels = array(
             'department' => $this->l('Department'),
             'project' => $this->l('Project'),
-            'purchase_order_number' => $this->l('Purchase order number'),
+            'purchase_order_number' => $this->l('PO Number'),
             'invoice_email' => $this->l('Invoice email address'),
         );
         $placeholders = array(


### PR DESCRIPTION
One phrase for the purchase-order field, **`PO Number`**, on the admin switch and the checkout tile alike. Part of a cross-plugin sweep (TWO-25278) that standardises every plugin on the short phrase, reversing TWO-25271 which had briefly standardised on the longer one.

The short phrase wins because it leaves no stale translation key behind, carries no cosmetic-breakage risk for a shop upgrading, and renders better in the field.

## Surfaces

| location | change |
| -- | -- |
| `twopayment.php` switch | `Show Purchase order number field` → `Show PO Number field` |
| `twopayment.php` switch help text | `…a purchase order number field…` → `…a PO Number field…` |
| `twopayment.php` `getOptionalCheckoutFieldsForDisplay()` | tile field label → `PO Number` |
| `README.md` | both references — optional-features list and field table |
| `CHANGELOG.md` | Unreleased → Changed |

The switch keeps the `Show <x> field` pattern shared with the invoice email, project and department switches, which are untouched.

## Migration

**None, and no new upgrade script.** Nothing is persisted and no configuration key is added or renamed, so the upgrade-script-filename rule does not apply here. The version bump is left to the `Version bump` workflow as usual.

## Translations

`translations/es.php` carries no entry for any of the three changed strings — verified by computing the md5 source hashes of all three and grepping for them, zero hits. So changing their source text orphans nothing. The Spanish gap for these strings predates this change and is unaffected by it.

## Not changed

Display copy only. `PS_TWO_ENABLE_PO_NUMBER`, the `two_purchase_order_number` input name, the `purchase_order_number` internal key and the `buyer_purchase_order_number` payload field are all untouched, so no stored configuration and no request shape changes. `tests/OptionalCheckoutFieldsSpec.php` asserts keys and payload shapes, not labels — confirmed, no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)