### PR TITLE
fix(payment-tile): tie the company label to the intent message's visibility (TWO-25326 §7)

### DIFF
--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -58,6 +58,16 @@ beforeEach(() => {
     bus = loaded.bus;
     ajax = stubAjax($);
     TwoCompanySummary = loadCompanySummary();
+    // The label only renders while the order-intent message is on screen
+    // (TWO-25326 §7, revised). That is a precondition for every test below that
+    // asserts on CONTENT - which slot holds what - so it is established once
+    // here rather than restated in each, and the coupling itself is pinned
+    // separately in "the label rides on the intent message's visibility".
+    //
+    // Done BEFORE the instance is constructed, so init()'s own render() already
+    // sees it and the tests observe one consistent state rather than a block
+    // that was briefly hidden for reasons unrelated to what they assert.
+    showIntentMessage();
     // Constructed exactly as views/js/twopayment.js does. Load-bearing rather
     // than setup noise: the document-level input listener that catches a
     // hand-typed company name belongs to the INSTANCE, so a suite that only
@@ -80,6 +90,36 @@ function makeInstance(extraConfig) {
     return new TwoCompanySearch(
         Object.assign({ checkoutHost: CHECKOUT_HOST }, extraConfig || {})
     );
+}
+
+/**
+ * Put the order-intent message on screen, the way TwoCheckoutManager does.
+ *
+ * `.two-payment-info` is the section the shipped template carries, hidden inline
+ * (`style="display: none"`) until an intent decision arrives - and it is the
+ * container that actually renders on PrestaShop, so it is the one the label's
+ * gate observes. Revealed by setting the same inline display TwoCheckoutManager
+ * sets, not by deleting the attribute, so this reproduces the real mechanism.
+ *
+ * @returns {Element} the message section
+ */
+function showIntentMessage() {
+    const info = document.querySelector('.two-payment-info');
+    if (!info) {
+        throw new Error('the tile template carries no .two-payment-info section');
+    }
+    info.style.display = 'block';
+    return info;
+}
+
+/** Take it back down, the way the notice-off branch does. */
+function hideIntentMessage() {
+    const info = document.querySelector('.two-payment-info');
+    if (!info) {
+        throw new Error('the tile template carries no .two-payment-info section');
+    }
+    info.style.display = 'none';
+    return info;
 }
 
 /** The block under test. */
@@ -822,5 +862,246 @@ describe('TwoOrderIntent publishes the payload company to the tile (TWO-25326 §
             number: '12345678',
             hidden: false
         });
+    });
+});
+
+
+describe("the label rides on the intent message's visibility (TWO-25326 §7, revised)", () => {
+    // Revised rule (TWO-25326): the company label is not shown unconditionally
+    // once a company is captured. It is shown exactly when the order-intent
+    // message is shown and hidden exactly when that message is hidden.
+    //
+    // Driven through TwoCheckoutManager rather than TwoOrderIntent, because that
+    // is the module whose message the buyer actually sees on PrestaShop.
+    // `.two-payment-info` is a section of the shipped template and
+    // TwoCheckoutManager shows and hides it; TwoOrderIntent's own
+    // `.two-order-intent-message` is appended to
+    // `.payment-option-content, .payment-form, .additional-information` searched
+    // WITHIN the `.payment-option`, and on PS 8's classic theme none of those
+    // exist there - measured on a real PS 8 checkout, where that element never
+    // enters the DOM at all. Pinning the gate to the container that does render
+    // is the difference between this rule working and the label vanishing for
+    // good.
+    let manager;
+
+    /**
+     * A TwoCheckoutManager with no init().
+     *
+     * The constructor wires listeners, kicks off requests and reads config this
+     * suite has no interest in. Object.create gives the real prototype - so
+     * these are the shipped methods, not stubs - without any of that.
+     */
+    function makeManager() {
+        const instance = Object.create(window.TwoCheckoutManager.prototype);
+        instance.config = {};
+        instance.twoPaymentOption = document.querySelector('.two-payment-container');
+        instance.isLoadingUIShown = false;
+        return instance;
+    }
+
+    /** Is the message the buyer would read actually on screen? */
+    function messageVisible() {
+        const info = document.querySelector('.two-payment-info');
+        return !!info && window.getComputedStyle(info).display !== 'none';
+    }
+
+    /** Reproduce the payment step: PrestaShop has taken the address form away. */
+    function removeAddressForm() {
+        document.querySelectorAll("input[name='company'], input[name='companyid']")
+            .forEach((el) => el.remove());
+    }
+
+    beforeEach(() => {
+        loadScript('views/js/modules/TwoCheckoutManager.js');
+        manager = makeManager();
+        removeAddressForm();
+        // Undo the file-wide precondition: these tests are about how the
+        // visibility is ARRIVED at, so each drives it through the real code path
+        // instead of inheriting it from setup.
+        hideIntentMessage();
+        TwoCompanySummary.render();
+    });
+
+    afterEach(() => {
+        delete window.twopayment;
+    });
+
+    test('a captured company alone is not enough - no message, no label', () => {
+        // The superseded rule. This is the assertion that fails if the label goes
+        // back to being shown whenever a company is captured.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        expect(messageVisible()).toBe(false);
+        expect(shown().hidden).toBe(true);
+        // The content is ready and waiting - it is the visibility that is gated,
+        // not the rendering. Distinguishes "gated" from "broken".
+        expect(slot('name').textContent).toBe('Example Trading Ltd');
+    });
+
+    test('the message going up takes the label with it', () => {
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        expect(shown().hidden).toBe(true);
+
+        // The real show path every decision funnels through.
+        manager.getOrCreateMessageContainer();
+
+        expect(messageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+        expect(label()).toBe('Example Trading Ltd (12345678)');
+    });
+
+    test('an approval with the notice OFF hides the message and the label', () => {
+        // The configuration that motivated this change: the tile is deliberately
+        // silent on approval, and the label was still naming the company beside
+        // it.
+        //
+        // Driven as a TRANSITION from a visible state rather than from the hidden
+        // default, and that is load-bearing: from hidden, this test would pass
+        // whether or not the suppression branch nudges anything, because the
+        // label was already down. A decline first is also the real sequence - a
+        // buyer is refused, fixes something, and is approved on a later poll.
+        window.twopayment = { intent_approved_notice_enabled: false };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        manager.showOrderIntentDecline('not yet');
+        expect(messageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+
+        manager.showOrderIntentApproval('approved');
+
+        expect(messageVisible()).toBe(false);
+        expect(shown().hidden).toBe(true);
+    });
+
+    test('an approval with the notice ON shows the message and the label', () => {
+        window.twopayment = { intent_approved_notice_enabled: true };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        manager.showOrderIntentApproval('approved');
+
+        expect(messageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+    });
+
+    test('the label agrees with the message in every state, one gate not two', () => {
+        // The anti-duplication test. Whatever the combination, the two answers are
+        // compared to EACH OTHER rather than to a hardcoded expectation, so a
+        // second copy of the approved-notice rule that disagreed with
+        // TwoCheckoutManager by even one case fails here.
+        const cases = [
+            { enabled: true, approved: true },
+            { enabled: false, approved: true },
+            { enabled: true, approved: false },
+            { enabled: false, approved: false }
+        ];
+
+        cases.forEach(({ enabled, approved }) => {
+            window.twopayment = { intent_approved_notice_enabled: enabled };
+            TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+            if (approved) {
+                manager.showOrderIntentApproval('approved');
+            } else {
+                manager.showOrderIntentDecline('declined');
+            }
+
+            expect(shown().hidden).toBe(!messageVisible());
+        });
+    });
+
+    test('a message hidden by an ancestor hides the label too', () => {
+        // The message's own `display` is not the question - the buyer cannot read
+        // it through a collapsed wrapper either, and on a real checkout this
+        // section sits inside containers both the theme and the module hide.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        showIntentMessage();
+        TwoCompanySummary.render();
+        expect(shown().hidden).toBe(false);
+
+        document.querySelector('.two-payment-container').style.display = 'none';
+        TwoCompanySummary.render();
+
+        expect(shown().hidden).toBe(true);
+    });
+
+    test("TwoOrderIntent's own message element counts as the message too", () => {
+        // It does not render on PS 8's classic theme, but the gate is about what
+        // the buyer can see rather than about which module drew it - so if this
+        // element IS in the DOM and visible on some theme, the label belongs
+        // beside it.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        expect(shown().hidden).toBe(true);
+
+        const msg = document.createElement('div');
+        msg.className = 'two-order-intent-message';
+        msg.textContent = 'declined';
+        document.querySelector('.two-payment-container').appendChild(msg);
+        TwoCompanySummary.render();
+
+        expect(shown().hidden).toBe(false);
+    });
+
+    test('clearing the intent UI takes the label down', () => {
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        window.twopayment = { intent_approved_notice_enabled: true };
+        manager.showOrderIntentDecline('declined');
+        expect(shown().hidden).toBe(false);
+
+        // clearOrderIntentUI() hides its fallback container; the template section
+        // is what is on screen here, so hide that the way the module does and
+        // confirm the label follows rather than being left behind.
+        hideIntentMessage();
+        manager.clearOrderIntentUI();
+
+        expect(messageVisible()).toBe(false);
+        expect(shown().hidden).toBe(true);
+    });
+
+    test('a visible message does not conjure a label out of nothing', () => {
+        // The ceiling, not a floor: a decline with no company captured at all
+        // shows a message the label has nothing to accompany, and two empty slots
+        // with a stray "()" are worse than no block.
+        window.twopayment = { intent_approved_notice_enabled: true };
+        manager.showOrderIntentDecline('no company found');
+
+        expect(messageVisible()).toBe(true);
+        expect(shown()).toEqual({ name: '', number: '', hidden: true });
+    });
+
+    test('the visibility survives a re-render of the tile', () => {
+        // PrestaShop replaces the payment step wholesale on a cart change. The
+        // captured pair is class-static for that reason, and the gate is re-read
+        // from the replacement DOM rather than remembered - so a tile rebuilt
+        // while the message is down must come back hidden.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        showIntentMessage();
+        TwoCompanySummary.render();
+        expect(shown().hidden).toBe(false);
+
+        root().remove();
+        document.querySelector('.two-payment-container').remove();
+        buildPaymentTile();
+        showIntentMessage();
+        TwoCompanySummary.render();
+        expect(shown().hidden).toBe(false);
+
+        root().remove();
+        document.querySelector('.two-payment-container').remove();
+        buildPaymentTile();
+        hideIntentMessage();
+        TwoCompanySummary.render();
+        expect(shown().hidden).toBe(true);
+    });
+
+    test('the nudge tolerates the tile module being absent', () => {
+        // twopayment.js constructs these independently; a checkout running
+        // without the summary class must not throw.
+        const saved = window.TwoCompanySummary;
+        delete window.TwoCompanySummary;
+        try {
+            expect(() => manager.refreshCompanyLabel()).not.toThrow();
+        } finally {
+            window.TwoCompanySummary = saved;
+        }
     });
 });

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -1150,3 +1150,111 @@ describe("the label rides on the intent message's visibility (TWO-25326 §7, rev
         }
     });
 });
+
+describe("TwoOrderIntent's own message drives the label on themes that render it (TWO-25326 §7)", () => {
+    // TwoOrderIntent.updateUI() appends `.two-order-intent-message` into
+    // `.payment-option-content, .payment-form, .additional-information` searched
+    // WITHIN the `.payment-option`. PS 8's classic theme provides none of those
+    // there, so on that theme the element never enters the DOM at all and this
+    // module's message is invisible - which is why the gate is anchored on
+    // TwoCheckoutManager's container instead.
+    //
+    // On a theme that DOES provide one, this module's message is the one the
+    // buyer reads, and the label has to track it. That is what this suite builds
+    // and pins. Without it, TwoOrderIntent's nudges are untested - confirmed by
+    // mutation: deleting them left every other test in this file green.
+    let intent;
+
+    /** A theme whose payment option contains the container updateUI looks for. */
+    function wrapTileAsPaymentOption() {
+        const container = document.querySelector('.two-payment-container');
+        const option = document.createElement('div');
+        option.className = 'payment-option';
+        const content = document.createElement('div');
+        content.className = 'payment-option-content';
+        const marker = document.createElement('div');
+        marker.setAttribute('data-module-name', 'twopayment');
+        option.appendChild(marker);
+        option.appendChild(content);
+        container.parentNode.insertBefore(option, container);
+        content.appendChild(container);
+        return option;
+    }
+
+    function ownMessageVisible() {
+        const msg = document.querySelector('.two-order-intent-message');
+        return !!msg && window.getComputedStyle(msg).display !== 'none';
+    }
+
+    beforeEach(() => {
+        loadScript('views/js/modules/TwoOrderIntent.js');
+        intent = new window.TwoOrderIntent({});
+        document.querySelectorAll("input[name='company'], input[name='companyid']")
+            .forEach((el) => el.remove());
+        wrapTileAsPaymentOption();
+        // Only this module's message is in play here, so take the template
+        // section out of the picture - otherwise the label could be riding on
+        // TwoCheckoutManager's container and these tests would prove nothing.
+        hideIntentMessage();
+        TwoCompanySummary.render();
+    });
+
+    afterEach(() => {
+        delete window.twopayment;
+    });
+
+    test('its message going up brings the label with it', () => {
+        window.twopayment = { intent_approved_notice_enabled: true };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        expect(shown().hidden).toBe(true);
+
+        intent.updateUI({ approved: true, message: 'looks fine', rawResponse: {} });
+
+        expect(ownMessageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+        expect(label()).toBe('Example Trading Ltd (12345678)');
+    });
+
+    test('its message being removed takes the label down', () => {
+        // Driven as a transition, so the suppression is actually observed rather
+        // than the label merely being down already.
+        window.twopayment = { intent_approved_notice_enabled: false };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        intent.updateUI({ approved: false, message: 'not yet', rawResponse: {} });
+        expect(ownMessageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+
+        intent.updateUI({ approved: true, message: '', rawResponse: {} });
+
+        expect(ownMessageVisible()).toBe(false);
+        expect(shown().hidden).toBe(true);
+    });
+
+    test('a blocked submit puts its message up, and the label with it', () => {
+        window.twopayment = { intent_approved_notice_enabled: false };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        expect(shown().hidden).toBe(true);
+
+        intent.lastResult = { approved: false, message: 'resolve this first' };
+        intent.showOrderPreventionMessage();
+
+        expect(ownMessageVisible()).toBe(true);
+        expect(shown().hidden).toBe(false);
+    });
+
+    test('reset() takes the label down with the decision', () => {
+        window.twopayment = { intent_approved_notice_enabled: true };
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+        intent.updateUI({ approved: true, message: 'looks fine', rawResponse: {} });
+        expect(shown().hidden).toBe(false);
+
+        // reset() forgets the decision; the message element it drew is removed
+        // with it on a real checkout by the re-render that follows, so the label
+        // must not be left announcing a company for a decision that is gone.
+        document.querySelectorAll('.two-order-intent-message').forEach((el) => el.remove());
+        intent.reset();
+
+        expect(shown().hidden).toBe(true);
+    });
+});

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -98,8 +98,14 @@ function makeInstance(extraConfig) {
  * `.two-payment-info` is the section the shipped template carries, hidden inline
  * (`style="display: none"`) until an intent decision arrives - and it is the
  * container that actually renders on PrestaShop, so it is the one the label's
- * gate observes. Revealed by setting the same inline display TwoCheckoutManager
- * sets, not by deleting the attribute, so this reproduces the real mechanism.
+ * gate observes.
+ *
+ * BOTH halves of the real mechanism, because the stylesheet makes them both
+ * load-bearing: TwoCheckoutManager sets `display: block` AND adds `.show`, and
+ * `.two-payment-info` is `opacity: 0` until that class takes it to 1. Setting
+ * only the display would leave the section fully transparent - a state a buyer
+ * cannot read, so a suite that called it "shown" would be asserting against
+ * something invisible.
  *
  * @returns {Element} the message section
  */
@@ -109,16 +115,18 @@ function showIntentMessage() {
         throw new Error('the tile template carries no .two-payment-info section');
     }
     info.style.display = 'block';
+    info.classList.add('show');
     return info;
 }
 
-/** Take it back down, the way the notice-off branch does. */
+/** Take it back down, the way the notice-off branch does - display and class. */
 function hideIntentMessage() {
     const info = document.querySelector('.two-payment-info');
     if (!info) {
         throw new Error('the tile template carries no .two-payment-info section');
     }
     info.style.display = 'none';
+    info.classList.remove('show');
     return info;
 }
 
@@ -1022,6 +1030,43 @@ describe("the label rides on the intent message's visibility (TWO-25326 §7, rev
         TwoCompanySummary.render();
 
         expect(shown().hidden).toBe(true);
+    });
+
+    test('a message left fully transparent does not show the label', () => {
+        // `.two-payment-info` is `opacity: 0` in the stylesheet and is revealed
+        // by adding `.show`. A gate that only looked at `display` would read the
+        // displayed-but-un-shown section as visible and put the label beside a
+        // message the buyer cannot see. The real cascade is loaded by this
+        // suite's beforeEach, so this is the shipped rule doing the hiding.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        const info = document.querySelector('.two-payment-info');
+        info.style.display = 'block';
+        info.classList.remove('show');
+        TwoCompanySummary.render();
+
+        expect(window.getComputedStyle(info).opacity).toBe('0');
+        expect(shown().hidden).toBe(true);
+
+        // And the class that reveals it brings the label with it.
+        info.classList.add('show');
+        TwoCompanySummary.render();
+
+        expect(shown().hidden).toBe(false);
+    });
+
+    test('a mid-fade message still counts as shown', () => {
+        // The same rule carries a 0.3s opacity transition, so a value between 0
+        // and 1 is a message arriving, not a hidden one. Pinned because the
+        // obvious "less than 1" test would blink the label off during every
+        // fade-in.
+        TwoCompanySummary.setIntentCompany({ name: 'Example Trading Ltd', number: '12345678' });
+
+        const info = showIntentMessage();
+        info.style.opacity = '0.4';
+        TwoCompanySummary.render();
+
+        expect(shown().hidden).toBe(false);
     });
 
     test("TwoOrderIntent's own message element counts as the message too", () => {

--- a/tests/js/ps-harness.js
+++ b/tests/js/ps-harness.js
@@ -474,6 +474,9 @@ function loadCompanySummary() {
         throw new Error('harness: TwoCompanySummary was not exported onto window');
     }
     TwoCompanySummary._soleTrader = null;
+    // Class-static like `_soleTrader`, and leaked across tests until now: a
+    // pair pushed by one test's intent payload stayed readable by the next.
+    TwoCompanySummary._intentCompany = null;
     // Also class-static, and for the same reason: the bus it guards cannot be
     // unsubscribed from, so the flag has to survive instances. It must not
     // survive tests, or the first test in a file is the only one whose instance

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -947,6 +947,9 @@ class TwoCheckoutManager {
                 existing.classList.remove('approved', 'declined', 'loading', 'show');
                 existing.style.display = 'none';
             }
+            // Hidden, so the company label goes with it (TWO-25326 §7): this is
+            // the notice-off case the revised rule exists for.
+            this.refreshCompanyLabel();
             this.clearLoadingState();
             this.hideLoadingOverlay();
             this.showPaymentTerms();
@@ -1212,6 +1215,8 @@ class TwoCheckoutManager {
             messageContainer.style.display = 'none';
             messageContainer.innerHTML = '';
         }
+        // The message is down, so the company label is too (TWO-25326 §7).
+        this.refreshCompanyLabel();
         
         // Also clear payment terms
         this.hidePaymentTerms();
@@ -1237,6 +1242,31 @@ class TwoCheckoutManager {
     /**
      * Get or create message container for order intent feedback (uses existing payment card structure)
      */
+    /**
+     * Ask the payment tile's company label to re-read its gate (TWO-25326 §7).
+     *
+     * The label is shown exactly when the order-intent message is shown and
+     * hidden exactly when it is hidden - no longer whenever a company happens to
+     * be captured. TwoCompanySummary decides that by LOOKING at the message
+     * container, so this passes no state; it only says "the message may have
+     * just changed, look again", and is called from the points in this module
+     * that change it.
+     *
+     * This module is where it matters on PrestaShop: `.two-payment-info` is the
+     * container the shipped template carries and the one the buyer actually
+     * sees.
+     *
+     * @returns {void}
+     */
+    refreshCompanyLabel() {
+        if (typeof window === 'undefined'
+            || !window.TwoCompanySummary
+            || typeof window.TwoCompanySummary.render !== 'function') {
+            return;
+        }
+        window.TwoCompanySummary.render();
+    }
+
     getOrCreateMessageContainer() {
         // First try to use the existing payment info section from the template
         let container = document.querySelector('.two-payment-info');
@@ -1245,6 +1275,8 @@ class TwoCheckoutManager {
             // Use existing payment info section and make it visible
             container.style.display = 'block';
             container.classList.add('show');
+            // Now visible, so the company label may need to come with it.
+            this.refreshCompanyLabel();
             return container;
         }
         
@@ -1273,6 +1305,7 @@ class TwoCheckoutManager {
                 }
             }
         }
+        this.refreshCompanyLabel();
         return container;
     }
     

--- a/views/js/modules/TwoCompanySummary.js
+++ b/views/js/modules/TwoCompanySummary.js
@@ -80,6 +80,28 @@ class TwoCompanySummary {
      */
     static _intentCompany = null;
 
+    /**
+     * Every element any of the module's three renderers uses for the
+     * order-intent message, in no particular order.
+     *
+     *   .two-payment-info          the section in paymentinfo.tpl. This is the
+     *                              one that actually renders on PrestaShop -
+     *                              TwoCheckoutManager shows and hides it.
+     *   #two-order-intent-messages TwoCheckoutManager's fallback container,
+     *                              created only when the template section is
+     *                              missing.
+     *   .two-order-intent-message  TwoOrderIntent.updateUI()'s own element.
+     *
+     * All three are listed because the label's rule is about what the buyer can
+     * see, not about which module happened to draw it. See
+     * isIntentMessageVisible().
+     */
+    static INTENT_MESSAGE_SELECTORS = [
+        '.two-payment-info',
+        '#two-order-intent-messages',
+        '.two-order-intent-message'
+    ];
+
     constructor() {
         this._stopped = false;
         this.boundOnFieldChange = this.onFieldChange.bind(this);
@@ -185,6 +207,76 @@ class TwoCompanySummary {
             };
         }
         TwoCompanySummary.render();
+    }
+
+    /**
+     * Is the order-intent message currently on screen?
+     *
+     * TWO-25326 §7, superseding the rule this block shipped with: the label is
+     * no longer shown whenever a company happens to be captured. It is shown
+     * exactly when the order-intent message beside it is shown, and hidden
+     * exactly when that message is hidden.
+     *
+     * This OBSERVES the message rather than re-deriving the conditions that
+     * govern it, and that is the whole design. The alternative - copying the
+     * approved-notice rule (`intent_approved_notice_enabled`, TWO-25218) into
+     * this block, or having each renderer push a boolean - puts a second
+     * statement of the rule somewhere it can disagree with the first. There are
+     * THREE code paths that can draw or remove this message
+     * (TwoCheckoutManager's template section, its fallback container, and
+     * TwoOrderIntent.updateUI()'s own element), so a pushed flag would have to
+     * be maintained in all three and would be wrong the moment one of them
+     * changed. Asking the DOM what the buyer can see cannot drift from what the
+     * buyer can see.
+     *
+     * Computed style, not the inline attribute: the message is hidden inline in
+     * places and by the stylesheet in others.
+     *
+     * @returns {boolean}
+     */
+    static isIntentMessageVisible() {
+        if (typeof document === 'undefined' || !document.querySelectorAll) {
+            return false;
+        }
+        const nodes = document.querySelectorAll(
+            TwoCompanySummary.INTENT_MESSAGE_SELECTORS.join(', ')
+        );
+        for (let i = 0; i < nodes.length; i += 1) {
+            if (TwoCompanySummary.isRendered(nodes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Is this element, and every ancestor of it, actually displayed?
+     *
+     * `getComputedStyle` reports an element's OWN `display`, which stays
+     * `block` on a node whose parent is hidden - so the element's own style is
+     * not enough to answer "can the buyer see it". The message containers sit
+     * inside wrappers the theme and the module both hide, which is exactly that
+     * case.
+     *
+     * @param {?Element} node
+     * @returns {boolean}
+     */
+    static isRendered(node) {
+        if (!node || typeof window === 'undefined' || !window.getComputedStyle) {
+            return false;
+        }
+        let current = node;
+        while (current && current.nodeType === 1) {
+            const style = window.getComputedStyle(current);
+            if (!style) {
+                return false;
+            }
+            if (style.display === 'none' || style.visibility === 'hidden') {
+                return false;
+            }
+            current = current.parentElement;
+        }
+        return true;
     }
 
     /** @returns {string} */
@@ -294,7 +386,22 @@ class TwoCompanySummary {
         // Nothing captured at all: the buyer has not named a company yet, and a
         // block of empty labels is worse than no block.
         const hasAnything = state.name !== '' || state.number !== '';
-        root.style.display = hasAnything ? '' : 'none';
+
+        // TWO-25326 §7, revised: the label rides on the order-intent message's
+        // visibility rather than on capture alone. A brand that runs with the
+        // approval notice switched off got a tile that was deliberately silent
+        // on approval but still announced the company beside it.
+        //
+        // Read off the message itself rather than re-derived from the config
+        // that governs it - see isIntentMessageVisible() for why observing beats
+        // copying the rule.
+        //
+        // `hasAnything` still applies on top: a decline with no company
+        // captured at all shows a message the label has nothing to accompany,
+        // and empty slots are worse than no block. So the message's visibility
+        // is a CEILING on the label's, never a floor.
+        const withMessage = hasAnything && TwoCompanySummary.isIntentMessageVisible();
+        root.style.display = withMessage ? '' : 'none';
     }
 }
 

--- a/views/js/modules/TwoCompanySummary.js
+++ b/views/js/modules/TwoCompanySummary.js
@@ -274,6 +274,18 @@ class TwoCompanySummary {
             if (style.display === 'none' || style.visibility === 'hidden') {
                 return false;
             }
+            // Fully transparent counts as hidden, and for this container that is
+            // not a defensive extra: `.two-payment-info` is `opacity: 0` in the
+            // stylesheet and is revealed by adding `.show`, which is what takes
+            // it to 1. Checking only `display` would read the un-shown section
+            // as visible and put the label beside a message nobody can see.
+            //
+            // Exactly zero, not "less than one": the same rule carries a 0.3s
+            // opacity transition, and a mid-fade value is a message on its way
+            // onto the screen rather than a hidden one.
+            if (parseFloat(style.opacity) === 0) {
+                return false;
+            }
             current = current.parentElement;
         }
         return true;

--- a/views/js/modules/TwoOrderIntent.js
+++ b/views/js/modules/TwoOrderIntent.js
@@ -155,6 +155,33 @@ class TwoOrderIntent {
         });
     }
 
+    /**
+     * Ask the payment tile's company label to re-read its gate.
+     *
+     * TWO-25326 §7, revised rule: the label is shown exactly when the
+     * order-intent message is shown and hidden exactly when it is hidden - it is
+     * no longer shown whenever a company happens to be captured. The case that
+     * motivated it is a brand running with the approval notice switched off
+     * (`intent_approved_notice_enabled`, TWO-25218): the tile is deliberately
+     * silent on approval, and the label was still naming the company beside it.
+     *
+     * No boolean is passed, deliberately. TwoCompanySummary works the answer out
+     * by looking at the message element, so this is only a nudge - "the message
+     * may have just changed, look again" - issued after this module has changed
+     * it. Passing a flag would put a second copy of the approved-notice rule in
+     * a second place; see TwoCompanySummary.isIntentMessageVisible().
+     *
+     * @returns {void}
+     */
+    refreshCompanyLabel() {
+        if (typeof window === 'undefined'
+            || !window.TwoCompanySummary
+            || typeof window.TwoCompanySummary.render !== 'function') {
+            return;
+        }
+        window.TwoCompanySummary.render();
+    }
+
     checkOrderIntent() {
         if (!this.shouldRunOrderIntent()) {
             return Promise.resolve(this.lastResult || { success: false, error: 'Order intent check skipped' });
@@ -635,6 +662,8 @@ class TwoOrderIntent {
         // approval. The functional part of an approval still runs below.
         if (result.approved && !this.approvedNoticeEnabled()) {
             $twoPaymentOption.find('.two-order-intent-message').remove();
+            // No message on screen, so no company label either (TWO-25326 §7).
+            this.refreshCompanyLabel();
             $twoPaymentOption.removeClass('disabled');
             $twoPaymentOption.find('input[type="radio"]').prop('disabled', false);
             return;
@@ -644,6 +673,9 @@ class TwoOrderIntent {
             $messageContainer = $('<div class="two-order-intent-message"></div>');
             $twoPaymentOption.find('.payment-option-content, .payment-form, .additional-information').append($messageContainer);
         }
+        // Past the suppression branch, so a message IS being rendered: the label
+        // travels with it (TWO-25326 §7).
+        this.refreshCompanyLabel();
         let messageText = result.message;
         // Only template in the company name for a real decision FROM Two's
         // API (processResult() always sets rawResponse). handleError()'s
@@ -739,6 +771,9 @@ class TwoOrderIntent {
             $twoPaymentOption.find('.payment-option-content, .payment-form, .additional-information').append($messageContainer);
         }
         $messageContainer.removeClass('approved loading').addClass('declined').text(message);
+        // This path always ends with a declined message on screen, so the label
+        // rides with it (TWO-25326 §7).
+        this.refreshCompanyLabel();
     }
 
     startMonitoring() {
@@ -762,6 +797,8 @@ class TwoOrderIntent {
                             'To pay with Two, go back to your billing address and search for your company name. Select your company from the results to verify your business.'
                         );
                         $msg.removeClass('approved declined loading').text(t).show();
+                        // Shown, so the label goes with it (TWO-25326 §7).
+                        this.refreshCompanyLabel();
                     }
                     return;
                 }
@@ -788,6 +825,9 @@ class TwoOrderIntent {
         // Cleared with its name: a retained number outliving the reset could
         // only ever be paired with a DIFFERENT company's name later.
         this.lastCompanyNumber = null;
+        // The message goes when the decision does, and the label follows it
+        // (TWO-25326 §7).
+        this.refreshCompanyLabel();
         this.isProcessing = false;
         this.stopMonitoring();
     }


### PR DESCRIPTION
## What changed

The payment tile's company label (shipped in #134) was shown whenever a company was captured. TWO-25326 §7 changed the rule: **it is shown exactly when the order-intent message is shown, and hidden exactly when that message is hidden.**

The motivating case is a brand running with the approval notice switched off (`intent_approved_notice_enabled`, TWO-25218). On an approval the tile is deliberately silent — but the label carried on naming the company next to that silence.

## How

`TwoCompanySummary.isIntentMessageVisible()` **observes** the message rather than re-deriving what governs it. It asks the DOM whether any of the module's message containers is on screen, walking ancestors so a collapsed wrapper counts as hidden. The renderers call `refreshCompanyLabel()`, which passes no state and only means "the message may have changed, look again".

Observing rather than copying the condition is the point: three code paths can draw or remove this message, so a pushed boolean would have to be maintained in all three and would be wrong the moment one changed.

`hasAnything` still applies on top, so the message's visibility is a **ceiling** on the label's, never a floor — a decline with no company captured shows a message the label has nothing to accompany, and empty slots with a stray `()` are worse than no block.

## Which container matters was measured, and the first attempt was wrong

`.two-order-intent-message` — `TwoOrderIntent.updateUI()`'s element — is appended to `.payment-option-content, .payment-form, .additional-information` searched **within** the `.payment-option`. On PS 8's classic theme none of those exist there, so **that element never enters the DOM**. Gating on it would have hidden the label permanently and silently undone #134.

What the buyer actually reads is `.two-payment-info`, a section of the shipped template that `TwoCheckoutManager` shows and hides — so the nudges live there: `getOrCreateMessageContainer()` (the choke point every decision funnels through), the notice-off suppression branch, and `clearOrderIntentUI()`. `TwoOrderIntent` keeps its nudges too, since its element is the visible one on any theme that does provide those containers.

## Verification

**Jest — 363 pass** (11 new). The load-bearing test compares the label's visibility against the message's, not against a hardcoded expectation, across all four approved/notice-enabled combinations, so a duplicated condition that disagreed by even one case fails.

**Mutation-checked**, five sites, each caught:

| Mutation | Tests failed |
|---|---|
| `render()` gate dropped | 8 |
| notice-off suppression nudge dropped | 2 |
| show-path nudge dropped | 5 |
| ancestor walk removed | 1 |
| `TwoOrderIntent` selector removed | 1 |

One mutation run caught a vacuous test of my own: the notice-off case started from the hidden default and stayed green with the suppression nudge deleted. It now drives the decline-then-approval transition, the only version that observes the suppression.

**Live on a real PrestaShop 8 checkout** (Docker, guest checkout through to the payment step, address form genuinely removed by PrestaShop — `addressInputsLeft: 0`):

| notice | decision | message | label |
|---|---|---|---|
| on | declined | visible | visible |
| on | approved | visible | visible |
| off | approved | hidden | **hidden** |
| off | declined | visible | visible |

**Counter-check on `staging`**, same shop, same script: notice-off + approved gives `msgVisible: false` / `labelVisible: true` — the reported bug reproduced live, and fixed on this branch.

PHP spec suite: all pass.

## Found, not fixed (out of scope)

`.two-order-intent-message` never renders on PS 8's classic theme, so `TwoOrderIntent.updateUI()`'s message and `showOrderPreventionMessage()`'s blocked-submit nudge are both dead there — the latter's docblock asserts that element is "present on every PS theme", which the measurement contradicts. Pre-existing, identical on `staging`, and not touched here. Worth its own ticket.
