### PR TITLE
feat(company-search): show selected company's org number inline, in grey (TWO-25288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **The selected company's registration number is now shown inline, in grey, next to the field** (TWO-25288, umbrella TWO-24739)
+  - Once a search result is chosen, a small grey `<span class="two-company-id-hint">` appears to the right of the company name field showing that company's org number, so the buyer can see which registration the plugin is about to submit without opening dev tools. It reuses this module's existing `#6b7280` muted-grey token (see `.two-info-label`) rather than introducing a second shade of grey
+  - It clears whenever the hidden `companyid` field it mirrors is cleared: an edit to the company name, a country change, a re-selection whose result has no org number yet (e.g. GB, resolved a moment later via the details lookup), or `reset()`. It never drifts from the value that actually gets submitted
+  - This plugin has no separate visible company-id/org-number field to hide — `TwoCompanySearch.js` already writes the org number into a `type="hidden"` input, and no `.tpl` template renders a company-id field to the buyer. So only the additive inline hint was needed here
+  - No template change: inserted and positioned by `views/js/modules/TwoCompanySearch.js` alone. No migration, no configuration key, no database column, no request-shape change
+  - New Jest coverage in `tests/js/company-search-rerender.test.js` (`the inline grey company-id hint (TWO-25288)`)
 - **The company field now says what it wants, before and below the search threshold** (TWO-25288, umbrella TWO-24739)
   - **Empty field**: the placeholder now reads `Enter company name to search` (was `Search your company name`). The placeholder is the one slot an empty field has, so the wording there was replaced rather than joined by a second hint — a message row hanging under a field the buyer has not touched yet is noise, not help
   - **Below the threshold**: the dropdown now shows `Please enter 3 or more characters`. Previously it showed **nothing at all** — the widget simply never opened its menu — which to a buyer is indistinguishable from a search that ran and found no match, and that reads as "my company is not registered here". It is rendered by the same message-row mechanism as the existing "Searching…", "temporarily unavailable" and "select your country" rows, so it is non-selectable, skipped by keyboard navigation, and cannot be written into the field

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -1947,3 +1947,82 @@ describe('the custom fallback used when jQuery UI is absent', () => {
         expect(liveField().hasClass('two-company-search-loading')).toBe(false);
     });
 });
+
+describe('the inline grey company-id hint (TWO-25288)', () => {
+    function hintText() {
+        return $('.two-company-id-hint').text();
+    }
+
+    test('is empty before any selection', () => {
+        makeInstance();
+
+        expect($('.two-company-id-hint').length).toBe(1);
+        expect(hintText()).toBe('');
+    });
+
+    test('shows the selected company\'s org number', () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '12345678' }
+        });
+
+        expect(hintText()).toBe('12345678');
+    });
+
+    test('is cleared by reset()', () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '12345678' }
+        });
+
+        search.reset();
+
+        expect(hintText()).toBe('');
+    });
+
+    test('is cleared when the buyer edits the company name after selecting one', () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '12345678' }
+        });
+
+        // Mirrors clearStaleOrganizationSelection()'s own trigger: an input event
+        // on the company field once a selection marker exists.
+        liveField().val('Example Trading Lt').trigger('input');
+
+        expect(hintText()).toBe('');
+    });
+
+    test('picks up a GB org number that only arrives via the details lookup', async () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', lookup_id: 'lookup-abc-123' }
+        });
+
+        // No organization_number on the search result itself, so the hint must
+        // not claim one yet.
+        expect(hintText()).toBe('');
+
+        ajax.last().succeed({
+            addresses: [{ type: 'BUSINESS', street_address: '1 Example Street' }],
+            national_identifier: { id: '87654321' }
+        });
+        await flushPromises();
+
+        expect(hintText()).toBe('87654321');
+    });
+
+    test('a second, hidden-number selection does not keep the first hint on screen', () => {
+        const search = makeInstance();
+        search.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '12345678' }
+        });
+        expect(hintText()).toBe('12345678');
+
+        search.onCompanySelected(null, {
+            item: { value: 'Second Trading Ltd', lookup_id: 'lookup-def-456' }
+        });
+
+        expect(hintText()).toBe('');
+    });
+});

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -597,6 +597,28 @@
 }
 
 /*
+ * Selected company's organisation number, shown inline next to the company
+ * name field once a search result is chosen (TWO-25288). Reuses the plugin's
+ * existing muted-grey token (see .two-info-label above) rather than a
+ * one-off lighter grey, so it reads consistently with the other inline hints
+ * already in this checkout instead of introducing a second shade of grey.
+ * Positioned absolutely inside whatever field wrapper it lands in - the
+ * companion JS makes that wrapper `position: relative` only if it is
+ * currently static, since the wrapper markup comes from theme/core
+ * PrestaShop templates this plugin does not own.
+ */
+.two-company-id-hint {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6b7280;
+    font-size: 11px;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+/*
  * Payment terms chip selector (TWO-24752). Replaces the previous slider.
  * Structure/behaviour mirrors the Magento (Hyva) and WooCommerce chip
  * selectors; the palette keeps PrestaShop's existing slate accent

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -153,6 +153,7 @@ class TwoCompanySearch {
         }
         
         this.createOrganizationField();
+        this.createCompanyIdHintField();
         this.clearStaleOrganizationSelection();
         this.setupCompanyInputSync();
         this.setupAddressIdentifierSync();
@@ -173,6 +174,45 @@ class TwoCompanySearch {
         }
         
         this.organizationField = orgField;
+    }
+
+    /**
+     * Create or ensure the inline "selected company's org number" hint span
+     * exists next to the company field (TWO-25288). Grey, informational
+     * only - never a form field, never submitted.
+     */
+    createCompanyIdHintField() {
+        let hintField = $('.two-company-id-hint');
+
+        if (hintField.length === 0) {
+            hintField = $('<span class="two-company-id-hint"></span>');
+            this.companyField.after(hintField);
+
+            // The hint is positioned absolutely (see two.css), which needs a
+            // positioned ancestor. The company field's wrapper markup comes
+            // from theme/core PrestaShop templates this plugin does not own,
+            // so only force `relative` when the wrapper is still `static` -
+            // never override a wrapper that already has its own positioning.
+            const wrapper = this.companyField.parent();
+            if (wrapper.length && wrapper.css('position') === 'static') {
+                wrapper.css('position', 'relative');
+            }
+        }
+
+        this.companyIdHintField = hintField;
+    }
+
+    /**
+     * Show or clear the inline org-number hint. Called on selection and on
+     * every path that clears the hidden companyid field, so the two never
+     * drift apart.
+     *
+     * @param {string} [value]
+     */
+    setCompanyIdHint(value) {
+        if (this.companyIdHintField && this.companyIdHintField.length) {
+            this.companyIdHintField.text(value ? String(value) : '');
+        }
     }
 
     normalizeCompanyName(value) {
@@ -216,18 +256,21 @@ class TwoCompanySearch {
         if (!company) {
             this.organizationField.val('');
             this.organizationField.removeAttr('data-two-company-name');
+            this.setCompanyIdHint('');
             return;
         }
 
         // If companyid exists but has no selection marker, treat it as stale after address/form re-renders.
         if (!taggedCompany) {
             this.organizationField.val('');
+            this.setCompanyIdHint('');
             return;
         }
 
         if (this.normalizeCompanyName(company) !== this.normalizeCompanyName(taggedCompany)) {
             this.organizationField.val('');
             this.organizationField.removeAttr('data-two-company-name');
+            this.setCompanyIdHint('');
         }
     }
 
@@ -1303,17 +1346,23 @@ class TwoCompanySearch {
         if (ui.item.organization_number) {
             this.organizationField.val(ui.item.organization_number);
             this.organizationField.attr('data-two-company-name', ui.item.value);
-            
+            this.setCompanyIdHint(ui.item.organization_number);
+
             // Persist for reliability across steps
             this.persistCompanyToCookie({
                 company: ui.item.value,
                 companyid: ui.item.organization_number
             });
-            
+
             // Also sync to the DNI / VAT fields - gated on the address-lookup
             // toggle inside the writer (TWO-25203). Unconditional overwrite so
             // a re-search replaces the previous company's number.
             this.writeOrganizationToAddressIdentifiers(ui.item.organization_number);
+        } else {
+            // No org number on this result (e.g. GB, resolved later via
+            // fetchCompanyDetails/lookup_id) - don't show a stale hint from a
+            // previous selection in the meantime.
+            this.setCompanyIdHint('');
         }
 
         // For some countries (e.g. GB), org number may only be present in company details.
@@ -1390,6 +1439,7 @@ class TwoCompanySearch {
                 if (!currentOrgNumber || currentOrgNumber !== natIdVal) {
                     this.organizationField.val(natIdVal);
                     this.organizationField.attr('data-two-company-name', this.companyField ? this.companyField.val() : '');
+                    this.setCompanyIdHint(natIdVal);
                     this.writeOrganizationToAddressIdentifiers(natIdVal);
                     // Persist to cookie so backend can use it during order placement
                     this.persistCompanyToCookie({
@@ -1509,6 +1559,7 @@ class TwoCompanySearch {
             this.organizationField.val('');
             this.organizationField.removeAttr('data-two-company-name');
         }
+        this.setCompanyIdHint('');
     }
     
     /**
@@ -1574,6 +1625,7 @@ class TwoCompanySearch {
                     this.organizationField.val('');
                     this.organizationField.removeAttr('data-two-company-name');
                 }
+                this.setCompanyIdHint('');
                 // Recreate autocomplete to ensure new country is used immediately
                 this.setupAutocomplete();
             };


### PR DESCRIPTION
## Summary

Item #50 (parented to TWO-25288 / company-search parity, TWO-24739 epic): show the selected company's registration number inline, in grey, next to the company name field.

- This repo has no separate visible company-id field to hide — `TwoCompanySearch.js` already writes the org number into a `type="hidden"` input, and no `.tpl` template renders a company-id field to the buyer. So only the additive inline hint was needed here.
- Adds a small `<span class="two-company-id-hint">` sibling to the company field, populated in `TwoCompanySearch.onCompanySelected()` and cleared everywhere the hidden `companyid` field itself gets cleared (buyer edits the name, country change, `reset()`, and the GB-style path where the number only arrives later via the details lookup).
- Styled with this module's existing `#6b7280` muted-grey token (see `.two-info-label`) rather than a new shade, to stay consistent with the plugin's other inline hints.

## Test plan

- [x] `npm run test:js` (Jest + jsdom, real jQuery UI widget) — all 174 tests pass, including 6 new cases in `tests/js/company-search-rerender.test.js` covering: hint empty before selection, shows org number on selection, cleared by `reset()`, cleared on company-name edit, picked up from the deferred GB details-lookup path, and cleared again on a second selection with no number yet.
- [x] `node --check` on the modified JS module.
- Playwright e2e suite (`tests/e2e`) needs a live merchant backend and was not run; not applicable to this change (no template/markup change, JS-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
