### PR TITLE
fix(company-search): a company selection must never write the org number into the VAT field (TWO-25326)

### DIFF
--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -175,7 +175,8 @@ cache:
 form (which it does for something as ordinary as a country change):
 
 - a company selected through the real widget (menu focus + select, not a direct
-  `onCompanySelected()` call) lands in `company`, `companyid`, `dni` and `vat_number`; a
+  `onCompanySelected()` call) lands in `company`, `companyid` and `dni` — and never in
+  `vat_number`, because an organisation number is not a VAT number; a
   lookup-id-only company gets its number and address from the detail endpoint; the
   address-lookup toggle stops the address fill without stopping `companyid`; and selecting
   the unavailable row writes nothing.
@@ -198,7 +199,7 @@ form (which it does for something as ordinary as a country change):
 - a stale organisation number is cleared across a re-render: a matching pair survives,
   a differing name or an absent selection marker clears it, and the comparison ignores
   case and whitespace because themes and server round-trips both reflow them.
-- the submit hook restores `dni`/`vat_number` from `companyid` without overwriting a value
+- the submit hook restores `dni` from `companyid` without overwriting a value
   the buyer typed, and a buyer-typed DNI becomes the organisation number when none was
   selected.
 - the company-detail fill: the request carries `withCredentials: false` in its own right
@@ -295,8 +296,8 @@ form (which it does for something as ordinary as a country change):
   are dropped; the session company is cleared through its own endpoint action,
   asserted to be a POST carrying the token and asserted *not* to be the save
   action, which rejects an empty company id and would therefore clear nothing; and
-  the address step's `dni` / `vat_number` are dropped, which is the pair the server
-  reads off the saved address independently of the session company.
+  the address step's `dni` is dropped, which the server reads off the saved address
+  independently of the session company.
 
   Two things about those cases are deliberate. The selection is completed **through
   jQuery UI's own menu**, not by setting the hidden field by hand: a hand-set

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -984,11 +984,11 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
          * own menu and therefore through onCompanySelected().
          *
          * Deliberately NOT `organizationField.val(...)` by hand. A selection
-         * writes THREE places - the hidden organisation field, `dni` and
-         * `vat_number` - and a hand-set stand-in reaches only the first, so the
-         * two address identifiers stay empty and every assertion about what a
-         * clear does to them passes vacuously. That is exactly how the disowned
-         * organisation number survived into the order payload unnoticed.
+         * writes TWO places - the hidden organisation field and `dni` - and a
+         * hand-set stand-in reaches only the first, so the address identifier
+         * stays empty and every assertion about what a clear does to it passes
+         * vacuously. That is exactly how the disowned organisation number
+         * survived into the order payload unnoticed.
          */
         function selectFirstCompany() {
             const widget = searchInput().autocomplete('instance');
@@ -1032,21 +1032,20 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
          * The organisation number is what decides WHO gets credit-checked and
          * invoiced, so a buyer who disowns a company and types their own name
          * must not leave that company's number anywhere the server can read it.
-         * `dni` and `vat_number` are read off the saved address by the server's
-         * own resolver, independently of the session company, so leaving them
-         * behind makes the typed name cosmetic.
+         * `dni` is read off the saved address by the server's own resolver,
+         * independently of the session company, so leaving it behind makes the
+         * typed name cosmetic.
          */
-        test('the identification and VAT numbers the lookup wrote are dropped too', () => {
+        test('the identification number the lookup wrote is dropped too', () => {
             withEndpoint(() => {
                 const instance = makeInstance();
                 search(AT_THRESHOLD);
                 ajax.last().succeed(SEARCH_RESPONSE);
 
                 selectFirstCompany();
-                // Bootstrapped-guard: with these empty the assertions below could
+                // Bootstrapped-guard: with this empty the assertion below could
                 // not fail whatever the clear does.
                 expect($("input[name='dni']").val()).toBe('12345678');
-                expect($("input[name='vat_number']").val()).toBe('12345678');
 
                 // Driven through the API rather than by clicking the button:
                 // §2 HIDES that button once hasConfirmedSelection() is true, which
@@ -1055,7 +1054,6 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
                 instance.enterManualEntryMode();
 
                 expect($("input[name='dni']").val()).toBe('');
-                expect($("input[name='vat_number']").val()).toBe('');
             });
         });
 
@@ -1087,7 +1085,6 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
                 expect(instance.organizationField.val()).toBe('');
                 expect(instance.organizationField.attr('data-two-company-name')).toBeUndefined();
                 expect($("input[name='dni']").val()).toBe('');
-                expect($("input[name='vat_number']").val()).toBe('');
             });
         });
 
@@ -1120,7 +1117,7 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
                 instance.enterManualEntryMode();
 
                 expect($("input[name='dni']").val()).toBe('55554444');
-                // The one they did NOT touch is still the lookup's and still goes.
+                // And the VAT field was never the lookup's to write or clear.
                 expect($("input[name='vat_number']").val()).toBe('');
             });
         });
@@ -1482,7 +1479,40 @@ describe('selecting a company through the real widget', () => {
             'Example Trading Ltd'
         );
         expect($("input[name='dni']").val()).toBe('12345678');
-        expect($("input[name='vat_number']").val()).toBe('12345678');
+        // An organisation number is NOT a VAT number, so the selection must
+        // leave the VAT field exactly as it found it.
+        expect($("input[name='vat_number']").val()).toBe('');
+        expect(
+            $("input[name='vat_number']").attr('data-two-autofilled-value')
+        ).toBeUndefined();
+    });
+
+    test('a company selection never writes into the VAT-number field', () => {
+        makeInstance();
+        // The buyer's own VAT number, already in the form. The selection path
+        // overwrites the identifiers it owns unconditionally (a re-search has to
+        // replace the previous company's number), so if the VAT field were still
+        // on that list this value would be destroyed as well as falsified.
+        $("input[name='vat_number']").val('GB123456789');
+
+        selectFirstResult('exa', SEARCH_RESPONSE);
+
+        expect($("input[name='dni']").val()).toBe('12345678');
+        expect($("input[name='vat_number']").val()).toBe('GB123456789');
+    });
+
+    test('the pre-submit sync never writes into the VAT-number field', () => {
+        const instance = makeInstance();
+        selectFirstResult('exa', SEARCH_RESPONSE);
+        // A re-render between selection and submit blanks the address inputs;
+        // the submit hook restores what it owns, which is `dni` and nothing else.
+        $("input[name='dni']").val('');
+        $("input[name='vat_number']").val('');
+
+        instance.syncOrganizationToAddressIdentifiers();
+
+        expect($("input[name='dni']").val()).toBe('12345678');
+        expect($("input[name='vat_number']").val()).toBe('');
     });
 
     test('selecting the unavailable row writes nothing into the field', () => {
@@ -1780,10 +1810,11 @@ describe('the organisation number reaches the address identifiers on submit', ()
 
         submitForm();
 
-        // The selection writes these too, but a re-render between selection and
-        // submit can blank them; the submit hook is the last chance to restore.
+        // The selection writes this too, but a re-render between selection and
+        // submit can blank it; the submit hook is the last chance to restore.
         expect($("input[name='dni']").val()).toBe('12345678');
-        expect($("input[name='vat_number']").val()).toBe('12345678');
+        // Never the VAT field - an organisation number is not a VAT number.
+        expect($("input[name='vat_number']").val()).toBe('');
     });
 
     test('a value the buyer typed is not overwritten on submit', () => {
@@ -2224,7 +2255,7 @@ describe('a destroyed instance cannot act on the live DOM', () => {
         expect($("input[name='dni']").val()).toBe('12345678');
     });
 
-    test('the address-lookup toggle gates the dni/vat writes but not companyid', () => {
+    test('the address-lookup toggle gates the dni write but not companyid', () => {
         const live = makeInstance({ addressLookupEnabled: false });
 
         live.onCompanySelected(null, {

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -685,7 +685,9 @@ describe('the hidden companyid input is untouched', () => {
         // Pinned here as well as in the company-search suite, because this
         // change added a call into the middle of onCompanySelected().
         expect($("input[name='dni']").val()).toBe('12345678');
-        expect($("input[name='vat_number']").val()).toBe('12345678');
+        // And still never the VAT field: an organisation number is not a VAT
+        // number, so a selection must leave that field alone.
+        expect($("input[name='vat_number']").val()).toBe('');
     });
 });
 

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1404,7 +1404,7 @@ class TwoCompanySearch {
     }
 
     /**
-     * Single gate for the DNI / vat_number writes the lookup performs - the
+     * Single gate for the `dni` writes the lookup performs - the
      * selection handler, the company-details refinement, and the pre-submit
      * sync all go through here rather than each carrying its own condition.
      *
@@ -1437,21 +1437,35 @@ class TwoCompanySearch {
     }
 
     /**
-     * The two address inputs a company selection mirrors its organisation number
+     * The address inputs a company selection mirrors its organisation number
      * into.
      *
-     * One list rather than the selector pair written twice, because the clear has
-     * to walk exactly the fields the write walks. A field present in one list and
+     * `dni` ("Identification number") only. **`vat_number` is deliberately NOT
+     * in this list and must never be added back.** An organisation number is
+     * not a VAT number: the two identifiers have different formats, different
+     * issuing registers, and a company can hold the first without ever holding
+     * the second. Writing the org number into the VAT field puts a value the
+     * buyer never gave into a field the buyer is answerable for, and it is
+     * wrong even when the two strings happen to coincide.
+     *
+     * It also has a silent side effect on tax. The shop reads a non-empty
+     * `vat_number` on a foreign address as a B2B reverse-charge exemption -
+     * the same condition core's price calculation switches tax off with - so a
+     * mirrored org number can zero the resolved VAT rate on an order whose
+     * buyer is not VAT-registered at all.
+     *
+     * One list rather than the selector written twice, because the clear has to
+     * walk exactly the fields the write walks. A field present in one list and
      * absent from the other is a disowned organisation number left in the form.
      *
      * @returns {Array<Object>} jQuery objects, any of which may be empty
      */
     addressIdentifierFields() {
-        return [$("input[name='dni']"), $("input[name='vat_number']")];
+        return [$("input[name='dni']")];
     }
 
     /**
-     * Drop the identification / VAT numbers, but ONLY the ones the lookup itself
+     * Drop the identification numbers, but ONLY the ones the lookup itself
      * wrote and the buyer has not since changed.
      *
      * Not a blanket clear, and that constraint is what makes this method
@@ -2037,8 +2051,8 @@ class TwoCompanySearch {
      * carries the old company.
      *
      * THREE halves, in truth. The selection also mirrors the organisation number
-     * into the address form's identification-number and VAT-number inputs, and
-     * the server reads those off the saved address on a path of their own,
+     * into the address form's identification-number input, and the server reads
+     * that off the saved address on a path of its own,
      * independently of the session company. Worse, the pre-submit sync adopts an
      * identification number with no organisation number beside it AS the
      * organisation number - so a `dni` left behind here is re-adopted at submit
@@ -3062,7 +3076,7 @@ class TwoCompanySearch {
                 companyid: ui.item.organization_number
             });
 
-            // Also sync to the DNI / VAT fields - gated on the address-lookup
+            // Also sync to the DNI field - gated on the address-lookup
             // toggle inside the writer (TWO-25203). Unconditional overwrite so
             // a re-search replaces the previous company's number.
             this.writeOrganizationToAddressIdentifiers(ui.item.organization_number);


### PR DESCRIPTION
## The bug

Reported directly: selecting a company at the PrestaShop checkout shows the
organisation number, and *also* writes that number into the **VAT number**
field. An organisation number is not a VAT number.

## Root cause

`TwoCompanySearch.addressIdentifierFields()` returned a list of **two** inputs —
`dni` ("Identification number") and `vat_number` — and the selection handler,
the company-details refinement and the pre-submit sync all mirror the
organisation number into every field on that list.

The `dni` half is intended: that is the field the module's own server-side
org-number resolver reads off the saved address, independently of the session
company. The `vat_number` half has been there since the feature was first
written and was never correct. It is the classic assumption that the two
identifiers are interchangeable — they are not. Different formats, different
issuing registers, and a company can hold a company-registration number without
being VAT-registered at all.

Nothing separate depends on it. There is no VAT-lookup or VAT-autofill feature
anywhere in the plugin (the only other `vat_number` mention outside tests is a
translated field *label*), so this write had no legitimate twin to preserve.

## Two consequences, not one

1. **The buyer is made answerable for a number they never gave.** And because
   the selection path overwrites unconditionally — deliberately, so that a
   re-search replaces the previous company's number — a VAT number the buyer
   *had already typed* was destroyed by the next company selection. Reproduced
   in a real browser: `GB123456789` in the field, select a company, field
   becomes `12345678`.
2. **It could silently zero VAT.** A non-empty `vat_number` on a
   foreign address is the exact condition the shop reads as a B2B
   reverse-charge exemption — the same one core's price calculation switches
   tax off with, and which the module's own declared-rate resolver mirrors.
   A mirrored organisation number therefore looks like a valid cross-border
   VAT registration and can resolve the rate to `0.0` for a buyer who is not
   VAT-registered.

## The fix

`vat_number` comes off that list, leaving `dni` alone on it. Because the write
and the matching clear walk the *same* list by design, that one change fixes
both directions at once: the lookup no longer writes the field, and no longer
claims ownership of it in order to clear it — so a buyer-typed VAT number now
survives both a selection and a switch to manual entry.

`companyid` still carries the number into the Two flow, so nothing downstream
loses the organisation number. The server-side resolver's ability to *find* an
org number in `vat_number` is a read-side fallback and is untouched.

The docblock now states why the field is absent and that it must not come back —
the list's previous comment described the pairing as intentional, which is how
this survived several reviews of the surrounding code.

## Verification

**Jest — 371 passed, 5 suites.** Two new dedicated tests plus the existing
selection/submit/clear assertions retargeted:

- `a company selection never writes into the VAT-number field` — seeds a real
  buyer VAT number first, so it fails on *destruction* as well as falsification.
- `the pre-submit sync never writes into the VAT-number field`.

**Mutation-checked both ways.** Reinstating `vat_number` on the list fails
exactly 5 tests (both new ones plus the three existing selection/submit
assertions) and passes 366; restoring returns 371/371. The mutation was
confirmed present in the tree before each run rather than assumed.

**PHP suite: `All tests passed.`**

**Real browser, local Docker + Playwright** (PS 8, real cart, guest checkout,
US address with `dni` + `vat_number` in the address layout, company search
stubbed at the network boundary so the whole widget → dropdown → real click →
selection-handler path is the shipping code):

- buyer's `GB123456789` typed first → select a company → `dni` = `12345678`,
  VAT field still `GB123456789`, no autofill marker on it.
- empty VAT field → select a company → `dni` = `12345678`, VAT field still
  empty.
- pre-submit sync fires → `dni` restored, VAT field still empty.
- **and the same spec against the unfixed file inside the container fails with
  `Expected "GB123456789" / Received "12345678"`** — i.e. it reproduces the
  reported bug, so the passing run is not vacuous.

## Note for the checklist

The e2e harness cannot currently host this as a permanent test: `dni` and
`vat_number` only render when they are in the country's address layout, which
`dev/ci/*` does not seed. Adding that is a harness change rather than part of
this fix — flagging it rather than doing it here. The Jest coverage above is
the durable regression guard.

Not addressed here: an address row saved by an *earlier* build may still hold an
organisation number in its `vat_number` column. This PR stops new ones being
created; it does not migrate existing data.
