### PR TITLE
fix: 5 live checkout bugs found post-PR#129 (TWO-30.x.14)

### DIFF
--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -94,6 +94,75 @@ describe('the real jQuery UI widget is what gets bound', () => {
         expect(liveField().autocomplete('option', 'minLength')).toBe(0);
         expect(liveField().autocomplete('option', 'delay')).toBe(300);
     });
+
+    test('#30.x.14 bug 2.1: the menu opens with a visible gap below the field, not flush against it', () => {
+        makeInstance();
+
+        // Live-verified: jQuery UI's own default (`my: "left top"` against
+        // `at: "left bottom"`) butted the menu directly against the field
+        // with zero pixels between them, reading as one continuous control.
+        // `top+8` is what actually opens a gap a buyer can see.
+        expect(liveField().autocomplete('option', 'position')).toEqual({
+            my: 'left top+8',
+            at: 'left bottom',
+            collision: 'none'
+        });
+    });
+});
+
+describe('#30.x.14 bug 2.1: focusing the field opens a control, not just plain typing', () => {
+    function menu() {
+        return $('ul.ui-autocomplete');
+    }
+
+    test('focusing an EMPTY field opens the menu showing the hint row', () => {
+        makeInstance();
+        const field = liveField();
+
+        expect(menu().css('display')).toBe('none');
+
+        field.trigger('focus');
+
+        expect(menu().css('display')).not.toBe('none');
+        expect(menu().find('li').hasClass('two-autocomplete-focus-hint')).toBe(true);
+    });
+
+    test('focusing a field already holding a searchable term re-opens its results, not the hint', () => {
+        const instance = makeInstance();
+        const field = liveField();
+        const atThreshold = 'a'.repeat(TwoCompanySearch.MIN_SEARCH_LENGTH);
+
+        field.val(atThreshold);
+        field.trigger('focus');
+        ajax.last().succeed(SEARCH_RESPONSE);
+
+        expect(menu().find('li.two-autocomplete-focus-hint')).toHaveLength(0);
+        expect(menu().find('li').not('.two-autocomplete-manual-entry')).toHaveLength(SEARCH_RESPONSE.items.length);
+        void instance;
+    });
+
+    test('focusing the field while in manual entry opens nothing', () => {
+        const instance = makeInstance();
+        const field = liveField();
+
+        instance.enterManualEntryMode();
+        field.trigger('focus');
+
+        expect(menu().css('display')).toBe('none');
+    });
+
+    test('a destroyed instance does not reopen the menu on focus', () => {
+        const instance = makeInstance();
+        const field = liveField();
+
+        instance.destroy();
+        // destroy() unbinds the namespaced handler; nothing left to throw or
+        // reopen the menu on a field the instance no longer owns. The widget
+        // itself is torn down too, so the menu element is gone outright
+        // rather than merely hidden.
+        expect(() => field.trigger('focus')).not.toThrow();
+        expect(menu()).toHaveLength(0);
+    });
 });
 
 describe('the company-search hints (TWO-25288)', () => {
@@ -242,14 +311,21 @@ describe('the company-search hints (TWO-25288)', () => {
             expect($('ul.ui-autocomplete li.two-autocomplete-too-short')).toHaveLength(0);
         });
 
-        test('an empty field shows no row at all', () => {
+        test('an empty field shows exactly the focus-open hint row, no search made', () => {
             makeInstance();
 
             search('');
 
-            // The placeholder is already the hint for this state; a dropdown
-            // repeating it under an untouched field is noise.
-            expect(rows()).toHaveLength(0);
+            // #30.x.14 bug 2.1: a click/focus into an empty field must open
+            // something - a plain `response([])` here is indistinguishable
+            // from "not a dropdown at all", which was the live complaint.
+            // Still not a real search: no company can be searched for on an
+            // empty term, so no request goes out and the row is the same
+            // placeholder text repeated, not a live result.
+            expect(rows()).toHaveLength(1);
+            expect(rows().hasClass('two-autocomplete-focus-hint')).toBe(true);
+            expect(rows().hasClass('ui-state-disabled')).toBe(true);
+            expect(rows().attr('aria-disabled')).toBe('true');
             expect(ajax.calls).toHaveLength(0);
         });
 
@@ -479,7 +555,13 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25288)', () => 
 
         search('');
 
-        expect(rows()).toHaveLength(0);
+        // #30.x.14 bug 2.1: an empty field now shows the focus-open hint row
+        // instead of nothing, but the manual-entry row itself is still gated
+        // out here - "not on the list" is a claim about a search that has not
+        // happened yet, same reasoning as the below-threshold case above.
+        expect(rows()).toHaveLength(1);
+        expect(rows().hasClass('two-autocomplete-focus-hint')).toBe(true);
+        expect(manualRow()).toHaveLength(0);
     });
 
     test('it is NOT disabled and NOT aria-disabled, unlike every message row', () => {
@@ -664,6 +746,32 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25288)', () => 
         expect(menu().css('display')).not.toBe('none');
         expect(rows()).toHaveLength(2);
         expect(rows().last().hasClass('two-autocomplete-manual-entry')).toBe(true);
+    });
+
+    test('#30.x.14 bug 2.5: clicking it does not bubble into an ancestor handler (accordion-toggle regression)', () => {
+        const instance = makeInstance();
+        const field = liveField();
+
+        search(AT_THRESHOLD);
+        ajax.last().succeed(SEARCH_RESPONSE);
+        field.autocomplete('option', 'select')(null, { item: instance.buildManualEntryItem() });
+
+        const link = $('.two-company-search-back');
+        expect(link).toHaveLength(1);
+
+        // Stands in for the checkout theme's own delegated accordion-toggle
+        // handler on the address step container - live, this click bubbled up
+        // into whatever collapses that step and closed the whole address
+        // section the buyer was mid-edit in.
+        let ancestorClicks = 0;
+        link.closest('.js-address-form').on('click', () => { ancestorClicks += 1; });
+
+        link.trigger('click');
+
+        expect(ancestorClicks).toBe(0);
+        // The button's own behaviour must still run - this is stopPropagation,
+        // not a swallowed click.
+        expect(instance._manualEntry).toBe(false);
     });
 
     test('a country change while in manual entry does not strand the buyer', () => {

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -110,30 +110,52 @@ describe('the real jQuery UI widget is what gets bound', () => {
     });
 });
 
-describe('#30.x.14 bug 2.1: focusing the field opens a control, not just plain typing', () => {
+describe('#30.x.14 bug 2.1: a real click opens a control, plain keyboard focus does not', () => {
     function menu() {
         return $('ul.ui-autocomplete');
     }
 
-    test('focusing an EMPTY field opens the menu showing the hint row', () => {
+    /** A real user click: mousedown fires before focus, in that order. */
+    function click(field) {
+        field.trigger('mousedown');
+        field.trigger('focus');
+    }
+
+    test('clicking into an EMPTY field opens the menu showing the hint row', () => {
         makeInstance();
         const field = liveField();
 
         expect(menu().css('display')).toBe('none');
 
-        field.trigger('focus');
+        click(field);
 
         expect(menu().css('display')).not.toBe('none');
         expect(menu().find('li').hasClass('two-autocomplete-focus-hint')).toBe(true);
     });
 
-    test('focusing a field already holding a searchable term re-opens its results, not the hint', () => {
+    test('plain keyboard focus (Tab, no mousedown) opens nothing', () => {
+        // Round-1 adversarial review finding (Vader): the hint row is
+        // aria-disabled/keyboard-skipped by design, so opening it for a
+        // keyboard user with no signal of intent to search would announce a
+        // result becoming available with nothing they could actually select
+        // - a regression from the old, silent behaviour. Gating on a real
+        // `mousedown` (which Tab never fires) is what keeps Tab silent while
+        // still opening for an actual click.
+        makeInstance();
+        const field = liveField();
+
+        field.trigger('focus');
+
+        expect(menu().css('display')).toBe('none');
+    });
+
+    test('clicking a field already holding a searchable term re-opens its results, not the hint', () => {
         const instance = makeInstance();
         const field = liveField();
         const atThreshold = 'a'.repeat(TwoCompanySearch.MIN_SEARCH_LENGTH);
 
         field.val(atThreshold);
-        field.trigger('focus');
+        click(field);
         ajax.last().succeed(SEARCH_RESPONSE);
 
         expect(menu().find('li.two-autocomplete-focus-hint')).toHaveLength(0);
@@ -141,27 +163,76 @@ describe('#30.x.14 bug 2.1: focusing the field opens a control, not just plain t
         void instance;
     });
 
-    test('focusing the field while in manual entry opens nothing', () => {
+    test('clicking the field while in manual entry opens nothing', () => {
         const instance = makeInstance();
         const field = liveField();
 
         instance.enterManualEntryMode();
+        click(field);
+
+        expect(menu().css('display')).toBe('none');
+    });
+
+    test('the pointer signal is one-shot: a second focus with no mousedown in between does not reopen it', () => {
+        makeInstance();
+        const field = liveField();
+
+        click(field);
+        expect(menu().css('display')).not.toBe('none');
+
+        // jQuery UI's own `close()` is conditioned on the menu passing
+        // jQuery's `:visible` check - a real layout test that jsdom never
+        // computes, so it is a no-op here (same reasoning documented on
+        // TwoCompanySearch.enterManualEntryMode(), which hides the menu
+        // element directly for the same reason). Doing the same here closes
+        // it deterministically so this test is about whether the SECOND
+        // focus below reopens it, not about jQuery UI's own blur/close
+        // timing.
+        field.autocomplete('instance').menu.element.hide();
+        expect(menu().css('display')).toBe('none');
+
         field.trigger('focus');
 
         expect(menu().css('display')).toBe('none');
     });
 
-    test('a destroyed instance does not reopen the menu on focus', () => {
+    test('a destroyed instance does not reopen the menu on click', () => {
         const instance = makeInstance();
         const field = liveField();
 
         instance.destroy();
-        // destroy() unbinds the namespaced handler; nothing left to throw or
-        // reopen the menu on a field the instance no longer owns. The widget
-        // itself is torn down too, so the menu element is gone outright
-        // rather than merely hidden.
-        expect(() => field.trigger('focus')).not.toThrow();
+        // destroy() unbinds both namespaced handlers; nothing left to throw
+        // or reopen the menu on a field the instance no longer owns. The
+        // widget itself is torn down too, so the menu element is gone
+        // outright rather than merely hidden.
+        expect(() => click(field)).not.toThrow();
         expect(menu()).toHaveLength(0);
+    });
+
+    test('moving to a replaced field during setupAutocomplete() unbinds the old field\'s pointer/focus handlers', () => {
+        // Round-1 adversarial review finding (Han): setupAutocomplete()'s
+        // "moving to a replaced field" branch released the old field's
+        // jQuery UI widget but left `focus.twoCompanyOpen` /
+        // `mousedown.twoCompanyOpen` bound to it directly (they are bound
+        // via jQuery, not through the widget, so `autocomplete('destroy')`
+        // does not touch them).
+        const instance = makeInstance();
+        const oldField = liveField();
+
+        replaceAddressForm({ country: 'GB' });
+        instance.setupAutocomplete();
+
+        // The old node is detached, so it can never receive a REAL user
+        // mousedown/focus again - but a directly `.trigger()`ed one still
+        // reaches any handler still bound, which is exactly what a leaked
+        // binding would answer to.
+        expect(() => {
+            oldField.trigger('mousedown');
+            oldField.trigger('focus');
+        }).not.toThrow();
+        // No menu opens for the detached node - it has no widget any more -
+        // and the live field's own listener is unaffected.
+        expect($('ul.ui-autocomplete').filter((i, el) => $(el).css('display') !== 'none')).toHaveLength(0);
     });
 });
 
@@ -746,6 +817,31 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25288)', () => 
         expect(menu().css('display')).not.toBe('none');
         expect(rows()).toHaveLength(2);
         expect(rows().last().hasClass('two-autocomplete-manual-entry')).toBe(true);
+    });
+
+    test('#30.x.14: clicking the reverse link fires exactly one search, not two', () => {
+        // Round-1 adversarial review finding (Vader): exitManualEntryMode()
+        // used to BOTH `.trigger('focus')` (which the then-ungated
+        // `focus.twoCompanyOpen` handler treated as a fresh open) AND make
+        // its own explicit `autocomplete('search', term)` call - firing the
+        // search twice on every click. A raw ajax-call count can't tell the
+        // two apart: the result cache created for this same term by the
+        // search below serves BOTH calls with zero network requests either
+        // way, whether the fix landed or not. Spying on the one shared call
+        // site (openSearchForCurrentTerm()) is what actually distinguishes
+        // them.
+        const instance = makeInstance();
+        const field = liveField();
+
+        search(AT_THRESHOLD);
+        ajax.last().succeed(SEARCH_RESPONSE);
+        field.autocomplete('option', 'select')(null, { item: instance.buildManualEntryItem() });
+
+        const spy = jest.spyOn(instance, 'openSearchForCurrentTerm');
+        $('.two-company-search-back').trigger('click');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
     });
 
     test('#30.x.14 bug 2.5: clicking it does not bubble into an ancestor handler (accordion-toggle regression)', () => {

--- a/tests/js/company-search-reveal.test.js
+++ b/tests/js/company-search-reveal.test.js
@@ -457,6 +457,35 @@ describe('the same chip works on the custom fallback path (jQuery UI absent)', (
 });
 
 describe('regressions found in adversarial review', () => {
+    test('#30.x.14 round-2 (Vader): a stale pointer-focus flag does not make revealSearch() double-dispatch', () => {
+        // `_pointerFocusPending` (TwoCompanySearch.js) is set by a `mousedown`
+        // on the field and consumed by the next `focus`. A real click INTO an
+        // already-focused field - e.g. the buyer clicking again mid-typing to
+        // reposition the caret - fires `mousedown` with no accompanying
+        // `focus` (the field was already focused, so focus does not change),
+        // leaving the flag stuck `true`. If the field then genuinely blurs
+        // (the reveal chip sits on top and clicking it moves real DOM focus
+        // to the chip) and revealSearch() later does `.trigger('focus')`,
+        // that stale `true` would make the namespaced handler fire its own
+        // extra `openSearchForCurrentTerm()` call on top of revealSearch()'s
+        // own explicit one - two searches from one chip click.
+        const instance = makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        const field = liveField();
+
+        // Simulate the stale flag directly - reproducing the exact prior
+        // mousedown-while-focused gesture would need real browser focus
+        // semantics jsdom does not model, but the flag IS the mechanism
+        // under test.
+        instance._pointerFocusPending = true;
+
+        const spy = jest.spyOn(instance, 'openSearchForCurrentTerm');
+        chip().trigger('click');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
+
     test('a country change while revealed disarms the pending restore instead of resurrecting a stale pairing', () => {
         // The country <select>'s own change handler runs on this SAME
         // instance (unlike a genuine updatedAddressForm re-render, which

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -608,6 +608,16 @@
 .two-company-field-wrap {
     display: block;
     position: relative;
+    /*
+     * #30.x.14 bug 2.2, live-verified: the org-number hint below is
+     * absolutely positioned (see `.two-company-id-hint`), so it takes no
+     * space in normal flow and the next form field started immediately at
+     * this wrapper's own bottom edge - touching the hint text with no gap.
+     * A small padding-bottom reserves room in the flow for the hint's own
+     * height without touching the wrapper's rendered width or the field's
+     * own box.
+     */
+    padding-bottom: 4px;
 }
 
 /*
@@ -1229,7 +1239,15 @@
     overflow-y: auto;
     border: 1px solid #ccc !important;
     border-radius: 4px !important;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
+    /*
+     * #30.x.14 bug 2.1, live-verified: with the previous shadow the panel's
+     * grey border sat flush against the field's own border (0px gap live),
+     * reading as one continuous control rather than a floating panel - on
+     * top of the JS `position` option now opening an 8px gap (see
+     * TwoCompanySearch.js), a visibly heavier shadow is what actually sells
+     * that gap as intentional rather than looking like a rendering seam.
+     */
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
     background: white !important;
     z-index: 9999 !important;
 }
@@ -1356,6 +1374,17 @@
 .two-autocomplete-manual-entry {
     cursor: pointer;
     border-top: 1px solid #e0e0e0;
+    /*
+     * #30.x.14 bug 2.3, live-verified: this row rendered in the same
+     * `rgb(34,34,34)` body-text colour as every ordinary company result, with
+     * nothing distinguishing it as the one actionable, non-company row in the
+     * list. Matches WC's `#search_company_btn` link-blue so the affordance
+     * reads as clickable across platforms. The `!important` override just
+     * below is what actually wins - jQuery UI's menu widget slaps its own
+     * `ui-menu-item-wrapper` class (styled `color: #333 !important` earlier
+     * in this file) onto whatever `_renderItem` returns, this row included.
+     */
+    color: #3043d1;
     /* -webkit-sticky first: an engine that only understands the prefixed
        form ignores the unprefixed line below rather than the other way
        round, and a browser that understands `sticky` also accepts (and
@@ -1374,6 +1403,22 @@
 }
 
 /*
+ * `!important` for the same reason the message-row override above needs it:
+ * jQuery UI's menu widget applies `ui-menu-item-wrapper` (coloured
+ * `#333 !important` near the top of this section) to this row's own
+ * `<div>` too, on top of whatever class `_renderItem` gave it. Covers
+ * hover/active/focus explicitly - the generic `.ui-menu-item-wrapper:hover`
+ * rule also re-asserts `#333 !important` on interaction, which would
+ * otherwise win back the moment the buyer points at or arrows onto this row.
+ */
+.ui-autocomplete .two-autocomplete-manual-entry.ui-menu-item > div,
+.ui-autocomplete .two-autocomplete-manual-entry.ui-menu-item > div:hover,
+.ui-autocomplete .two-autocomplete-manual-entry.ui-menu-item > div.ui-state-active,
+.ui-autocomplete .two-autocomplete-manual-entry.ui-menu-item > div.ui-state-focus {
+    color: #3043d1 !important;
+}
+
+/*
  * The way back out of manual entry. A real <button>, so every one of the
  * browser's button defaults has to be undone to make it read as a link.
  */
@@ -1385,7 +1430,8 @@
     background: none;
     font: inherit;
     color: #1976d2;
-    text-decoration: underline;
+    /* #30.x.14 bug 2.4, live-verified: Doug does not want this underlined. */
+    text-decoration: none;
     cursor: pointer;
 }
 

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -613,11 +613,20 @@
      * absolutely positioned (see `.two-company-id-hint`), so it takes no
      * space in normal flow and the next form field started immediately at
      * this wrapper's own bottom edge - touching the hint text with no gap.
-     * A small padding-bottom reserves room in the flow for the hint's own
-     * height without touching the wrapper's rendered width or the field's
-     * own box.
+     * `--two-company-hint-clearance` reserves room in the flow for it
+     * without touching the wrapper's rendered width or the field's own box.
+     *
+     * The value has to cover the hint's own real footprint, not just a
+     * cosmetic 4px (round-1 adversarial review finding, Han): that rule sets
+     * `font-size: 11px` with a `margin-top: 2px` of its own, which alone
+     * renders at roughly 15-16px tall - a bare 4px here left the hint
+     * overlapping the next field by most of its own height. One shared
+     * custom property, read by both rules below, so the wrapper's reserved
+     * space and the hint's real footprint cannot drift apart again the way
+     * the original 4px did.
      */
-    padding-bottom: 4px;
+    --two-company-hint-clearance: 18px;
+    padding-bottom: var(--two-company-hint-clearance);
 }
 
 /*
@@ -637,6 +646,13 @@
     position: absolute;
     top: 100%;
     right: 0;
+    /*
+     * If this margin, the font-size below, or the line-height they resolve
+     * to ever grows, re-check `--two-company-hint-clearance` on
+     * `.two-company-field-wrap` above still comfortably exceeds it (#30.x.14
+     * bug 2.2) - that variable is what stops this hint from overlapping the
+     * next form field, and the two are not otherwise tied together.
+     */
     margin-top: 2px;
     color: #6b7280;
     font-size: 11px;

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -577,6 +577,21 @@ class TwoCompanySearch {
         this._revealed = true;
         this.companyField.val('');
         this.updateRevealChip();
+        // Cleared BEFORE `.trigger('focus')` below, not after (round-2
+        // adversarial review finding, Vader): `_pointerFocusPending` can be
+        // left stale `true` by an earlier mousedown that landed on an
+        // ALREADY-focused field (e.g. the buyer clicking again mid-typing to
+        // reposition the caret) - a real click that fires no paired `focus`
+        // to consume the flag, because focus does not change. If this field
+        // genuinely still held focus at that point and only lost it later
+        // when the chip itself was clicked, `.trigger('focus')` below is a
+        // REAL focus transition and the namespaced handler would read that
+        // stale `true` and call `openSearchForCurrentTerm()` on its own -
+        // stacking with the explicit call on the next line into two searches
+        // from one click. Clearing here first makes the explicit call below
+        // the only one that can ever fire from this method, regardless of
+        // whatever the flag was carrying in.
+        this._pointerFocusPending = false;
         this.companyField.trigger('focus');
         // A real click (or key activation) on the chip got us here, so open
         // directly rather than relying on the pointer-gated
@@ -1613,6 +1628,12 @@ class TwoCompanySearch {
         if (!this.companyField || this.companyField.length === 0) {
             return;
         }
+        // Cleared before `.trigger('focus')`, same reasoning and same round-2
+        // adversarial review finding (Vader) as revealSearch() above: a
+        // stale `true` left by an earlier mousedown-on-an-already-focused-
+        // field must not let the namespaced handler fire its own extra
+        // `openSearchForCurrentTerm()` call on top of the explicit one below.
+        this._pointerFocusPending = false;
         this.companyField.trigger('focus');
 
         if (this.companyField.hasClass('ui-autocomplete-input')) {

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1056,10 +1056,21 @@ class TwoCompanySearch {
                         response([]);
                         return;
                     }
-                    // Empty field: the placeholder is already the hint for this
-                    // state, so opening a dropdown to repeat it would be noise.
+                    // Empty field, but a search WAS asked for (a click/focus
+                    // into the field, not a keystroke - see the `focus`
+                    // handler below). #30.x.14 bug 2.1, live-verified: with
+                    // `response([])` here, focusing an empty field opened
+                    // nothing at all - the field just accepted typed input,
+                    // with no visible control the buyer could point to as
+                    // "this is a search widget". A one-row hint gives that
+                    // click something to show, the same way Mag/WC's
+                    // select2/selectWoo combobox opens a panel on click before
+                    // a single character is typed. Goes through the same
+                    // `two_unavailable` message-row plumbing as
+                    // buildTooShortItem() below - reachable but unselectable,
+                    // keyboard-skipped, muted styling.
                     if (term.length === 0) {
-                        response([]);
+                        response([this.buildFocusHintItem()]);
                         return;
                     }
                     // Typed, but not enough to search on. Say so instead of
@@ -1124,6 +1135,16 @@ class TwoCompanySearch {
                 // 300ms matches the custom fallback path below and the
                 // Magento/WooCommerce plugins.
                 delay: 300,
+                // #30.x.14 bug 2.1, live-verified: jQuery UI's own default
+                // (`my: "left top"` against `at: "left bottom"`) butts the
+                // menu directly against the field with a zero-pixel seam - on
+                // screen it reads as one continuous control rather than a
+                // floating panel distinct from the input, which is exactly
+                // the "still just editing in the field" complaint. `top+8`
+                // opens a real gap so the two are visibly separate boxes, the
+                // same visual break Mag/WC's select2/selectWoo panel has
+                // below its own combobox.
+                position: { my: 'left top+8', at: 'left bottom', collision: 'none' },
                 select: (event, ui) => {
                     // The manual-entry row IS actionable, unlike the message
                     // rows: it runs its action and then returns false, which is
@@ -1286,6 +1307,32 @@ class TwoCompanySearch {
             } catch (e) {
                 // Older jQuery UI without `instance`; styling only, safe to skip.
             }
+
+            // #30.x.14 bug 2.1, live-verified: focusing an empty field opened
+            // nothing - jQuery UI only ever searches on `input`/keydown, never
+            // on plain focus, so a click into the field looked and behaved
+            // exactly like a plain text box until the buyer typed a
+            // character. Forcing a search on focus - which, for an empty
+            // term, now renders the hint row via buildFocusHintItem() above -
+            // is what gives that click something to open, matching Mag/WC's
+            // combobox opening its panel on click before any typing.
+            //
+            // Namespaced and unbound-then-rebound (not `.one()`): this runs on
+            // every setupAutocomplete() re-entry (country change,
+            // updatedAddressForm), which re-resolves `this.companyField`
+            // against a node that may not carry a previous binding, and a
+            // stale binding on an abandoned node is otherwise never cleaned
+            // up until that node is GC'd.
+            this.companyField.off('focus.twoCompanyOpen').on('focus.twoCompanyOpen', () => {
+                if (this._destroyed || this._manualEntry) {
+                    return;
+                }
+                try {
+                    this.companyField.autocomplete('search', this.companyField.val() || '');
+                } catch (e) {
+                    // Widget not ready/already torn down; nothing to open.
+                }
+            });
         } else {
             this.setupCustomAutocomplete();
         }
@@ -1575,6 +1622,17 @@ class TwoCompanySearch {
             .text(this.getBackToSearchText());
         link.on('click.twoManualEntry', (event) => {
             event.preventDefault();
+            // Stop the click here (#30.x.14 bug 2.5, live-verified): with no
+            // stopPropagation, this click bubbled up into whatever delegated
+            // accordion-toggle handler the checkout theme binds on the
+            // address step container, and that handler read the same click
+            // as "collapse this step" - closing the whole address section the
+            // buyer was in the middle of, rather than just switching this
+            // field back to search. This button is a plain sibling inside
+            // that step's markup, not something the accordion is meant to
+            // hear from at all, so the fix is to keep the click here rather
+            // than let it carry on up past a node that never asked for it.
+            event.stopPropagation();
             this.exitManualEntryMode();
         });
 
@@ -1707,6 +1765,25 @@ class TwoCompanySearch {
             value: '',
             two_unavailable: true,
             two_row_class: 'two-autocomplete-too-short'
+        };
+    }
+
+    /**
+     * Pseudo-result carrying the "click opened this" hint through jQuery UI's
+     * result-list plumbing (#30.x.14 bug 2.1). Reuses the same placeholder
+     * copy the empty field already shows, so the dropdown does not introduce
+     * a second, differently-worded hint for the same state - just makes the
+     * existing one visible in the one place a buyer who has already clicked
+     * in is looking.
+     *
+     * @returns {Object}
+     */
+    buildFocusHintItem() {
+        return {
+            label: TwoCompanySearch.getEmptyFieldHintText(),
+            value: '',
+            two_unavailable: true,
+            two_row_class: 'two-autocomplete-focus-hint'
         };
     }
 
@@ -2879,6 +2956,11 @@ class TwoCompanySearch {
                 this.companyField.removeClass(
                     'two-company-search-input two-company-search-loading ui-autocomplete-loading'
                 );
+                // Bound directly via jQuery, not through the widget - the
+                // `autocomplete('destroy')` call below only unwinds bindings
+                // the widget itself made, so this one has to go by hand or it
+                // outlives the instance on a field a fresh instance may reuse.
+                this.companyField.off('focus.twoCompanyOpen');
             }
             // Destroy autocomplete instance if present
             if (this.companyField && this.companyField.length && this.companyField.hasClass('ui-autocomplete-input')) {

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -578,6 +578,12 @@ class TwoCompanySearch {
         this.companyField.val('');
         this.updateRevealChip();
         this.companyField.trigger('focus');
+        // A real click (or key activation) on the chip got us here, so open
+        // directly rather than relying on the pointer-gated
+        // `focus.twoCompanyOpen` handler - the `.trigger('focus')` above
+        // fires no `mousedown` on this field, so that gate would otherwise
+        // never fire for this path (#30.x.14, see openSearchForCurrentTerm()).
+        this.openSearchForCurrentTerm();
     }
 
     /**
@@ -978,6 +984,14 @@ class TwoCompanySearch {
                 previousField.removeClass(
                     'two-company-search-input two-company-search-loading ui-autocomplete-loading'
                 );
+                // Bound directly via jQuery, not through the widget -
+                // `autocomplete('destroy')` above only unwinds bindings the
+                // widget itself made (review finding, Han: harmless today
+                // only because a detached node can never receive a native
+                // focus/mousedown event again, an invariant this method does
+                // not otherwise rely on and the next DOM-recycling path could
+                // break silently).
+                previousField.off('focus.twoCompanyOpen mousedown.twoCompanyOpen');
             }
             this.companyField = currentField;
         }
@@ -1317,6 +1331,21 @@ class TwoCompanySearch {
             // is what gives that click something to open, matching Mag/WC's
             // combobox opening its panel on click before any typing.
             //
+            // Gated on a REAL pointer down, not on focus alone (round-1
+            // adversarial review finding, Vader): a plain `focus` fires for a
+            // keyboard user simply tabbing through the address form with no
+            // intent to search, and this hint row is deliberately
+            // `aria-disabled`/keyboard-skipped (see buildFocusHintItem()) - a
+            // screen reader would announce a result becoming available with
+            // nothing the buyer could actually arrow onto, which reads as a
+            // broken result set rather than a hint. `mousedown` fires on this
+            // field ONLY for a direct pointer interaction with it; Tab never
+            // fires it. Reset immediately after the one `focus` it gates -
+            // this is a one-shot signal for the NEXT focus, not a sticky mode.
+            this.companyField.off('mousedown.twoCompanyOpen').on('mousedown.twoCompanyOpen', () => {
+                this._pointerFocusPending = true;
+            });
+
             // Namespaced and unbound-then-rebound (not `.one()`): this runs on
             // every setupAutocomplete() re-entry (country change,
             // updatedAddressForm), which re-resolves `this.companyField`
@@ -1324,14 +1353,12 @@ class TwoCompanySearch {
             // stale binding on an abandoned node is otherwise never cleaned
             // up until that node is GC'd.
             this.companyField.off('focus.twoCompanyOpen').on('focus.twoCompanyOpen', () => {
-                if (this._destroyed || this._manualEntry) {
+                const pointerFocus = this._pointerFocusPending;
+                this._pointerFocusPending = false;
+                if (this._destroyed || this._manualEntry || !pointerFocus) {
                     return;
                 }
-                try {
-                    this.companyField.autocomplete('search', this.companyField.val() || '');
-                } catch (e) {
-                    // Widget not ready/already torn down; nothing to open.
-                }
+                this.openSearchForCurrentTerm();
             });
         } else {
             this.setupCustomAutocomplete();
@@ -1588,13 +1615,16 @@ class TwoCompanySearch {
         }
         this.companyField.trigger('focus');
 
-        const term = String(this.companyField.val() || '');
         if (this.companyField.hasClass('ui-autocomplete-input')) {
-            try {
-                this.companyField.autocomplete('search', term);
-            } catch (e) {
-                // no-op
-            }
+            // A real click (or Enter/Space) on this button got us here, so
+            // open directly rather than relying on the pointer-gated
+            // `focus.twoCompanyOpen` handler - same reasoning as
+            // revealSearch(). This ALSO removes a duplicate search a round-1
+            // adversarial review found (Vader): the old code both triggered
+            // `focus` (which the then-ungated handler treated as a fresh
+            // open) and made this same explicit call, firing the search
+            // twice on every "Search for company" click.
+            this.openSearchForCurrentTerm();
             return;
         }
         if (this._customAutocomplete && this._customAutocomplete.inputEl) {
@@ -1785,6 +1815,35 @@ class TwoCompanySearch {
             two_unavailable: true,
             two_row_class: 'two-autocomplete-focus-hint'
         };
+    }
+
+    /**
+     * Force the jQuery UI widget to (re-)search whatever the field currently
+     * holds, opening its menu (#30.x.14 bug 2.1).
+     *
+     * The ONE place that does this, called both from the pointer-gated
+     * `focus.twoCompanyOpen` handler in setupAutocomplete() AND directly from
+     * revealSearch() / exitManualEntryMode() below - those two already know a
+     * real user gesture (a click or key activation on the reveal chip / the
+     * back-to-search button) asked for the dropdown to reopen, so they call
+     * this directly rather than going through the pointer-on-THIS-field gate,
+     * which their own `.trigger('focus')` would never satisfy (it fires no
+     * `mousedown` on this field). Consolidating on one call site here is also
+     * what removes the double-search a round-1 adversarial review found
+     * (Vader): exitManualEntryMode() used to both `.trigger('focus')` - which
+     * the old, ungated handler treated as a fresh open - AND make its own
+     * explicit `autocomplete('search', term)` call, firing the search twice
+     * on every "Search for company" click.
+     */
+    openSearchForCurrentTerm() {
+        if (this._destroyed || !this.companyField || !this.companyField.length) {
+            return;
+        }
+        try {
+            this.companyField.autocomplete('search', this.companyField.val() || '');
+        } catch (e) {
+            // Widget not ready/already torn down; nothing to open.
+        }
     }
 
     /**
@@ -2960,7 +3019,7 @@ class TwoCompanySearch {
                 // `autocomplete('destroy')` call below only unwinds bindings
                 // the widget itself made, so this one has to go by hand or it
                 // outlives the instance on a field a fresh instance may reuse.
-                this.companyField.off('focus.twoCompanyOpen');
+                this.companyField.off('focus.twoCompanyOpen mousedown.twoCompanyOpen');
             }
             // Destroy autocomplete instance if present
             if (this.companyField && this.companyField.length && this.companyField.hasClass('ui-autocomplete-input')) {


### PR DESCRIPTION
## Summary

Five live checkout bugs Doug found testing prestashop-dev.staging.two.inc after PR #129 (merged tonight), which fixed the dropdown-width overflow but left the underlying interaction/visual issues below.

- **2.1** — Company-search dropdown didn't open on focus/click (only on typing), and once open sat flush against the field with no visible separation. Forces a search on focus (rendering a hint row for an empty term), and adds an 8px gap + heavier shadow so the panel reads as a genuinely separate floating control.
- **2.2** — Org-number hint collided with the next form field (no reserved space below it). Added `padding-bottom` to the field wrapper.
- **2.3** — "My company is not on the list" rendered in the same colour as ordinary results. Coloured link-blue (`#3043d1`, matching WC's `#search_company_btn`).
- **2.4** — "Search for a company" (manual-entry mode) rendered underlined. Removed.
- **2.5** — Clicking "Search for a company" closed the whole address accordion (missing `stopPropagation`, click bubbled into the theme's accordion-toggle handler). Fixed.

See commit message for full root-cause detail per bug.

## Honesty note on 2.1

This does **not** replace jQuery UI autocomplete with a select2-style combobox (PS doesn't vendor one, and that would be a much larger, riskier change). It keeps the field as a plain editable input — which the bug mandate explicitly said was fine — and makes the existing separately-positioned jQuery UI menu behave and look like a real, immediately-openable, visually distinct popup rather than a same-appearance addendum to the field. Verified live before/after (see PR thread).

## Test plan
- [x] `npx jest --config tests/js/jest.config.js` — 315/315 passing (5 test suites)
- [x] New tests added for focus-open behaviour, position gap, and the stopPropagation regression; mutation-verified (reverting stopPropagation fails the new test)
- [x] Live-verified via Chrome-from-WSL against prestashop-dev.staging.two.inc, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)