### PR TITLE
fix: stop silently dropping Two checkout assets on PS8 (TWO-53PS regression)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,17 +41,6 @@ parameters:
 			count: 1
 			path: twopayment.php
 
-		# False positive at the 1.7.6.0 analysis floor: Tools::hasMediaServer()
-		# was added to core in 1.7.7 alongside the media-server file_exists()
-		# resolution it guards against (TWO-53PS). The call site is guarded by
-		# method_exists('Tools', 'hasMediaServer'), so it is unreachable on
-		# versions where the method does not exist.
-		-
-			message: '#^Call to an undefined static method Tools\:\:hasMediaServer\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: twopayment.php
-
 		# False positive: every path through postProcess() ends in
 		# Tools::redirectAdmin() (which exits), but core does not annotate it
 		# @return never, so phpstan expects the AdminControllerCore-declared

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -287,24 +287,67 @@ final class AssetCacheBustingSpec
         // still exact on identity - Vader's delete-one/duplicate-another
         // mutation changes which ids are present regardless of ordering, so
         // it's still caught.
-        $expectedFrontIds = array(
-            'two-checkout-manager',
-            'two-company-search',
-            'two-company-summary',
-            'two-css',
-            'two-optional-fields',
-            'two-order-intent',
-            'two-script',
-            'two-sole-trader',
+        // Maps each id to the ONE relative path it must register (round-5
+        // adversarial review, Vader): round 4's checks only confirmed the
+        // right SET of ids is present and that each call is internally
+        // self-consistent (its own getTwoModuleAssetPath() and
+        // getTwoAssetVersion() arguments match each other) - neither catches
+        // a call whose id is left correct but whose backing file is swapped
+        // for a different one (e.g. 'two-order-intent' silently registering
+        // TwoCompanySearch.js instead of TwoOrderIntent.js): the id set is
+        // untouched and the call is still self-consistent, so both round-4
+        // assertions pass while checkout genuinely loses TwoOrderIntent.js.
+        // Binding id -> expected path closes that gap.
+        $expectedFrontPathsById = array(
+            'two-css' => 'views/css/two.css',
+            'two-company-search' => 'views/js/modules/TwoCompanySearch.js',
+            'two-order-intent' => 'views/js/modules/TwoOrderIntent.js',
+            'two-sole-trader' => 'views/js/modules/TwoSoleTrader.js',
+            'two-optional-fields' => 'views/js/modules/TwoOptionalFields.js',
+            'two-company-summary' => 'views/js/modules/TwoCompanySummary.js',
+            'two-checkout-manager' => 'views/js/modules/TwoCheckoutManager.js',
+            'two-script' => 'views/js/twopayment.js',
         );
-        $expectedAdminIds = array('module-twopayment-admin-css');
+        $expectedAdminPathsById = array(
+            'module-twopayment-admin-css' => 'views/css/two.css',
+        );
 
         $actualFrontIds = self::extractCallIds($frontStatements);
         sort($actualFrontIds);
-        TinyAssert::same($expectedFrontIds, $actualFrontIds, 'hookActionFrontControllerSetMedia() must register exactly this set of asset ids');
-        TinyAssert::same($expectedAdminIds, self::extractCallIds($adminStatements), 'hookActionAdminControllerSetMedia() must register exactly this set of asset ids');
+        TinyAssert::same(self::sortedKeys($expectedFrontPathsById), $actualFrontIds, 'hookActionFrontControllerSetMedia() must register exactly this set of asset ids');
+        TinyAssert::same(array_keys($expectedAdminPathsById), self::extractCallIds($adminStatements), 'hookActionAdminControllerSetMedia() must register exactly this set of asset ids');
 
-        foreach (array_merge($frontStatements, $adminStatements) as $statement) {
+        self::assertCallsMatchExpectedPaths($frontStatements, $expectedFrontPathsById);
+        self::assertCallsMatchExpectedPaths($adminStatements, $expectedAdminPathsById);
+    }
+
+    /**
+     * @param array<string, string> $map
+     *
+     * @return array<int, string>
+     */
+    private static function sortedKeys(array $map): array
+    {
+        $keys = array_keys($map);
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * For each call statement: its getTwoModuleAssetPath(...) and
+     * getTwoAssetVersion(...) arguments must both equal the ONE relative
+     * path $expectedPathsById says its own id should register - not merely
+     * equal each other (see the docblock above
+     * testCheckoutHookUsesCleanPathAndVersionParamForEveryRegisteredAsset()
+     * for why "equal each other" alone is not enough).
+     *
+     * @param array<int, string>    $statements
+     * @param array<string, string> $expectedPathsById
+     */
+    private static function assertCallsMatchExpectedPaths(array $statements, array $expectedPathsById): void
+    {
+        foreach ($statements as $statement) {
             TinyAssert::true(
                 strpos($statement, 'getTwoModuleAssetPath(') !== false,
                 "register*() call must build its path via getTwoModuleAssetPath(), got: {$statement}"
@@ -314,15 +357,17 @@ final class AssetCacheBustingSpec
                 "register*() call must pass 'version' => \$this->getTwoAssetVersion(...), got: {$statement}"
             );
 
+            $ids = self::extractCallIds(array($statement));
+            $id = $ids[0];
+            TinyAssert::true(array_key_exists($id, $expectedPathsById), "no expected path registered for id '{$id}' - update \$expectedPathsById if this id is intentional");
+            $expectedPath = $expectedPathsById[$id];
+
             $modulePathArgs = self::extractQuotedArgsAfter($statement, 'getTwoModuleAssetPath');
             $versionArgs = self::extractQuotedArgsAfter($statement, 'getTwoAssetVersion');
             TinyAssert::same(1, count($modulePathArgs), "expected exactly one getTwoModuleAssetPath(...) argument, got: {$statement}");
             TinyAssert::same(1, count($versionArgs), "expected exactly one getTwoAssetVersion(...) argument, got: {$statement}");
-            TinyAssert::same(
-                $modulePathArgs[0],
-                $versionArgs[0],
-                "getTwoModuleAssetPath() and getTwoAssetVersion() must reference the SAME relative path within one call, got: {$statement}"
-            );
+            TinyAssert::same($expectedPath, $modulePathArgs[0], "id '{$id}' must build its path from '{$expectedPath}', got: {$statement}");
+            TinyAssert::same($expectedPath, $versionArgs[0], "id '{$id}' must version '{$expectedPath}', got: {$statement}");
         }
     }
 

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -123,6 +123,15 @@ final class AssetCacheBustingSpec
      * call site back to appending the version onto the path - the change that
      * broke checkout in PR #127/TWO-53PS - drops that call's contribution to
      * one or both counts, and this fails.
+     *
+     * Per-call-site, not body-wide aggregate counts (adversarial review
+     * finding): a whole-body substr_count() can be satisfied by padding -
+     * e.g. a stray comment repeating "getTwoModuleAssetPath(" or
+     * "'version' => $this->getTwoAssetVersion(" elsewhere in the body - while
+     * one real call site quietly reverts to the broken path-append pattern.
+     * Every register*() call line is matched and required to carry BOTH
+     * tokens on that same line, so a reverted call site fails on its own
+     * line rather than being masked by another line's tokens.
      */
     private static function testCheckoutHookUsesCleanPathAndVersionParamForEveryRegisteredAsset(): void
     {
@@ -143,13 +152,23 @@ final class AssetCacheBustingSpec
             . 'fails to resolve via file_exists() and drops the asset entirely (TWO-53PS regression).'
         );
 
-        $registerCallCount = substr_count($body, '->registerJavascript(') + substr_count($body, '->registerStylesheet(');
-        $cleanPathCount = substr_count($body, 'getTwoModuleAssetPath(');
-        $versionParamCount = substr_count($body, "'version' => \$this->getTwoAssetVersion(");
+        $lines = explode("\n", $body);
+        $registerLines = array_values(array_filter($lines, function ($line) {
+            return strpos($line, '->registerJavascript(') !== false || strpos($line, '->registerStylesheet(') !== false;
+        }));
 
-        TinyAssert::true($registerCallCount >= 7, "expected at least 7 register*() calls in the hook, found {$registerCallCount}");
-        TinyAssert::same($registerCallCount, $cleanPathCount, 'every register*() call must build its path via getTwoModuleAssetPath()');
-        TinyAssert::same($registerCallCount, $versionParamCount, "every register*() call must pass 'version' => \$this->getTwoAssetVersion(...)");
+        TinyAssert::true(count($registerLines) >= 7, 'expected at least 7 register*() call lines in the hook, found ' . count($registerLines));
+
+        foreach ($registerLines as $line) {
+            TinyAssert::true(
+                strpos($line, 'getTwoModuleAssetPath(') !== false,
+                "register*() call must build its path via getTwoModuleAssetPath() on its own line, got: {$line}"
+            );
+            TinyAssert::true(
+                strpos($line, "'version' => \$this->getTwoAssetVersion(") !== false,
+                "register*() call must pass 'version' => \$this->getTwoAssetVersion(...) on its own line, got: {$line}"
+            );
+        }
     }
 
     /**

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -267,6 +267,43 @@ final class AssetCacheBustingSpec
         TinyAssert::same(8, count($frontStatements), 'expected exactly 8 register*() call sites in hookActionFrontControllerSetMedia() (1 CSS + 7 JS), found ' . count($frontStatements) . ' - a call site was added, removed, or renamed');
         TinyAssert::same(1, count($adminStatements), 'expected exactly 1 registerStylesheet() call site in hookActionAdminControllerSetMedia(), found ' . count($adminStatements) . ' - it was added, removed, or renamed');
 
+        // Identity, not just count (round-4 adversarial review, Vader): a
+        // count-only check passes if one real call site is deleted and a
+        // DIFFERENT one duplicated in its place (e.g. a bad merge/copy-paste
+        // that drops TwoOrderIntent.js but keeps the count at 8 by
+        // duplicating TwoCompanySearch.js) - checkout genuinely loses an
+        // asset while every assertion above stays green. Pin the exact,
+        // ordered set of ids this hook must register, and require each
+        // call's getTwoModuleAssetPath(...) and getTwoAssetVersion(...)
+        // arguments to reference the SAME relative path as each other (a
+        // duplicated call registering the wrong asset under a fresh id
+        // would still show up as an id-list mismatch below).
+        // Compared as sorted sets, not source order: extractCallStatements()
+        // is invoked once per method name (registerJavascript, then
+        // registerStylesheet), so $frontStatements interleaves them in
+        // pattern-call order, not the source's actual line order (two-css
+        // is a registerStylesheet call textually first in the hook, but
+        // lands last here). A sorted-set comparison is order-independent but
+        // still exact on identity - Vader's delete-one/duplicate-another
+        // mutation changes which ids are present regardless of ordering, so
+        // it's still caught.
+        $expectedFrontIds = array(
+            'two-checkout-manager',
+            'two-company-search',
+            'two-company-summary',
+            'two-css',
+            'two-optional-fields',
+            'two-order-intent',
+            'two-script',
+            'two-sole-trader',
+        );
+        $expectedAdminIds = array('module-twopayment-admin-css');
+
+        $actualFrontIds = self::extractCallIds($frontStatements);
+        sort($actualFrontIds);
+        TinyAssert::same($expectedFrontIds, $actualFrontIds, 'hookActionFrontControllerSetMedia() must register exactly this set of asset ids');
+        TinyAssert::same($expectedAdminIds, self::extractCallIds($adminStatements), 'hookActionAdminControllerSetMedia() must register exactly this set of asset ids');
+
         foreach (array_merge($frontStatements, $adminStatements) as $statement) {
             TinyAssert::true(
                 strpos($statement, 'getTwoModuleAssetPath(') !== false,
@@ -276,7 +313,51 @@ final class AssetCacheBustingSpec
                 strpos($statement, "'version' => \$this->getTwoAssetVersion(") !== false,
                 "register*() call must pass 'version' => \$this->getTwoAssetVersion(...), got: {$statement}"
             );
+
+            $modulePathArgs = self::extractQuotedArgsAfter($statement, 'getTwoModuleAssetPath');
+            $versionArgs = self::extractQuotedArgsAfter($statement, 'getTwoAssetVersion');
+            TinyAssert::same(1, count($modulePathArgs), "expected exactly one getTwoModuleAssetPath(...) argument, got: {$statement}");
+            TinyAssert::same(1, count($versionArgs), "expected exactly one getTwoAssetVersion(...) argument, got: {$statement}");
+            TinyAssert::same(
+                $modulePathArgs[0],
+                $versionArgs[0],
+                "getTwoModuleAssetPath() and getTwoAssetVersion() must reference the SAME relative path within one call, got: {$statement}"
+            );
         }
+    }
+
+    /**
+     * First string-literal argument (the register*() id) of each call
+     * statement, in order.
+     *
+     * @param array<int, string> $statements
+     *
+     * @return array<int, string>
+     */
+    private static function extractCallIds(array $statements): array
+    {
+        return array_map(function ($statement) {
+            TinyAssert::true(
+                preg_match("/\\(\\s*'([^']*)'/", $statement, $matches) === 1,
+                "could not extract a leading string-literal id from call statement: {$statement}"
+            );
+
+            return $matches[1];
+        }, $statements);
+    }
+
+    /**
+     * Every quoted argument passed to $functionName(...) within $statement,
+     * e.g. extractQuotedArgsAfter("...getTwoAssetVersion('views/css/two.css')...", 'getTwoAssetVersion')
+     * returns ['views/css/two.css'].
+     *
+     * @return array<int, string>
+     */
+    private static function extractQuotedArgsAfter(string $statement, string $functionName): array
+    {
+        preg_match_all("/" . preg_quote($functionName, '/') . "\\('([^']*)'\\)/", $statement, $matches);
+
+        return $matches[1];
     }
 
     /**

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -138,6 +138,19 @@ final class AssetCacheBustingSpec
      * captured whole, and a decoy elsewhere in the body can no longer stand
      * in for tokens the call itself must carry.
      *
+     * Paren-counting is string-literal-aware (round-3 adversarial review,
+     * Vader): a literal '(' or ')' inside a single- or double-quoted PHP
+     * string argument is valid code and must not perturb the depth count,
+     * or a call whose id/path string happens to contain a stray paren could
+     * either truncate its own capture early or run past its closing paren
+     * into the NEXT call's text - silently dropping that next call from the
+     * results (which the exact-count assertion below exists to catch) or, in
+     * the worst case, absorbing so much text that a later strpos() offset
+     * moves past a real call site entirely. Not exploitable against any
+     * current asset id/path in this module (verified: none contain '(', ')',
+     * '//', or '/*'), but the scanner itself must not depend on that staying
+     * true forever.
+     *
      * @return array<int, string> one entry per call site found
      */
     private static function extractCallStatements(string $source, string $methodCall): array
@@ -151,18 +164,37 @@ final class AssetCacheBustingSpec
             TinyAssert::true($parenStart !== false, "malformed call site for {$methodCall} - no opening paren found");
 
             $depth = 0;
+            $quoteChar = null;
             $i = $parenStart;
             for (; $i < $length; $i++) {
-                if ($source[$i] === '(') {
+                $char = $source[$i];
+
+                if ($quoteChar !== null) {
+                    if ($char === '\\') {
+                        ++$i; // skip the escaped character (e.g. \' or \\), it can't end the string
+                        continue;
+                    }
+                    if ($char === $quoteChar) {
+                        $quoteChar = null;
+                    }
+                    continue;
+                }
+
+                if ($char === "'" || $char === '"') {
+                    $quoteChar = $char;
+                    continue;
+                }
+
+                if ($char === '(') {
                     ++$depth;
-                } elseif ($source[$i] === ')') {
+                } elseif ($char === ')') {
                     --$depth;
                     if ($depth === 0) {
                         break;
                     }
                 }
             }
-            TinyAssert::true($depth === 0, "unbalanced parens for {$methodCall} call starting at offset {$pos}");
+            TinyAssert::true($depth === 0 && $quoteChar === null, "unbalanced parens or unterminated string for {$methodCall} call starting at offset {$pos}");
 
             $statements[] = substr($source, $pos, $i - $pos + 1);
             $offset = $i + 1;
@@ -219,15 +251,23 @@ final class AssetCacheBustingSpec
             );
         }
 
-        $callStatements = array_merge(
+        $frontStatements = array_merge(
             self::extractCallStatements($frontBody, '->registerJavascript('),
-            self::extractCallStatements($frontBody, '->registerStylesheet('),
-            self::extractCallStatements($adminBody, '->registerStylesheet(')
+            self::extractCallStatements($frontBody, '->registerStylesheet(')
         );
+        $adminStatements = self::extractCallStatements($adminBody, '->registerStylesheet(');
 
-        TinyAssert::true(count($callStatements) >= 8, 'expected at least 8 register*() call sites (7+ checkout, 1+ admin), found ' . count($callStatements));
+        // Exact counts, not a loose ">=" floor (round-3 adversarial review,
+        // Han): a floor only catches a surviving call site reverting its
+        // pattern, not a whole call site vanishing outright - which is
+        // exactly the silent-asset-drop failure mode TWO-53PS caused. These
+        // numbers are the real current count of register*() calls in each
+        // hook; update them deliberately if a call site is ever added or
+        // removed on purpose.
+        TinyAssert::same(8, count($frontStatements), 'expected exactly 8 register*() call sites in hookActionFrontControllerSetMedia() (1 CSS + 7 JS), found ' . count($frontStatements) . ' - a call site was added, removed, or renamed');
+        TinyAssert::same(1, count($adminStatements), 'expected exactly 1 registerStylesheet() call site in hookActionAdminControllerSetMedia(), found ' . count($adminStatements) . ' - it was added, removed, or renamed');
 
-        foreach ($callStatements as $statement) {
+        foreach (array_merge($frontStatements, $adminStatements) as $statement) {
             TinyAssert::true(
                 strpos($statement, 'getTwoModuleAssetPath(') !== false,
                 "register*() call must build its path via getTwoModuleAssetPath(), got: {$statement}"

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -3,125 +3,166 @@
 declare(strict_types=1);
 
 /**
- * Coverage for getTwoVersionedAssetPath() (TWO-53PS).
+ * Coverage for getTwoModuleAssetPath()/getTwoAssetVersion() (TWO-53PS, and the
+ * regression it caused - fixed here).
  *
- * Assets were registered via registerJavascript()/registerStylesheet() with no
- * version/cache-busting parameter on the URL, so a stale copy could be served
- * from the browser cache or a CDN in front of it for hours after deploy. The
- * fix appends "?v=<filemtime>" to the module-relative path, which changes
- * whenever the file's content (and therefore mtime) changes.
+ * PrestaShop's register{Stylesheet,Javascript}() resolve the relative path
+ * string to a real file via a literal file_exists() check
+ * (classes/assets/AbstractAssetManager.php getFullPath()) BEFORE the asset is
+ * added to the render list; the 'version' param is only appended to the URL
+ * AFTER that resolution succeeds (classes/assets/JavascriptManager.php /
+ * StylesheetManager.php add()). TWO-53PS originally cache-busted by appending
+ * "?v=<mtime>" directly onto the path passed into register*() - which meant
+ * file_exists() was checking a path that could never be a real file, so core
+ * silently dropped every Two JS/CSS asset with no error, exception, or log
+ * line. Config injected via Media::addJsDef() kept working (it doesn't go
+ * through this path), which is why the bug looked like a partial page load
+ * rather than a hard failure. The fix: pass the clean relative path, and put
+ * the cache-busting value in the 'version' param core already supports.
+ *
+ * The regression test below models core's real file_exists()-before-version
+ * behaviour in the stub controller, so it fails the same way production did
+ * if the path handed to register*() ever again carries a query string.
  */
 final class AssetCacheBustingSpec
 {
     public static function runAll(): void
     {
-        self::testPathIsPrefixedWithModuleDirectory();
-        self::testVersionQueryStringMatchesFileMtime();
-        self::testVersionChangesWhenFileMtimeChanges();
-        self::testMissingFileFallsBackToUnversionedPath();
+        self::testModuleAssetPathCarriesNoQueryString();
+        self::testAssetVersionMatchesFileMtime();
+        self::testAssetVersionChangesWhenFileMtimeChanges();
+        self::testMissingFileYieldsNullVersion();
         self::testLeadingSlashOnRelativePathIsNormalised();
-        self::testHasMediaServerSkipsVersioning();
-        self::testAddCssFallbackAppendsVersionQueryString();
+        self::testCheckoutHookUsesCleanPathAndVersionParamForEveryRegisteredAsset();
+        self::testAddCssFallbackCarriesNoQueryString();
     }
 
-    private static function callVersionedPath(string $relativePath)
+    private static function callModuleAssetPath(string $relativePath)
     {
         $module = new TwopaymentTestHarness();
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoVersionedAssetPath');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoModuleAssetPath');
 
         return $method->invoke($module, $relativePath);
     }
 
-    private static function testPathIsPrefixedWithModuleDirectory(): void
+    private static function callAssetVersion(string $relativePath, ?string $localPath = null)
     {
-        $path = self::callVersionedPath('views/css/two.css');
-        TinyAssert::true(
-            strpos($path, 'modules/twopayment/views/css/two.css') === 0,
-            "expected module-relative prefix, got: {$path}"
-        );
+        $module = new TwopaymentTestHarness();
+        if ($localPath !== null) {
+            $module->local_path = $localPath;
+        }
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoAssetVersion');
+
+        return $method->invoke($module, $relativePath);
     }
 
-    private static function testVersionQueryStringMatchesFileMtime(): void
+    private static function testModuleAssetPathCarriesNoQueryString(): void
+    {
+        $path = self::callModuleAssetPath('views/css/two.css');
+        TinyAssert::same('modules/twopayment/views/css/two.css', $path);
+        TinyAssert::false(strpos($path, '?') !== false, "module asset path must never carry a query string, got: {$path}");
+    }
+
+    private static function testAssetVersionMatchesFileMtime(): void
     {
         $module = new TwopaymentTestHarness();
         $realMtime = @filemtime(rtrim($module->local_path, '/') . '/views/css/two.css');
         TinyAssert::true($realMtime !== false, 'fixture file must exist for this assertion to be meaningful');
 
-        $path = self::callVersionedPath('views/css/two.css');
-        TinyAssert::same('modules/twopayment/views/css/two.css?v=' . $realMtime, $path);
+        $version = self::callAssetVersion('views/css/two.css');
+        TinyAssert::same((string) $realMtime, $version);
     }
 
-    private static function testVersionChangesWhenFileMtimeChanges(): void
+    private static function testAssetVersionChangesWhenFileMtimeChanges(): void
     {
         $tmpFile = sys_get_temp_dir() . '/two-asset-cache-busting-spec-' . uniqid('', true) . '.js';
         file_put_contents($tmpFile, 'console.log("v1");');
         touch($tmpFile, 1000000000);
 
-        $module = new TwopaymentTestHarness();
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoVersionedAssetPath');
-
-        // local_path is a dynamic property (mirrors PrestaShop's real
-        // Module::$local_path, not declared on the stub) - point it at a
-        // throwaway fixture rather than depending on real module asset
-        // mtimes for this specific "changes on change" assertion.
-        $module->local_path = dirname($tmpFile);
-
-        $before = $method->invoke($module, basename($tmpFile));
+        $before = self::callAssetVersion(basename($tmpFile), dirname($tmpFile));
 
         touch($tmpFile, 2000000000);
         clearstatcache(true, $tmpFile);
 
-        $after = $method->invoke($module, basename($tmpFile));
+        $after = self::callAssetVersion(basename($tmpFile), dirname($tmpFile));
 
         unlink($tmpFile);
 
-        TinyAssert::true($before !== $after, 'versioned URL must change when the file mtime changes');
-        TinyAssert::true(strpos($before, '?v=1000000000') !== false, "expected v1 mtime in: {$before}");
-        TinyAssert::true(strpos($after, '?v=2000000000') !== false, "expected v2 mtime in: {$after}");
+        TinyAssert::true($before !== $after, 'version must change when the file mtime changes');
+        TinyAssert::same('1000000000', $before);
+        TinyAssert::same('2000000000', $after);
     }
 
-    private static function testMissingFileFallsBackToUnversionedPath(): void
+    private static function testMissingFileYieldsNullVersion(): void
     {
-        $path = self::callVersionedPath('views/js/modules/DoesNotExist-' . uniqid() . '.js');
-        TinyAssert::true(strpos($path, '?v=') === false, "expected no version query string, got: {$path}");
-        TinyAssert::true(strpos($path, 'modules/twopayment/views/js/modules/DoesNotExist') === 0, $path);
+        $version = self::callAssetVersion('views/js/modules/DoesNotExist-' . uniqid() . '.js');
+        TinyAssert::true($version === null, 'missing file must yield a null version, not a query string');
     }
 
     private static function testLeadingSlashOnRelativePathIsNormalised(): void
     {
-        $withSlash = self::callVersionedPath('/views/css/two.css');
-        $withoutSlash = self::callVersionedPath('views/css/two.css');
+        $withSlash = self::callModuleAssetPath('/views/css/two.css');
+        $withoutSlash = self::callModuleAssetPath('views/css/two.css');
         TinyAssert::same($withoutSlash, $withSlash);
     }
 
     /**
-     * Legacy PS_MEDIA_SERVER_1/2/3 domain-sharding mode: PrestaShop's own
-     * remote-media resolution (FrontController::registerStylesheet /
-     * registerJavascript) does a literal file_exists() on this same relative
-     * path, which would fail once "?v=..." is appended. Versioning must be
-     * skipped entirely in that mode rather than risk breaking asset loading.
+     * The regression test, done as a source-slice (this hook depends on
+     * Country::getCountries() and live merchant-term/FX refreshes that the
+     * test stubs don't model, so it can't safely be invoked end-to-end here -
+     * same constraint CompanySearchCountrySourcingSpec works around for the
+     * same hook).
+     *
+     * Counts call sites rather than searching for the literal "?v=" text,
+     * because this very file's comments now say "?v=<mtime>" while explaining
+     * the bug the fix guards against - a text search would be fooled by its
+     * own documentation. Instead: every register{Javascript,Stylesheet}() call
+     * in the hook body must build its path via getTwoModuleAssetPath() (never
+     * the removed getTwoVersionedAssetPath()) and must pass a
+     * 'version' => $this->getTwoAssetVersion(...) option. Reverting any one
+     * call site back to appending the version onto the path - the change that
+     * broke checkout in PR #127/TWO-53PS - drops that call's contribution to
+     * one or both counts, and this fails.
      */
-    private static function testHasMediaServerSkipsVersioning(): void
+    private static function testCheckoutHookUsesCleanPathAndVersionParamForEveryRegisteredAsset(): void
     {
-        Tools::setTestHasMediaServer(true);
-        $path = self::callVersionedPath('views/css/two.css');
-        Tools::resetTestValues();
+        $source = file_get_contents(dirname(__DIR__) . '/twopayment.php');
+        TinyAssert::true($source !== false, 'could not read twopayment.php');
 
-        TinyAssert::same('modules/twopayment/views/css/two.css', $path);
+        $start = strpos($source, 'public function hookActionFrontControllerSetMedia()');
+        TinyAssert::true($start !== false, 'hookActionFrontControllerSetMedia() not found in twopayment.php');
+        $end = strpos($source, 'private function getTwoModuleAssetPath', $start);
+        TinyAssert::true($end !== false, 'getTwoModuleAssetPath() not found after the hook - has it moved or been removed?');
+
+        $body = substr($source, $start, $end - $start);
+
+        TinyAssert::false(
+            strpos($body, 'getTwoVersionedAssetPath') !== false,
+            'hookActionFrontControllerSetMedia() still references the removed getTwoVersionedAssetPath() - '
+            . 'that helper appended the cache-busting version onto the path itself, which core silently '
+            . 'fails to resolve via file_exists() and drops the asset entirely (TWO-53PS regression).'
+        );
+
+        $registerCallCount = substr_count($body, '->registerJavascript(') + substr_count($body, '->registerStylesheet(');
+        $cleanPathCount = substr_count($body, 'getTwoModuleAssetPath(');
+        $versionParamCount = substr_count($body, "'version' => \$this->getTwoAssetVersion(");
+
+        TinyAssert::true($registerCallCount >= 7, "expected at least 7 register*() calls in the hook, found {$registerCallCount}");
+        TinyAssert::same($registerCallCount, $cleanPathCount, 'every register*() call must build its path via getTwoModuleAssetPath()');
+        TinyAssert::same($registerCallCount, $versionParamCount, "every register*() call must pass 'version' => \$this->getTwoAssetVersion(...)");
     }
 
     /**
      * Pre-1.7 admin controllers without registerStylesheet() fall back to the
      * legacy addCSS($url) API. That branch builds its own URL from
-     * $this->_path rather than getTwoVersionedAssetPath()'s 'modules/...'
-     * prefix, but must still get the same "?v=<mtime>" cache-busting via the
-     * shared getTwoAssetVersionQueryString() helper.
+     * $this->_path and must NOT append a version query string onto it - the
+     * same file_exists()-on-a-query-string trap applies there too, via
+     * Controller::addCSS() -> getAssetUriFromLegacyDeprecatedMethod() ->
+     * registerStylesheet($id, $uri).
      */
-    private static function testAddCssFallbackAppendsVersionQueryString(): void
+    private static function testAddCssFallbackCarriesNoQueryString(): void
     {
         $module = new TwopaymentTestHarness();
-        $realMtime = @filemtime(rtrim($module->local_path, '/') . '/views/css/two.css');
-        TinyAssert::true($realMtime !== false, 'fixture file must exist for this assertion to be meaningful');
 
         $controller = new class {
             public $controller_name = 'AdminModules';
@@ -143,9 +184,6 @@ final class AssetCacheBustingSpec
         Tools::resetTestValues();
 
         TinyAssert::same(1, count($controller->addedCss));
-        TinyAssert::true(
-            strpos($controller->addedCss[0], '?v=' . $realMtime) !== false,
-            "expected version query string in: {$controller->addedCss[0]}"
-        );
+        TinyAssert::false(strpos($controller->addedCss[0], '?') !== false, "addCSS fallback must carry no query string, got: {$controller->addedCss[0]}");
     }
 }

--- a/tests/AssetCacheBustingSpec.php
+++ b/tests/AssetCacheBustingSpec.php
@@ -107,66 +107,134 @@ final class AssetCacheBustingSpec
     }
 
     /**
+     * Strips PHP comments before any token-matching below. Not a general PHP
+     * tokenizer - just enough to stop a decoy comment (block or trailing
+     * line-comment) from padding out the tokens a regression assertion greps
+     * for. Safe for the narrow slices this spec scans: none of the string
+     * literals in the register*() calls it guards contain "//" or "/*".
+     *
+     * Round-2 adversarial review (Vader) found the previous per-line version
+     * of this test could be defeated by a decoy TRAILING COMMENT on the same
+     * line as a reverted call - e.g. `...->registerJavascript('id', 'path' .
+     * '?v=' . @filemtime(...), [...]); // getTwoModuleAssetPath( 'version' =>
+     * $this->getTwoAssetVersion(` - which contains both guarded-for tokens
+     * without ever really calling either. Stripping comments first closes
+     * that gap.
+     */
+    private static function stripComments(string $php): string
+    {
+        $noBlockComments = preg_replace('#/\*.*?\*/#s', '', $php);
+        return preg_replace('#//[^\n]*#', '', $noBlockComments);
+    }
+
+    /**
+     * Extracts each `->$methodCall(...)` statement as its own string, from
+     * the method name through the matching (paren-depth-balanced) closing
+     * `)`. Round-2 adversarial review (Han/Vader) found the previous per-LINE
+     * version of this test both missed the admin hook's registerStylesheet()
+     * call (which spans several lines) and was fragile against any future
+     * legitimate line-wrap of a checkout-hook call. Matching the whole
+     * statement, wherever its parens close, fixes both: multi-line calls are
+     * captured whole, and a decoy elsewhere in the body can no longer stand
+     * in for tokens the call itself must carry.
+     *
+     * @return array<int, string> one entry per call site found
+     */
+    private static function extractCallStatements(string $source, string $methodCall): array
+    {
+        $statements = array();
+        $offset = 0;
+        $length = strlen($source);
+
+        while (($pos = strpos($source, $methodCall, $offset)) !== false) {
+            $parenStart = strpos($source, '(', $pos);
+            TinyAssert::true($parenStart !== false, "malformed call site for {$methodCall} - no opening paren found");
+
+            $depth = 0;
+            $i = $parenStart;
+            for (; $i < $length; $i++) {
+                if ($source[$i] === '(') {
+                    ++$depth;
+                } elseif ($source[$i] === ')') {
+                    --$depth;
+                    if ($depth === 0) {
+                        break;
+                    }
+                }
+            }
+            TinyAssert::true($depth === 0, "unbalanced parens for {$methodCall} call starting at offset {$pos}");
+
+            $statements[] = substr($source, $pos, $i - $pos + 1);
+            $offset = $i + 1;
+        }
+
+        return $statements;
+    }
+
+    /**
      * The regression test, done as a source-slice (this hook depends on
      * Country::getCountries() and live merchant-term/FX refreshes that the
      * test stubs don't model, so it can't safely be invoked end-to-end here -
      * same constraint CompanySearchCountrySourcingSpec works around for the
      * same hook).
      *
-     * Counts call sites rather than searching for the literal "?v=" text,
-     * because this very file's comments now say "?v=<mtime>" while explaining
-     * the bug the fix guards against - a text search would be fooled by its
-     * own documentation. Instead: every register{Javascript,Stylesheet}() call
-     * in the hook body must build its path via getTwoModuleAssetPath() (never
-     * the removed getTwoVersionedAssetPath()) and must pass a
-     * 'version' => $this->getTwoAssetVersion(...) option. Reverting any one
-     * call site back to appending the version onto the path - the change that
-     * broke checkout in PR #127/TWO-53PS - drops that call's contribution to
-     * one or both counts, and this fails.
-     *
-     * Per-call-site, not body-wide aggregate counts (adversarial review
-     * finding): a whole-body substr_count() can be satisfied by padding -
-     * e.g. a stray comment repeating "getTwoModuleAssetPath(" or
-     * "'version' => $this->getTwoAssetVersion(" elsewhere in the body - while
-     * one real call site quietly reverts to the broken path-append pattern.
-     * Every register*() call line is matched and required to carry BOTH
-     * tokens on that same line, so a reverted call site fails on its own
-     * line rather than being masked by another line's tokens.
+     * Every register{Javascript,Stylesheet}() call site - in BOTH
+     * hookActionFrontControllerSetMedia() (checkout) and
+     * hookActionAdminControllerSetMedia() (admin/order pages, TWO-53PS's
+     * registerStylesheet() call there uses the identical pattern) - must
+     * build its path via getTwoModuleAssetPath() (never the removed
+     * getTwoVersionedAssetPath()) and must pass a
+     * 'version' => $this->getTwoAssetVersion(...) option, checked against
+     * comment-stripped source and the whole paren-balanced call statement
+     * rather than a raw line - see stripComments() and
+     * extractCallStatements() for what each closes off. Reverting any one
+     * call site back to appending the version onto the path - the change
+     * that broke checkout in PR #127/TWO-53PS - drops that call's own
+     * statement text below both tokens, and this fails.
      */
     private static function testCheckoutHookUsesCleanPathAndVersionParamForEveryRegisteredAsset(): void
     {
         $source = file_get_contents(dirname(__DIR__) . '/twopayment.php');
         TinyAssert::true($source !== false, 'could not read twopayment.php');
 
-        $start = strpos($source, 'public function hookActionFrontControllerSetMedia()');
-        TinyAssert::true($start !== false, 'hookActionFrontControllerSetMedia() not found in twopayment.php');
-        $end = strpos($source, 'private function getTwoModuleAssetPath', $start);
-        TinyAssert::true($end !== false, 'getTwoModuleAssetPath() not found after the hook - has it moved or been removed?');
+        $frontStart = strpos($source, 'public function hookActionFrontControllerSetMedia()');
+        TinyAssert::true($frontStart !== false, 'hookActionFrontControllerSetMedia() not found in twopayment.php');
+        $frontEnd = strpos($source, 'private function getTwoModuleAssetPath', $frontStart);
+        TinyAssert::true($frontEnd !== false, 'getTwoModuleAssetPath() not found after the hook - has it moved or been removed?');
 
-        $body = substr($source, $start, $end - $start);
+        $adminStart = strpos($source, 'public function hookActionAdminControllerSetMedia()');
+        TinyAssert::true($adminStart !== false, 'hookActionAdminControllerSetMedia() not found in twopayment.php');
+        $adminEnd = strpos($source, 'public function hookPaymentOptions', $adminStart);
+        TinyAssert::true($adminEnd !== false, 'hookPaymentOptions() not found after the admin hook - has it moved?');
 
-        TinyAssert::false(
-            strpos($body, 'getTwoVersionedAssetPath') !== false,
-            'hookActionFrontControllerSetMedia() still references the removed getTwoVersionedAssetPath() - '
-            . 'that helper appended the cache-busting version onto the path itself, which core silently '
-            . 'fails to resolve via file_exists() and drops the asset entirely (TWO-53PS regression).'
+        $frontBody = self::stripComments(substr($source, $frontStart, $frontEnd - $frontStart));
+        $adminBody = self::stripComments(substr($source, $adminStart, $adminEnd - $adminStart));
+
+        foreach (array('hookActionFrontControllerSetMedia' => $frontBody, 'hookActionAdminControllerSetMedia' => $adminBody) as $hookName => $body) {
+            TinyAssert::false(
+                strpos($body, 'getTwoVersionedAssetPath') !== false,
+                "{$hookName}() still references the removed getTwoVersionedAssetPath() - that helper appended "
+                . 'the cache-busting version onto the path itself, which core silently fails to resolve via '
+                . 'file_exists() and drops the asset entirely (TWO-53PS regression).'
+            );
+        }
+
+        $callStatements = array_merge(
+            self::extractCallStatements($frontBody, '->registerJavascript('),
+            self::extractCallStatements($frontBody, '->registerStylesheet('),
+            self::extractCallStatements($adminBody, '->registerStylesheet(')
         );
 
-        $lines = explode("\n", $body);
-        $registerLines = array_values(array_filter($lines, function ($line) {
-            return strpos($line, '->registerJavascript(') !== false || strpos($line, '->registerStylesheet(') !== false;
-        }));
+        TinyAssert::true(count($callStatements) >= 8, 'expected at least 8 register*() call sites (7+ checkout, 1+ admin), found ' . count($callStatements));
 
-        TinyAssert::true(count($registerLines) >= 7, 'expected at least 7 register*() call lines in the hook, found ' . count($registerLines));
-
-        foreach ($registerLines as $line) {
+        foreach ($callStatements as $statement) {
             TinyAssert::true(
-                strpos($line, 'getTwoModuleAssetPath(') !== false,
-                "register*() call must build its path via getTwoModuleAssetPath() on its own line, got: {$line}"
+                strpos($statement, 'getTwoModuleAssetPath(') !== false,
+                "register*() call must build its path via getTwoModuleAssetPath(), got: {$statement}"
             );
             TinyAssert::true(
-                strpos($line, "'version' => \$this->getTwoAssetVersion(") !== false,
-                "register*() call must pass 'version' => \$this->getTwoAssetVersion(...) on its own line, got: {$line}"
+                strpos($statement, "'version' => \$this->getTwoAssetVersion(") !== false,
+                "register*() call must pass 'version' => \$this->getTwoAssetVersion(...), got: {$statement}"
             );
         }
     }

--- a/twopayment.php
+++ b/twopayment.php
@@ -3423,19 +3423,30 @@ class Twopayment extends PaymentModule
         )));
         
         // Register Two payment CSS and JavaScript files
-        // Cache-busting: the versioned path (?v=<filemtime>) is what actually
-        // changes when a file changes, forcing both the browser cache and any
-        // CDN in front of it (e.g. Cloudflare) to fetch fresh content. See
-        // TWO-53PS - assets were previously served with no version/cache-busting
-        // at all, so a stale copy could be served for hours after deploy.
-        $this->context->controller->registerStylesheet('two-css', $this->getTwoVersionedAssetPath('views/css/two.css'), array('priority' => 200, 'media' => 'all'));
+        // Cache-busting: 'version' is PrestaShop's own register{Stylesheet,Javascript}()
+        // param (classes/controller/FrontController.php), applied by core AFTER it
+        // resolves the plain relative path to a real file via getFullPath()'s
+        // file_exists() check (classes/assets/AbstractAssetManager.php). See TWO-53PS -
+        // assets were previously served with no version/cache-busting at all, so a
+        // stale copy could be served for hours after deploy.
+        //
+        // NOT appended to the path itself (the previous, broken approach): getFullPath()
+        // does a literal file_exists() on the exact relativePath string to resolve it to
+        // a real file on disk before core ever turns it into a URL. A path with a
+        // "?v=<mtime>" suffix is never a real file, so that check silently fails and
+        // JavascriptManager::register() / StylesheetManager::register() drop the asset
+        // entirely with no error, exception, or log line - it just never enters the
+        // render list. That is what PR #127 (TWO-53PS) shipped and broke checkout: config
+        // (Media::addJsDef) rendered fine because it doesn't go through this path, but
+        // every registerJavascript()/registerStylesheet() call silently no-opped.
+        $this->context->controller->registerStylesheet('two-css', $this->getTwoModuleAssetPath('views/css/two.css'), array('priority' => 200, 'media' => 'all', 'version' => $this->getTwoAssetVersion('views/css/two.css')));
 
         // CRITICAL FIX: Remove async loading and ensure proper load order for reliable initialization
         // Ensures they load AFTER jQuery
-        $this->context->controller->registerJavascript('two-company-search', $this->getTwoVersionedAssetPath('views/js/modules/TwoCompanySearch.js'), array('priority' => 201, 'async' => false));
-        $this->context->controller->registerJavascript('two-order-intent', $this->getTwoVersionedAssetPath('views/js/modules/TwoOrderIntent.js'), array('priority' => 202, 'async' => false));
-        $this->context->controller->registerJavascript('two-sole-trader', $this->getTwoVersionedAssetPath('views/js/modules/TwoSoleTrader.js'), array('priority' => 204, 'async' => false));
-        $this->context->controller->registerJavascript('two-optional-fields', $this->getTwoVersionedAssetPath('views/js/modules/TwoOptionalFields.js'), array('priority' => 204, 'async' => false));
+        $this->context->controller->registerJavascript('two-company-search', $this->getTwoModuleAssetPath('views/js/modules/TwoCompanySearch.js'), array('priority' => 201, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoCompanySearch.js')));
+        $this->context->controller->registerJavascript('two-order-intent', $this->getTwoModuleAssetPath('views/js/modules/TwoOrderIntent.js'), array('priority' => 202, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoOrderIntent.js')));
+        $this->context->controller->registerJavascript('two-sole-trader', $this->getTwoModuleAssetPath('views/js/modules/TwoSoleTrader.js'), array('priority' => 204, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoSoleTrader.js')));
+        $this->context->controller->registerJavascript('two-optional-fields', $this->getTwoModuleAssetPath('views/js/modules/TwoOptionalFields.js'), array('priority' => 204, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoOptionalFields.js')));
         // Read-only company summary in the payment tile (TWO-25288).
         //
         // The priority is cosmetic, not a dependency guarantee, and it would be
@@ -3446,68 +3457,53 @@ class Twopayment extends PaymentModule
         // equivalent. What actually makes the call safe is the `window
         // .TwoCompanySummary && typeof ... === 'function'` guard at the call site,
         // which also covers the address step, where the tile does not exist.
-        $this->context->controller->registerJavascript('two-company-summary', $this->getTwoVersionedAssetPath('views/js/modules/TwoCompanySummary.js'), array('priority' => 200, 'async' => false));
+        $this->context->controller->registerJavascript('two-company-summary', $this->getTwoModuleAssetPath('views/js/modules/TwoCompanySummary.js'), array('priority' => 200, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoCompanySummary.js')));
         // Phone validation removed - Two API handles phone number validation
-        $this->context->controller->registerJavascript('two-checkout-manager', $this->getTwoVersionedAssetPath('views/js/modules/TwoCheckoutManager.js'), array('priority' => 205, 'async' => false));
-        $this->context->controller->registerJavascript('two-script', $this->getTwoVersionedAssetPath('views/js/twopayment.js'), array('priority' => 206, 'async' => false));
+        $this->context->controller->registerJavascript('two-checkout-manager', $this->getTwoModuleAssetPath('views/js/modules/TwoCheckoutManager.js'), array('priority' => 205, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/modules/TwoCheckoutManager.js')));
+        $this->context->controller->registerJavascript('two-script', $this->getTwoModuleAssetPath('views/js/twopayment.js'), array('priority' => 206, 'async' => false, 'version' => $this->getTwoAssetVersion('views/js/twopayment.js')));
     }
 
     /**
-     * Build a cache-busted, module-relative asset path for register{Javascript,Stylesheet}().
-     *
-     * PrestaShop's register* methods accept a 'version' param on 8.0+ only
-     * (classes/controller/FrontController.php), so it is silently ignored on
-     * the 1.7.x versions this module still supports. Appending "?v=<mtime>"
-     * directly to the relative path instead works identically across every
-     * supported PrestaShop version (1.7.6 - 9.x), because register* passes
-     * the local ('server' => 'local', the default here) path straight through
-     * as a plain string with no filesystem re-resolution of it.
-     *
-     * Best-effort: if the file can't be stat'd (e.g. moved/missing), the
-     * unversioned relative path is returned rather than throwing, matching
-     * this module's existing best-effort filemtime usage elsewhere
-     * (getTwoDeployedAtLabel).
-     *
-     * Skipped entirely when Tools::hasMediaServer() is active: PrestaShop's
-     * remote-media-server asset resolution (classes/controller/FrontController.php,
-     * legacy PS_MEDIA_SERVER_1/2/3 domain sharding) does a literal file_exists()
-     * on this same path string, which would fail once a "?v=..." query string
-     * is appended (it isn't a real file on disk). That legacy split-domain
-     * setup is rare and not something this module documents support for, so
-     * we fail back to the old, working, unversioned behaviour there rather
-     * than risk breaking asset loading on checkout.
+     * Plain module-relative asset path for register{Javascript,Stylesheet}(), e.g.
+     * 'modules/twopayment/views/js/twopayment.js'. Deliberately carries NO query
+     * string: core resolves this exact string to a real file via file_exists()
+     * before it ever becomes a URL (classes/assets/AbstractAssetManager.php
+     * getFullPath()), so anything that isn't a literal path on disk is silently
+     * dropped - no exception, no log line, the asset just never renders. Version
+     * the asset via the 'version' param on the register{Stylesheet,Javascript}()
+     * call instead (see getTwoAssetVersion()), which core applies to the URL only
+     * after that resolution has already succeeded.
      *
      * @param string $relative_path path relative to this module's own directory,
      *                               e.g. 'views/js/twopayment.js'
      *
-     * @return string 'modules/twopayment/<relative_path>[?v=<mtime>]'
+     * @return string 'modules/twopayment/<relative_path>'
      */
-    private function getTwoVersionedAssetPath($relative_path)
+    private function getTwoModuleAssetPath($relative_path)
     {
-        $module_relative_path = 'modules/' . $this->name . '/' . ltrim($relative_path, '/');
-
-        if (method_exists('Tools', 'hasMediaServer') && Tools::hasMediaServer()) {
-            return $module_relative_path;
-        }
-
-        return $module_relative_path . $this->getTwoAssetVersionQueryString($relative_path);
+        return 'modules/' . $this->name . '/' . ltrim($relative_path, '/');
     }
 
     /**
-     * '?v=<filemtime>' for a module asset, or '' if the file can't be stat'd.
-     * Shared by getTwoVersionedAssetPath() and the legacy addCSS() fallback
-     * below, which needs the query string but not the 'modules/...' prefix
-     * (it builds its own URL from $this->_path).
+     * Cache-busting value for the register{Stylesheet,Javascript}() 'version' param:
+     * the asset file's mtime, or null if it can't be stat'd (e.g. moved/missing) -
+     * core treats a null/falsy 'version' as "don't version this asset" and falls
+     * back to the plain resolved URL, matching this module's existing best-effort
+     * filemtime usage elsewhere (getTwoDeployedAtLabel).
+     *
+     * PrestaShop only reads 'version' on 8.0+ (classes/controller/FrontController.php);
+     * on the 1.7.x versions this module still supports the array key is simply
+     * ignored, so assets load unversioned there rather than not loading at all.
      *
      * @param string $relative_path path relative to this module's own directory
      *
-     * @return string '' or '?v=<mtime>'
+     * @return string|null filemtime as a string, or null
      */
-    private function getTwoAssetVersionQueryString($relative_path)
+    private function getTwoAssetVersion($relative_path)
     {
         $mtime = @filemtime(rtrim($this->local_path, '/') . '/' . ltrim($relative_path, '/'));
 
-        return $mtime ? '?v=' . $mtime : '';
+        return $mtime ? (string) $mtime : null;
     }
 
     /**
@@ -3538,15 +3534,22 @@ class Twopayment extends PaymentModule
         if (method_exists($controller, 'registerStylesheet')) {
             $controller->registerStylesheet(
                 'module-twopayment-admin-css',
-                $this->getTwoVersionedAssetPath('views/css/two.css'),
-                array('media' => 'all', 'priority' => 200)
+                $this->getTwoModuleAssetPath('views/css/two.css'),
+                array('media' => 'all', 'priority' => 200, 'version' => $this->getTwoAssetVersion('views/css/two.css'))
             );
 
             return;
         }
 
         if (method_exists($controller, 'addCSS')) {
-            $controller->addCSS($this->_path . 'views/css/two.css' . $this->getTwoAssetVersionQueryString('views/css/two.css'));
+            // addCSS() has no 'version' param and its legacy path (Controller::addCSS()
+            // -> getAssetUriFromLegacyDeprecatedMethod() -> registerStylesheet($id, $uri))
+            // hits the exact same file_exists()-on-a-query-string trap as above if a
+            // "?v=..." suffix is appended here - unversioned but loading beats versioned
+            // and silently dropped. This branch only runs on controllers old enough to
+            // lack registerStylesheet() at all, so it's not worth a parallel version
+            // mechanism.
+            $controller->addCSS($this->_path . 'views/css/two.css');
         }
     }
 


### PR DESCRIPTION
## Summary

PR #127 (TWO-53PS) cache-busted module JS/CSS by appending `?v=<mtime>` directly onto the relative path passed into `registerJavascript()`/`registerStylesheet()`. PrestaShop core resolves that exact path string to a real file via a literal `file_exists()` check (`AbstractAssetManager::getFullPath()`) **before** the asset is added to the render list; a path with a query string is never a real file on disk, so the check silently fails and the asset is dropped entirely - no exception, no log line, nothing in `ps_log`.

Consequence: every Two JS/CSS file (`TwoCompanySearch.js`, `twopayment.js`, `two.css`, etc.) stopped rendering on checkout, while the inline config (`Media::addJsDef`, a separate rendering path that doesn't go through `register*()`) kept working - which is why this looked like a partial/stale-cache page load rather than a hard failure, and why it was originally (wrongly) attributed to CDN cache staleness.

Confirmed against real core source before fixing (`classes/assets/{Abstract,Javascript,Stylesheet}Manager.php`, PS 8.2.7 on `prestashop-dev-staging`) and reproduced live: `window.twopayment` config present, zero `twopayment`-matching `<script>`/`<link>` tags or network requests.

## Fix

- New `getTwoModuleAssetPath()` returns the clean, unversioned module-relative path (replaces `getTwoVersionedAssetPath()`).
- New `getTwoAssetVersion()` returns just the mtime (or null), passed via the `'version'` param PrestaShop's `register*()` already supports on 8.0+ - applied to the URL only **after** core's file resolution succeeds, so it can no longer break resolution.
- Removed the now-obsolete `Tools::hasMediaServer()` special case (and its phpstan baseline entry): core's own remote-media-server handling in `register*()` already covers that path once we stop mangling the input string, so the special case was solving a problem our own bug created.
- Legacy `addCSS()` fallback (pre-1.7 admin controllers) now also passes a clean path - unversioned there, but loading beats versioned-and-silently-dropped.

**Scope note (adversarial review finding):** PrestaShop only added the `'version'` param to its asset-registration defaults in 8.0.0 (confirmed absent in 1.7.6.9/1.7.7.0/1.7.8.0 core source). On PS 1.7.6-1.7.9 installs the `'version'` array key we pass is silently ignored by core, so those assets load correctly but **unversioned** - this PR restores loading everywhere, but only restores cache-busting (the original TWO-53PS goal) on PS 8.0+. Flagging so this isn't read as full TWO-53PS coverage across the whole `1.7.6-9.x` range the module claims to support.

## Test plan

- [x] `php tests/run.php` - full suite green, including rewritten `AssetCacheBustingSpec`
- [x] Mutation-tested: reverted one call site back to the old path-append pattern, confirmed the new regression assertion fails with the exact error a reviewer would want to see, then restored
- [x] `phpstan analyse` clean (removed the now-unmatched `hasMediaServer` baseline ignore)
- [ ] Live re-verification on `prestashop-dev.staging.two.inc` after merge (checkout address step, populated cart): confirm `TwoCompanySearch.js` etc. load and the company field renders as the search/autocomplete widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
