### PR TITLE
feat(company-search): click-to-reveal search box on both PS paths (TWO-25288)

### DIFF
--- a/tests/js/company-search-reveal.test.js
+++ b/tests/js/company-search-reveal.test.js
@@ -1,0 +1,483 @@
+/**
+ * TWO-25288 element 2: click-to-reveal search box.
+ *
+ * Woo/Luma's select2 keeps a `.select2-selection__rendered` chip in front of a
+ * separate `.select2-search__field` the buyer actually types into, so typing
+ * never touches the confirmed name until a result is chosen. PrestaShop's
+ * address form has no such split - `input[name='company']` IS the search box
+ * on both render paths - so the same protection is built here as a covering
+ * chip (`.two-company-search-reveal`) that is shown only while a confirmed
+ * selection exists and stands aside the moment the buyer reopens the search.
+ *
+ * The riskiest part of this build is PrestaShop replacing the address form's
+ * DOM on `updatedAddressForm` for something as ordinary as a country change
+ * (TwoCheckoutManager.handleAddressFormUpdate()) - so the chip, like the
+ * empty-field hint next to it, has to be rebuilt every time setupAutocomplete()
+ * re-runs, not only once at construction.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    buildAddressForm,
+    replaceAddressForm,
+    stubAjax,
+    releaseWidgets
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+const SEARCH_RESPONSE = {
+    items: [{ name: 'Example Trading Ltd', national_identifier: { id: '12345678' } }]
+};
+const OTHER_RESPONSE = {
+    items: [{ name: 'Another Company Ltd', national_identifier: { id: '87654321' } }]
+};
+
+let TwoCompanySearch;
+let $;
+let bus;
+let ajax;
+
+beforeEach(() => {
+    buildAddressForm({ country: 'GB' });
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    bus = loaded.bus;
+    ajax = stubAjax($);
+});
+
+afterEach(() => {
+    releaseWidgets($);
+    ajax.restore();
+    document.body.innerHTML = '';
+    jest.useRealTimers();
+});
+
+function makeInstance(extraConfig) {
+    return new TwoCompanySearch(
+        Object.assign({ checkoutHost: CHECKOUT_HOST }, extraConfig || {})
+    );
+}
+
+function liveField() {
+    return $("input[name='company']");
+}
+
+function chip() {
+    return $('.two-company-search-reveal');
+}
+
+/**
+ * Whether the chip is currently shown. The chip element itself is created
+ * once, on the first setupAutocomplete() call, and toggled with jQuery's
+ * show()/hide() from then on - so "absent" in the buyer's sense means hidden,
+ * not missing from the DOM. jQuery's `:visible` pseudo-selector depends on
+ * layout (offsetWidth/height/getClientRects()), which jsdom does not compute,
+ * so it is unusable here; the inline `display` jQuery's show()/hide() sets is
+ * checked directly instead.
+ */
+function chipVisible() {
+    const el = chip();
+    return el.length > 0 && el.css('display') !== 'none';
+}
+
+/** Search, settle, then pick the first row the way a buyer's click does. */
+function selectFirstResult(term, response) {
+    const field = liveField();
+    const instance = field.autocomplete('instance');
+    field.val(term);
+    instance.search(term);
+    ajax.last().succeed(response);
+    const row = instance.menu.element.children('li').first();
+    instance.menu.focus(null, row);
+    instance.menu.select($.Event('click'));
+    return field;
+}
+
+/**
+ * Pre-seed the address form with a confirmed pair, as if the server had
+ * round-tripped a previous selection - the same construction the rerender
+ * suite's stale-organisation tests use, reused here because a genuine
+ * re-render carries this forward while `replaceAddressForm()` alone does not.
+ */
+function seedConfirmedPair(company, companyid) {
+    const form = document.querySelector('form');
+    form.querySelector("input[name='company']").value = company;
+    const hidden = document.createElement('input');
+    hidden.type = 'hidden';
+    hidden.name = 'companyid';
+    hidden.value = companyid;
+    hidden.setAttribute('data-two-company-name', company);
+    form.appendChild(hidden);
+}
+
+describe('the chip is shown only for a confirmed selection', () => {
+    test('absent when nothing has been searched for', () => {
+        makeInstance();
+        expect(chipVisible()).toBe(false);
+    });
+
+    test('appears once a real selection lands, showing the picked name', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        expect(chipVisible()).toBe(true);
+        expect(chip().text()).toBe('Example Trading Ltd');
+    });
+
+    test('it is a real, focusable, accessibly-labelled button', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        expect(chip().prop('tagName')).toBe('BUTTON');
+        expect(chip().attr('type')).toBe('button');
+        expect(chip().attr('aria-label')).toContain('Example Trading Ltd');
+    });
+
+    test('covers the field and takes it out of the tab order', () => {
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        expect(field.attr('tabindex')).toBe('-1');
+    });
+
+    test('a selection carrying no organisation number (deferred GB lookup) shows no chip yet', () => {
+        makeInstance();
+        selectFirstResult('exa', {
+            items: [{ name: 'Example Trading Ltd', lookup_id: 'lookup-abc' }]
+        });
+
+        // No organisation number landed with the pick itself, so there is
+        // nothing confirmed to protect until fetchCompanyDetails() resolves.
+        expect(chipVisible()).toBe(false);
+    });
+
+    test('manual entry never shows a chip over free-typed text', () => {
+        const instance = makeInstance();
+        const field = liveField();
+        field.val('exa');
+        field.autocomplete('instance').search('exa');
+        ajax.last().succeed(SEARCH_RESPONSE);
+
+        field.autocomplete('option', 'select')(null, { item: instance.buildManualEntryItem() });
+        field.val('My Own Trading Name');
+        field.trigger('input');
+
+        expect(chipVisible()).toBe(false);
+    });
+});
+
+describe('clicking the chip reveals a fresh search box', () => {
+    test('blanks the field, focuses it, and hides the chip', () => {
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+
+        expect(field.val()).toBe('');
+        expect(document.activeElement).toBe(field.get(0));
+        expect(chipVisible()).toBe(false);
+        expect(field.attr('tabindex')).toBeUndefined();
+    });
+
+    test('typing into the revealed field does not touch the covered name until a pick is made', () => {
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        field.val('Ano');
+        field.trigger('input');
+        field.autocomplete('instance').search('Ano');
+
+        // The buyer is mid-search; the confirmed name from before is gone from
+        // the visible field (by design - see the module's own reasoning) but
+        // has not been overwritten by keystrokes landing on top of it, and
+        // nothing has been submitted as a new company yet.
+        expect(field.val()).toBe('Ano');
+        expect($("input[name='companyid']").val()).toBe('');
+    });
+
+    test('the search still works normally once revealed', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        const field = liveField();
+
+        chip().trigger('click');
+        const picked = selectFirstResult('ano', OTHER_RESPONSE);
+
+        expect(picked.val()).toBe('Another Company Ltd');
+        expect($("input[name='companyid']").val()).toBe('87654321');
+        expect(chip().text()).toBe('Another Company Ltd');
+        expect(chipVisible()).toBe(true);
+        expect(field.attr('tabindex')).toBe('-1');
+    });
+});
+
+describe('abandoning a revealed search restores what it covered', () => {
+    test('blurring with nothing picked puts the name AND the organisation number back', () => {
+        jest.useFakeTimers();
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        field.val('some other typing');
+        field.trigger('blur');
+
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('Example Trading Ltd');
+        expect($("input[name='companyid']").val()).toBe('12345678');
+        expect($("input[name='companyid']").attr('data-two-company-name')).toBe(
+            'Example Trading Ltd'
+        );
+        expect(chipVisible()).toBe(true);
+        expect(chip().text()).toBe('Example Trading Ltd');
+        expect(field.attr('tabindex')).toBe('-1');
+    });
+
+    test('typing alone (before the threshold) already cleared the tag - blur restore still recovers it', () => {
+        // Regression guard for the exact hazard the module documents at length
+        // elsewhere: clearStaleOrganizationSelection() fires on the very first
+        // keystroke into the revealed (now-empty) field and clears the hidden
+        // organisation number and its tag well before any blur happens. The
+        // snapshot revealSearch() took has to be what puts both back - reading
+        // the live (already-cleared) fields at blur time would restore the
+        // name with nothing behind it.
+        jest.useFakeTimers();
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        field.val('x');
+        field.trigger('input');
+        expect($("input[name='companyid']").val()).toBe('');
+
+        field.trigger('blur');
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('Example Trading Ltd');
+        expect($("input[name='companyid']").val()).toBe('12345678');
+    });
+
+    test('a pick before the blur timer elapses wins - the stale timer does not clobber it', () => {
+        jest.useFakeTimers();
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        const field = liveField();
+
+        chip().trigger('click');
+        field.trigger('blur');
+        // The pick lands inside the same 200ms window as the pending restore.
+        const instance = field.autocomplete('instance');
+        field.val('ano');
+        instance.search('ano');
+        ajax.last().succeed(OTHER_RESPONSE);
+        const row = instance.menu.element.children('li').first();
+        instance.menu.focus(null, row);
+        instance.menu.select($.Event('click'));
+
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('Another Company Ltd');
+        expect($("input[name='companyid']").val()).toBe('87654321');
+    });
+
+    test('entering manual entry mid-reveal disarms the restore instead of fighting it later', () => {
+        jest.useFakeTimers();
+        const instance = makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        instance.enterManualEntryMode();
+        field.val('My Own Trading Name');
+
+        jest.advanceTimersByTime(250);
+
+        // The buyer's own manual entry must survive - not be silently
+        // overwritten by a restore that belongs to a different escape path.
+        expect(field.val()).toBe('My Own Trading Name');
+        expect(chipVisible()).toBe(false);
+    });
+});
+
+describe('the chip survives PrestaShop replacing the address form', () => {
+    test('a fresh instance on the re-rendered DOM shows the chip again, bound to the new field', () => {
+        makeInstance();
+        const first = selectFirstResult('exa', SEARCH_RESPONSE);
+        const firstChip = chip().get(0);
+        expect(chipVisible()).toBe(true);
+
+        // PrestaShop re-renders from server state, which carries the confirmed
+        // pair forward - unlike a bare DOM wipe, this is what a real
+        // `updatedAddressForm` looks like for an already-selected company.
+        replaceAddressForm({ country: 'GB' });
+        seedConfirmedPair('Example Trading Ltd', '12345678');
+        // The old form (and its chip) is gone with it.
+        expect(chip()).toHaveLength(0);
+        expect(liveField().get(0)).not.toBe(first.get(0));
+
+        // The instance's own `updatedAddressForm` handler re-runs
+        // setupAutocomplete() against whatever field is live now.
+        bus.emit('updatedAddressForm');
+
+        expect(chipVisible()).toBe(true);
+        expect(chip().get(0)).not.toBe(firstChip);
+        expect(chip().text()).toBe('Example Trading Ltd');
+        expect(liveField().attr('tabindex')).toBe('-1');
+    });
+
+    test('clicking the chip on the re-rendered field still reveals a working search', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        replaceAddressForm({ country: 'GB' });
+        seedConfirmedPair('Example Trading Ltd', '12345678');
+        bus.emit('updatedAddressForm');
+
+        chip().trigger('click');
+        const field = liveField();
+
+        expect(field.val()).toBe('');
+        expect(document.activeElement).toBe(field.get(0));
+
+        field.val('ano');
+        field.autocomplete('instance').search('ano');
+        ajax.last().succeed(OTHER_RESPONSE);
+        const row = field.autocomplete('instance').menu.element.children('li').first();
+        field.autocomplete('instance').menu.focus(null, row);
+        field.autocomplete('instance').menu.select($.Event('click'));
+
+        expect(field.val()).toBe('Another Company Ltd');
+        expect(chip().text()).toBe('Another Company Ltd');
+    });
+
+    test('a re-render with no persisted selection leaves the chip absent, not stale', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        expect(chipVisible()).toBe(true);
+
+        // Ordinary re-render with nothing carried forward (e.g. the buyer had
+        // not selected anything yet on a fresh address).
+        replaceAddressForm({ country: 'GB' });
+        bus.emit('updatedAddressForm');
+
+        expect(chipVisible()).toBe(false);
+    });
+});
+
+describe('the same chip works on the custom fallback path (jQuery UI absent)', () => {
+    let savedUi;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        savedUi = $.ui;
+        // A theme can ship jQuery without jQuery UI, or load it late - both
+        // take this path. Path B has to get its own reveal chip built by
+        // hand, same as the jQuery UI path.
+        $.ui = undefined;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        $.ui = savedUi;
+    });
+
+    /** Type into the field and let the 300ms debounce elapse. */
+    function type(term) {
+        const input = document.querySelector("input[name='company']");
+        input.value = term;
+        input.dispatchEvent(new window.Event('input'));
+        jest.advanceTimersByTime(300);
+        return input;
+    }
+
+    /** A real company row, excluding the manual-entry/message footer rows. */
+    function firstCompanyRow() {
+        return $('.two-autocomplete-item')
+            .not('.two-autocomplete-manual-entry, .two-autocomplete-message')
+            .first();
+    }
+
+    function selectFirstResultFallback(term, response) {
+        type(term);
+        ajax.last().succeed(response);
+        firstCompanyRow().get(0).dispatchEvent(
+            new window.MouseEvent('mousedown', { bubbles: true, cancelable: true })
+        );
+        return liveField();
+    }
+
+    test('bootstrapped-guard: this is genuinely the fallback path', () => {
+        makeInstance();
+        expect(liveField().hasClass('ui-autocomplete-input')).toBe(false);
+        expect(chipVisible()).toBe(false);
+    });
+
+    test('the chip appears after a selection and shows the picked name', () => {
+        makeInstance();
+        const field = selectFirstResultFallback('exa', SEARCH_RESPONSE);
+
+        expect(field.val()).toBe('Example Trading Ltd');
+        expect(chipVisible()).toBe(true);
+        expect(chip().text()).toBe('Example Trading Ltd');
+        expect(field.attr('tabindex')).toBe('-1');
+    });
+
+    test('clicking the chip reveals a blank field the buyer can search again from', () => {
+        makeInstance();
+        const field = selectFirstResultFallback('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+
+        expect(field.val()).toBe('');
+        expect(document.activeElement).toBe(field.get(0));
+        expect(chipVisible()).toBe(false);
+
+        const picked = selectFirstResultFallback('ano', OTHER_RESPONSE);
+        expect(picked.val()).toBe('Another Company Ltd');
+        expect(chip().text()).toBe('Another Company Ltd');
+    });
+
+    test('abandoning a revealed search on this path restores the covered pair too', () => {
+        makeInstance();
+        const field = selectFirstResultFallback('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        field.val('some other typing');
+        field.trigger('input');
+        field.trigger('blur');
+
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('Example Trading Ltd');
+        expect($("input[name='companyid']").val()).toBe('12345678');
+    });
+});
+
+describe('teardown', () => {
+    test('destroy() removes the chip and its click handler', () => {
+        const instance = makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        expect(chip()).toHaveLength(1);
+
+        instance.destroy();
+
+        expect(chip()).toHaveLength(0);
+    });
+
+    test('a second instance on the same field does not leave two chips behind', () => {
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        expect(chip()).toHaveLength(1);
+
+        const second = makeInstance();
+        second.companyField.val('Example Trading Ltd');
+        second.organizationField.val('12345678');
+        second.organizationField.attr('data-two-company-name', 'Example Trading Ltd');
+        second.updateRevealChip();
+
+        expect(chip()).toHaveLength(1);
+    });
+});

--- a/tests/js/company-search-reveal.test.js
+++ b/tests/js/company-search-reveal.test.js
@@ -481,6 +481,67 @@ describe('regressions found in adversarial review', () => {
         expect(chipVisible()).toBe(false);
     });
 
+    test('a same-instance updatedAddressForm re-render while revealed disarms the pending restore too', () => {
+        // setupAutocomplete() re-resolves `this.companyField` to whatever
+        // field is live now - a `document.contains()` check alone cannot
+        // tell "detached" from "reassigned to a DIFFERENT, still-live field",
+        // so the reveal has to be disarmed explicitly before this handler
+        // calls setupAutocomplete(), the same way the country-select
+        // handler already is.
+        jest.useFakeTimers();
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        liveField().trigger('blur');
+
+        // PrestaShop re-renders the form (e.g. for an unrelated reason) while
+        // the 200ms restore is still pending, on this SAME instance.
+        replaceAddressForm({ country: 'GB' });
+        bus.emit('updatedAddressForm');
+
+        jest.advanceTimersByTime(250);
+
+        // The new, freshly-rendered field must not be silently overwritten
+        // with the OLD company that was open for search on the OLD field.
+        // (replaceAddressForm() builds a fresh form with no `companyid`
+        // hidden input at all until init() recreates one - a full
+        // getModel-and-recreate-instance re-render would carry that field
+        // forward the same way `seedConfirmedPair()` simulates elsewhere in
+        // this file; this lightweight same-instance path just needs to prove
+        // nothing got WRITTEN into whatever is there.)
+        expect(liveField().val()).toBe('');
+        expect($("input[name='companyid']").val() || '').toBe('');
+        expect(chipVisible()).toBe(false);
+    });
+
+    test('a deferred lookup does not overwrite the address fields either, once the buyer has moved on', async () => {
+        // The same stale-lookup hazard the organisation-number guard closes
+        // also applies to the address autofill the same response can carry -
+        // both must be gated by the same "still on the same company" check.
+        makeInstance();
+        selectFirstResult('exa', {
+            items: [{ name: 'Example Trading Ltd', lookup_id: 'lookup-abc' }]
+        });
+
+        const field = liveField();
+        field.val('Something Else Entirely');
+        field.trigger('input');
+
+        ajax.last().succeed({
+            national_identifier: { id: '87654321' },
+            addresses: [
+                { type: 'BUSINESS', street_address: '1 Example Street', postal_code: 'EX1 1EX', city: 'Exampleton' }
+            ]
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect($("input[name='address1']").val()).toBe('');
+        expect($("input[name='postcode']").val()).toBe('');
+        expect($("input[name='city']").val()).toBe('');
+    });
+
     test('a deferred (GB-style) organisation number is not adopted if the buyer has since typed a different search', async () => {
         // fetchCompanyDetails() resolves after a real network round trip;
         // adopting it blindly would tag whatever the buyer is NOW typing with
@@ -519,41 +580,30 @@ describe('regressions found in adversarial review', () => {
         expect(field.attr('aria-hidden')).toBeUndefined();
     });
 
-    test('two live company fields on the page each get their own chip, not one adopted from the other', () => {
-        // Simulates separate invoice/delivery address forms, each with its
-        // own input[name='company'] - createRevealChip()/removeRevealChip()
-        // must scope to THIS instance's own field, not a document-wide class
-        // lookup, or a second instance silently adopts the first's chip.
-        document.body.innerHTML = document.body.innerHTML.replace(
-            '</form>\n</div>',
-            '</form>\n</div><div class="js-address-form"><form><input type=\'text\' name=\'company2\' value=\'\' /></form></div>'
-        );
-        // Re-point the second form's field to the same selector this module
-        // reads, by giving the harness's makeInstance() a distinct selector.
-        const second = new TwoCompanySearch({
-            checkoutHost: CHECKOUT_HOST,
-            companyFieldSelector: "input[name='company2']"
-        });
-        makeInstance();
-        selectFirstResult('exa', SEARCH_RESPONSE);
-
-        second.companyField.val('Another Company Ltd');
-        second.organizationField.val('87654321');
-        second.organizationField.attr('data-two-company-name', 'Another Company Ltd');
-        second.updateRevealChip();
-
-        expect(chip()).toHaveLength(2);
-        expect(second.companyField.siblings('.two-company-search-reveal')).toHaveLength(1);
-        expect(liveField().siblings('.two-company-search-reveal')).toHaveLength(1);
-        expect(second.companyField.siblings('.two-company-search-reveal').get(0))
-            .not.toBe(liveField().siblings('.two-company-search-reveal').get(0));
-
-        second.destroy();
-
-        // The other field's chip must survive the second instance's teardown.
-        expect(chip()).toHaveLength(1);
-        expect(chipVisible()).toBe(true);
-    });
+    // NOTE on chip scoping: createRevealChip()/removeRevealChip() look up
+    // the chip via `this.companyField.siblings(...)` rather than a
+    // document-wide class selector, which is a strict improvement over a
+    // global lookup and is exercised by "a second instance on the same
+    // field does not leave two chips behind" below. An earlier version of
+    // this suite additionally claimed this fully solves "two independent
+    // company fields on the page at once" (e.g. separate invoice/delivery
+    // address forms), constructed via two TwoCompanySearch instances with
+    // hand-picked, distinct `companyFieldSelector` values. Adversarial
+    // review (round 2) correctly identified that as testing an architecture
+    // that does not exist in production: TwoCheckoutManager.initializeCompanySearch()
+    // is a page-wide SINGLETON that always uses the default
+    // `input[name='company']` selector, so if PrestaShop core ever renders
+    // two such inputs simultaneously, this class holds ONE instance whose
+    // `this.companyField` jQuery collection matches BOTH nodes - a
+    // pre-existing assumption throughout this whole file (organizationField,
+    // companyIdHintField, etc. are all resolved the same unscoped way, none
+    // of it introduced by TWO-25288 element 2), not something the chip
+    // scoping change touches or claims to fix. That test was removed rather
+    // than kept as false assurance; whether PrestaShop core can genuinely
+    // render two live company fields on one page is an open question for a
+    // separate ticket, not this one. The single-field case this scoping
+    // change DOES cover is exercised in the "teardown" block below ("a
+    // second instance on the same field does not leave two chips behind").
 });
 
 describe('teardown', () => {

--- a/tests/js/company-search-reveal.test.js
+++ b/tests/js/company-search-reveal.test.js
@@ -456,6 +456,106 @@ describe('the same chip works on the custom fallback path (jQuery UI absent)', (
     });
 });
 
+describe('regressions found in adversarial review', () => {
+    test('a country change while revealed disarms the pending restore instead of resurrecting a stale pairing', () => {
+        // The country <select>'s own change handler runs on this SAME
+        // instance (unlike a genuine updatedAddressForm re-render, which
+        // destroy()s and replaces it) - so a reveal opened just before a
+        // country change must not leave its blur-restore timer armed against
+        // a snapshot captured under the PREVIOUS country.
+        jest.useFakeTimers();
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        chip().trigger('click');
+        liveField().trigger('blur');
+        // The country change happens inside the same window as the pending
+        // 200ms restore.
+        document.querySelector("select[name='id_country']").dispatchEvent(new window.Event('change'));
+
+        jest.advanceTimersByTime(250);
+
+        // Not the OLD company's pairing coming back from under the buyer.
+        expect(liveField().val()).toBe('');
+        expect($("input[name='companyid']").val()).toBe('');
+        expect(chipVisible()).toBe(false);
+    });
+
+    test('a deferred (GB-style) organisation number is not adopted if the buyer has since typed a different search', async () => {
+        // fetchCompanyDetails() resolves after a real network round trip;
+        // adopting it blindly would tag whatever the buyer is NOW typing with
+        // a different company's organisation number, and - since that tag is
+        // what hasConfirmedSelection() reads - cover the field they are
+        // actively using with the chip and pull it out of the tab order.
+        makeInstance();
+        selectFirstResult('exa', {
+            items: [{ name: 'Example Trading Ltd', lookup_id: 'lookup-abc' }]
+        });
+        expect(chipVisible()).toBe(false);
+
+        // The buyer moves on before the lookup resolves.
+        const field = liveField();
+        field.val('Something Else Entirely');
+        field.trigger('input');
+
+        ajax.last().succeed({ national_identifier: { id: '87654321' } });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect($("input[name='companyid']").val()).toBe('');
+        expect($("input[name='companyid']").attr('data-two-company-name')).toBeUndefined();
+        expect(chipVisible()).toBe(false);
+        expect(field.attr('tabindex')).toBeUndefined();
+        expect(field.val()).toBe('Something Else Entirely');
+    });
+
+    test('the covered field is aria-hidden while the chip shows it, and un-hidden once revealed', () => {
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+        expect(field.attr('aria-hidden')).toBe('true');
+
+        chip().trigger('click');
+
+        expect(field.attr('aria-hidden')).toBeUndefined();
+    });
+
+    test('two live company fields on the page each get their own chip, not one adopted from the other', () => {
+        // Simulates separate invoice/delivery address forms, each with its
+        // own input[name='company'] - createRevealChip()/removeRevealChip()
+        // must scope to THIS instance's own field, not a document-wide class
+        // lookup, or a second instance silently adopts the first's chip.
+        document.body.innerHTML = document.body.innerHTML.replace(
+            '</form>\n</div>',
+            '</form>\n</div><div class="js-address-form"><form><input type=\'text\' name=\'company2\' value=\'\' /></form></div>'
+        );
+        // Re-point the second form's field to the same selector this module
+        // reads, by giving the harness's makeInstance() a distinct selector.
+        const second = new TwoCompanySearch({
+            checkoutHost: CHECKOUT_HOST,
+            companyFieldSelector: "input[name='company2']"
+        });
+        makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        second.companyField.val('Another Company Ltd');
+        second.organizationField.val('87654321');
+        second.organizationField.attr('data-two-company-name', 'Another Company Ltd');
+        second.updateRevealChip();
+
+        expect(chip()).toHaveLength(2);
+        expect(second.companyField.siblings('.two-company-search-reveal')).toHaveLength(1);
+        expect(liveField().siblings('.two-company-search-reveal')).toHaveLength(1);
+        expect(second.companyField.siblings('.two-company-search-reveal').get(0))
+            .not.toBe(liveField().siblings('.two-company-search-reveal').get(0));
+
+        second.destroy();
+
+        // The other field's chip must survive the second instance's teardown.
+        expect(chip()).toHaveLength(1);
+        expect(chipVisible()).toBe(true);
+    });
+});
+
 describe('teardown', () => {
     test('destroy() removes the chip and its click handler', () => {
         const instance = makeInstance();

--- a/twopayment.php
+++ b/twopayment.php
@@ -3349,6 +3349,10 @@ class Twopayment extends PaymentModule
             // do not paraphrase either of these when translating.
             'company_search_manual_entry' => $this->l('My company is not on the list'),
             'company_search_back_to_search' => $this->l('Search for company'),
+            // Click-to-reveal chip (TWO-25288 element 2). Its visible text is
+            // the confirmed company name itself; this is the accessible name
+            // for the control, read instead of/alongside that text.
+            'company_search_edit' => $this->l('Search for a different company'),
             'sole_trader_registered_business' => $this->l('Registered business'),
             'sole_trader_label' => $this->l('Sole trader'),
         );

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1331,10 +1331,20 @@
     white-space: nowrap;
 }
 
-.two-company-search-reveal:hover,
-.two-company-search-reveal:focus {
+.two-company-search-reveal:hover {
     border-color: #999;
-    outline: none;
+}
+
+/*
+ * A real focus outline, not `outline: none` - this is now the sole way to
+ * reopen the search, so a keyboard user has to be able to see where they
+ * are. Same treatment as .two-autocomplete-manual-entry:focus above, for the
+ * same reason: an interactive control with no visible focus state is worse
+ * than no keyboard support at all.
+ */
+.two-company-search-reveal:focus {
+    outline: 2px solid #1976d2;
+    outline-offset: -2px;
 }
 
 /* Clean up unused styles */

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1302,6 +1302,41 @@
     cursor: pointer;
 }
 
+/*
+ * Click-to-reveal chip (TWO-25288 element 2). A sibling <button> absolutely
+ * positioned over the company field, standing in for select2's
+ * `.select2-selection__rendered` on the one surface where the address form's
+ * own input doubles as the search box. Shown only while a confirmed
+ * selection exists (see hasConfirmedSelection() in the companion JS), so
+ * typing into a freshly-revealed field never overwrites the name it was
+ * covering until a result is actually chosen.
+ */
+.two-company-search-reveal {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 6px 12px;
+    text-align: left;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    z-index: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.two-company-search-reveal:hover,
+.two-company-search-reveal:focus {
+    border-color: #999;
+    outline: none;
+}
+
 /* Clean up unused styles */
 .two-payment-loading,
 .payment-option img[src*="TwoLogo.svg"],

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -281,18 +281,20 @@ class TwoCompanySearch {
      * exactly the failure mode applyEmptyFieldHint() next to it already
      * guards against.
      *
-     * Checked by class name rather than by this instance's own reference, for
-     * the same reason removeBackToSearchLink() sweeps the whole document: a
-     * destroyed instance's chip is removed by destroy() below, but a second
-     * one existing alongside the live chip would be worse than a stale
-     * reference to a single one.
+     * Checked among this field's OWN siblings, not by a document-wide class
+     * lookup - unlike the passive org-id hint and the manual-entry reverse
+     * link, this chip is a focus-stealing, absolutely-positioned control, and
+     * PrestaShop can render more than one `input[name='company']` on the
+     * page at once (separate invoice/delivery address forms). A global
+     * lookup would let a second instance silently adopt the first instance's
+     * chip and cover the wrong field with it.
      */
     createRevealChip() {
         if (!this.companyField || !this.companyField.length) {
             return;
         }
 
-        let chip = $('.two-company-search-reveal');
+        let chip = this.companyField.siblings('.two-company-search-reveal').first();
         if (chip.length === 0) {
             chip = $('<button type="button" class="two-company-search-reveal"></button>');
             this.companyField.after(chip);
@@ -312,10 +314,15 @@ class TwoCompanySearch {
     }
 
     /**
-     * Remove the chip and unbind it. Sweeps every `.two-company-search-reveal`
-     * in the document, not only this instance's own reference, matching
-     * removeBackToSearchLink() next to it - a chip orphaned by a previous,
-     * destroyed instance must not sit alongside a fresh one.
+     * Remove the chip and unbind it.
+     *
+     * Also sweeps any `.two-company-search-reveal` orphaned among THIS
+     * field's own siblings (a previous, destroyed instance's chip on the
+     * SAME field) - the single-field case removeBackToSearchLink() guards
+     * against with a document-wide sweep. Deliberately scoped here rather
+     * than copying that global sweep: with more than one live company field
+     * on the page (see createRevealChip()), a global remove would delete
+     * another instance's still-in-use chip out from under it.
      */
     removeRevealChip() {
         if (this._revealChip) {
@@ -323,7 +330,9 @@ class TwoCompanySearch {
             this._revealChip.remove();
             this._revealChip = null;
         }
-        $('.two-company-search-reveal').off('.twoReveal').remove();
+        if (this.companyField && this.companyField.length) {
+            this.companyField.siblings('.two-company-search-reveal').off('.twoReveal').remove();
+        }
     }
 
     /**
@@ -348,16 +357,28 @@ class TwoCompanySearch {
         if (this._revealed || this._manualEntry || !this.hasConfirmedSelection()) {
             this._revealChip.hide().text('');
             if (this.companyField && this.companyField.length) {
-                this.companyField.removeAttr('tabindex');
+                // `tabindex="-1"` alone only removes the input from Tab
+                // order - it stays in the accessibility tree, so a screen
+                // reader jumping between form fields by their own shortcut
+                // (not Tab) would still land directly on a plain, editable
+                // text box holding the confirmed name, with no indication a
+                // button covers it. `aria-hidden` closes that gap; both are
+                // undone together here.
+                this.companyField.removeAttr('tabindex').removeAttr('aria-hidden');
             }
             return;
         }
+        // Trimmed for display, not the raw value: hasConfirmedSelection()
+        // compares through normalizeCompanyName(), which also trims, so a
+        // value like "  Example Trading Ltd  " can be confirmed while showing (and
+        // having read aloud) its own leading/trailing whitespace verbatim.
+        const displayName = String(this.companyField.val() || '').trim();
         this._revealChip
-            .text(this.companyField.val())
-            .attr('title', this.getEditCompanyText())
-            .attr('aria-label', this.getEditCompanyText() + ': ' + this.companyField.val())
+            .text(displayName)
+            .attr('title', this.getEditCompanyText() + ': ' + displayName)
+            .attr('aria-label', this.getEditCompanyText() + ': ' + displayName)
             .show();
-        this.companyField.attr('tabindex', '-1');
+        this.companyField.attr('tabindex', '-1').attr('aria-hidden', 'true');
     }
 
     /**
@@ -373,7 +394,14 @@ class TwoCompanySearch {
         if (this._destroyed || this._revealed) {
             return;
         }
-        if (!this.companyField || !this.companyField.length) {
+        // The chip's click handler can fire in the same tick PrestaShop
+        // replaces the address form (a country change racing the click) -
+        // this instance is not `_destroyed` yet in that instant, but the
+        // field it is holding is already detached. Blanking/focusing a
+        // detached node is a silent no-op the buyer would read as a dead
+        // click, so bail rather than act on a stale reference.
+        if (!this.companyField || !this.companyField.length
+            || !document.contains(this.companyField.get(0))) {
             return;
         }
         this._revealSnapshot = {
@@ -406,15 +434,20 @@ class TwoCompanySearch {
      * field without picking anything sees the same confirmed company they
      * started with.
      *
-     * Delayed 200ms, matching the fallback dropdown's own blur handling, so a
-     * click on a result - which keeps the field focused through
-     * preventDefault on mousedown, on both render paths - resolves and calls
-     * collapseReveal() FIRST. If `_revealed` is still true once the delay
-     * elapses, nothing claimed the open search.
+     * Delayed 200ms - deliberately a touch longer than the fallback
+     * dropdown's own 150ms close-on-blur, not matching it - so a click on a
+     * result (which keeps the field focused through preventDefault on
+     * mousedown, on both render paths) resolves and calls collapseReveal()
+     * FIRST. If `_revealed` is still true once the delay elapses, nothing
+     * claimed the open search.
      *
      * Guarded on `_manualEntry` too: entering manual entry mid-reveal must not
      * have this timer put the old company back seconds later out from under
-     * the buyer's own "not on the list" choice.
+     * the buyer's own "not on the list" choice. Also stood down explicitly by
+     * setupCountryChangeListener()'s own change handler, which - unlike a
+     * genuine `updatedAddressForm` re-render - runs on this SAME instance and
+     * would otherwise leave this timer armed against a snapshot captured
+     * under the previous country.
      */
     setupRevealBlurRestore() {
         if (!this.companyField || this.companyField.length === 0) {
@@ -422,27 +455,53 @@ class TwoCompanySearch {
         }
         this.companyField.off('blur.twoReveal');
         this.companyField.on('blur.twoReveal', () => {
-            clearTimeout(this._revealBlurTimerId);
-            this._revealBlurTimerId = setTimeout(() => {
-                if (this._destroyed || !this._revealed || this._manualEntry) {
-                    return;
-                }
-                const snap = this._revealSnapshot || {};
-                this.companyField.val(snap.company || '');
-                if (this.organizationField && this.organizationField.length) {
-                    this.organizationField.val(snap.orgId || '');
-                    if (snap.orgTag !== undefined) {
-                        this.organizationField.attr('data-two-company-name', snap.orgTag);
-                    } else {
-                        this.organizationField.removeAttr('data-two-company-name');
-                    }
-                }
-                this.setCompanyIdHint(snap.orgId || '');
-                this._revealed = false;
-                this._revealSnapshot = null;
-                this.updateRevealChip();
-            }, 200);
+            this.armRevealBlurRestore();
         });
+    }
+
+    /**
+     * (Re-)arm the deferred restore. A standalone method rather than logic
+     * inlined in setupRevealBlurRestore()'s handler, so the custom fallback
+     * path's manual-entry row - which blurs the field to move focus onto
+     * itself, then blurs AGAIN on the way out - can re-arm the same timer on
+     * its own `blur`, matching how it already re-arms the dropdown's own
+     * close timer. Without that, tabbing onto the row cancels this timer (see
+     * its `focus` handler) but leaving the row again would never re-cancel or
+     * re-fire it, silently disabling the abandoned-search restore for the
+     * rest of that visit.
+     */
+    armRevealBlurRestore() {
+        clearTimeout(this._revealBlurTimerId);
+        this._revealBlurTimerId = setTimeout(() => {
+            if (this._destroyed || !this._revealed || this._manualEntry) {
+                return;
+            }
+            // The field this instance held at reveal time may have been
+            // replaced or detached by an address-form re-render that
+            // happened without going through destroy() on THIS instance
+            // (it wouldn't be live to run this callback at all if it had
+            // been destroyed) - defensive rather than reachable today, but
+            // cheap, and consistent with the DOM-replacement guards this
+            // file uses everywhere else.
+            if (!this.companyField || !this.companyField.length
+                || !document.contains(this.companyField.get(0))) {
+                return;
+            }
+            const snap = this._revealSnapshot || {};
+            this.companyField.val(snap.company || '');
+            if (this.organizationField && this.organizationField.length) {
+                this.organizationField.val(snap.orgId || '');
+                if (snap.orgTag !== undefined) {
+                    this.organizationField.attr('data-two-company-name', snap.orgTag);
+                } else {
+                    this.organizationField.removeAttr('data-two-company-name');
+                }
+            }
+            this.setCompanyIdHint(snap.orgId || '');
+            this._revealed = false;
+            this._revealSnapshot = null;
+            this.updateRevealChip();
+        }, 200);
     }
 
     normalizeCompanyName(value) {
@@ -1576,9 +1635,17 @@ class TwoCompanySearch {
                 }
             });
             // Focus arriving here blurs the input; cancel the close it queued.
+            // Also cancel the reveal-restore timer (TWO-25288 element 2) for
+            // the same reason: that is a SEPARATE blur binding on the same
+            // field, and without this a buyer who tabs here and pauses more
+            // than 200ms - still navigating the open list, having picked
+            // nothing - would have their in-progress search silently
+            // overwritten underneath a dropdown they are still looking at.
             row.addEventListener('focus', () => {
                 clearTimeout(blurTimer.id);
                 blurTimer.id = null;
+                clearTimeout(this._revealBlurTimerId);
+                this._revealBlurTimerId = null;
             });
             // And re-arm it on the way out, or the list is left open for good.
             // The input is otherwise the only node that closes this list, and
@@ -1586,8 +1653,16 @@ class TwoCompanySearch {
             // is open - so tabbing onward, or clicking away, would leave the list
             // painted over the address form until the next keystroke. `onBlur` is
             // declared further down this same closure and is only ever reached
-            // from an event, long after setup has finished.
-            row.addEventListener('blur', () => onBlur());
+            // from an event, long after setup has finished. Also re-arms the
+            // reveal-restore timer its own `focus` handler above cancelled -
+            // leaving the row without doing so would silently disable the
+            // abandoned-search restore for the rest of this reveal.
+            row.addEventListener('blur', () => {
+                onBlur();
+                if (this._revealed) {
+                    this.armRevealBlurRestore();
+                }
+            });
             list.appendChild(row);
             return row;
         };
@@ -2171,9 +2246,10 @@ class TwoCompanySearch {
 
         // Optional: Fetch additional details for address auto-fill if lookup_id is available
         if (ui.item.lookup_id) {
+            const selectedName = ui.item.value;
             this.fetchCompanyDetails(ui.item.lookup_id)
                 .then(details => {
-                    this.autoFillAddressIfNeeded(details);
+                    this.autoFillAddressIfNeeded(details, selectedName);
                 })
                 .catch(error => {
                     // Silently fail - address auto-fill is not critical
@@ -2234,7 +2310,7 @@ class TwoCompanySearch {
     /**
      * Auto-fill address if needed (simplified version)
      */
-    autoFillAddressIfNeeded(details) {
+    autoFillAddressIfNeeded(details, selectedName) {
         try {
             // Update organization number if we have a more authoritative one
             const natId = (details && (details.national_identifier || details.nationalIdentifier)) ||
@@ -2245,7 +2321,19 @@ class TwoCompanySearch {
                 natIdVal = details.registration_number || details.company_number ||
                            (details.company && (details.company.registration_number || details.company.company_number)) || null;
             }
-            if (natIdVal) {
+            // This lookup was fired from the moment of selection and can
+            // resolve well after it (a real network round trip) - if the
+            // buyer has since typed a different search, the field's CURRENT
+            // value is no longer the company this number belongs to. Adopting
+            // it anyway would tag someone else's organisation number onto
+            // whatever the buyer is now typing, and - since that tag is
+            // exactly what hasConfirmedSelection() reads - cover the field
+            // they are actively using with the reveal chip and pull it out of
+            // the tab order underneath them. Bail rather than risk either.
+            const stillOnSameCompany = selectedName === undefined
+                || this.normalizeCompanyName(this.companyField ? this.companyField.val() : '')
+                    === this.normalizeCompanyName(selectedName);
+            if (natIdVal && stillOnSameCompany) {
                 const currentOrgNumber = this.organizationField.val();
                 if (!currentOrgNumber || currentOrgNumber !== natIdVal) {
                     this.organizationField.val(natIdVal);
@@ -2434,7 +2522,24 @@ class TwoCompanySearch {
             }
             this.countryListener = () => {
                 try { sessionStorage.setItem('two_country_changed', '1'); } catch (e) {}
-                
+
+                // Stand down an open reveal (TWO-25288 element 2) BEFORE
+                // blanking anything below. This runs on the SAME instance
+                // (unlike a genuine updatedAddressForm re-render, which
+                // destroy()s and replaces it) - so without this, a reveal
+                // opened just before a country change leaves `_revealed` true
+                // and its 200ms blur-restore timer armed. That timer's guard
+                // only checks `_destroyed`/`_manualEntry`, so it fires anyway
+                // and overwrites whatever this country change (or anything
+                // the buyer did after it) just put in the field with a
+                // snapshot captured under the PREVIOUS country - restoring an
+                // organisation number that no longer matches what is
+                // selected.
+                clearTimeout(this._revealBlurTimerId);
+                this._revealBlurTimerId = null;
+                this._revealed = false;
+                this._revealSnapshot = null;
+
                 if (this.companyField && this.companyField.length > 0) {
                     if (this.companyField.hasClass('ui-autocomplete-input')) {
                         this.companyField.autocomplete('close');

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -147,6 +147,20 @@ class TwoCompanySearch {
         this._manualEntry = false;
         this._backToSearchLink = null;
 
+        // Click-to-reveal (TWO-25288 element 2). Woo/Luma's select2 keeps a
+        // `.select2-selection__rendered` chip showing the confirmed name in
+        // front of a separate `.select2-search__field` the buyer actually
+        // types into, so typing never touches the displayed name until a
+        // result is chosen. This field has no such split - the address form's
+        // own `input[name='company']` IS the search box - so the same
+        // protection is built as a covering chip: shown only while
+        // hasConfirmedSelection() is true, hidden the moment the buyer opens
+        // it back up. See revealSearch() / collapseReveal().
+        this._revealChip = null;
+        this._revealed = false;
+        this._revealSnapshot = null;
+        this._revealBlurTimerId = null;
+
         this.init();
     }
     
@@ -223,6 +237,214 @@ class TwoCompanySearch {
         }
     }
 
+    /**
+     * @returns {string} accessible name for the reveal chip
+     */
+    getEditCompanyText() {
+        return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_edit)
+            || 'Search for a different company';
+    }
+
+    /**
+     * Whether the field currently holds a company the buyer actually PICKED,
+     * as opposed to a name sitting next to a stale or absent organisation
+     * number. Deliberately the same test clearStaleOrganizationSelection()
+     * already uses - the file must have exactly one notion of "confirmed",
+     * not a second one that can quietly drift from it.
+     *
+     * @returns {boolean}
+     */
+    hasConfirmedSelection() {
+        if (!this.companyField || !this.companyField.length
+            || !this.organizationField || !this.organizationField.length) {
+            return false;
+        }
+        const company = String(this.companyField.val() || '').trim();
+        const orgNumber = String(this.organizationField.val() || '').trim();
+        const tag = String(this.organizationField.attr('data-two-company-name') || '').trim();
+        if (!company || !orgNumber || !tag) {
+            return false;
+        }
+        return this.normalizeCompanyName(company) === this.normalizeCompanyName(tag);
+    }
+
+    /**
+     * Create the click-to-reveal chip (TWO-25288 element 2), idempotently.
+     *
+     * A sibling `<button>`, absolutely positioned over the real input - the
+     * same wrapper createCompanyIdHintField() already forces to
+     * `position: relative` when it is still static. Called from
+     * setupAutocomplete(), not only init(): that method is what re-runs on
+     * every country change and `updatedAddressForm`, re-resolving whatever
+     * field PrestaShop just put on the page, so the chip has to be rebuilt on
+     * the same schedule or it goes missing the moment the DOM is replaced -
+     * exactly the failure mode applyEmptyFieldHint() next to it already
+     * guards against.
+     *
+     * Checked by class name rather than by this instance's own reference, for
+     * the same reason removeBackToSearchLink() sweeps the whole document: a
+     * destroyed instance's chip is removed by destroy() below, but a second
+     * one existing alongside the live chip would be worse than a stale
+     * reference to a single one.
+     */
+    createRevealChip() {
+        if (!this.companyField || !this.companyField.length) {
+            return;
+        }
+
+        let chip = $('.two-company-search-reveal');
+        if (chip.length === 0) {
+            chip = $('<button type="button" class="two-company-search-reveal"></button>');
+            this.companyField.after(chip);
+
+            const wrapper = this.companyField.parent();
+            if (wrapper.length && wrapper.css('position') === 'static') {
+                wrapper.css('position', 'relative');
+            }
+
+            chip.on('click.twoReveal', (event) => {
+                event.preventDefault();
+                this.revealSearch();
+            });
+        }
+
+        this._revealChip = chip;
+    }
+
+    /**
+     * Remove the chip and unbind it. Sweeps every `.two-company-search-reveal`
+     * in the document, not only this instance's own reference, matching
+     * removeBackToSearchLink() next to it - a chip orphaned by a previous,
+     * destroyed instance must not sit alongside a fresh one.
+     */
+    removeRevealChip() {
+        if (this._revealChip) {
+            this._revealChip.off('.twoReveal');
+            this._revealChip.remove();
+            this._revealChip = null;
+        }
+        $('.two-company-search-reveal').off('.twoReveal').remove();
+    }
+
+    /**
+     * Sync the chip's visibility/text and the field's tab-reachability to the
+     * current state.
+     *
+     * Hidden while `_revealed` (the buyer has opened the search and typing
+     * must reach the real field directly) or `_manualEntry` (same reason),
+     * and whenever there is no confirmed selection to protect - an empty or
+     * manually-typed field is exactly the plain-input behaviour that shipped
+     * before this element and needs no cover.
+     *
+     * `tabindex="-1"` while the chip covers the field is deliberate, not
+     * decorative: without it a keyboard user tabs through TWO stops for what
+     * must read as one control - the chip button, then the input hiding
+     * behind it.
+     */
+    updateRevealChip() {
+        if (!this._revealChip || !this._revealChip.length) {
+            return;
+        }
+        if (this._revealed || this._manualEntry || !this.hasConfirmedSelection()) {
+            this._revealChip.hide().text('');
+            if (this.companyField && this.companyField.length) {
+                this.companyField.removeAttr('tabindex');
+            }
+            return;
+        }
+        this._revealChip
+            .text(this.companyField.val())
+            .attr('title', this.getEditCompanyText())
+            .attr('aria-label', this.getEditCompanyText() + ': ' + this.companyField.val())
+            .show();
+        this.companyField.attr('tabindex', '-1');
+    }
+
+    /**
+     * Reveal the search box. Snapshots the confirmed pairing the chip was
+     * covering - name, organisation number AND its tag - so an abandoned
+     * search (see setupRevealBlurRestore()) can put back exactly what was
+     * there, not merely the visible name. Restoring the name alone and
+     * leaving the organisation number cleared (clearStaleOrganizationSelection()
+     * runs on the very first keystroke into the now-empty field) would show a
+     * confirmed-looking company with nothing behind it.
+     */
+    revealSearch() {
+        if (this._destroyed || this._revealed) {
+            return;
+        }
+        if (!this.companyField || !this.companyField.length) {
+            return;
+        }
+        this._revealSnapshot = {
+            company: String(this.companyField.val() || ''),
+            orgId: this.organizationField && this.organizationField.length
+                ? String(this.organizationField.val() || '') : '',
+            orgTag: this.organizationField && this.organizationField.length
+                ? this.organizationField.attr('data-two-company-name') : undefined
+        };
+        this._revealed = true;
+        this.companyField.val('');
+        this.updateRevealChip();
+        this.companyField.trigger('focus');
+    }
+
+    /**
+     * Stand reveal state down because something else already decided what the
+     * field should show - a fresh selection (onCompanySelected) or manual
+     * entry. Does NOT touch the field's value; the caller has already set it.
+     */
+    collapseReveal() {
+        this._revealed = false;
+        this._revealSnapshot = null;
+        this.updateRevealChip();
+    }
+
+    /**
+     * Bind the blur handler that resolves an opened-but-abandoned search:
+     * restore the snapshot revealSearch() took, so the buyer leaving the
+     * field without picking anything sees the same confirmed company they
+     * started with.
+     *
+     * Delayed 200ms, matching the fallback dropdown's own blur handling, so a
+     * click on a result - which keeps the field focused through
+     * preventDefault on mousedown, on both render paths - resolves and calls
+     * collapseReveal() FIRST. If `_revealed` is still true once the delay
+     * elapses, nothing claimed the open search.
+     *
+     * Guarded on `_manualEntry` too: entering manual entry mid-reveal must not
+     * have this timer put the old company back seconds later out from under
+     * the buyer's own "not on the list" choice.
+     */
+    setupRevealBlurRestore() {
+        if (!this.companyField || this.companyField.length === 0) {
+            return;
+        }
+        this.companyField.off('blur.twoReveal');
+        this.companyField.on('blur.twoReveal', () => {
+            clearTimeout(this._revealBlurTimerId);
+            this._revealBlurTimerId = setTimeout(() => {
+                if (this._destroyed || !this._revealed || this._manualEntry) {
+                    return;
+                }
+                const snap = this._revealSnapshot || {};
+                this.companyField.val(snap.company || '');
+                if (this.organizationField && this.organizationField.length) {
+                    this.organizationField.val(snap.orgId || '');
+                    if (snap.orgTag !== undefined) {
+                        this.organizationField.attr('data-two-company-name', snap.orgTag);
+                    } else {
+                        this.organizationField.removeAttr('data-two-company-name');
+                    }
+                }
+                this.setCompanyIdHint(snap.orgId || '');
+                this._revealed = false;
+                this._revealSnapshot = null;
+                this.updateRevealChip();
+            }, 200);
+        });
+    }
+
     normalizeCompanyName(value) {
         return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
     }
@@ -290,6 +512,11 @@ class TwoCompanySearch {
         this.companyField.off('.twoCompanySync');
         this.companyField.on('input.twoCompanySync change.twoCompanySync', () => {
             this.clearStaleOrganizationSelection();
+            // Belt and braces alongside collapseReveal()/setupRevealBlurRestore()
+            // (TWO-25288 element 2): whatever just cleared the tag above must
+            // not leave the chip showing a name with nothing confirmed behind
+            // it, however the field's value ended up changing.
+            this.updateRevealChip();
         });
     }
 
@@ -552,6 +779,14 @@ class TwoCompanySearch {
         // address form and never run that override. Before the path branch, so
         // both render paths get it.
         this.applyEmptyFieldHint();
+
+        // Click-to-reveal chip (TWO-25288 element 2). Same reasoning as the
+        // hint above: this method is the one that re-runs against whatever
+        // field PrestaShop just put on the page, so the chip and its blur
+        // handling have to be rebuilt here, not only in init().
+        this.createRevealChip();
+        this.updateRevealChip();
+        this.setupRevealBlurRestore();
 
         // Use jQuery UI autocomplete if available; otherwise fallback to custom.
         // `$.fn.autocomplete` alone is not proof of jQuery UI - the older
@@ -946,6 +1181,12 @@ class TwoCompanySearch {
             return;
         }
         this._manualEntry = true;
+        // Stand down an open reveal (TWO-25288 element 2) explicitly. Its own
+        // blur handler already checks `_manualEntry` before restoring, but
+        // clearing the snapshot here too means nothing is left to restore
+        // even if that ordering ever changes.
+        this._revealed = false;
+        this._revealSnapshot = null;
 
         // Drop the previously selected company BEFORE anything else.
         //
@@ -964,6 +1205,11 @@ class TwoCompanySearch {
         // directly under the results the buyer just chose from, so it cannot ship
         // relying on that.
         this.clearSelectedCompany();
+        // clearSelectedCompany() just dropped the org number and its tag, so
+        // hasConfirmedSelection() is now false - reflect that in the chip
+        // immediately rather than leaving it showing a name that no longer
+        // has a selection behind it.
+        this.updateRevealChip();
 
         if (this.companyField && this.companyField.length) {
             if (this.companyField.hasClass('ui-autocomplete-input')) {
@@ -1008,6 +1254,10 @@ class TwoCompanySearch {
         }
         this._manualEntry = false;
         this.removeBackToSearchLink();
+        // The field still holds whatever the buyer typed in manual entry, with
+        // no organisation number behind it - hasConfirmedSelection() is false,
+        // so this leaves the chip hidden rather than covering active typing.
+        this.updateRevealChip();
 
         if (!this.companyField || this.companyField.length === 0) {
             return;
@@ -1891,7 +2141,7 @@ class TwoCompanySearch {
         
         // SIMPLE & RELIABLE: Direct field assignment like old tillit.js
         this.companyField.val(ui.item.value);
-        
+
         // Set organization number immediately if available
         if (ui.item.organization_number) {
             this.organizationField.val(ui.item.organization_number);
@@ -1945,9 +2195,18 @@ class TwoCompanySearch {
 
         this.refreshCompanySummary();
 
+        // A fresh pick resolves whatever reveal state was open (TWO-25288
+        // element 2) - the chip re-covers the field with the new name rather
+        // than waiting for blur to notice. LAST, deliberately: the org number
+        // and its tag are what hasConfirmedSelection() reads, and both are
+        // already committed by this point on every branch above (immediate
+        // org number, or none at all - the deferred GB case resolves its own
+        // chip state from autoFillAddressIfNeeded() below).
+        this.collapseReveal();
+
         return true;
     }
-    
+
     /**
      * Fetch detailed company information
      */
@@ -2002,6 +2261,11 @@ class TwoCompanySearch {
                     // and this is the first point one exists, so the summary
                     // rendered at selection time showed a blank number slot.
                     this.refreshCompanySummary();
+                    // Same reason the reveal chip (TWO-25288 element 2) was left
+                    // uncovered by onCompanySelected() on this path - it reads
+                    // hasConfirmedSelection(), which only becomes true once the
+                    // tag written two lines up exists.
+                    this.updateRevealChip();
                 }
             }
             // Find addresses list in various shapes
@@ -2251,6 +2515,10 @@ class TwoCompanySearch {
             // LIVE document and bind this dying instance's listener to it.
             clearTimeout(this._countryRetryTimeoutId);
             this._countryRetryTimeoutId = null;
+            // Same reason: a deferred reveal-restore firing after teardown
+            // would write into a detached field (TWO-25288 element 2).
+            clearTimeout(this._revealBlurTimerId);
+            this._revealBlurTimerId = null;
             // Unbind from the element actually bound. setupCountryChangeListener
             // picks the first of five fallback selectors, so re-querying only
             // `select[name='id_country']` here missed the listener entirely on a
@@ -2292,6 +2560,13 @@ class TwoCompanySearch {
         // a node that outlives this instance otherwise.
         try {
             this.removeBackToSearchLink();
+        } catch (e) {
+            // no-op
+        }
+        // Its own try for the same reason as the reverse link: a live click
+        // handler on a node that would otherwise outlive this instance.
+        try {
+            this.removeRevealChip();
         } catch (e) {
             // no-op
         }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -283,11 +283,17 @@ class TwoCompanySearch {
      *
      * Checked among this field's OWN siblings, not by a document-wide class
      * lookup - unlike the passive org-id hint and the manual-entry reverse
-     * link, this chip is a focus-stealing, absolutely-positioned control, and
-     * PrestaShop can render more than one `input[name='company']` on the
-     * page at once (separate invoice/delivery address forms). A global
-     * lookup would let a second instance silently adopt the first instance's
-     * chip and cover the wrong field with it.
+     * link, this chip is a focus-stealing, absolutely-positioned control, so
+     * a global lookup would let a second, independently-constructed instance
+     * silently adopt the first instance's chip. This scoping does NOT by
+     * itself make the chip safe if PrestaShop core ever renders two live
+     * `input[name='company']` nodes at once under ONE instance - this class
+     * is a page-wide singleton (see TwoCheckoutManager.initializeCompanySearch())
+     * that resolves `this.companyField` from a bare selector with no
+     * `.first()`, the same pre-existing assumption every other method here
+     * (organizationField, companyIdHintField, ...) already makes and that
+     * this PR does not change. That is a separate, unresolved question about
+     * this class's single-field architecture, not something element 2 closes.
      */
     createRevealChip() {
         if (!this.companyField || !this.companyField.length) {
@@ -2356,9 +2362,13 @@ class TwoCompanySearch {
                     this.updateRevealChip();
                 }
             }
-            // Find addresses list in various shapes
+            // Find addresses list in various shapes. Gated by the SAME
+            // stillOnSameCompany check as the organisation number above - a
+            // stale deferred lookup overwriting street/city/postcode with an
+            // abandoned company's address is exactly the same hazard, just on
+            // different fields, and this response can carry both.
             const addresses = (details && (details.addresses || (details.company && details.company.addresses))) || [];
-            if (Array.isArray(addresses) && addresses.length > 0) {
+            if (Array.isArray(addresses) && addresses.length > 0 && stillOnSameCompany) {
                 this.autoFillAddress(addresses);
             }
         } catch (e) {
@@ -2600,6 +2610,20 @@ class TwoCompanySearch {
                 if (this._destroyed) {
                     return;
                 }
+                // Stand down an open reveal (TWO-25288 element 2) BEFORE
+                // re-resolving the field below. setupAutocomplete() reassigns
+                // `this.companyField` to whatever node is live now - if a
+                // reveal's blur-restore timer is still pending at that point,
+                // `document.contains()` alone cannot tell "detached" from
+                // "reassigned to a DIFFERENT, still-live field", and would
+                // write the pre-re-render snapshot into the wrong node.
+                // Same disarm setupCountryChangeListener()'s own change
+                // handler already does, and for the identical reason: this
+                // handler runs on the SAME instance, not through destroy().
+                clearTimeout(this._revealBlurTimerId);
+                this._revealBlurTimerId = null;
+                this._revealed = false;
+                this._revealSnapshot = null;
                 // Address form was re-rendered; re-bind country listener and autocomplete
                 this.setupCountryChangeListener(0);
                 this.setupAutocomplete();


### PR DESCRIPTION
## Summary

- Element 2 of TWO-25288 (company-search UX alignment): a click-to-reveal chip over the address-form company field, on both PrestaShop render paths (jQuery UI autocomplete and the custom fallback used when a theme has no jQuery UI).
- The chip shows the confirmed company name and covers the field; clicking it blanks the field for a fresh search rather than letting keystrokes overwrite the displayed name directly, matching the behaviour the other plugins get for free from select2's separate search box.
- Abandoning an opened search (blur with nothing picked) restores the exact prior name + organisation number pair, not just the display text - typing into the emptied field clears the organisation number on the very first keystroke via the existing stale-selection guard, so the restore has to put both back together.
- The chip is rebuilt on every `setupAutocomplete()` call, the same hook the empty-field hint already uses, so it survives PrestaShop replacing the address form's DOM on `updatedAddressForm` (country change, etc).

## Test plan

- [x] `npm run test:js` - full suite green (281 tests, including a new `tests/js/company-search-reveal.test.js` covering both render paths, re-render survival, blur-abandon restore, and teardown)
- [x] Mutation-verified: removing the chip's re-creation call from `setupAutocomplete()` fails 15/22 new tests, including the re-render-survival tests
- [x] Mutation-verified: removing the organisation-number/tag restore from the blur handler (leaving only the name restored) fails the two tests specifically guarding that hazard
- [x] `php -l twopayment.php` - no syntax errors (single new translatable string added)