### PR TITLE
fix: reveal chip click self-reverts ~200ms after opening a fresh search (TWO-30.x.15)

### DIFF
--- a/tests/js/company-search-reveal.test.js
+++ b/tests/js/company-search-reveal.test.js
@@ -169,6 +169,57 @@ describe('the chip is shown only for a confirmed selection', () => {
     });
 });
 
+describe('a real mouse click on the chip does not revert itself (TWO-30.x.15)', () => {
+    // A genuine mouse click on the chip button fires a native `blur` on the
+    // company field BEFORE the click handler runs - browser event order is
+    // mousedown -> blur (previously-focused element) -> focus (the chip,
+    // itself focusable) -> mouseup -> click. `chip().trigger('click')` used
+    // by every other test in this file skips straight to the click handler
+    // and never fires that leading blur, which is why this exact regression
+    // (live-verified against prestashop-dev.staging.two.inc) shipped past
+    // the existing suite: it only exercises the click handler in isolation.
+    test('a blur immediately before the click does not restore the covered company 200ms later', () => {
+        jest.useFakeTimers();
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        // The field can still hold focus at this point despite the chip
+        // covering it (updateRevealChip() sets tabindex="-1"/aria-hidden
+        // without forcing a blur) - so the chip's own mousedown moves focus
+        // away from it first, exactly like a real click does.
+        field.trigger('blur');
+        chip().trigger('click');
+
+        // Before the fix, the blur above armed a 200ms restore timer whose
+        // guard only checks `_revealed` at FIRE time - by which point the
+        // click just above has already set `_revealed = true`, so the guard
+        // passes and it restores the very selection the click just opened a
+        // fresh search to replace.
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('');
+        expect($("input[name='companyid']").val()).toBe('12345678');
+        expect(chipVisible()).toBe(false);
+        expect(document.activeElement).toBe(field.get(0));
+    });
+
+    test('typing after that same blur-then-click sequence is not overwritten', () => {
+        jest.useFakeTimers();
+        makeInstance();
+        const field = selectFirstResult('exa', SEARCH_RESPONSE);
+
+        field.trigger('blur');
+        chip().trigger('click');
+        field.val('Different Corp');
+        field.trigger('input');
+
+        jest.advanceTimersByTime(250);
+
+        expect(field.val()).toBe('Different Corp');
+        expect(chipVisible()).toBe(false);
+    });
+});
+
 describe('clicking the chip reveals a fresh search box', () => {
     test('blanks the field, focuses it, and hides the chip', () => {
         makeInstance();

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -567,6 +567,35 @@ class TwoCompanySearch {
             || !document.contains(this.companyField.get(0))) {
             return;
         }
+        // Cancel any blur-restore timer already armed on THIS field before
+        // touching anything else (TWO-30.x.15, live bug found post-#130).
+        //
+        // A real mouse click on the chip fires a native `blur` on the
+        // company field BEFORE this method runs: the field can still hold
+        // focus at that point despite `tabindex="-1"`/`aria-hidden` (both are
+        // set by updateRevealChip() without forcing a blur), and mousedown on
+        // the chip button - a separate, focusable element - moves focus away
+        // from it in the browser's normal mousedown-then-click order. That
+        // blur is `setupRevealBlurRestore()`'s own trigger: it arms a 200ms
+        // timer via armRevealBlurRestore() whose only guard is `_revealed` AT
+        // FIRE TIME, not at arm time.
+        //
+        // Every other place in this file that can leave that timer stale
+        // (country change, `updatedAddressForm`, destroy()) clears it
+        // explicitly for exactly this reason - this method was the one gap.
+        // Here the gap is worse than "stale": the guard doesn't merely fail
+        // to protect, it actively fires. By the time the 200ms elapses,
+        // `_revealed` has already been set true a few lines below by THIS
+        // SAME click, so the stale timer's guard passes and it "restores"
+        // the snapshot this method just took - overwriting the freshly
+        // opened search with the very company the buyer clicked away from,
+        // silently re-showing the chip and wiping whatever the buyer had
+        // typed in the meantime. Live-verified: the field visibly reverted
+        // to the previously selected company ~200ms after a real click on
+        // the chip, with no console error and no event firing at the moment
+        // of revert - it was this timer, not a broken search.
+        clearTimeout(this._revealBlurTimerId);
+        this._revealBlurTimerId = null;
         this._revealSnapshot = {
             company: String(this.companyField.val() || ''),
             orgId: this.organizationField && this.organizationField.length


### PR DESCRIPTION
## Summary

New live bug Doug found this morning, on top of PR #130 (merged): the click-to-reveal chip (TWO-25288 element 2) appeared to open a fresh search when clicked, then silently reverted to the previously selected company about 200ms later - wiping any typing in between and re-showing the chip.

## Root cause

A real mouse click on the chip fires a native `blur` on the company field **before** the click handler runs (the field can still hold focus despite `tabindex="-1"`/`aria-hidden`, and mousedown on the separately-focusable chip button moves focus away from it first - standard browser mousedown→blur→focus→mouseup→click order).

That blur is `setupRevealBlurRestore()`'s own trigger: it arms a 200ms restore timer (`armRevealBlurRestore()`) whose only guard checks `_revealed` **at fire time**. By the time it fires, `revealSearch()` (running synchronously from the click a moment later) has already set `_revealed = true` - so the guard passes, and the stale timer restores the very selection `revealSearch()` just replaced.

Every other place in this file that can leave that timer stale (country change, `updatedAddressForm`, `destroy()`) already clears it explicitly for this reason. `revealSearch()` was the one gap - and the worst one, since the guard doesn't just fail to protect, it actively fires against the fresh reveal it should have no opinion on.

## Fix

Clear the pending blur-restore timer at the very start of `revealSearch()`, before taking the new snapshot.

## Tests

Added two regression tests that simulate the real blur-then-click event order. The existing suite only ever did `chip().trigger('click')`, which never fires the leading blur and so never exercised this path.

Mutation-verified: both new tests fail against the pre-fix code with the exact observed symptom (field reverts to the covered company, chip reappears, ~200ms later).

## Live verification (prestashop-dev.staging.two.inc)

Before writing the fix, reproduced live via browser automation:
- Selected a real company → chip appears, covers the field.
- Clicked the chip → field cleared and focused correctly for ~1s, then **reverted** to the original company with the chip reappearing, with zero console errors and no event firing at the moment of revert (pointed straight at a timer, not a broken search).
- Separately confirmed (on a fresh, non-reveal path) that focus-triggered hint → typing → real search results works correctly end-to-end, including down to below the minimum length and back up, cursor never leaving the main field - so this is scoped specifically to the reveal-chip race, not the search/hint mechanism PR #130 built.

After the fix, re-verified live:
- Select a company → chip shown.
- Click chip → field blanks and stays blank/focused past 200ms (no revert).
- Type a new company name → real results appear and update as expected.
- Clear back down below the minimum length → hint reappears.
- Cursor never left the main field throughout.

## Honesty note

This fix is scoped to the one race condition found and verified live. It does not change the underlying single-input (no separate combobox search box) architecture PR #130's own description already flagged as a known, accepted difference from the Woo/Magento reference implementations.