### PR TITLE
fix(order-intent): wait for a tile company selection before checking intent (TWO-25326)

### DIFF
--- a/tests/js/order-intent-tile-timing.test.js
+++ b/tests/js/order-intent-tile-timing.test.js
@@ -1,0 +1,201 @@
+/**
+ * TWO-25326. Doug found this running a real checkout with "Enable Company
+ * Search In Address Entry" set to No (company search relocated into the
+ * payment tile): the order-intent check ran the instant the payment tile
+ * mounted/was selected, before the buyer had picked a company from the
+ * search results the tile contains.
+ *
+ * Address mode never had this problem - by the time the payment step (and
+ * its generic "Two payment selected" triggers) exists, address-step company
+ * capture is already resolved, well before the tile even renders. In tile
+ * mode the company control lives INSIDE the tile, so the same generic
+ * triggers used to fire checkOrderIntent() off the tile's own mount/default-
+ * selection, independent of whether TwoCompanySearch.onCompanySelected() had
+ * ever run.
+ *
+ * These tests pin TwoCheckoutManager.canAutoTriggerOrderIntent(): in tile
+ * mode it must hold the generic triggers back until a selection (or manual
+ * entry) has actually happened, and address mode must be unaffected.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    loadOrderIntent,
+    loadScript,
+    releaseWidgets,
+    buildAddressForm
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+const ORDER_INTENT_URL = 'https://shop.example.test/module/twopayment/orderintent';
+
+let TwoCompanySearch;
+let TwoOrderIntent;
+let TwoCheckoutManager;
+let $;
+
+/**
+ * The tile-mode payment step: Two is the ONLY payment method (so
+ * TwoCheckoutManager treats it as selected by default, with no buyer click
+ * needed - the exact case initializeModules() auto-triggers off) and the
+ * company-search control is mounted inside the tile, matching
+ * paymentinfo.tpl's `#two_tile_company` when the admin setting is off.
+ */
+function buildTilePaymentStepWithTwoAutoSelected() {
+    document.body.innerHTML = [
+        '<div class="payment-options">',
+        '  <div class="payment-option" data-module-name="twopayment">',
+        "    <input type='radio' name='payment-option' value='twopayment' checked />",
+        '    <div class="two-payment-container">',
+        '      <section class="two-payment-info" style="display: none;">',
+        '        <p class="two-subtitle"></p>',
+        '        <p class="two-payment-message"></p>',
+        '      </section>',
+        '      <div class="two-tile-company-search" id="two-tile-company-search">',
+        "        <input type='text' class='form-control' id='two_tile_company' name='two_tile_company' autocomplete='off' />",
+        '      </div>',
+        '    </div>',
+        '  </div>',
+        '</div>'
+    ].join('\n');
+}
+
+beforeEach(() => {
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    TwoOrderIntent = loadOrderIntent();
+    loadScript('views/js/modules/TwoCheckoutManager.js');
+    TwoCheckoutManager = window.TwoCheckoutManager;
+
+    window.twopayment = {
+        order_intent_url: ORDER_INTENT_URL,
+        ajax_token: 'test-token',
+        checkout_host: CHECKOUT_HOST,
+        billing_country: 'GB'
+    };
+
+    // TwoOrderIntent.checkOrderIntent() is the exact boundary the bug is
+    // about ("did the network check run"), decoupled from the ajax/promise
+    // plumbing inside it - stubbed rather than driven through $.ajax so the
+    // assertions below stay about WHEN it runs, not HOW its response
+    // resolves.
+    jest.spyOn(TwoOrderIntent.prototype, 'checkOrderIntent')
+        .mockImplementation(() => Promise.resolve({ success: true, approved: true }));
+});
+
+afterEach(() => {
+    releaseWidgets($);
+    document.body.innerHTML = '';
+    delete window.twopayment;
+    delete window.TwoCheckoutManager_Instance;
+    document.cookie = 'two_company_id=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+});
+
+function makeTileManager() {
+    const manager = new TwoCheckoutManager({
+        checkoutHost: CHECKOUT_HOST,
+        orderIntentEnabled: true,
+        orderIntentUrl: ORDER_INTENT_URL,
+        ajaxToken: 'test-token',
+        companySearchInAddressArea: false
+    });
+    // Mirrors views/js/twopayment.js's real bootstrap wiring: onCompanySelected()
+    // reaches the manager through this global.
+    window.TwoCheckoutManager_Instance = manager;
+    return manager;
+}
+
+describe('tile mode: order-intent waits for an actual company selection', () => {
+    beforeEach(() => {
+        buildTilePaymentStepWithTwoAutoSelected();
+    });
+
+    test('mounting the tile with Two auto-selected does not fire the check', () => {
+        makeTileManager();
+
+        expect(TwoOrderIntent.prototype.checkOrderIntent).not.toHaveBeenCalled();
+    });
+
+    test('selecting a company from the search results fires the check', () => {
+        const manager = makeTileManager();
+        expect(TwoOrderIntent.prototype.checkOrderIntent).not.toHaveBeenCalled();
+
+        manager.companySearch.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '11111111' }
+        });
+
+        expect(TwoOrderIntent.prototype.checkOrderIntent).toHaveBeenCalled();
+    });
+
+    /**
+     * The GB-style deferred path: the search result carries no organisation
+     * number up front (it only arrives later via fetchCompanyDetails), so
+     * the selection callback still has to count as "selected" immediately -
+     * gating on hasConfirmedSelection() (which needs the org number) would
+     * wedge this open forever for a buyer who really did pick something.
+     */
+    test('selecting a result with no organisation number yet still counts as a selection', () => {
+        const manager = makeTileManager();
+
+        manager.companySearch.onCompanySelected(null, {
+            item: { value: 'No Number Ltd' }
+        });
+
+        expect(TwoOrderIntent.prototype.checkOrderIntent).toHaveBeenCalled();
+    });
+
+    /**
+     * Once a selection has happened, the generic "Two payment selected"
+     * triggers (radio change, periodic check, etc.) are exactly as safe as
+     * they are in address mode - the gate only needs to hold before the
+     * first selection, not forever.
+     */
+    test('after a selection, the generic payment-option-change trigger is no longer blocked', () => {
+        const manager = makeTileManager();
+        manager.companySearch.onCompanySelected(null, {
+            item: { value: 'Example Trading Ltd', organization_number: '11111111' }
+        });
+        TwoOrderIntent.prototype.checkOrderIntent.mockClear();
+        manager.orderIntent.lastResult = null;
+        // Past triggerOrderIntentForSelection()'s own 800ms same-selection
+        // cooldown, unrelated to the tile-selection gate under test here.
+        manager._lastIntentRunAt = 0;
+
+        manager.handlePaymentOptionChange(document.querySelector('input[type="radio"]'));
+
+        expect(TwoOrderIntent.prototype.checkOrderIntent).toHaveBeenCalled();
+    });
+});
+
+describe('address mode: existing behaviour is unaffected', () => {
+    beforeEach(() => {
+        buildAddressForm({ country: 'GB' });
+        // Address mode's payment step: no tile-mounted search control at all.
+        document.body.insertAdjacentHTML(
+            'beforeend',
+            [
+                '<div class="payment-options">',
+                '  <div class="payment-option" data-module-name="twopayment">',
+                "    <input type='radio' name='payment-option' value='twopayment' checked />",
+                '  </div>',
+                '</div>'
+            ].join('\n')
+        );
+    });
+
+    test('mounting the payment step with Two auto-selected still fires the check immediately, as before', () => {
+        const manager = new TwoCheckoutManager({
+            checkoutHost: CHECKOUT_HOST,
+            orderIntentEnabled: true,
+            orderIntentUrl: ORDER_INTENT_URL,
+            ajaxToken: 'test-token',
+            companySearchInAddressArea: true
+        });
+        window.TwoCheckoutManager_Instance = manager;
+
+        expect(TwoOrderIntent.prototype.checkOrderIntent).toHaveBeenCalled();
+    });
+});

--- a/views/js/modules/TwoCheckoutManager.js
+++ b/views/js/modules/TwoCheckoutManager.js
@@ -35,6 +35,13 @@ class TwoCheckoutManager {
         this._intentCooldownMs = 800;
         this._lastIntentRunAt = 0;
         this._initialIntentTriggered = false;
+        // TWO-25326: in tile mode, has the buyer actually picked (or
+        // manually entered) a company yet? Set true by
+        // TwoCompanySearch.onCompanySelected() the moment a search result is
+        // picked - see canAutoTriggerOrderIntent(). Irrelevant in address
+        // mode, where company capture already happened at the address step,
+        // well before the payment tile (and this flag) exist.
+        this._tileCompanySelected = false;
         // Monotonic sequence for surcharge cart-line syncs: only the LATEST
         // selection's response may drive the UI (last-wins against re-ordered
         // AJAX responses when the buyer clicks between options quickly), and
@@ -376,7 +383,7 @@ class TwoCheckoutManager {
             if (this.currentStep !== 'payment') {
                 return;
             }
-            if (this.isTwoPaymentSelected() && this.config.orderIntentEnabled) {
+            if (this.isTwoPaymentSelected() && this.config.orderIntentEnabled && this.canAutoTriggerOrderIntent()) {
                 // Only trigger if we haven't processed this selection recently AND we don't have a result yet
                 const hasResult = this.orderIntent && this.orderIntent.lastResult;
                 const recentlyChecked = this._lastSelectionCheck && (Date.now() - this._lastSelectionCheck < 5000);
@@ -406,7 +413,7 @@ class TwoCheckoutManager {
         // is idempotent, so repeated change events are harmless.
         this.syncSurchargeCartLine(isTwoSelected);
 
-        if (isTwoSelected && this.config.orderIntentEnabled) {
+        if (isTwoSelected && this.config.orderIntentEnabled && this.canAutoTriggerOrderIntent()) {
             // Ensure orderIntent is initialized even after dynamic DOM changes
             if (!this.orderIntent && window.TwoOrderIntent) {
                 this.initializeOrderIntent();
@@ -426,7 +433,7 @@ class TwoCheckoutManager {
             this.clearOrderIntentResultFromServer();
         }
     }
-    
+
     /**
      * Reconcile the cart's hidden surcharge line with the current payment
      * selection via the syncSurchargeLine AJAX action, then - only when the
@@ -636,8 +643,8 @@ class TwoCheckoutManager {
      */
     handleTwoPaymentSelection() {
         const isTwoSelected = this.isTwoPaymentSelected();
-        
-        if (isTwoSelected && this.config.orderIntentEnabled) {
+
+        if (isTwoSelected && this.config.orderIntentEnabled && this.canAutoTriggerOrderIntent()) {
             if (!this.orderIntent && window.TwoOrderIntent) {
                 this.initializeOrderIntent();
             }
@@ -655,6 +662,44 @@ class TwoCheckoutManager {
         }
     }
     
+    /**
+     * TWO-25326: is it safe to auto-fire the order-intent check off a generic
+     * "Two payment selected/mounted/re-rendered" signal, as opposed to an
+     * actual company selection?
+     *
+     * In address mode this is always true: by the time the payment step (and
+     * this generic signal) exists, address-step company capture - or its
+     * deliberate absence - is already resolved, well before the payment tile
+     * even renders.
+     *
+     * In tile mode the company control lives INSIDE the tile, so the same
+     * generic signal fires the instant the tile mounts or Two is
+     * auto-selected as the only payment method - before the buyer has picked
+     * anything. Gate it on an actual selection (or manual entry - "My
+     * company is not on the list" is a choice too, just not one made through
+     * search results) having happened first.
+     *
+     * Deliberately NOT applied to triggerOrderIntentForSelection() callers
+     * that ARE the selection event itself (TwoCompanySearch's own
+     * onCompanySelected callback) or the payment-confirmation submit-time
+     * check (handlePaymentConfirmation) - the latter is the last-resort
+     * safety net that must still run and block submission if the buyer never
+     * selected anything.
+     *
+     * @returns {boolean}
+     */
+    canAutoTriggerOrderIntent() {
+        if (this.config.companySearchInAddressArea) {
+            return true;
+        }
+        if (this._tileCompanySelected) {
+            return true;
+        }
+        return !!(this.companySearch
+            && typeof this.companySearch.isManualEntry === 'function'
+            && this.companySearch.isManualEntry());
+    }
+
     /**
      * Trigger order intent specifically for payment selection
      */
@@ -1912,7 +1957,7 @@ class TwoCheckoutManager {
         }
         
         // If on payment step and Two is selected, trigger order intent
-        if (this.currentStep === 'payment' && this.isTwoPaymentSelected() && this.config.orderIntentEnabled) {
+        if (this.currentStep === 'payment' && this.isTwoPaymentSelected() && this.config.orderIntentEnabled && this.canAutoTriggerOrderIntent()) {
             setTimeout(() => {
                 if (this.orderIntent && !this.isLoadingUIShown) {
                     this.triggerOrderIntentForSelection();
@@ -1920,7 +1965,8 @@ class TwoCheckoutManager {
             }, 500);
         }
     }
-    
+
+
     /**
      * Handle PrestaShop address form updates
      */
@@ -1982,7 +2028,7 @@ class TwoCheckoutManager {
             }
             
             // Only trigger once per form update - no retry loop
-            if (this.isTwoPaymentSelected() && this.orderIntent) {
+            if (this.isTwoPaymentSelected() && this.orderIntent && this.canAutoTriggerOrderIntent()) {
                 // Small delay to let DOM settle
                 setTimeout(() => {
                     this.triggerOrderIntentForSelection();
@@ -2072,8 +2118,11 @@ class TwoCheckoutManager {
         // Initialize order intent for payment step with business accounts
         if (this.config.orderIntentEnabled && this.currentStep === 'payment' && this.isBusinessAccount) {
             this.initializeOrderIntent();
-            // If Two is already selected by default (only payment method), trigger intent once
-            if (this.isTwoPaymentSelected() && !this._initialIntentTriggered) {
+            // If Two is already selected by default (only payment method), trigger intent once.
+            // TWO-25326: gated on canAutoTriggerOrderIntent() - in tile mode this method runs
+            // on the tile's initial mount, before the buyer has picked a company from the
+            // search results it contains, so firing unconditionally here was the bug.
+            if (this.isTwoPaymentSelected() && !this._initialIntentTriggered && this.canAutoTriggerOrderIntent()) {
                 this._initialIntentTriggered = true;
                 this.triggerOrderIntentForSelection();
             }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -505,6 +505,19 @@ class TwoCompanySearch {
     }
 
     /**
+     * Whether the buyer is currently in "My company is not on the list" mode,
+     * typing a company name directly rather than picking one from search
+     * results. TwoCheckoutManager's tile-mode order-intent gate
+     * (canAutoTriggerOrderIntent()) treats this as a selection too - the
+     * buyer has made their choice, just not through the search results.
+     *
+     * @returns {boolean}
+     */
+    isManualEntry() {
+        return !!this._manualEntry;
+    }
+
+    /**
      * Build the anchored dropdown panel, idempotently (TWO-25326 §1/§2).
      *
      * DOM ORDER IS THE DESIGN HERE, not an implementation detail. Every part
@@ -3052,6 +3065,23 @@ class TwoCompanySearch {
         }
         if (!ui.item) {
             return false;
+        }
+
+        // TWO-25326: the buyer has now actually picked a company from the
+        // search results - the moment TwoCheckoutManager's tile-mode gate
+        // (canAutoTriggerOrderIntent()) is waiting for, as opposed to the
+        // tile merely being displayed/mounted/selected as a payment option.
+        // Set unconditionally, regardless of whether this result carries an
+        // organisation number yet (GB resolves it later via lookup_id) -
+        // hasConfirmedSelection() is the wrong test here because it can stay
+        // false forever for a name-only company, which would wedge this gate
+        // shut for a buyer who really did select something.
+        try {
+            if (window.TwoCheckoutManager_Instance) {
+                window.TwoCheckoutManager_Instance._tileCompanySelected = true;
+            }
+        } catch (e) {
+            // noop
         }
 
         const triggerOrderIntentRecheck = () => {


### PR DESCRIPTION
## Summary

Fixes a real bug Doug found testing PrestaShop with "Enable Company Search In Address Entry" disabled (company search placed in the payment tile): the order-intent check ran the instant the payment tile mounted/was auto-selected, before the buyer had actually picked a company from the tile's search results.

**Root cause**: several generic "Two payment selected" triggers in `TwoCheckoutManager.js` (`initializeModules()`, `handleDynamicContentChange()`, `handlePaymentOptionChange()`, `handleTwoPaymentSelection()`, `handlePaymentFormUpdate()`, and a periodic fallback check) all funnel into `triggerOrderIntentForSelection()` unconditionally whenever Two is the selected payment method - regardless of whether a company had been captured. Address mode never surfaced this because company capture happens at the address step, well before the payment tile (and these triggers) even exist. In tile mode the company control lives *inside* the tile, so the same generic signal fired off tile mount/default-selection with no company data at all.

**Fix**: added `TwoCheckoutManager.canAutoTriggerOrderIntent()` - always `true` in address mode; in tile mode, `true` only once `TwoCompanySearch.onCompanySelected()` has actually run for a search result (or the buyer is in manual-entry mode). `TwoCompanySearch.onCompanySelected()` now sets a flag on the `TwoCheckoutManager` instance the moment a result is picked, unconditionally - not gated on `hasConfirmedSelection()`, since that requires an organisation number that some countries (e.g. GB) only resolve later via a deferred lookup, and would otherwise wedge the gate shut for a real selection.

Every generic mount/selection-driven auto-trigger is now gated on this. The explicit selection-callback trigger (the fix's actual "run now" signal) and the payment-confirmation submit-time check are left unguarded - the latter is the last-resort safety net that must still block order submission if the buyer never selected anything.

## Test plan

- [x] Added `tests/js/order-intent-tile-timing.test.js`: pins that mounting the tile with Two auto-selected does **not** fire `checkOrderIntent()`, that selecting a company (with or without an immediate organisation number) does, that the generic triggers work normally again after a selection, and that address mode is unaffected.
- [x] Confirmed the new tests fail without the fix (reverted the two source files locally, reran) and pass with it.
- [x] Full suite: `npm run test:js` - 347/347 passing (342 pre-existing + 5 new).
