### PR TITLE
TWO-25281/fix: remove unwanted invoice-email hint text on the checkout

### DIFF
--- a/twopayment.php
+++ b/twopayment.php
@@ -3603,7 +3603,7 @@ class Twopayment extends PaymentModule
             'department' => '',
             'project' => '',
             'purchase_order_number' => '',
-            'invoice_email' => $this->l('Only for invoices sent by Two'),
+            'invoice_email' => '',
         );
 
         $fields = array();


### PR DESCRIPTION
## Defect

The PrestaShop checkout showed hint text **"Only for invoices sent by Two"** as the placeholder on the invoice-email-address field. It was never asked for and is removed here.

## Change

`twopayment.php`, `getOptionalCheckoutFieldsForDisplay()`: the `$placeholders` entry for `invoice_email` becomes `''`, matching `department`, `project` and `purchase_order_number`, which all already have empty placeholders.

One line. `views/templates/hook/paymentinfo.tpl` already guards the attribute:

```smarty
{if $field.placeholder} placeholder="{$field.placeholder|escape:'html':'UTF-8'}"{/if}
```

so an empty value emits **no** `placeholder` attribute at all rather than an empty one.

## Verification

- The string had no translation entries anywhere under `translations/`, so there is no dead translation copy to remove.
- `tests/OptionalCheckoutFieldsSpec.php` makes no assertion on any placeholder, so nothing needed updating.
- A repo-wide grep for `Only for invoices` now returns nothing.

## No version bump

Display-string only: nothing is persisted, there is no schema or config change and no upgrade script is involved, so the migration-bearing version-bump rule (upgrade scripts discovered by filename, `ps_module.version` being `varchar(8)`) does not apply.

## Related, deliberately not changed

The WooCommerce plugin carries an equivalent placeholder with the product name interpolated into it, plus matching translation-catalogue entries. Left in place — only the PrestaShop instance was flagged. Worth a separate ticket if the copy should be dropped everywhere.

Closes TWO-25281

🤖 Generated with [Claude Code](https://claude.com/claude-code)