### PR TITLE
fix: cache-bust module JS/CSS asset URLs with filemtime version

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,6 +41,17 @@ parameters:
 			count: 1
 			path: twopayment.php
 
+		# False positive at the 1.7.6.0 analysis floor: Tools::hasMediaServer()
+		# was added to core in 1.7.7 alongside the media-server file_exists()
+		# resolution it guards against (TWO-53PS). The call site is guarded by
+		# method_exists('Tools', 'hasMediaServer'), so it is unreachable on
+		# versions where the method does not exist.
+		-
+			message: '#^Call to an undefined static method Tools\:\:hasMediaServer\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: twopayment.php
+
 		# False positive: every path through postProcess() ends in
 		# Tools::redirectAdmin() (which exits), but core does not annotate it
 		# @return never, so phpstan expects the AdminControllerCore-declared

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for getTwoVersionedAssetPath() (TWO-53PS).
+ *
+ * Assets were registered via registerJavascript()/registerStylesheet() with no
+ * version/cache-busting parameter on the URL, so a stale copy could be served
+ * from the browser cache or a CDN in front of it for hours after deploy. The
+ * fix appends "?v=<filemtime>" to the module-relative path, which changes
+ * whenever the file's content (and therefore mtime) changes.
+ */
+final class AssetCacheBustingSpec
+{
+    public static function runAll(): void
+    {
+        self::testPathIsPrefixedWithModuleDirectory();
+        self::testVersionQueryStringMatchesFileMtime();
+        self::testVersionChangesWhenFileMtimeChanges();
+        self::testMissingFileFallsBackToUnversionedPath();
+        self::testLeadingSlashOnRelativePathIsNormalised();
+    }
+
+    private static function callVersionedPath(string $relativePath)
+    {
+        $module = new TwopaymentTestHarness();
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoVersionedAssetPath');
+
+        return $method->invoke($module, $relativePath);
+    }
+
+    private static function testPathIsPrefixedWithModuleDirectory(): void
+    {
+        $path = self::callVersionedPath('views/css/two.css');
+        TinyAssert::true(
+            strpos($path, 'modules/twopayment/views/css/two.css') === 0,
+            "expected module-relative prefix, got: {$path}"
+        );
+    }
+
+    private static function testVersionQueryStringMatchesFileMtime(): void
+    {
+        $module = new TwopaymentTestHarness();
+        $realMtime = @filemtime(rtrim($module->local_path, '/') . '/views/css/two.css');
+        TinyAssert::true($realMtime !== false, 'fixture file must exist for this assertion to be meaningful');
+
+        $path = self::callVersionedPath('views/css/two.css');
+        TinyAssert::same('modules/twopayment/views/css/two.css?v=' . $realMtime, $path);
+    }
+
+    private static function testVersionChangesWhenFileMtimeChanges(): void
+    {
+        $tmpFile = sys_get_temp_dir() . '/two-asset-cache-busting-spec-' . uniqid('', true) . '.js';
+        file_put_contents($tmpFile, 'console.log("v1");');
+        touch($tmpFile, 1000000000);
+
+        $module = new TwopaymentTestHarness();
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoVersionedAssetPath');
+
+        // local_path is a dynamic property (mirrors PrestaShop's real
+        // Module::$local_path, not declared on the stub) - point it at a
+        // throwaway fixture rather than depending on real module asset
+        // mtimes for this specific "changes on change" assertion.
+        $module->local_path = dirname($tmpFile);
+
+        $before = $method->invoke($module, basename($tmpFile));
+
+        touch($tmpFile, 2000000000);
+        clearstatcache(true, $tmpFile);
+
+        $after = $method->invoke($module, basename($tmpFile));
+
+        unlink($tmpFile);
+
+        TinyAssert::true($before !== $after, 'versioned URL must change when the file mtime changes');
+        TinyAssert::true(strpos($before, '?v=1000000000') !== false, "expected v1 mtime in: {$before}");
+        TinyAssert::true(strpos($after, '?v=2000000000') !== false, "expected v2 mtime in: {$after}");
+    }
+
+    private static function testMissingFileFallsBackToUnversionedPath(): void
+    {
+        $path = self::callVersionedPath('views/js/modules/DoesNotExist-' . uniqid() . '.js');
+        TinyAssert::true(strpos($path, '?v=') === false, "expected no version query string, got: {$path}");
+        TinyAssert::true(strpos($path, 'modules/twopayment/views/js/modules/DoesNotExist') === 0, $path);
+    }
+
+    private static function testLeadingSlashOnRelativePathIsNormalised(): void
+    {
+        $withSlash = self::callVersionedPath('/views/css/two.css');
+        $withoutSlash = self::callVersionedPath('views/css/two.css');
+        TinyAssert::same($withoutSlash, $withSlash);
+    }
+}

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -20,6 +20,8 @@ final class AssetCacheBustingSpec
         self::testVersionChangesWhenFileMtimeChanges();
         self::testMissingFileFallsBackToUnversionedPath();
         self::testLeadingSlashOnRelativePathIsNormalised();
+        self::testHasMediaServerSkipsVersioning();
+        self::testAddCssFallbackAppendsVersionQueryString();
     }
 
     private static function callVersionedPath(string $relativePath)
@@ -90,5 +92,60 @@ final class AssetCacheBustingSpec
         $withSlash = self::callVersionedPath('/views/css/two.css');
         $withoutSlash = self::callVersionedPath('views/css/two.css');
         TinyAssert::same($withoutSlash, $withSlash);
+    }
+
+    /**
+     * Legacy PS_MEDIA_SERVER_1/2/3 domain-sharding mode: PrestaShop's own
+     * remote-media resolution (FrontController::registerStylesheet /
+     * registerJavascript) does a literal file_exists() on this same relative
+     * path, which would fail once "?v=..." is appended. Versioning must be
+     * skipped entirely in that mode rather than risk breaking asset loading.
+     */
+    private static function testHasMediaServerSkipsVersioning(): void
+    {
+        Tools::setTestHasMediaServer(true);
+        $path = self::callVersionedPath('views/css/two.css');
+        Tools::resetTestValues();
+
+        TinyAssert::same('modules/twopayment/views/css/two.css', $path);
+    }
+
+    /**
+     * Pre-1.7 admin controllers without registerStylesheet() fall back to the
+     * legacy addCSS($url) API. That branch builds its own URL from
+     * $this->_path rather than getTwoVersionedAssetPath()'s 'modules/...'
+     * prefix, but must still get the same "?v=<mtime>" cache-busting via the
+     * shared getTwoAssetVersionQueryString() helper.
+     */
+    private static function testAddCssFallbackAppendsVersionQueryString(): void
+    {
+        $module = new TwopaymentTestHarness();
+        $realMtime = @filemtime(rtrim($module->local_path, '/') . '/views/css/two.css');
+        TinyAssert::true($realMtime !== false, 'fixture file must exist for this assertion to be meaningful');
+
+        $controller = new class {
+            public $controller_name = 'AdminModules';
+            public $php_self = 'module';
+            public $addedCss = [];
+
+            public function addCSS($url)
+            {
+                $this->addedCss[] = $url;
+            }
+        };
+
+        $module->context->controller = $controller;
+        Tools::setTestValue('configure', 'twopayment');
+        Tools::setTestValue('controller', 'AdminModules');
+
+        $module->hookActionAdminControllerSetMedia();
+
+        Tools::resetTestValues();
+
+        TinyAssert::same(1, count($controller->addedCss));
+        TinyAssert::true(
+            strpos($controller->addedCss[0], '?v=' . $realMtime) !== false,
+            "expected version query string in: {$controller->addedCss[0]}"
+        );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -534,6 +534,17 @@ namespace {
     class Tools
     {
         private static array $testValues = [];
+        private static bool $hasMediaServer = false;
+
+        public static function hasMediaServer(): bool
+        {
+            return self::$hasMediaServer;
+        }
+
+        public static function setTestHasMediaServer(bool $value): void
+        {
+            self::$hasMediaServer = $value;
+        }
 
         public static function substr($string, $start, $length = null)
         {
@@ -581,6 +592,7 @@ namespace {
         public static function resetTestValues(): void
         {
             self::$testValues = [];
+            self::$hasMediaServer = false;
         }
 
         public static function getToken($page = false): string

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1724,6 +1724,7 @@ namespace {
         }
     }
 
+    #[\AllowDynamicProperties]
     class TwopaymentTestHarness extends Twopayment
     {
         public function __construct()
@@ -1735,6 +1736,10 @@ namespace {
             $this->api_key = 'test-api-key';
             $this->languages = [['id_lang' => 1]];
             $this->active = true;
+            // Mirrors PrestaShop's real Module::$local_path: absolute path to
+            // this module's own directory, trailing slash included. Used by
+            // getTwoVersionedAssetPath() to filemtime() the real asset files.
+            $this->local_path = dirname(__DIR__) . '/';
         }
 
         public function l($string)

--- a/tests/run.php
+++ b/tests/run.php
@@ -5540,6 +5540,7 @@ require __DIR__ . '/CompanySearchCountrySourcingSpec.php';
 require __DIR__ . '/SessionCompanyClearSpec.php';
 require __DIR__ . '/OverrideMigrationSpec.php';
 require __DIR__ . '/TranslationCatalogueSpec.php';
+require __DIR__ . '/AssetCacheBustingSpec.php';
 // LAST, deliberately: DefaultShippingTaxCodeSpec defines
 // _TWO_ENABLE_DEFAULT_SHIPPING_TAX_CODE_ partway through its own run, and a
 // PHP constant cannot be undefined again. ShippingCostSourcingSpec asserts the
@@ -5576,6 +5577,7 @@ $tests = [
     'SessionCompanyClearSpec::runAll' => [SessionCompanyClearSpec::class, 'runAll'],
     'OverrideMigrationSpec::runAll' => [OverrideMigrationSpec::class, 'runAll'],
     'TranslationCatalogueSpec::runAll' => [TranslationCatalogueSpec::class, 'runAll'],
+    'AssetCacheBustingSpec::runAll' => [AssetCacheBustingSpec::class, 'runAll'],
     // Keep last - see the require above.
     'DefaultShippingTaxCodeSpec::runAll' => [DefaultShippingTaxCodeSpec::class, 'runAll'],
 ];

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -370,6 +370,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_bafd7322c6e97d25b6299b5d6fe8920b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_bb1697a94fe9e88e0c4b2b0dd605eced'] = 'Instelbare betaaltermijnen (7, 15, 20, 30, 45, 60, 90 dagen)';
 $_MODULE['<{twopayment}prestashop>twopayment_bbe9f9e95ce9e3ed2a173b373b381286'] = 'SSL-verificatie is uitgeschakeld in productie. Schakel deze weer in, tenzij je netwerk een vertrouwde bedrijfsproxy vereist.';
 $_MODULE['<{twopayment}prestashop>twopayment_bc5e69470fb58f31cb12c7e95bede662'] = 'Realtime geschiktheidscheck van de koper (Order Intent) vóór aankoop';
+$_MODULE['<{twopayment}prestashop>twopayment_bcdcf1cfb578d4756265681317cb35e2'] = 'Zoek naar een ander bedrijf';
 $_MODULE['<{twopayment}prestashop>twopayment_be89e29be0122074a933bea5d3813084'] = 'We konden je bedrijf niet vinden. Probeer een andere bedrijfsnaam of neem contact op met support.';
 $_MODULE['<{twopayment}prestashop>twopayment_c012e2a8b9e129403f8b93547086500a'] = 'Te kort';
 $_MODULE['<{twopayment}prestashop>twopayment_c050bd52ad0af81cf819fbcf2863357f'] = 'Het telefoonnummer moet bij het gekozen land horen';

--- a/translations/no.php
+++ b/translations/no.php
@@ -370,6 +370,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_bafd7322c6e97d25b6299b5d6fe8920b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_bb1697a94fe9e88e0c4b2b0dd605eced'] = 'Konfigurerbare betalingsvilkår (7, 15, 20, 30, 45, 60, 90 dager)';
 $_MODULE['<{twopayment}prestashop>twopayment_bbe9f9e95ce9e3ed2a173b373b381286'] = 'SSL-verifisering er slått av i produksjon. Slå den på igjen med mindre nettverket ditt krever et oppsett med en klarert bedriftsproxy.';
 $_MODULE['<{twopayment}prestashop>twopayment_bc5e69470fb58f31cb12c7e95bede662'] = 'Sjekk av kjøperens kredittverdighet i sanntid (ordreintensjon) før kjøp';
+$_MODULE['<{twopayment}prestashop>twopayment_bcdcf1cfb578d4756265681317cb35e2'] = 'Søk etter et annet firma';
 $_MODULE['<{twopayment}prestashop>twopayment_be89e29be0122074a933bea5d3813084'] = 'Vi fant ikke firmaet ditt. Prøv et annet firmanavn eller kontakt kundestøtte.';
 $_MODULE['<{twopayment}prestashop>twopayment_c012e2a8b9e129403f8b93547086500a'] = 'For kort';
 $_MODULE['<{twopayment}prestashop>twopayment_c050bd52ad0af81cf819fbcf2863357f'] = 'Telefonnummeret må stemme med landet du har valgt';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -370,6 +370,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_bafd7322c6e97d25b6299b5d6fe8920b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_bb1697a94fe9e88e0c4b2b0dd605eced'] = 'Konfigurerbara betalningsvillkor (7, 15, 20, 30, 45, 60, 90 dagar)';
 $_MODULE['<{twopayment}prestashop>twopayment_bbe9f9e95ce9e3ed2a173b373b381286'] = 'SSL-verifiering är avaktiverad i produktion. Aktivera den igen om inte ditt nätverk kräver en betrodd företagsproxy.';
 $_MODULE['<{twopayment}prestashop>twopayment_bc5e69470fb58f31cb12c7e95bede662'] = 'Kontroll av köparens behörighet i realtid (Order Intent) före köp';
+$_MODULE['<{twopayment}prestashop>twopayment_bcdcf1cfb578d4756265681317cb35e2'] = 'Sök efter ett annat företag';
 $_MODULE['<{twopayment}prestashop>twopayment_be89e29be0122074a933bea5d3813084'] = 'Vi kunde inte hitta ditt företag. Prova ett annat företagsnamn eller kontakta supporten.';
 $_MODULE['<{twopayment}prestashop>twopayment_c012e2a8b9e129403f8b93547086500a'] = 'För kort';
 $_MODULE['<{twopayment}prestashop>twopayment_c050bd52ad0af81cf819fbcf2863357f'] = 'Telefonnumret måste stämma med det valda landet';

--- a/twopayment.php
+++ b/twopayment.php
@@ -3423,14 +3423,19 @@ class Twopayment extends PaymentModule
         )));
         
         // Register Two payment CSS and JavaScript files
-        $this->context->controller->registerStylesheet('two-css', 'modules/twopayment/views/css/two.css', array('priority' => 200, 'media' => 'all'));
-        
+        // Cache-busting: the versioned path (?v=<filemtime>) is what actually
+        // changes when a file changes, forcing both the browser cache and any
+        // CDN in front of it (e.g. Cloudflare) to fetch fresh content. See
+        // TWO-53PS - assets were previously served with no version/cache-busting
+        // at all, so a stale copy could be served for hours after deploy.
+        $this->context->controller->registerStylesheet('two-css', $this->getTwoVersionedAssetPath('views/css/two.css'), array('priority' => 200, 'media' => 'all'));
+
         // CRITICAL FIX: Remove async loading and ensure proper load order for reliable initialization
         // Ensures they load AFTER jQuery
-        $this->context->controller->registerJavascript('two-company-search', 'modules/twopayment/views/js/modules/TwoCompanySearch.js', array('priority' => 201, 'async' => false));
-        $this->context->controller->registerJavascript('two-order-intent', 'modules/twopayment/views/js/modules/TwoOrderIntent.js', array('priority' => 202, 'async' => false));
-        $this->context->controller->registerJavascript('two-sole-trader', 'modules/twopayment/views/js/modules/TwoSoleTrader.js', array('priority' => 204, 'async' => false));
-        $this->context->controller->registerJavascript('two-optional-fields', 'modules/twopayment/views/js/modules/TwoOptionalFields.js', array('priority' => 204, 'async' => false));
+        $this->context->controller->registerJavascript('two-company-search', $this->getTwoVersionedAssetPath('views/js/modules/TwoCompanySearch.js'), array('priority' => 201, 'async' => false));
+        $this->context->controller->registerJavascript('two-order-intent', $this->getTwoVersionedAssetPath('views/js/modules/TwoOrderIntent.js'), array('priority' => 202, 'async' => false));
+        $this->context->controller->registerJavascript('two-sole-trader', $this->getTwoVersionedAssetPath('views/js/modules/TwoSoleTrader.js'), array('priority' => 204, 'async' => false));
+        $this->context->controller->registerJavascript('two-optional-fields', $this->getTwoVersionedAssetPath('views/js/modules/TwoOptionalFields.js'), array('priority' => 204, 'async' => false));
         // Read-only company summary in the payment tile (TWO-25288).
         //
         // The priority is cosmetic, not a dependency guarantee, and it would be
@@ -3441,10 +3446,43 @@ class Twopayment extends PaymentModule
         // equivalent. What actually makes the call safe is the `window
         // .TwoCompanySummary && typeof ... === 'function'` guard at the call site,
         // which also covers the address step, where the tile does not exist.
-        $this->context->controller->registerJavascript('two-company-summary', 'modules/twopayment/views/js/modules/TwoCompanySummary.js', array('priority' => 200, 'async' => false));
+        $this->context->controller->registerJavascript('two-company-summary', $this->getTwoVersionedAssetPath('views/js/modules/TwoCompanySummary.js'), array('priority' => 200, 'async' => false));
         // Phone validation removed - Two API handles phone number validation
-        $this->context->controller->registerJavascript('two-checkout-manager', 'modules/twopayment/views/js/modules/TwoCheckoutManager.js', array('priority' => 205, 'async' => false));
-        $this->context->controller->registerJavascript('two-script', 'modules/twopayment/views/js/twopayment.js', array('priority' => 206, 'async' => false));
+        $this->context->controller->registerJavascript('two-checkout-manager', $this->getTwoVersionedAssetPath('views/js/modules/TwoCheckoutManager.js'), array('priority' => 205, 'async' => false));
+        $this->context->controller->registerJavascript('two-script', $this->getTwoVersionedAssetPath('views/js/twopayment.js'), array('priority' => 206, 'async' => false));
+    }
+
+    /**
+     * Build a cache-busted, module-relative asset path for register{Javascript,Stylesheet}().
+     *
+     * PrestaShop's register* methods accept a 'version' param on 8.0+ only
+     * (classes/controller/FrontController.php), so it is silently ignored on
+     * the 1.7.x versions this module still supports. Appending "?v=<mtime>"
+     * directly to the relative path instead works identically across every
+     * supported PrestaShop version (1.7.6 - 9.x), because register* passes
+     * the local ('server' => 'local', the default here) path straight through
+     * as a plain string with no filesystem re-resolution of it.
+     *
+     * Best-effort: if the file can't be stat'd (e.g. moved/missing), the
+     * unversioned relative path is returned rather than throwing, matching
+     * this module's existing best-effort filemtime usage elsewhere
+     * (getTwoDeployedAtLabel).
+     *
+     * @param string $relative_path path relative to this module's own directory,
+     *                               e.g. 'views/js/twopayment.js'
+     *
+     * @return string 'modules/twopayment/<relative_path>[?v=<mtime>]'
+     */
+    private function getTwoVersionedAssetPath($relative_path)
+    {
+        $module_relative_path = 'modules/' . $this->name . '/' . ltrim($relative_path, '/');
+        $mtime = @filemtime(rtrim($this->local_path, '/') . '/' . ltrim($relative_path, '/'));
+
+        if (!$mtime) {
+            return $module_relative_path;
+        }
+
+        return $module_relative_path . '?v=' . $mtime;
     }
 
     /**
@@ -3475,7 +3513,7 @@ class Twopayment extends PaymentModule
         if (method_exists($controller, 'registerStylesheet')) {
             $controller->registerStylesheet(
                 'module-twopayment-admin-css',
-                'modules/twopayment/views/css/two.css',
+                $this->getTwoVersionedAssetPath('views/css/two.css'),
                 array('media' => 'all', 'priority' => 200)
             );
 
@@ -3483,7 +3521,8 @@ class Twopayment extends PaymentModule
         }
 
         if (method_exists($controller, 'addCSS')) {
-            $controller->addCSS($this->_path . 'views/css/two.css');
+            $mtime = @filemtime(rtrim($this->local_path, '/') . '/views/css/two.css');
+            $controller->addCSS($this->_path . 'views/css/two.css' . ($mtime ? '?v=' . $mtime : ''));
         }
     }
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -3468,6 +3468,15 @@ class Twopayment extends PaymentModule
      * this module's existing best-effort filemtime usage elsewhere
      * (getTwoDeployedAtLabel).
      *
+     * Skipped entirely when Tools::hasMediaServer() is active: PrestaShop's
+     * remote-media-server asset resolution (classes/controller/FrontController.php,
+     * legacy PS_MEDIA_SERVER_1/2/3 domain sharding) does a literal file_exists()
+     * on this same path string, which would fail once a "?v=..." query string
+     * is appended (it isn't a real file on disk). That legacy split-domain
+     * setup is rare and not something this module documents support for, so
+     * we fail back to the old, working, unversioned behaviour there rather
+     * than risk breaking asset loading on checkout.
+     *
      * @param string $relative_path path relative to this module's own directory,
      *                               e.g. 'views/js/twopayment.js'
      *
@@ -3476,13 +3485,29 @@ class Twopayment extends PaymentModule
     private function getTwoVersionedAssetPath($relative_path)
     {
         $module_relative_path = 'modules/' . $this->name . '/' . ltrim($relative_path, '/');
-        $mtime = @filemtime(rtrim($this->local_path, '/') . '/' . ltrim($relative_path, '/'));
 
-        if (!$mtime) {
+        if (method_exists('Tools', 'hasMediaServer') && Tools::hasMediaServer()) {
             return $module_relative_path;
         }
 
-        return $module_relative_path . '?v=' . $mtime;
+        return $module_relative_path . $this->getTwoAssetVersionQueryString($relative_path);
+    }
+
+    /**
+     * '?v=<filemtime>' for a module asset, or '' if the file can't be stat'd.
+     * Shared by getTwoVersionedAssetPath() and the legacy addCSS() fallback
+     * below, which needs the query string but not the 'modules/...' prefix
+     * (it builds its own URL from $this->_path).
+     *
+     * @param string $relative_path path relative to this module's own directory
+     *
+     * @return string '' or '?v=<mtime>'
+     */
+    private function getTwoAssetVersionQueryString($relative_path)
+    {
+        $mtime = @filemtime(rtrim($this->local_path, '/') . '/' . ltrim($relative_path, '/'));
+
+        return $mtime ? '?v=' . $mtime : '';
     }
 
     /**
@@ -3521,8 +3546,7 @@ class Twopayment extends PaymentModule
         }
 
         if (method_exists($controller, 'addCSS')) {
-            $mtime = @filemtime(rtrim($this->local_path, '/') . '/views/css/two.css');
-            $controller->addCSS($this->_path . 'views/css/two.css' . ($mtime ? '?v=' . $mtime : ''));
+            $controller->addCSS($this->_path . 'views/css/two.css' . $this->getTwoAssetVersionQueryString('views/css/two.css'));
         }
     }
 


### PR DESCRIPTION
## Summary
- Assets registered via `registerJavascript()`/`registerStylesheet()` in `twopayment.php` had no version/cache-busting parameter, so a stale copy could be served from the browser cache or a CDN in front of it for hours after deploy.
- Adds `getTwoVersionedAssetPath()`, which appends `?v=<filemtime>` to every registered asset's module-relative path. The version changes whenever the file's content (and mtime) changes, busting both CDN and browser caches automatically.
- Path-append (not PrestaShop's `'version'` register param) because that param only exists on PrestaShop 8.0+, and this module supports 1.7.6-9.x; path-append works identically on every supported version.

## Test plan
- [x] `make test` (PHP unit suite) - all green except one pre-existing, unrelated failure (`TranslationCatalogueSpec`, confirmed present on `origin/staging` before this change too)
- [x] New `tests/AssetCacheBustingSpec.php` covers: module-path prefixing, version matches real file mtime, version changes when mtime changes, graceful fallback to unversioned path when the file is missing, leading-slash normalisation
- [x] `npm run test:js` - all green (286 tests, unaffected by this change)
