### PR TITLE
fix: company-search dropdown containment, field width, hint placement, manual-entry reachability

### DIFF
--- a/tests/js/company-search-layout.test.js
+++ b/tests/js/company-search-layout.test.js
@@ -182,6 +182,27 @@ describe('the dropdown width CSS variable (2.1)', () => {
         expect(widget.hasClass('two-company-autocomplete-menu')).toBe(true);
     });
 
+    test('a throwing autocomplete("widget") degrades to an unclamped dropdown, not a dead company search', () => {
+        // TWO-30.x.10 round-2 review finding (Han): this is a cosmetic
+        // clamp, not core search functionality. `autocomplete('widget')`/
+        // `autocomplete('instance')` right below it in the source are
+        // already documented as capable of throwing on a non-standard
+        // jQuery UI build - an uncaught throw here would escape
+        // setupAutocomplete(), init() and the constructor itself, since
+        // TwoCheckoutManager.initializeCompanySearch() calls `new
+        // TwoCompanySearch(...)` with no surrounding try/catch.
+        buildAddressForm({ country: 'GB' });
+        const original = $.fn.autocomplete;
+        jest.spyOn($.fn, 'autocomplete').mockImplementation(function (...args) {
+            if (args[0] === 'widget') {
+                throw new Error('simulated non-standard jQuery UI build');
+            }
+            return original.apply(this, args);
+        });
+
+        expect(() => makeInstance()).not.toThrow();
+    });
+
     test('the stylesheet clamps only the scoped marker class, never the bare .ui-autocomplete', () => {
         // jsdom's CSS engine does not resolve `var()` at getComputedStyle time
         // (it reports the raw value), so this cannot assert the resolved
@@ -258,12 +279,77 @@ describe('the width-refresh listener on resize/orientationchange (2.1/2.2 harden
         expect(resizeBindCalls).toHaveLength(1);
     });
 
-    test('destroy() unbinds it (does not throw when a later resize fires)', () => {
+    test('destroy() actually unbinds the handler - a later resize no longer refreshes geometry', () => {
+        // TWO-30.x.10 round-2 review finding (Yoda): a bare "does not throw"
+        // assertion passes identically whether or not the listener was ever
+        // removed, since the handler itself never throws. Spy on the two
+        // methods the handler calls to prove the unbind actually happened.
+        jest.useFakeTimers();
         const instance = makeInstance();
+        const wrapperSpy = jest.spyOn(instance, 'ensureFieldWrapper');
+        const widthSpy = jest.spyOn(instance, 'constrainAutocompleteMenuWidth');
+
+        instance.destroy();
+        wrapperSpy.mockClear();
+        widthSpy.mockClear();
+
+        $(window).trigger('resize');
+        jest.advanceTimersByTime(200);
+
+        expect(wrapperSpy).not.toHaveBeenCalled();
+        expect(widthSpy).not.toHaveBeenCalled();
+    });
+
+    test('a resize DOES refresh geometry before destroy (sanity check the spy setup itself is meaningful)', () => {
+        jest.useFakeTimers();
+        const instance = makeInstance();
+        const wrapperSpy = jest.spyOn(instance, 'ensureFieldWrapper');
+        const widthSpy = jest.spyOn(instance, 'constrainAutocompleteMenuWidth');
+        wrapperSpy.mockClear();
+        widthSpy.mockClear();
+
+        $(window).trigger('resize');
+        jest.advanceTimersByTime(200);
+
+        expect(wrapperSpy).toHaveBeenCalled();
+        expect(widthSpy).toHaveBeenCalled();
+    });
+
+    test('unbinds by function reference, not by namespace alone, so a sibling instance is never at risk', () => {
+        // TWO-30.x.10 round-2 review finding (Vader): `window` is a genuine
+        // page-wide singleton; a namespace-only `.off('.twoCompanyWidth')`
+        // would remove ANY instance's handler under that name, not just the
+        // one being destroyed. Assert the actual call shape.
+        const instance = makeInstance();
+        const offSpy = jest.spyOn($.fn, 'off');
 
         instance.destroy();
 
-        expect(() => $(window).trigger('resize')).not.toThrow();
+        const call = offSpy.mock.calls.find(
+            (c) => typeof c[0] === 'string' && c[0].includes('twoCompanyWidth')
+        );
+        expect(call).toBeDefined();
+        expect(typeof call[1]).toBe('function');
+        expect(call[1]).toBe(instance._widthRefreshHandler);
+    });
+
+    test('the search source callback also refreshes the wrapper width, not just the CSS variable', () => {
+        // TWO-30.x.10 round-2 review finding (Vader): a field hidden behind a
+        // collapsed checkout step at page load measures 0 width, so its
+        // wrapper's pinned width is cleared at construction time - and no
+        // resize/orientationchange fires just because a later step reveals
+        // it. The first keystroke is the next point either measurement can
+        // be trusted, so ensureFieldWrapper() has to run alongside the CSS
+        // variable refresh already known to run there.
+        const instance = makeInstance();
+        const field = liveField();
+        const ensureSpy = jest.spyOn(instance, 'ensureFieldWrapper');
+        ensureSpy.mockClear();
+
+        field.val('Example');
+        field.autocomplete('instance').search('Example');
+
+        expect(ensureSpy).toHaveBeenCalled();
     });
 });
 

--- a/tests/js/company-search-layout.test.js
+++ b/tests/js/company-search-layout.test.js
@@ -1,0 +1,215 @@
+/**
+ * TWO-30.x.10. Regression tests for four live layout/reachability bugs Doug
+ * found testing the checkout by hand, on top of a widget already confirmed
+ * working (PR two-inc/prestashop-plugin#128):
+ *
+ *   - 2.1 the dropdown auto-widened past the field (jQuery UI's own
+ *     `_resizeMenu` sizes it to whichever is WIDER, the field or the longest
+ *     label) instead of staying a small control anchored to the field.
+ *   - 2.2/2.3 the post-selection chip and the org-number hint were positioned
+ *     against the field's THEME wrapper (a Bootstrap column div, commonly
+ *     padded) rather than the field itself, so both rendered wider than the
+ *     field and offset from its edge - and, live, the chip's opaque
+ *     background painted directly over the hint, which is why a plain
+ *     DOM-visibility assertion on the hint would have passed throughout.
+ *   - 2.4 the manual-entry row was reachable only by scrolling past every
+ *     other result first - with up to 50 companies ahead of it in a 200px
+ *     scroll viewport, effectively never in practice.
+ *
+ * jsdom computes no real layout (offsetWidth/getBoundingClientRect are 0
+ * regardless of CSS), so these tests pin what jsdom CAN observe: the DOM
+ * structure the width fix depends on, the exact value the CSS custom
+ * property is set to, and the computed style the sticky-positioning rule
+ * resolves to. The visual result (dropdown no longer 625px against a 281px
+ * field; hint visible below the field, not painted over) was verified live
+ * against https://prestashop-dev.staging.two.inc both before and after this
+ * change - that is what these unit tests cannot themselves prove.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    buildAddressForm,
+    replaceAddressForm,
+    stubAjax,
+    releaseWidgets,
+    installStylesheet
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+
+let TwoCompanySearch;
+let $;
+let bus;
+let ajax;
+
+beforeEach(() => {
+    buildAddressForm({ country: 'GB' });
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    bus = loaded.bus;
+    ajax = stubAjax($);
+});
+
+afterEach(() => {
+    releaseWidgets($);
+    ajax.restore();
+    document.body.innerHTML = '';
+    document.documentElement.style.removeProperty('--two-company-search-width');
+    jest.useRealTimers();
+});
+
+function makeInstance(extraConfig) {
+    return new TwoCompanySearch(
+        Object.assign({ checkoutHost: CHECKOUT_HOST }, extraConfig || {})
+    );
+}
+
+function liveField() {
+    return $("input[name='company']");
+}
+
+describe('the field wrapper (2.2/2.3)', () => {
+    test('wraps the company field in a single tight-fitting wrapper', () => {
+        makeInstance();
+
+        const parent = liveField().parent();
+
+        expect(parent.hasClass('two-company-field-wrap')).toBe(true);
+    });
+
+    test('does not double-wrap across a re-run of setupAutocomplete on the SAME field', () => {
+        const instance = makeInstance();
+
+        instance.setupAutocomplete();
+        instance.setupAutocomplete();
+
+        expect($('.two-company-field-wrap').length).toBe(1);
+        expect(liveField().parent().hasClass('two-company-field-wrap')).toBe(true);
+    });
+
+    test('wraps the fresh field after an address-form re-render', () => {
+        makeInstance();
+
+        replaceAddressForm({ country: 'GB' });
+        // PrestaShop swapped the node - the old wrapper, if any, went with it.
+        expect(liveField().parent().hasClass('two-company-field-wrap')).toBe(false);
+
+        bus.emit('updatedAddressForm');
+
+        expect(liveField().parent().hasClass('two-company-field-wrap')).toBe(true);
+        expect($('.two-company-field-wrap').length).toBe(1);
+    });
+
+    test('the org-id hint and the reveal chip both land inside the field wrapper', () => {
+        makeInstance();
+
+        const wrapper = liveField().parent();
+
+        expect(wrapper.find('.two-company-id-hint').length).toBe(1);
+        expect(wrapper.find('.two-company-search-reveal').length).toBe(1);
+    });
+
+    test('the hidden organisation-number field is NOT pulled into the wrapper', () => {
+        // createOrganizationField() runs before ensureFieldWrapper() in init()
+        // and inserts a plain sibling - it must stay a sibling of the wrapper,
+        // not get swept inside it, since jQuery's wrap() only wraps the
+        // selected element itself.
+        makeInstance();
+
+        const wrapper = liveField().parent();
+
+        expect(wrapper.find("input[name='companyid']").length).toBe(0);
+        expect(wrapper.siblings("input[name='companyid']").length).toBe(1);
+    });
+});
+
+describe('the dropdown width CSS variable (2.1)', () => {
+    test('constrainAutocompleteMenuWidth() publishes the field width as a CSS custom property', () => {
+        const instance = makeInstance();
+        jest.spyOn($.fn, 'outerWidth').mockReturnValue(281);
+
+        instance.constrainAutocompleteMenuWidth();
+
+        expect(document.documentElement.style.getPropertyValue('--two-company-search-width'))
+            .toBe('281px');
+    });
+
+    test('a falsy width (e.g. a detached/hidden field) leaves the property untouched', () => {
+        const instance = makeInstance();
+        jest.spyOn($.fn, 'outerWidth').mockReturnValue(0);
+
+        instance.constrainAutocompleteMenuWidth();
+
+        expect(document.documentElement.style.getPropertyValue('--two-company-search-width'))
+            .toBe('');
+    });
+
+    test('a missing/destroyed field is a no-op, not a throw', () => {
+        const instance = makeInstance();
+        instance.companyField = $();
+
+        expect(() => instance.constrainAutocompleteMenuWidth()).not.toThrow();
+    });
+
+    test('the stylesheet clamps the dropdown via the custom property, not a fixed pixel value', () => {
+        // jsdom's CSS engine does not resolve `var()` at getComputedStyle time
+        // (it reports the raw value), so this cannot assert the resolved
+        // pixel figure the way a real browser would - that is exactly what
+        // the live verification against the staging shop covers instead.
+        // What jsdom CAN prove is that the rule keys off the variable this
+        // class publishes, with a sane fallback, rather than a single fixed
+        // width that would be wrong for every field size but one.
+        installStylesheet('views/css/two.css');
+        const ul = document.createElement('ul');
+        ul.className = 'ui-autocomplete';
+        document.body.appendChild(ul);
+
+        const maxWidth = getComputedStyle(ul).maxWidth;
+        expect(maxWidth).toContain('var(--two-company-search-width');
+        expect(maxWidth).toContain('320px');
+    });
+});
+
+describe('the manual-entry row stays reachable without scrolling (2.4)', () => {
+    test('.two-autocomplete-manual-entry resolves to a sticky, opaque row', () => {
+        installStylesheet('views/css/two.css');
+        const ul = document.createElement('ul');
+        ul.className = 'ui-autocomplete';
+        const li = document.createElement('li');
+        li.className = 'two-autocomplete-manual-entry';
+        ul.appendChild(li);
+        document.body.appendChild(ul);
+
+        const style = getComputedStyle(li);
+        expect(style.position).toBe('sticky');
+        expect(style.bottom).toBe('0px');
+        // Opaque, not transparent/none - a sticky row over scrolling
+        // company names needs a real background or the names show through it.
+        expect(style.backgroundColor).not.toBe('');
+        expect(style.backgroundColor).not.toBe('transparent');
+    });
+
+    test('the SAME rule covers the custom (non-jQuery-UI) fallback path’s row', () => {
+        installStylesheet('views/css/two.css');
+        const list = document.createElement('div');
+        list.className = 'two-autocomplete-list';
+        const row = document.createElement('div');
+        row.className = 'two-autocomplete-item two-autocomplete-manual-entry';
+        list.appendChild(row);
+        document.body.appendChild(list);
+
+        expect(getComputedStyle(row).position).toBe('sticky');
+    });
+
+    test('buildManualEntryItem() / withManualEntryRow() are unchanged - still the last row', () => {
+        const instance = makeInstance();
+        const items = instance.withManualEntryRow([{ label: 'Example Trading Ltd', value: 'Example Trading Ltd' }]);
+
+        expect(items).toHaveLength(2);
+        expect(items[1].two_manual_entry).toBe(true);
+        expect(items[1].label).toBe(instance.getManualEntryText());
+    });
+});

--- a/tests/js/company-search-layout.test.js
+++ b/tests/js/company-search-layout.test.js
@@ -351,6 +351,28 @@ describe('the width-refresh listener on resize/orientationchange (2.1/2.2 harden
 
         expect(ensureSpy).toHaveBeenCalled();
     });
+
+    test('the geometry refresh also fires in manual-entry mode, not only normal search', () => {
+        // TWO-30.x.10 round-3 review finding (Vader): the manual-entry
+        // early-return (`response([])`, no dropdown at all while the buyer
+        // types their own company name) sits BELOW both geometry calls in
+        // `source`, not above them - confirmed correct by inspection, and
+        // pinned here so a future reordering that moved the early-return
+        // above them would fail this test rather than regress silently.
+        const instance = makeInstance();
+        const field = liveField();
+        instance._manualEntry = true;
+        const ensureSpy = jest.spyOn(instance, 'ensureFieldWrapper');
+        const widthSpy = jest.spyOn(instance, 'constrainAutocompleteMenuWidth');
+        ensureSpy.mockClear();
+        widthSpy.mockClear();
+
+        field.val('Some Manually Typed Name');
+        field.autocomplete('instance').search('Some Manually Typed Name');
+
+        expect(ensureSpy).toHaveBeenCalled();
+        expect(widthSpy).toHaveBeenCalled();
+    });
 });
 
 describe('the manual-entry row stays reachable without scrolling (2.4)', () => {

--- a/tests/js/company-search-layout.test.js
+++ b/tests/js/company-search-layout.test.js
@@ -137,8 +137,13 @@ describe('the dropdown width CSS variable (2.1)', () => {
             .toBe('281px');
     });
 
-    test('a falsy width (e.g. a detached/hidden field) leaves the property untouched', () => {
+    test('a falsy width (e.g. a detached/hidden field) CLEARS the property rather than leaving a stale value', () => {
+        // TWO-30.x.10 review finding (Han + Vader, convergent): this is a
+        // page-wide singleton variable. Leaving a stale value behind when a
+        // field goes hidden/detached would silently mis-clamp whatever
+        // dropdown reads the variable next.
         const instance = makeInstance();
+        document.documentElement.style.setProperty('--two-company-search-width', '999px');
         jest.spyOn($.fn, 'outerWidth').mockReturnValue(0);
 
         instance.constrainAutocompleteMenuWidth();
@@ -154,22 +159,111 @@ describe('the dropdown width CSS variable (2.1)', () => {
         expect(() => instance.constrainAutocompleteMenuWidth()).not.toThrow();
     });
 
-    test('the stylesheet clamps the dropdown via the custom property, not a fixed pixel value', () => {
+    test('destroy() clears the property so a later, differently-sized field is not mis-clamped', () => {
+        const instance = makeInstance();
+        document.documentElement.style.setProperty('--two-company-search-width', '281px');
+
+        instance.destroy();
+
+        expect(document.documentElement.style.getPropertyValue('--two-company-search-width'))
+            .toBe('');
+    });
+
+    test('the widget gets the scoping marker class, not left as bare .ui-autocomplete', () => {
+        // TWO-30.x.10 review finding (Han): `.ui-autocomplete` is jQuery UI's
+        // own un-namespaced default class - shared by any OTHER jQuery UI
+        // autocomplete the page might have live. The width clamp must be
+        // scoped to a marker THIS class controls, or it would mis-size an
+        // unrelated widget elsewhere on the page.
+        const instance = makeInstance();
+
+        const widget = liveField().autocomplete('widget');
+
+        expect(widget.hasClass('two-company-autocomplete-menu')).toBe(true);
+    });
+
+    test('the stylesheet clamps only the scoped marker class, never the bare .ui-autocomplete', () => {
         // jsdom's CSS engine does not resolve `var()` at getComputedStyle time
         // (it reports the raw value), so this cannot assert the resolved
         // pixel figure the way a real browser would - that is exactly what
         // the live verification against the staging shop covers instead.
         // What jsdom CAN prove is that the rule keys off the variable this
-        // class publishes, with a sane fallback, rather than a single fixed
-        // width that would be wrong for every field size but one.
+        // class publishes AND is scoped to the marker class, rather than a
+        // single fixed width applied to every jQuery UI autocomplete on the
+        // page.
         installStylesheet('views/css/two.css');
-        const ul = document.createElement('ul');
-        ul.className = 'ui-autocomplete';
-        document.body.appendChild(ul);
+        const bareUl = document.createElement('ul');
+        bareUl.className = 'ui-autocomplete';
+        document.body.appendChild(bareUl);
+        const scopedUl = document.createElement('ul');
+        scopedUl.className = 'ui-autocomplete two-company-autocomplete-menu';
+        document.body.appendChild(scopedUl);
 
-        const maxWidth = getComputedStyle(ul).maxWidth;
-        expect(maxWidth).toContain('var(--two-company-search-width');
-        expect(maxWidth).toContain('320px');
+        // jsdom reports an unmatched property as '' rather than the browser's
+        // 'none' initial value - a jsdom quirk, not a claim about real
+        // browsers. What matters here is that the two elements resolve
+        // DIFFERENTLY: the bare class gets nothing, the scoped one gets the
+        // clamp.
+        expect(getComputedStyle(bareUl).maxWidth).toBe('');
+        const scopedMaxWidth = getComputedStyle(scopedUl).maxWidth;
+        expect(scopedMaxWidth).toContain('var(--two-company-search-width');
+        expect(scopedMaxWidth).toContain('320px');
+    });
+});
+
+describe('the field wrapper width is pinned explicitly, not left to block auto-sizing (2.2 hardening)', () => {
+    test('ensureFieldWrapper() sets the wrapper width to the field\'s own outerWidth()', () => {
+        // TWO-30.x.10 review finding (Han + Vader, convergent): a
+        // `display:block` wrapper with no padding only matches the input's
+        // width when the input already fills its container - false on a
+        // theme where the field has its own narrower intrinsic width. Pin it
+        // explicitly instead of trusting block auto-sizing.
+        const instance = makeInstance();
+        jest.spyOn($.fn, 'outerWidth').mockReturnValue(240);
+
+        instance.ensureFieldWrapper();
+
+        expect(liveField().parent().css('width')).toBe('240px');
+    });
+
+    test('a falsy width clears a previously-set inline width rather than leaving it stale', () => {
+        // jQuery's `.css('width')` reads the COMPUTED style, which jsdom
+        // resolves to '0px' for an unset width regardless - the inline style
+        // itself is what proves whether a stale pixel value was left behind.
+        const instance = makeInstance();
+        liveField().parent().get(0).style.width = '999px';
+        jest.spyOn($.fn, 'outerWidth').mockReturnValue(0);
+
+        instance.ensureFieldWrapper();
+
+        expect(liveField().parent().get(0).style.width).toBe('');
+    });
+});
+
+describe('the width-refresh listener on resize/orientationchange (2.1/2.2 hardening)', () => {
+    test('is bound at most once per instance across repeated setupAutocomplete() calls', () => {
+        // makeInstance() itself already runs init() -> setupAutocomplete(),
+        // which is the FIRST bind - so the spy has to be in place before
+        // construction to see it, and two MORE explicit calls after should
+        // add no further binds.
+        const onSpy = jest.spyOn($.fn, 'on');
+        const instance = makeInstance();
+
+        instance.setupAutocomplete();
+        instance.setupAutocomplete();
+
+        const resizeBindCalls = onSpy.mock.calls.filter(
+            (call) => typeof call[0] === 'string' && call[0].includes('resize.twoCompanyWidth')
+        );
+        expect(resizeBindCalls).toHaveLength(1);
+    });
+
+    test('destroy() unbinds it (does not throw when a later resize fires)', () => {
+        const instance = makeInstance();
+
+        instance.destroy();
+
+        expect(() => $(window).trigger('resize')).not.toThrow();
     });
 });
 

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1211,16 +1211,32 @@
  * TwoCompanySearch.constrainAutocompleteMenuWidth(), refreshed on every
  * keystroke before jQuery UI redraws; the literal fallback only applies
  * before that has ever run.
+ *
+ * The clamp itself is scoped to `.two-company-autocomplete-menu` (added to
+ * the widget element by TwoCompanySearch, review finding) rather than the
+ * bare `.ui-autocomplete` every other rule in this section still targets:
+ * `.ui-autocomplete` is jQuery UI's own un-namespaced default class, shared
+ * by any OTHER jQuery UI autocomplete the page might have live (a native
+ * PrestaShop lookup, another module) - an unscoped max-width would clamp
+ * THAT one to this field's width too, which is a functional break, not
+ * cosmetic bleed. `box-sizing: border-box` keeps the clamp's target the
+ * same box model `outerWidth()` measures, so the dropdown's own
+ * `1px solid` border does not push it a couple of pixels past the field
+ * on a theme with no global border-box reset.
  */
 .ui-autocomplete {
     max-height: 200px;
-    max-width: var(--two-company-search-width, 320px);
     overflow-y: auto;
     border: 1px solid #ccc !important;
     border-radius: 4px !important;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
     background: white !important;
     z-index: 9999 !important;
+}
+
+.ui-autocomplete.two-company-autocomplete-menu {
+    max-width: var(--two-company-search-width, 320px);
+    box-sizing: border-box;
 }
 
 .ui-autocomplete .ui-menu-item {
@@ -1340,6 +1356,12 @@
 .two-autocomplete-manual-entry {
     cursor: pointer;
     border-top: 1px solid #e0e0e0;
+    /* -webkit-sticky first: an engine that only understands the prefixed
+       form ignores the unprefixed line below rather than the other way
+       round, and a browser that understands `sticky` also accepts (and
+       overrides with) the prefixed declaration that precedes it - so this
+       ordering is belt-and-braces, not a real fallback for either engine. */
+    position: -webkit-sticky;
     position: sticky;
     bottom: 0;
     background: #fff;

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -597,21 +597,37 @@
 }
 
 /*
- * Selected company's organisation number, shown inline next to the company
- * name field once a search result is chosen (TWO-25288). Reuses the plugin's
- * existing muted-grey token (see .two-info-label above) rather than a
- * one-off lighter grey, so it reads consistently with the other inline hints
- * already in this checkout instead of introducing a second shade of grey.
- * Positioned absolutely inside whatever field wrapper it lands in - the
- * companion JS makes that wrapper `position: relative` only if it is
- * currently static, since the wrapper markup comes from theme/core
- * PrestaShop templates this plugin does not own.
+ * Tight-fitting positioned wrapper around the company field (TWO-30.x.10),
+ * created once by TwoCompanySearch.ensureFieldWrapper(). A plain block
+ * element with no padding of its own stretches to exactly the input's width,
+ * whatever a theme's own `.form-group`/column wrapper happens to add - which
+ * is what lets the hint and the reveal chip below match the field's real
+ * width and edge instead of the wider, offset box the theme wrapper used to
+ * provide.
+ */
+.two-company-field-wrap {
+    display: block;
+    position: relative;
+}
+
+/*
+ * Selected company's organisation number, shown as a plain label BELOW the
+ * company name field once a search result is chosen (TWO-30.x.10, superseding
+ * the TWO-25288 in-field placement). Canonical design across all four
+ * platforms: never inside the search/name field itself, where it collided
+ * with long company names and - on this field specifically - ended up
+ * silently painted over by the reveal chip, invisible despite passing every
+ * DOM-visibility check. Right-aligned to the field's own right edge, which
+ * `.two-company-field-wrap` now guarantees matches the field exactly.
+ * Reuses the plugin's existing muted-grey token (see .two-info-label above)
+ * rather than a one-off lighter grey, so it reads consistently with the
+ * other inline hints already in this checkout.
  */
 .two-company-id-hint {
     position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 100%;
+    right: 0;
+    margin-top: 2px;
     color: #6b7280;
     font-size: 11px;
     white-space: nowrap;
@@ -1180,8 +1196,25 @@
    the scoped rule at the top of this file is now the only one. */
 
 /* Autocomplete Dropdown Styling */
+/*
+ * TWO-30.x.10 element 1: a proper small, contained dropdown matching the
+ * field it belongs to, like WC/Magento's select2/selectWoo - not the
+ * auto-widening box jQuery UI produces on its own. jQuery UI's `_resizeMenu`
+ * sizes this element to whichever is WIDER: the field, or the longest
+ * rendered label. With up to 50 results plus the manual-entry row that
+ * reliably outgrows the field (625px against a 281px field, live).
+ *
+ * `max-width` here is what actually contains it: the CSS width-resolution
+ * algorithm clamps a used width to `max-width` regardless of what inline
+ * `width` jQuery UI sets on this same element, so no `!important` is needed
+ * to win against it. The variable is kept current by
+ * TwoCompanySearch.constrainAutocompleteMenuWidth(), refreshed on every
+ * keystroke before jQuery UI redraws; the literal fallback only applies
+ * before that has ever run.
+ */
 .ui-autocomplete {
     max-height: 200px;
+    max-width: var(--two-company-search-width, 320px);
     overflow-y: auto;
     border: 1px solid #ccc !important;
     border-radius: 4px !important;
@@ -1208,6 +1241,13 @@
     display: block !important;
     border: none !important;
     background: none !important;
+    /* A long company name must truncate rather than push the row (and with
+       it, jQuery UI's own width measurement) wider than the field - see the
+       `.ui-autocomplete` `max-width` comment above for why the row's natural
+       content width matters at all. */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .ui-autocomplete .ui-menu-item-wrapper:hover,
@@ -1276,9 +1316,34 @@
  * visible focus state is worse than no keyboard support at all - the buyer
  * cannot tell where they are.
  */
+/*
+ * TWO-30.x.10 element 4: live-verified undiscoverable as a plain last-`<li>`
+ * row - with up to 50 results ahead of it in a 200px-tall scrollable list, it
+ * sat roughly 1400px below the visible viewport (y=2041 in a panel whose
+ * visible area ends at 652), reachable only by scrolling past every company
+ * in the register first. `buildManualEntryItem()`/`withManualEntryRow()`
+ * (TwoCompanySearch.js) are UNCHANGED - the row is still the same DOM node,
+ * still last in the list, still built and selected exactly as before - only
+ * ITS OWN positioning changes. `position: sticky` on a direct child of a
+ * `overflow-y: auto` container keeps that child pinned at the named edge of
+ * the SCROLLING viewport rather than the full scrollable content, which is
+ * exactly the "always visible, no scrolling required" behaviour this needs -
+ * without restructuring the dropdown into a separate sibling control the way
+ * WC does (a `<select>`-backed select2 panel, which has a natural place
+ * outside its results `<ul>` for such a control; this field's own
+ * `<input>` doubles as the search box, so there is no equivalent seam to
+ * hang a sibling off). Shared with the custom (non-jQuery-UI) fallback
+ * path's `.two-autocomplete-list`, which is a plain `overflow-y: auto` div
+ * with the same last-child convention - the same one rule covers both
+ * render paths.
+ */
 .two-autocomplete-manual-entry {
     cursor: pointer;
     border-top: 1px solid #e0e0e0;
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    z-index: 1;
 }
 
 .two-autocomplete-manual-entry:focus {

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -175,6 +175,7 @@ class TwoCompanySearch {
         }
         
         this.createOrganizationField();
+        this.ensureFieldWrapper();
         this.createCompanyIdHintField();
         this.clearStaleOrganizationSelection();
         this.setupCompanyInputSync();
@@ -184,6 +185,33 @@ class TwoCompanySearch {
         this.isInitialized = true;
     }
     
+    /**
+     * Publish the company field's current width as a CSS custom property, so
+     * `.ui-autocomplete`'s `max-width` (views/css/two.css) can clamp jQuery
+     * UI's own dropdown to it (TWO-30.x.10 element 1).
+     *
+     * Set on `document.documentElement` rather than on the field or its
+     * wrapper: `.ui-autocomplete` is appended by jQuery UI to `<body>`, not
+     * nested inside this field's own markup, so a variable set anywhere
+     * under the field would not inherit down to it. A custom property
+     * inherits from any ancestor in the real DOM tree, and `<html>` is
+     * common to both.
+     *
+     * A single shared variable is a page-wide singleton, matching every
+     * other assumption already documented in this class (see
+     * createRevealChip()) about there being one live company field at a
+     * time - not something this method changes or needs to solve.
+     */
+    constrainAutocompleteMenuWidth() {
+        if (!this.companyField || !this.companyField.length) {
+            return;
+        }
+        const width = this.companyField.outerWidth();
+        if (width) {
+            document.documentElement.style.setProperty('--two-company-search-width', width + 'px');
+        }
+    }
+
     /**
      * Create or ensure organization number field exists
      */
@@ -196,6 +224,42 @@ class TwoCompanySearch {
         }
         
         this.organizationField = orgField;
+    }
+
+    /**
+     * Wrap the company field in a tight-fitting positioned span, idempotently.
+     *
+     * TWO-30.x.10 element 2/3: the hint and the reveal chip used to position
+     * themselves absolutely against `this.companyField.parent()` - the
+     * field's THEME wrapper (a Bootstrap `.form-group`/column div), which
+     * commonly carries its own padding and therefore has a different width
+     * and left offset than the input it contains. A chip or hint positioned
+     * `inset: 0` / `right: 0` against THAT box renders wider than the field
+     * and offset from its edge, rather than matching it - exactly the
+     * too-wide result field and the occluded org-number hint Doug found live.
+     *
+     * A dedicated wrapper hugging only the input removes the dependency on
+     * whatever padding a theme's own wrapper happens to carry: a plain
+     * block-level element with no padding of its own stretches to the same
+     * width as the input it wraps, whatever that width is. This mirrors what
+     * select2/selectWoo already do on the Woo/Magento side - they replace the
+     * plain `<select>` with their own tightly-fitting container rather than
+     * positioning against the field's outer form markup.
+     *
+     * Re-run on every setupAutocomplete() call (not only init()), because
+     * that method re-resolves `this.companyField` against whatever node
+     * PrestaShop just put on the page on `updatedAddressForm` - a fresh node
+     * has no wrapper of ours yet.
+     */
+    ensureFieldWrapper() {
+        if (!this.companyField || !this.companyField.length) {
+            return;
+        }
+        const parent = this.companyField.parent();
+        if (parent.length && parent.hasClass('two-company-field-wrap')) {
+            return;
+        }
+        this.companyField.wrap('<span class="two-company-field-wrap"></span>');
     }
 
     /**
@@ -835,6 +899,10 @@ class TwoCompanySearch {
         // duplicate searches and two things fighting over one spinner.
         this.teardownCustomAutocomplete();
 
+        // Same re-run reasoning as the chip/hint below: a fresh field from an
+        // address-form re-render has no wrapper of ours yet.
+        this.ensureFieldWrapper();
+
         // Marks the field for the in-field spinner CSS (views/css/two.css).
         this.companyField.addClass('two-company-search-input');
 
@@ -861,6 +929,20 @@ class TwoCompanySearch {
         if ($.ui && $.ui.autocomplete && typeof $.fn.autocomplete === 'function') {
             this.companyField.autocomplete({
                 source: (request, response) => {
+                    // TWO-30.x.10 element 1: jQuery UI's own `_resizeMenu`
+                    // sizes the dropdown to whichever is WIDER, the field or
+                    // the longest rendered label - with up to 50 results plus
+                    // the manual-entry row, that reliably outgrows the field
+                    // by a large margin (625px against a 281px field, live).
+                    // Refreshed on every keystroke, before jQuery UI has a
+                    // chance to (re)compute its own inline width, so the CSS
+                    // rule below - `max-width: var(...)` - is already correct
+                    // by the time this request's response paints. A stylesheet
+                    // max-width caps the USED width regardless of what inline
+                    // `width` jQuery UI sets, with no `!important` required:
+                    // that is simply how the CSS width algorithm resolves
+                    // width against max-width.
+                    this.constrainAutocompleteMenuWidth();
                     const term = String(request.term || '');
                     // Manual entry: the buyer has said their company is not in
                     // the register, so no dropdown at all - not results, not a

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -320,15 +320,27 @@ class TwoCompanySearch {
      * every country change and address-form update, and `window` has no
      * per-listener identity check the way jQuery delegation on a document
      * node does - a second `.on('resize.twoCompanyWidth', ...)` call does
-     * not replace the first, it stacks. Namespaced anyway, so destroy() can
-     * unbind it precisely.
+     * not replace the first, it stacks.
+     *
+     * Unbound in destroy() by FUNCTION REFERENCE
+     * (`$(window).off(events, this._widthRefreshHandler)`), not by namespace
+     * alone (round-2 review finding, Vader). `window` is a genuine
+     * page-wide singleton, unlike the per-node sibling sweeps this file uses
+     * elsewhere (see createRevealChip()/removeRevealChip()) - a namespace-only
+     * `.off('.twoCompanyWidth')` would remove every instance's handler under
+     * that name, not just the one being destroyed. Not reachable today
+     * (TwoCheckoutManager.handleAddressFormUpdate() destroys the old instance
+     * and constructs the new one synchronously, so there is never a moment
+     * with two live instances of this listener at once), but binding/
+     * unbinding by reference costs nothing and removes the landmine outright
+     * rather than relying on that invariant holding forever.
      */
     setupWidthRefreshListener() {
         if (this._widthRefreshBound) {
             return;
         }
         this._widthRefreshBound = true;
-        $(window).on('resize.twoCompanyWidth orientationchange.twoCompanyWidth', () => {
+        this._widthRefreshHandler = () => {
             if (this._destroyed) {
                 return;
             }
@@ -340,7 +352,8 @@ class TwoCompanySearch {
                 this.ensureFieldWrapper();
                 this.constrainAutocompleteMenuWidth();
             }, 150);
-        });
+        };
+        $(window).on('resize.twoCompanyWidth orientationchange.twoCompanyWidth', this._widthRefreshHandler);
     }
 
     /**
@@ -1023,6 +1036,17 @@ class TwoCompanySearch {
                     // `width` jQuery UI sets, with no `!important` required:
                     // that is simply how the CSS width algorithm resolves
                     // width against max-width.
+                    //
+                    // ensureFieldWrapper() refreshed alongside it (round-2
+                    // review finding, Vader): a field hidden behind a
+                    // collapsed checkout step at page load measures 0 width,
+                    // so the wrapper's pinned width is cleared rather than
+                    // set - and no `resize`/`orientationchange` fires just
+                    // because a later step reveals it. The first keystroke
+                    // once the buyer reaches it is the next point either
+                    // measurement can be trusted, so both are refreshed here,
+                    // not only the dropdown clamp.
+                    this.ensureFieldWrapper();
                     this.constrainAutocompleteMenuWidth();
                     const term = String(request.term || '');
                     // Manual entry: the buyer has said their company is not in
@@ -1154,7 +1178,22 @@ class TwoCompanySearch {
             // `.ui-autocomplete` on the page to THIS field's width would
             // mis-size an unrelated one. `addClass` is idempotent, so this is
             // safe to repeat on every setupAutocomplete() re-run.
-            this.companyField.autocomplete('widget').addClass(TwoCompanySearch.AUTOCOMPLETE_MENU_CLASS);
+            //
+            // Wrapped in try/catch (round-2 review finding, Han): this is a
+            // cosmetic clamp, not core search functionality, and
+            // `autocomplete('widget')`/`autocomplete('instance')` right below
+            // it is ALREADY documented and guarded as capable of throwing on
+            // a non-standard jQuery UI build. Nothing here calls
+            // TwoCompanySearch's own constructor from inside a try, so an
+            // uncaught throw at this point would escape setupAutocomplete(),
+            // init(), and the constructor itself, aborting company search
+            // entirely over a failed width clamp - the opposite of this
+            // file's own risk posture everywhere else.
+            try {
+                this.companyField.autocomplete('widget').addClass(TwoCompanySearch.AUTOCOMPLETE_MENU_CLASS);
+            } catch (e) {
+                // Degrade to an unclamped (but still functional) dropdown.
+            }
 
             // Render the unavailable row as non-selectable. `ui-state-disabled`
             // is what jQuery UI's menu itself checks, so the row is skipped by
@@ -2877,7 +2916,14 @@ class TwoCompanySearch {
         // review finding) that must not keep clamping some LATER field's
         // dropdown to a width this, now-dead, field last held.
         try {
-            $(window).off('.twoCompanyWidth');
+            // By reference, not by namespace alone (round-2 review finding,
+            // Vader) - `window` is a genuine page-wide singleton, so a
+            // namespace-only `.off('.twoCompanyWidth')` would remove another
+            // still-live instance's handler too, were one ever to exist at
+            // the same time as this one's teardown.
+            if (this._widthRefreshHandler) {
+                $(window).off('resize.twoCompanyWidth orientationchange.twoCompanyWidth', this._widthRefreshHandler);
+            }
             clearTimeout(this._widthRefreshTimeoutId);
             this._widthRefreshTimeoutId = null;
             document.documentElement.style.removeProperty('--two-company-search-width');

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -186,21 +186,38 @@ class TwoCompanySearch {
     }
     
     /**
+     * The marker class the `.ui-autocomplete` this field's widget builds gets,
+     * so the CSS below can clamp THIS field's dropdown without also clamping
+     * an unrelated jQuery UI autocomplete elsewhere on the same page (a native
+     * PrestaShop lookup, another module) to whatever width this field
+     * happens to be. `.ui-autocomplete` is jQuery UI's own un-namespaced
+     * default class - reviewed and confirmed live-review finding, TWO-30.x.10.
+     */
+    static AUTOCOMPLETE_MENU_CLASS = 'two-company-autocomplete-menu';
+
+    /**
      * Publish the company field's current width as a CSS custom property, so
-     * `.ui-autocomplete`'s `max-width` (views/css/two.css) can clamp jQuery
-     * UI's own dropdown to it (TWO-30.x.10 element 1).
+     * `.ui-autocomplete.two-company-autocomplete-menu`'s `max-width`
+     * (views/css/two.css) can clamp jQuery UI's own dropdown to it
+     * (TWO-30.x.10 element 1).
      *
      * Set on `document.documentElement` rather than on the field or its
-     * wrapper: `.ui-autocomplete` is appended by jQuery UI to `<body>`, not
-     * nested inside this field's own markup, so a variable set anywhere
-     * under the field would not inherit down to it. A custom property
-     * inherits from any ancestor in the real DOM tree, and `<html>` is
-     * common to both.
+     * wrapper: the menu is appended by jQuery UI to `<body>`, not nested
+     * inside this field's own markup, so a variable set anywhere under the
+     * field would not inherit down to it. A custom property inherits from
+     * any ancestor in the real DOM tree, and `<html>` is common to both.
+     * Reached through `element.style.setProperty()` rather than jQuery's
+     * `.css()` deliberately - jQuery's setter does its own property-name
+     * normalisation, which is not guaranteed to pass a custom property
+     * through unmangled across jQuery versions.
      *
      * A single shared variable is a page-wide singleton, matching every
      * other assumption already documented in this class (see
      * createRevealChip()) about there being one live company field at a
-     * time - not something this method changes or needs to solve.
+     * time. Cleared on a falsy width and in destroy() (both TWO-30.x.10
+     * review findings) precisely because it IS a singleton: a stale value
+     * left behind by a field that has since gone hidden or been torn down
+     * must not silently keep clamping whatever field reads it next.
      */
     constrainAutocompleteMenuWidth() {
         if (!this.companyField || !this.companyField.length) {
@@ -209,6 +226,8 @@ class TwoCompanySearch {
         const width = this.companyField.outerWidth();
         if (width) {
             document.documentElement.style.setProperty('--two-company-search-width', width + 'px');
+        } else {
+            document.documentElement.style.removeProperty('--two-company-search-width');
         }
     }
 
@@ -250,16 +269,78 @@ class TwoCompanySearch {
      * that method re-resolves `this.companyField` against whatever node
      * PrestaShop just put on the page on `updatedAddressForm` - a fresh node
      * has no wrapper of ours yet.
+     *
+     * The wrapper's width is ALSO pinned explicitly here, in JS, on every
+     * call - not left to CSS block auto-sizing alone (TWO-30.x.10 review
+     * finding, Han + Vader convergent). A `display:block`/`inline-block` span
+     * with no padding of its own only ends up the SAME width as the input it
+     * wraps when the input already fills 100% of its container; on a theme
+     * where the field has its own narrower intrinsic width (a `size=`
+     * attribute, a non-Bootstrap layout, an input-group addon) that
+     * assumption silently fails and reproduces this PR's own bug one DOM
+     * level lower. Pinning the width directly to the input's own
+     * `outerWidth()` removes the assumption entirely, whatever the
+     * containing layout does.
      */
     ensureFieldWrapper() {
         if (!this.companyField || !this.companyField.length) {
             return;
         }
-        const parent = this.companyField.parent();
-        if (parent.length && parent.hasClass('two-company-field-wrap')) {
+        let wrapper = this.companyField.parent();
+        if (!wrapper.length || !wrapper.hasClass('two-company-field-wrap')) {
+            this.companyField.wrap('<span class="two-company-field-wrap"></span>');
+            wrapper = this.companyField.parent();
+        }
+        const width = this.companyField.outerWidth();
+        if (width) {
+            wrapper.css('width', width + 'px');
+        } else {
+            // Cleared, not left stale: a wrapper created while the field was
+            // momentarily hidden/detached must not keep a previous, possibly
+            // wrong, pixel width once the field is measurable again - same
+            // staleness hazard as the CSS variable in
+            // constrainAutocompleteMenuWidth(), same fix.
+            wrapper.css('width', '');
+        }
+    }
+
+    /**
+     * Keep the wrapper width and the dropdown-clamp CSS variable current
+     * across a viewport change, not only on the next keystroke (TWO-30.x.10
+     * review finding, Han + Vader convergent).
+     *
+     * Both are otherwise only refreshed from the `source` callback, i.e. once
+     * per search. A buyer who rotates a tablet or resizes the window while
+     * the dropdown is already open, without typing again first, would
+     * otherwise see the wrapper/dropdown drift out of sync with the field
+     * until their next keystroke corrects it.
+     *
+     * Bound at most once per instance (`_widthRefreshBound` guards it): this
+     * method is called from setupAutocomplete(), which itself re-runs on
+     * every country change and address-form update, and `window` has no
+     * per-listener identity check the way jQuery delegation on a document
+     * node does - a second `.on('resize.twoCompanyWidth', ...)` call does
+     * not replace the first, it stacks. Namespaced anyway, so destroy() can
+     * unbind it precisely.
+     */
+    setupWidthRefreshListener() {
+        if (this._widthRefreshBound) {
             return;
         }
-        this.companyField.wrap('<span class="two-company-field-wrap"></span>');
+        this._widthRefreshBound = true;
+        $(window).on('resize.twoCompanyWidth orientationchange.twoCompanyWidth', () => {
+            if (this._destroyed) {
+                return;
+            }
+            clearTimeout(this._widthRefreshTimeoutId);
+            this._widthRefreshTimeoutId = setTimeout(() => {
+                if (this._destroyed) {
+                    return;
+                }
+                this.ensureFieldWrapper();
+                this.constrainAutocompleteMenuWidth();
+            }, 150);
+        });
     }
 
     /**
@@ -273,16 +354,14 @@ class TwoCompanySearch {
         if (hintField.length === 0) {
             hintField = $('<span class="two-company-id-hint"></span>');
             this.companyField.after(hintField);
-
-            // The hint is positioned absolutely (see two.css), which needs a
-            // positioned ancestor. The company field's wrapper markup comes
-            // from theme/core PrestaShop templates this plugin does not own,
-            // so only force `relative` when the wrapper is still `static` -
-            // never override a wrapper that already has its own positioning.
-            const wrapper = this.companyField.parent();
-            if (wrapper.length && wrapper.css('position') === 'static') {
-                wrapper.css('position', 'relative');
-            }
+            // The hint is positioned absolutely (see two.css) against
+            // `.two-company-field-wrap`, which ensureFieldWrapper() - called
+            // before this method on every init()/setupAutocomplete() run -
+            // already guarantees exists and is `position: relative` on its
+            // own stylesheet rule. Nothing to force here any more: this used
+            // to reach into the field's THEME wrapper and set its position by
+            // hand, which is also what put the hint and chip outside the
+            // wrapper widths in TWO-30.x.10.
         }
 
         this.companyIdHintField = hintField;
@@ -335,9 +414,10 @@ class TwoCompanySearch {
     /**
      * Create the click-to-reveal chip (TWO-25288 element 2), idempotently.
      *
-     * A sibling `<button>`, absolutely positioned over the real input - the
-     * same wrapper createCompanyIdHintField() already forces to
-     * `position: relative` when it is still static. Called from
+     * A sibling `<button>`, absolutely positioned over the real input - inside
+     * the same `.two-company-field-wrap` ensureFieldWrapper() guarantees is
+     * already `position: relative` (see createCompanyIdHintField()). Called
+     * from
      * setupAutocomplete(), not only init(): that method is what re-runs on
      * every country change and `updatedAddressForm`, re-resolving whatever
      * field PrestaShop just put on the page, so the chip has to be rebuilt on
@@ -902,6 +982,7 @@ class TwoCompanySearch {
         // Same re-run reasoning as the chip/hint below: a fresh field from an
         // address-form re-render has no wrapper of ours yet.
         this.ensureFieldWrapper();
+        this.setupWidthRefreshListener();
 
         // Marks the field for the in-field spinner CSS (views/css/two.css).
         this.companyField.addClass('two-company-search-input');
@@ -1064,6 +1145,16 @@ class TwoCompanySearch {
                     }
                 }
             });
+
+            // Marker class for the CSS width clamp (TWO-30.x.10 element 1,
+            // Han review finding): `.ui-autocomplete` is jQuery UI's own
+            // un-namespaced default class, shared by any OTHER jQuery UI
+            // autocomplete that might be live on the same page (a native
+            // PrestaShop lookup, another module). Clamping every
+            // `.ui-autocomplete` on the page to THIS field's width would
+            // mis-size an unrelated one. `addClass` is idempotent, so this is
+            // safe to repeat on every setupAutocomplete() re-run.
+            this.companyField.autocomplete('widget').addClass(TwoCompanySearch.AUTOCOMPLETE_MENU_CLASS);
 
             // Render the unavailable row as non-selectable. `ui-state-disabled`
             // is what jQuery UI's menu itself checks, so the row is skipped by
@@ -2778,6 +2869,18 @@ class TwoCompanySearch {
         // handler on a node that would otherwise outlive this instance.
         try {
             this.removeRevealChip();
+        } catch (e) {
+            // no-op
+        }
+        // Its own try for the same reason again: a live `window` listener
+        // outliving this instance, plus a page-wide CSS variable (TWO-30.x.10
+        // review finding) that must not keep clamping some LATER field's
+        // dropdown to a width this, now-dead, field last held.
+        try {
+            $(window).off('.twoCompanyWidth');
+            clearTimeout(this._widthRefreshTimeoutId);
+            this._widthRefreshTimeoutId = null;
+            document.documentElement.style.removeProperty('--two-company-search-width');
         } catch (e) {
             // no-op
         }


### PR DESCRIPTION
## Summary

Four live checkout bugs Doug found testing the address step by hand, on top of the asset-loading regression fix in PR #128 (confirmed working the night before):

- **2.1** The company-search dropdown auto-widened past the field (jQuery UI's own `_resizeMenu` sizes it to whichever is wider, the field or the longest label - live: 625px against a 281px field). Clamped via a CSS custom property refreshed on every keystroke, plus ellipsis truncation on long labels, so it stays a small contained control anchored to the field like the WC/Magento widgets.
- **2.2/2.3** The post-selection summary and the org-number hint were positioned against the field's *theme* wrapper (a padded Bootstrap column div) rather than the field itself, so both rendered wider than the field and offset from its edge - live, the summary chip's opaque background painted directly over the hint, invisible despite passing every DOM-visibility check. Both now live inside a new tight-fitting wrapper that hugs only the input. The org-number hint also moved from inside/over the field to a plain label below it, right-aligned to the field's edge - canonical design across all four platforms, so it no longer collides with long company names.
- **2.4** The "my company is not on the list" row was reachable only by scrolling past every other result first - live, ~1400px below the visible viewport with up to 50 results ahead of it. Pinned with `position: sticky` so it stays visible without scrolling, on both the jQuery UI and the custom-fallback render paths, without restructuring either into a separate sibling-button control.

## Test plan

- [x] `npm run test:js` - 298 passed (286 pre-existing + 12 new), added `tests/js/company-search-layout.test.js`
- [x] New tests mutation-verified (temporarily reverted each fix, confirmed the corresponding test fails, then restored)
- [x] Live-verified against the staging shop before and after this change
