### PR TITLE
fix(payment-tile): render the company label from the order-intent payload (TWO-25326 §7)

### DIFF
--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -640,3 +640,187 @@ describe('the hidden companyid input is untouched', () => {
         expect($("input[name='vat_number']").val()).toBe('12345678');
     });
 });
+
+describe('the payment tile is fed by the order-intent payload (TWO-25326 §7)', () => {
+    // The §7 failure recorded on TWO-25326 for PrestaShop: the tile label never
+    // rendered at all. Measured on a real PS 8 checkout - at the payment step
+    // PrestaShop marks the address step `-complete` and REMOVES the address
+    // form, so `input[name=company]` and the hidden `companyid` are both gone
+    // and readState() had nothing left to read. The block sat `display:none`
+    // with empty slots on every checkout.
+    //
+    // The pair now arrives from the module's own backend, on the same
+    // order-intent response that already feeds the intent message beside it.
+
+    /** Reproduce the payment step: PrestaShop has taken the address form away. */
+    function removeAddressForm() {
+        document.querySelectorAll("input[name='company'], input[name='companyid']")
+            .forEach((el) => el.remove());
+    }
+
+    test('the pushed pair paints the label once the address form is gone', () => {
+        removeAddressForm();
+        expect(shown()).toEqual({ name: '', number: '', hidden: true });
+
+        TwoCompanySummary.setIntentCompany({
+            name: 'Example Trading Ltd',
+            number: '12345678'
+        });
+
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+    });
+
+    test('a name with no number shows the name alone', () => {
+        // §5: a manual-entry buyer supplies a name and no number, and
+        // "Example Ltd ()" is worse than "Example Ltd".
+        removeAddressForm();
+
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '' });
+
+        expect(shown()).toEqual({ name: 'Example Trading Ltd', number: '', hidden: false });
+        expect(root().classList.contains('two-company-summary--has-number')).toBe(false);
+    });
+
+    test('the pair outlives a re-render of the tile', () => {
+        // PrestaShop replaces the payment step wholesale on a cart change,
+        // which is why this is held on the class and not the instance.
+        removeAddressForm();
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        root().remove();
+        buildPaymentTile();
+        TwoCompanySummary.render();
+
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+    });
+
+    test('a live address form still wins over the intent pair', () => {
+        // On the ADDRESS step both exist. The field the buyer is looking at is
+        // the truth; a stale intent pair from a company they have since moved
+        // off must not override it.
+        // A real instance, because it is what creates the hidden `companyid`
+        // input the DOM path reads.
+        makeInstance();
+        TwoCompanySummary.setIntentCompany({ name: 'Stale Holdings Ltd', number: '99999999' });
+
+        const nameField = document.querySelector("input[name='company']");
+        const idField = document.querySelector("input[name='companyid']");
+        nameField.value = 'Example Trading Ltd';
+        idField.value = '12345678';
+        idField.setAttribute('data-two-company-name', 'Example Trading Ltd');
+        TwoCompanySummary.render();
+
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+    });
+
+    test('an enrolled sole trader outranks the intent pair', () => {
+        // The enrolment happened on this step, in front of the buyer; the
+        // intent pair may predate it.
+        removeAddressForm();
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        TwoCompanySummary.setSoleTrader({ name: 'Sole Trader AS', number: 'NO-999888777' });
+
+        expect(shown()).toEqual({
+            name: 'Sole Trader AS',
+            number: 'NO-999888777',
+            hidden: false
+        });
+    });
+
+    test('null forgets the pair', () => {
+        removeAddressForm();
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        expect(shown().hidden).toBe(false);
+
+        TwoCompanySummary.setIntentCompany(null);
+
+        expect(shown()).toEqual({ name: '', number: '', hidden: true });
+    });
+});
+
+describe('TwoOrderIntent publishes the payload company to the tile (TWO-25326 §7)', () => {
+    // The wiring, tested separately from the rendering. Without this, deleting
+    // the publish call in TwoOrderIntent leaves every test above green while
+    // the tile goes blank again on a real checkout - the defect this whole
+    // section exists to close.
+    let intent;
+
+    beforeEach(() => {
+        loadScript('views/js/modules/TwoOrderIntent.js');
+        intent = new window.TwoOrderIntent({});
+        document.querySelectorAll("input[name='company'], input[name='companyid']")
+            .forEach((el) => el.remove());
+    });
+
+    const payloadFor = (name, number) => ({
+        buyer: { company: { company_name: name, organization_number: number } }
+    });
+
+    test('a payload with both values paints the label', () => {
+        intent.publishPayloadCompany(payloadFor('Example Trading Ltd', '12345678'));
+
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+        expect(intent.lastCompany).toBe('Example Trading Ltd');
+        expect(intent.lastCompanyNumber).toBe('12345678');
+    });
+
+    test('a payload with a name and no number shows the name alone', () => {
+        intent.publishPayloadCompany(payloadFor('Example Trading Ltd', ''));
+
+        expect(shown()).toEqual({ name: 'Example Trading Ltd', number: '', hidden: false });
+    });
+
+    test('a later name-only payload does not reuse the previous number', () => {
+        // The retained `lastCompanyNumber` is for the intent wording, not for
+        // the label. Pairing it with a different company's name would assert a
+        // company/number pairing that never existed - the one thing this block
+        // must never do.
+        intent.publishPayloadCompany(payloadFor('Example Trading Ltd', '12345678'));
+        expect(shown().number).toBe('12345678');
+
+        intent.publishPayloadCompany(payloadFor('Second Holdings Ltd', ''));
+
+        expect(shown()).toEqual({ name: 'Second Holdings Ltd', number: '', hidden: false });
+    });
+
+    test('a payload with no company touches nothing', () => {
+        intent.publishPayloadCompany(payloadFor('Example Trading Ltd', '12345678'));
+
+        intent.publishPayloadCompany({ buyer: {} });
+        intent.publishPayloadCompany(null);
+
+        // Still the last real company, not blanked: an intent call that failed
+        // to carry a company is not evidence the buyer lost theirs.
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+    });
+
+    test('values are trimmed', () => {
+        intent.publishPayloadCompany(payloadFor('  Example Trading Ltd  ', '  12345678  '));
+
+        expect(shown()).toEqual({
+            name: 'Example Trading Ltd',
+            number: '12345678',
+            hidden: false
+        });
+    });
+});

--- a/views/js/modules/TwoCompanySummary.js
+++ b/views/js/modules/TwoCompanySummary.js
@@ -72,6 +72,14 @@ class TwoCompanySummary {
      */
     static _soleTrader = null;
 
+    /**
+     * The company the order-intent payload was built for, pushed by
+     * TwoOrderIntent. See setIntentCompany() for why this exists at all.
+     *
+     * @type {?{name: string, number: string}}
+     */
+    static _intentCompany = null;
+
     constructor() {
         this._stopped = false;
         this.boundOnFieldChange = this.onFieldChange.bind(this);
@@ -145,6 +153,40 @@ class TwoCompanySummary {
         TwoCompanySummary.render();
     }
 
+    /**
+     * Record the company the order-intent payload was built for.
+     *
+     * The tile label (§7) cannot be read off the address form on this step:
+     * PrestaShop marks the address step `-complete` and removes that form from
+     * the DOM, so `company` and `companyid` are both gone by the time the
+     * payment tile exists. The block therefore rendered empty and stayed
+     * hidden on every PrestaShop checkout - the §7 failure recorded on
+     * TWO-25326.
+     *
+     * TwoOrderIntent pushes the pair here from the module's own backend
+     * response, which builds it server-side from the session company that
+     * outlives the form. That is the same channel already feeding the intent
+     * message beside this label, so the two cannot disagree about which
+     * company the buyer is being credit-checked as.
+     *
+     * Static for the reason `_soleTrader` is: the payment step's DOM is
+     * replaced wholesale on the next cart update, and this has to outlive it.
+     *
+     * @param {?{name: ?string, number: ?string}} pair Null forgets it.
+     * @returns {void}
+     */
+    static setIntentCompany(pair) {
+        if (!pair) {
+            TwoCompanySummary._intentCompany = null;
+        } else {
+            TwoCompanySummary._intentCompany = {
+                name: String(pair.name == null ? '' : pair.name).trim(),
+                number: String(pair.number == null ? '' : pair.number).trim()
+            };
+        }
+        TwoCompanySummary.render();
+    }
+
     /** @returns {string} */
     static normalizeName(value) {
         return String(value == null ? '' : value).trim().toLowerCase().replace(/\s+/g, ' ');
@@ -183,6 +225,17 @@ class TwoCompanySummary {
             return {
                 name: TwoCompanySummary._soleTrader.name,
                 number: TwoCompanySummary._soleTrader.number
+            };
+        }
+
+        // Only once the DOM has nothing to say, and AFTER the sole trader: an
+        // enrolment the buyer completed on this very step outranks the company
+        // an earlier intent call was built for. On the payment step the address
+        // form is gone, so this is the branch that actually renders the label.
+        if (name === '' && number === '' && TwoCompanySummary._intentCompany) {
+            return {
+                name: TwoCompanySummary._intentCompany.name,
+                number: TwoCompanySummary._intentCompany.number
             };
         }
 

--- a/views/js/modules/TwoOrderIntent.js
+++ b/views/js/modules/TwoOrderIntent.js
@@ -16,6 +16,9 @@ class TwoOrderIntent {
         this.isProcessing = false;
         this.checkIntervalId = null;
         this.lastCompany = null;
+        // Retained alongside lastCompany so the tile label survives a payload
+        // that omits the number; see publishPayloadCompany().
+        this.lastCompanyNumber = null;
     }
 
     t(key, fallback) {
@@ -91,6 +94,67 @@ class TwoOrderIntent {
         return true;
     }
     
+    /**
+     * Take the company out of the order-intent payload and publish it.
+     *
+     * Feeds two things: the company-aware intent wording, and the payment
+     * tile's company label (TWO-25326 §7).
+     *
+     * The tile is the reason this exists. That label used to be rendered by
+     * reading the address form's `company` and hidden `companyid` inputs, but
+     * by the time the payment step exists PrestaShop has marked the address
+     * step `-complete` and REMOVED that form - both inputs are gone, so the
+     * block rendered empty and stayed hidden on every PrestaShop checkout.
+     *
+     * The pair is already on its way here for another reason: this is the
+     * module's own backend answering with the payload it built server-side,
+     * from the session company that outlives the form. So the tile is fed from
+     * the same channel that feeds the intent message beside it, and the two
+     * cannot disagree about which company is being credit-checked.
+     *
+     * A method rather than an inline block in the promise chain so it can be
+     * tested without standing up the whole request pipeline.
+     *
+     * @param {?Object} payload Order-intent payload, as built by the backend.
+     * @returns {void}
+     */
+    publishPayloadCompany(payload) {
+        const company = (payload && payload.buyer && payload.buyer.company)
+            ? payload.buyer.company
+            : null;
+        const name = (company && company.company_name)
+            ? String(company.company_name).trim()
+            : '';
+        const number = (company && company.organization_number)
+            ? String(company.organization_number).trim()
+            : '';
+
+        if (name) {
+            this.lastCompany = name;
+        }
+        if (number) {
+            this.lastCompanyNumber = number;
+        }
+
+        if (!name) {
+            return;
+        }
+        if (typeof window === 'undefined'
+            || !window.TwoCompanySummary
+            || typeof window.TwoCompanySummary.setIntentCompany !== 'function') {
+            return;
+        }
+        window.TwoCompanySummary.setIntentCompany({
+            name: name,
+            // This payload's number, deliberately, and never the retained
+            // `lastCompanyNumber`: a payload carrying a name with no number
+            // must show the name alone, not pair it with a number left over
+            // from a company the buyer has moved off. readState()'s tag
+            // comparison guards the DOM path for the same reason.
+            number: number
+        });
+    }
+
     checkOrderIntent() {
         if (!this.shouldRunOrderIntent()) {
             return Promise.resolve(this.lastResult || { success: false, error: 'Order intent check skipped' });
@@ -111,15 +175,7 @@ class TwoOrderIntent {
             })
             .then(built => {
                 const payload = built ? built.payload : null;
-                const payloadCompany = (
-                    payload &&
-                    payload.buyer &&
-                    payload.buyer.company &&
-                    payload.buyer.company.company_name
-                ) ? String(payload.buyer.company.company_name).trim() : '';
-                if (payloadCompany) {
-                    this.lastCompany = payloadCompany;
-                }
+                this.publishPayloadCompany(payload);
                 // TWO-24799: the server recognised this exact decision snapshot
                 // and returned the decision it already has, so skip the 2.5-3s
                 // /v1/order_intent round trip. The server only does this when
@@ -729,6 +785,9 @@ class TwoOrderIntent {
     reset() {
         this.lastResult = null;
         this.lastCompany = null;
+        // Cleared with its name: a retained number outliving the reset could
+        // only ever be paired with a DIFFERENT company's name later.
+        this.lastCompanyNumber = null;
         this.isProcessing = false;
         this.stopMonitoring();
     }


### PR DESCRIPTION
Closes the last open PrestaShop item on TWO-25326: the §7 payment-tile company label.

## The bug

The label never rendered. The block was present and correctly positioned, but sat `display:none` with both slots empty — rendering `()` — on every PrestaShop checkout.

`TwoCompanySummary` read the pair off the address form's `company` and hidden `companyid` inputs. Measured on a real PrestaShop 8 at the payment step: PrestaShop marks the address step `-complete` and **removes that form from the DOM**. Both inputs are gone. There was nothing left to read, so no amount of re-reading the DOM could have fixed this.

## The fix

The pair was already on its way to the browser for another reason. The module's own backend answers the order-intent request with a payload it builds **server-side from the session company**, which outlives the form — and that payload already carries `buyer.company.company_name` and `.organization_number`. The name half is what the intent message *beside this label* is already interpolated from.

So the tile is now fed from that same channel. No server change was needed; the data was already arriving. A useful side effect: the label and the intent message next to it cannot disagree about which company is being credit-checked.

Three deliberate choices:

- **Publishing is its own method** (`publishPayloadCompany`) rather than an inline block in the promise chain, so the wiring is testable without standing up the whole request pipeline.
- **Precedence is DOM → sole trader → intent pair.** A live address field is what the buyer is looking at; an enrolment completed on this step outranks a company an earlier intent call was built for. The intent pair only wins when the DOM has nothing to say, which on the payment step is always.
- **The label uses *this* payload's number, never the retained `lastCompanyNumber`.** A payload with a name and no number shows the name alone rather than pairing it with a number from a company the buyer has moved off — the same rule `readState()`'s tag comparison already enforces on the DOM path.

## Verification

Against a **real PrestaShop 8 in Docker**, driven end-to-end through search → selection → address → delivery → payment:

```
text:                    "Example Trading Ltd (11111111)"
inPaymentStep:           true
visible:                 true
afterChips:              true
isInput:                 false
addressInputsRemaining:  0
addressStepClass:        "checkout-step -reachable -complete -clickable"
```

`addressInputsRemaining: 0` is the point — the label renders precisely *because* it no longer depends on inputs that no longer exist.

- Jest **352/352**, eleven new tests. **Mutation-checked in both halves**: removing the `readState()` branch fails 4; disabling the publish call fails 5. That second check matters — without it, deleting the wiring would leave every rendering test green while the tile went blank again on a real checkout.
- PHP offline suite 45/45.
- Full Playwright checkout suite 2/2.

## Note on live verification

This has **not** been verified on a staging shop, and cannot be before merge. `prestashop.staging.two.inc` tracks `@main` and `prestashop-dev.staging.two.inc` tracks `@staging` (per `platform-tools/prestashop/values/beta/`) — neither can run an unmerged branch, the same constraint already recorded for WooCommerce on this ticket. Once merged to `staging`, the dev twin will serve it and the confirming check should be run there.

<sub>Investigated and written by Claude.</sub>
