### PR TITLE
fix(company-search): manual-entry placeholder must describe the mode (TWO-25326 §2)

### DIFF
--- a/tests/js/company-search-dropdown.test.js
+++ b/tests/js/company-search-dropdown.test.js
@@ -931,3 +931,43 @@ describe('§5 the company number after selection', () => {
         expect(shown($('.two-company-id-hint'))).toBe(false);
     });
 });
+
+describe('the placeholder describes the mode the field is in (TWO-25326 §2)', () => {
+    // Found on the staging shop in a real browser: after switching to manual
+    // entry the field still read "Enter company name to search", instructing
+    // the buyer to do something the field no longer does.
+    test('manual entry swaps the search-mode placeholder', () => {
+        const search = makeInstance();
+        expect(companyField().attr('placeholder')).toBe('Enter company name to search');
+
+        openPanel();
+        panelParts().notListed.trigger('click');
+
+        expect(companyField().attr('placeholder')).toBe('Enter your company name');
+    });
+
+    test('returning to search puts the search wording back', () => {
+        const search = makeInstance();
+        openPanel();
+        panelParts().notListed.trigger('click');
+        expect(companyField().attr('placeholder')).toBe('Enter your company name');
+
+        search.exitManualEntryMode();
+
+        expect(companyField().attr('placeholder')).toBe('Enter company name to search');
+    });
+
+    test("a theme's own placeholder is left alone in both modes", () => {
+        // applyEmptyFieldHint() declines to overwrite a placeholder the theme
+        // set; this must not undo that from the other direction.
+        companyField().attr('placeholder', 'Firmennavn');
+        const search = makeInstance();
+
+        openPanel();
+        panelParts().notListed.trigger('click');
+        expect(companyField().attr('placeholder')).toBe('Firmennavn');
+
+        search.exitManualEntryMode();
+        expect(companyField().attr('placeholder')).toBe('Firmennavn');
+    });
+});

--- a/translations/es.php
+++ b/translations/es.php
@@ -396,6 +396,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_c86427e7020aa074399a2ecdb9c42a1d'] 
 $_MODULE['<{twopayment}prestashop>twopayment_7de934009c752b9208f359e4db589fa0'] = 'No tienes permiso para acceder a esta factura.';
 $_MODULE['<{twopayment}prestashop>twopayment_7aa0ef00af5612e50834b5bf969457e6'] = 'La búsqueda de empresas no está disponible temporalmente. Por favor, inténtalo de nuevo.';
 $_MODULE['<{twopayment}prestashop>twopayment_6fd95deaadec67e72965ee1c5a8d81cf'] = 'Introduce el nombre de la empresa para buscar';
+$_MODULE['<{twopayment}prestashop>twopayment_b880d635ee26e267ab68784bb47a0ad1'] = 'Introduce el nombre de tu empresa';
 $_MODULE['<{twopayment}prestashop>twopayment_11379daccc4d43380822ecb7bc5bc1b7'] = 'Introduce %d o más caracteres';
 $_MODULE['<{twopayment}prestashop>twopayment_a305be9a7fd5f6541e913ce81317976d'] = 'Mi empresa no está en la lista';
 $_MODULE['<{twopayment}prestashop>twopayment_070800fb9c7ae071aff6e63bded5c3c2'] = 'Buscar empresa';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -261,6 +261,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_6cae7c7478f2d404dc69e4e355172166'] 
 $_MODULE['<{twopayment}prestashop>twopayment_6d5cc1a38d6228cd43fb864b6c4d4b75'] = 'Deze betaalcallback kan niet worden gevalideerd. Probeer het afrekenen opnieuw.';
 $_MODULE['<{twopayment}prestashop>twopayment_6f3455d187a23443796efdcbe044096b'] = 'Geen btw';
 $_MODULE['<{twopayment}prestashop>twopayment_6fd95deaadec67e72965ee1c5a8d81cf'] = 'Voer bedrijfsnaam in om te zoeken';
+$_MODULE['<{twopayment}prestashop>twopayment_b880d635ee26e267ab68784bb47a0ad1'] = 'Voer uw bedrijfsnaam in';
 $_MODULE['<{twopayment}prestashop>twopayment_70121086cdb2e52ce9ac069b1781dc76'] = 'Er was een tijdelijk probleem bij het verifiëren van je betaling. Probeer het opnieuw of kies een andere betaalmethode.';
 $_MODULE['<{twopayment}prestashop>twopayment_701dfa446588bcb18e3a546249ca91a2'] = 'Verberg de betaalmethode onder deze orderwaarde (standaardvaluta van de winkel, op de hieronder gekozen belastinggrondslag). Laat leeg voor geen minimum.';
 $_MODULE['<{twopayment}prestashop>twopayment_70a6512b8cd4822b0d2e390dfe6c0177'] = 'Controle van de order intent is mislukt';

--- a/translations/no.php
+++ b/translations/no.php
@@ -261,6 +261,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_6cae7c7478f2d404dc69e4e355172166'] 
 $_MODULE['<{twopayment}prestashop>twopayment_6d5cc1a38d6228cd43fb864b6c4d4b75'] = 'Kunne ikke bekrefte betalingen fra Two. Prøv utsjekken på nytt.';
 $_MODULE['<{twopayment}prestashop>twopayment_6f3455d187a23443796efdcbe044096b'] = 'Ingen avgift';
 $_MODULE['<{twopayment}prestashop>twopayment_6fd95deaadec67e72965ee1c5a8d81cf'] = 'Skriv inn firmanavn for å søke';
+$_MODULE['<{twopayment}prestashop>twopayment_b880d635ee26e267ab68784bb47a0ad1'] = 'Skriv inn firmanavnet ditt';
 $_MODULE['<{twopayment}prestashop>twopayment_70121086cdb2e52ce9ac069b1781dc76'] = 'Det oppsto et midlertidig problem med å verifisere betalingen din. Prøv igjen eller velg en annen betalingsmåte.';
 $_MODULE['<{twopayment}prestashop>twopayment_701dfa446588bcb18e3a546249ca91a2'] = 'Skjul betalingsmåten under denne ordreverdien (butikkens standardvaluta, på avgiftsgrunnlaget som er valgt nedenfor). La feltet stå tomt for ingen minsteverdi.';
 $_MODULE['<{twopayment}prestashop>twopayment_70a6512b8cd4822b0d2e390dfe6c0177'] = 'Sjekken av ordreintensjonen mislyktes';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -261,6 +261,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_6cae7c7478f2d404dc69e4e355172166'] 
 $_MODULE['<{twopayment}prestashop>twopayment_6d5cc1a38d6228cd43fb864b6c4d4b75'] = 'Kunde inte bekräfta svaret från betalningsleverantören. Försök genomföra kassan igen.';
 $_MODULE['<{twopayment}prestashop>twopayment_6f3455d187a23443796efdcbe044096b'] = 'Ingen moms';
 $_MODULE['<{twopayment}prestashop>twopayment_6fd95deaadec67e72965ee1c5a8d81cf'] = 'Ange företagsnamn för att söka';
+$_MODULE['<{twopayment}prestashop>twopayment_b880d635ee26e267ab68784bb47a0ad1'] = 'Ange ditt företagsnamn';
 $_MODULE['<{twopayment}prestashop>twopayment_70121086cdb2e52ce9ac069b1781dc76'] = 'Det uppstod ett tillfälligt problem när din betalning skulle verifieras. Försök igen eller välj en annan betalningsmetod.';
 $_MODULE['<{twopayment}prestashop>twopayment_701dfa446588bcb18e3a546249ca91a2'] = 'Dölj betalningsmetoden under detta ordervärde (butikens standardvaluta, på den momsbasis som väljs nedan). Lämna fältet tomt för inget minimum.';
 $_MODULE['<{twopayment}prestashop>twopayment_70a6512b8cd4822b0d2e390dfe6c0177'] = 'Kontrollen av order intent misslyckades';

--- a/twopayment.php
+++ b/twopayment.php
@@ -3336,6 +3336,14 @@ class Twopayment extends PaymentModule
             // renders its own address form, and what survives PrestaShop
             // replacing the input on an address-form update.
             'company_search_placeholder' => $this->l('Enter company name to search'),
+            // The same slot, reworded for manual entry. The search wording is
+            // an instruction the field stops honouring the moment the buyer
+            // chooses "my company is not on the list" - it no longer searches
+            // anything, it is the plain input they type into - so leaving it
+            // there tells them to do something that will not happen. Only ever
+            // swapped for the search wording above, never over a placeholder a
+            // theme supplied; see syncCompanyFieldPlaceholder().
+            'company_manual_placeholder' => $this->l('Enter your company name'),
             // `%d` is deliberately left UNRESOLVED here. The browser JS holds the
             // one threshold constant and interpolates it, so the number this
             // sentence claims cannot drift from the number the search enforces.

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1135,6 +1135,50 @@ class TwoCompanySearch {
             this.companyField.removeAttr('aria-expanded');
             this.companyField.removeAttr('title');
         }
+        this.syncCompanyFieldPlaceholder(searchMode);
+    }
+
+    /**
+     * Keep the placeholder describing the mode the field is actually in.
+     *
+     * "Enter company name to search" is a search-mode instruction. In
+     * manual-entry mode the field no longer searches anything - it is the
+     * plain text input the buyer types their company into - so that wording
+     * tells them to do something the field will not do. Found on the staging
+     * shop in a real browser while verifying the manual-entry route.
+     *
+     * Only ever swaps a placeholder THIS class put there. applyEmptyFieldHint()
+     * declines to touch a placeholder a merchant theme or an address-form
+     * override already set, and undoing that here would take with one hand what
+     * that rule gives with the other - so a theme's own wording is left in both
+     * modes.
+     *
+     * @param {boolean} searchMode
+     */
+    syncCompanyFieldPlaceholder(searchMode) {
+        if (!this.companyField || !this.companyField.length) {
+            return;
+        }
+        const searchText = TwoCompanySearch.getEmptyFieldHintText();
+        const manualText = TwoCompanySearch.getManualEntryPlaceholderText();
+        const current = String(this.companyField.attr('placeholder') || '');
+        const wanted = searchMode ? searchText : manualText;
+        const ours = current === searchText || current === manualText;
+        if (!ours) {
+            return;
+        }
+        if (current !== wanted) {
+            this.companyField.attr('placeholder', wanted);
+        }
+    }
+
+    /**
+     * @returns {string} placeholder wording for manual-entry mode
+     */
+    static getManualEntryPlaceholderText() {
+        return (window.twopayment && window.twopayment.i18n
+            && window.twopayment.i18n.company_manual_placeholder)
+            || 'Enter your company name';
     }
 
     /**


### PR DESCRIPTION
Follow-up to #132, which was merged while this was in flight. Two commits that did not make that merge.

## What and why

Found on the staging shop **in a real browser**, verifying the manual-entry route that #132 introduced: after choosing "My company is not on the list", the company field still read *"Enter company name to search"*. In manual entry that field searches nothing — it is the plain text input the buyer types their company name into — so the placeholder was instructing them to do something the field no longer does.

The wording now follows the mode, and only ever a placeholder this class put there. `applyEmptyFieldHint()` deliberately declines to overwrite a placeholder a merchant theme or an address-form override already set; clobbering it from the other direction would take back what that rule gives, so a theme's own wording survives both modes.

## The translation gate caught a mistake of mine

The first commit's message claimed this whole group of strings was untranslated. **That was wrong.** I had grepped the catalogues for the *English source text*, but they store the *translated* text keyed by an md5 of the source — the grep could never have matched, and the conclusion I drew from it was unfounded. `TranslationCatalogueSpec` failed the build and was right to: the module looks the string up, so a missing entry renders English to a Dutch, Norwegian, Swedish or Spanish buyer. The second commit adds all four, taking its register from the search-mode twin rather than inventing one (`"Voer bedrijfsnaam in om te zoeken"` → `"Voer uw bedrijfsnaam in"`).

## Verification

- Jest 341/341. The three new tests are **mutation-checked**: two fail with the mode sync removed, and the third pins the theme-placeholder exemption.
- PHP offline suite 45/45, `TranslationCatalogueSpec` included.
- The underlying behaviour was observed live on `prestashop-dev.staging.two.inc`, which serves this branch byte-for-byte.

## Still open on TWO-25326 for PrestaShop

The §7 **payment-tile company label** does not render — `#two-company-summary` stays `display:none` with empty slots. PrestaShop removes the address form from the DOM at the payment step, so the client-side summary has nothing left to read; closing it means seeding the template from the server-side session company. Not attempted here — that resolver has side effects (it unsets the session company on a country mismatch). Detail and measurements are in the TWO-25326 comment.

<sub>Investigated and written by Claude.</sub>
