### PR TITLE
TWO-25386: section regrouping — PrestaShop admin config (Part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,11 @@ A complete minimal file:
 define('_TWO_ENABLE_DEFAULT_SHIPPING_TAX_CODE_', true);
 ```
 
-Then go to **Module Configuration → Advanced Settings**, pick a tax rules group in **Default shipping tax code**, and save.
+Then go to **Module Configuration → Order Management**, pick a tax rules group in **Default shipping tax code**, and save.
 
 Notes:
 
-- The constant controls **visibility of the field only**. A value already saved keeps being honoured if the constant is later removed (a server migration must not silently start declining orders), and saving Advanced Settings while the field is hidden never overwrites the stored selection.
+- The constant controls **visibility of the field only**. A value already saved keeps being honoured if the constant is later removed (a server migration must not silently start declining orders), and saving Order Management settings while the field is hidden never overwrites the stored selection.
 - Selecting a group that is later deleted is treated as "not set" — the order is refused, not relayed at 0%.
 - Every order that actually uses the fallback writes a warning to the shop log naming the group, its id and the resolved rate, e.g. `assuming the configured Default shipping tax code "IVA 21%" (tax_rules_group=12, rate=21%)`. If you never see that line, the fallback is not being used.
 
@@ -243,7 +243,7 @@ Payment is due at the **end of the current month (at fulfillment) plus X days**.
 - Module searches Two's Company API v2 (frontend call)
 - Customer selects a company from search results
 - Module stores organization number in hidden `companyid` field
-- Address fields, DNI and VAT number auto-fill from Two's data when available, and a re-search overwrites them with the newly selected company's values. Merchant-configurable (Advanced Settings -> "Autofill company address", enabled by default); with it off, the company search still records the company name and organisation number but writes nothing into the address step
+- Address fields, DNI and VAT number auto-fill from Two's data when available, and a re-search overwrites them with the newly selected company's values. Merchant-configurable (Company Lookup -> "Autofill company address", enabled by default); with it off, the company search still records the company name and organisation number but writes nothing into the address step
 - Selection persists in cookie to survive checkout step changes
 
 #### 2. Payment Step
@@ -279,7 +279,7 @@ Payment is due at the **end of the current month (at fulfillment) plus X days**.
 - Order state changes from `CONFIRMED` to `FULFILLED` in Two
 
 **Configuration:**
-- Configure fulfillment trigger statuses in module settings: **Two → Configuration → Order Status Mapping → Fulfillment Statuses**
+- Configure fulfillment trigger statuses in module settings: **Two → Configuration → Order Management → Fulfillment Statuses**
 - You can select multiple statuses (hold Ctrl/Cmd to select multiple)
 - Default: "Shipped" status triggers fulfillment
 - The form field shows currently active statuses in green text for easy reference
@@ -332,7 +332,7 @@ Payment is due at the **end of the current month (at fulfillment) plus X days**.
   - Idempotency keys prevent duplicate refund calls (race condition protection)
 
 **Configuration:**
-- Configure refund trigger status in module settings: **Two → Configuration → Order Status Mapping → Two: Order Refunded**
+- Configure refund trigger status in module settings: **Two → Configuration → Order Management → Two: Order Refunded**
 - Default: "Refunded" status triggers full refund
 - The module checks if order is already refunded to prevent duplicate refunds
 

--- a/tests/AddressLookupConfigSpec.php
+++ b/tests/AddressLookupConfigSpec.php
@@ -50,7 +50,7 @@ final class AddressLookupConfigSpec
     /** @return array<string,mixed> */
     private static function formValues(TwopaymentTestHarness $module): array
     {
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCompanyLookupFormValues');
 
         return $method->invoke($module);
     }
@@ -58,7 +58,7 @@ final class AddressLookupConfigSpec
     private static function save(TwopaymentTestHarness $module, $posted): void
     {
         Tools::setTestValue('PS_TWO_ADDRESS_LOOKUP', $posted);
-        $method = new ReflectionMethod(Twopayment::class, 'saveTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoCompanyLookupFormValues');
         $method->invoke($module);
     }
 

--- a/tests/AddressLookupGatingSpec.php
+++ b/tests/AddressLookupGatingSpec.php
@@ -63,14 +63,14 @@ final class AddressLookupGatingSpec
     /** @return array<string,mixed> */
     private static function formValues(TwopaymentTestHarness $module): array
     {
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCompanyLookupFormValues');
 
         return $method->invoke($module);
     }
 
     private static function save(TwopaymentTestHarness $module): void
     {
-        $method = new ReflectionMethod(Twopayment::class, 'saveTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoCompanyLookupFormValues');
         $method->invoke($module);
     }
 
@@ -253,7 +253,7 @@ final class AddressLookupGatingSpec
     {
         self::reset();
         $module = new TwopaymentTestHarness();
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoOtherForm');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCompanyLookupForm');
         $form = $method->invoke($module);
 
         $labels = array();

--- a/tests/AddressLookupGatingSpec.php
+++ b/tests/AddressLookupGatingSpec.php
@@ -271,17 +271,11 @@ final class AddressLookupGatingSpec
         // word after the first starts with a capital, allowing for proper nouns
         // and acronyms the module genuinely uses.
         $allowed = array('Two', 'DNI', 'VAT', 'SSL', 'PrestaShop');
-        // KNOWN EXCEPTION, listed rather than papered over: "Disable SSL
-        // Verification (Corporate Networks Only)" predates this change and is
-        // Title Case. Fixing it means re-keying it in four translation
-        // catalogues, which is not this change's scope - it is noted here so
-        // the next person to touch these labels knows it is outstanding rather
-        // than deliberate.
-        $known_exceptions = array('PS_TWO_DISABLE_SSL_VERIFY');
+        // "Disable SSL Verification (Corporate Networks Only)" (Title Case,
+        // a known pre-existing exception) no longer renders on THIS form -
+        // TWO-25386 Part 1 relocated it to the Diagnostics panel - so there is
+        // nothing left to except here.
         foreach ($labels as $name => $label) {
-            if (in_array($name, $known_exceptions, true)) {
-                continue;
-            }
             $words = preg_split('/\s+/', trim($label));
             foreach (array_slice($words, 1) as $word) {
                 $bare = trim($word, '(),.:"\'');

--- a/tests/CompanySearchLocationConfigSpec.php
+++ b/tests/CompanySearchLocationConfigSpec.php
@@ -52,7 +52,7 @@ final class CompanySearchLocationConfigSpec
     /** @return array<string,mixed> */
     private static function formValues(TwopaymentTestHarness $module): array
     {
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCompanyLookupFormValues');
 
         return $method->invoke($module);
     }
@@ -60,7 +60,7 @@ final class CompanySearchLocationConfigSpec
     private static function save(TwopaymentTestHarness $module, $posted): void
     {
         Tools::setTestValue('PS_TWO_ENABLE_COMPANY_NAME', $posted);
-        $method = new ReflectionMethod(Twopayment::class, 'saveTwoOtherFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoCompanyLookupFormValues');
         $method->invoke($module);
     }
 

--- a/tests/DefaultShippingTaxCodeSpec.php
+++ b/tests/DefaultShippingTaxCodeSpec.php
@@ -116,7 +116,7 @@ final class DefaultShippingTaxCodeSpec
     private static function advancedFieldNames(DefaultShippingTaxCodeHarness $module): array
     {
         $names = [];
-        foreach ($module->exposeOtherForm()['form']['input'] as $input) {
+        foreach ($module->exposeOrderManagementForm()['form']['input'] as $input) {
             $names[] = (string) ($input['name'] ?? '');
         }
 
@@ -126,7 +126,7 @@ final class DefaultShippingTaxCodeSpec
     /** The rendered default-shipping-tax-code input, or null when hidden. */
     private static function shippingTaxInput(DefaultShippingTaxCodeHarness $module): ?array
     {
-        foreach ($module->exposeOtherForm()['form']['input'] as $input) {
+        foreach ($module->exposeOrderManagementForm()['form']['input'] as $input) {
             if ((string) ($input['name'] ?? '') === self::CONFIG_KEY) {
                 return $input;
             }
@@ -283,12 +283,12 @@ final class DefaultShippingTaxCodeSpec
             in_array(self::CONFIG_KEY, $names, true),
             'The default-shipping-tax-code field must not be rendered while the flag is off'
         );
-        // The rest of Advanced Settings is untouched.
-        TinyAssert::true(in_array('PS_TWO_ENABLE_COMPANY_NAME', $names, true));
-        TinyAssert::true(in_array('PS_TWO_DISABLE_SSL_VERIFY', $names, true));
+        // The rest of Order Management is untouched.
+        TinyAssert::true(in_array('PS_TWO_FINALIZE_PURCHASE', $names, true));
+        TinyAssert::true(in_array('PS_TWO_ENABLE_TAX_SUBTOTALS', $names, true));
 
         TinyAssert::false(
-            array_key_exists(self::CONFIG_KEY, $module->exposeOtherFormValues()),
+            array_key_exists(self::CONFIG_KEY, $module->exposeOrderManagementFormValues()),
             'A hidden field must not contribute a form value either'
         );
     }
@@ -311,7 +311,7 @@ final class DefaultShippingTaxCodeSpec
         // submitted, this field is not in the form at all.
         Tools::setTestValue('PS_TWO_ENABLE_COMPANY_NAME', 1);
         Tools::setTestValue('PS_TWO_FINALIZE_PURCHASE', 1);
-        $module->exposeSaveOtherFormValues();
+        $module->exposeSaveOrderManagementFormValues();
 
         TinyAssert::same(
             '4210',
@@ -334,7 +334,7 @@ final class DefaultShippingTaxCodeSpec
 
         $module = new DefaultShippingTaxCodeHarness();
         Tools::setTestValue(self::CONFIG_KEY, '4100');
-        $module->exposeSaveOtherFormValues();
+        $module->exposeSaveOrderManagementFormValues();
 
         TinyAssert::same(
             '4210',
@@ -454,7 +454,7 @@ final class DefaultShippingTaxCodeSpec
 
         TinyAssert::same(
             '',
-            (string) $module->exposeOtherFormValues()[self::CONFIG_KEY],
+            (string) $module->exposeOrderManagementFormValues()[self::CONFIG_KEY],
             'An unconfigured field must pre-select the placeholder - never "No tax", which is a real treatment'
         );
     }
@@ -466,7 +466,7 @@ final class DefaultShippingTaxCodeSpec
         Configuration::updateValue(self::CONFIG_KEY, '4210');
 
         $module = new DefaultShippingTaxCodeHarness();
-        TinyAssert::same('4210', (string) $module->exposeOtherFormValues()[self::CONFIG_KEY]);
+        TinyAssert::same('4210', (string) $module->exposeOrderManagementFormValues()[self::CONFIG_KEY]);
     }
 
     /**
@@ -491,7 +491,7 @@ final class DefaultShippingTaxCodeSpec
         }
         TinyAssert::true(isset($byId['4900']), 'A deactivated but configured group must stay selectable');
         TinyAssert::same('Retired group (inactive)', $byId['4900']);
-        TinyAssert::same('4900', (string) $module->exposeOtherFormValues()[self::CONFIG_KEY]);
+        TinyAssert::same('4900', (string) $module->exposeOrderManagementFormValues()[self::CONFIG_KEY]);
     }
 
     private static function testSaveStoresAnExplicitSelection(): void
@@ -501,7 +501,7 @@ final class DefaultShippingTaxCodeSpec
 
         $module = new DefaultShippingTaxCodeHarness();
         Tools::setTestValue(self::CONFIG_KEY, '4210');
-        $module->exposeSaveOtherFormValues();
+        $module->exposeSaveOrderManagementFormValues();
 
         TinyAssert::same('4210', (string) Configuration::get(self::CONFIG_KEY));
     }
@@ -512,7 +512,7 @@ final class DefaultShippingTaxCodeSpec
         self::reset();
         $module = new DefaultShippingTaxCodeHarness();
         Tools::setTestValue(self::CONFIG_KEY, '0');
-        $module->exposeSaveOtherFormValues();
+        $module->exposeSaveOrderManagementFormValues();
 
         TinyAssert::same('0', (string) Configuration::get(self::CONFIG_KEY));
     }
@@ -526,7 +526,7 @@ final class DefaultShippingTaxCodeSpec
 
         $module = new DefaultShippingTaxCodeHarness();
         Tools::setTestValue(self::CONFIG_KEY, '');
-        $module->exposeSaveOtherFormValues();
+        $module->exposeSaveOrderManagementFormValues();
 
         TinyAssert::same('', (string) Configuration::get(self::CONFIG_KEY));
     }
@@ -539,12 +539,12 @@ final class DefaultShippingTaxCodeSpec
 
         foreach (['abc', '0.5', '-4210', '4211'] as $bad) {
             Tools::setTestValue(self::CONFIG_KEY, $bad);
-            $errors = $module->exposeValidOtherFormValues();
+            $errors = $module->exposeValidOrderManagementFormValues();
             TinyAssert::count(1, $errors, 'Value ' . $bad . ' must be rejected');
             TinyAssert::true(strpos($errors[0], 'Default shipping tax code') !== false);
 
             // ...and rejected values are never stored.
-            $module->exposeSaveOtherFormValues();
+            $module->exposeSaveOrderManagementFormValues();
             TinyAssert::same(
                 '',
                 (string) Configuration::get(self::CONFIG_KEY),
@@ -559,10 +559,10 @@ final class DefaultShippingTaxCodeSpec
         $module = new DefaultShippingTaxCodeHarness();
 
         Tools::setTestValue(self::CONFIG_KEY, '');
-        TinyAssert::count(0, $module->exposeValidOtherFormValues(), 'Unselected is a legitimate state');
+        TinyAssert::count(0, $module->exposeValidOrderManagementFormValues(), 'Unselected is a legitimate state');
 
         Tools::setTestValue(self::CONFIG_KEY, '0');
-        TinyAssert::count(0, $module->exposeValidOtherFormValues(), '"No tax" is a legitimate selection');
+        TinyAssert::count(0, $module->exposeValidOrderManagementFormValues(), '"No tax" is a legitimate selection');
     }
 
     // -----------------------------------------------------------------
@@ -831,28 +831,28 @@ final class DefaultShippingTaxCodeHarness extends TwopaymentTestHarness
         return $this->isTwoDefaultShippingTaxCodeFieldEnabled();
     }
 
-    public function exposeOtherForm(): array
+    public function exposeOrderManagementForm(): array
     {
-        return $this->getTwoOtherForm();
+        return $this->getTwoOrderManagementForm();
     }
 
-    public function exposeOtherFormValues(): array
+    public function exposeOrderManagementFormValues(): array
     {
-        return $this->getTwoOtherFormValues();
+        return $this->getTwoOrderManagementFormValues();
     }
 
     /** @return string[] The errors this submission would raise. */
-    public function exposeValidOtherFormValues(): array
+    public function exposeValidOrderManagementFormValues(): array
     {
         $this->errors = array();
-        $this->validTwoOtherFormValues();
+        $this->validTwoOrderManagementFormValues();
 
         return $this->errors;
     }
 
-    public function exposeSaveOtherFormValues(): void
+    public function exposeSaveOrderManagementFormValues(): void
     {
         $this->output = '';
-        $this->saveTwoOtherFormValues();
+        $this->saveTwoOrderManagementFormValues();
     }
 }

--- a/tests/MinimumOrderGateSpec.php
+++ b/tests/MinimumOrderGateSpec.php
@@ -382,10 +382,10 @@ final class MinimumOrderGateSpec
     private static function validatingModule(): object
     {
         return new class () extends TwopaymentTestHarness {
-            public function runPaymentSettingsValidation(): array
+            public function runCheckoutFieldsValidation(): array
             {
                 $this->errors = [];
-                $this->validTwoPaymentSettingsFormValues();
+                $this->validTwoCheckoutFieldsFormValues();
                 return $this->errors;
             }
         };
@@ -406,24 +406,24 @@ final class MinimumOrderGateSpec
         Tools::setTestValue('PS_TWO_PAYMENT_TERMS_30', '1');
 
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', '-5');
-        $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+        $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
         TinyAssert::count(1, $errors, 'negative value must be rejected');
 
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', 'abc');
-        $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+        $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
         TinyAssert::count(1, $errors, 'non-numeric value must be rejected');
 
         // Platform floor 1150 NOK = 100 EUR: a merchant value of 99 EUR would
         // lower the effective minimum below the platform floor - rejected.
         self::cachePlatformMinimum(['amount' => 1150.0, 'currency' => 'NOK', 'basis' => 'gross']);
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', '99');
-        $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+        $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
         TinyAssert::count(1, $errors, 'value below the platform floor must be rejected');
         TinyAssert::true(strpos($errors[0], '100 EUR (1150 NOK)') !== false, 'floor shown in shop currency with native figure: ' . $errors[0]);
 
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS', 'both');
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', '');
-        $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+        $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
         TinyAssert::count(1, $errors, 'unknown basis must be rejected');
     }
 
@@ -437,7 +437,7 @@ final class MinimumOrderGateSpec
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS', 'net');
         foreach (['', '100', '250,50'] as $value) {
             Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', $value);
-            $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+            $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
             TinyAssert::count(0, $errors, 'value "' . $value . '" must be accepted');
         }
 
@@ -446,7 +446,7 @@ final class MinimumOrderGateSpec
         // at checkout instead.
         self::cachePlatformMinimum(['amount' => 100.0, 'currency' => 'USD', 'basis' => 'gross']);
         Tools::setTestValue('PS_TWO_MERCHANT_MIN_ORDER', '1');
-        $errors = self::minimumOrderErrors($module->runPaymentSettingsValidation());
+        $errors = self::minimumOrderErrors($module->runCheckoutFieldsValidation());
         TinyAssert::count(0, $errors, 'unconvertible floor must not block the save');
     }
 }

--- a/tests/OptionalCheckoutFieldsSpec.php
+++ b/tests/OptionalCheckoutFieldsSpec.php
@@ -103,14 +103,14 @@ final class OptionalCheckoutFieldsSpec
     /** @return array<string,mixed> */
     private static function formValues(TwopaymentTestHarness $module): array
     {
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoPaymentSettingsFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCheckoutFieldsFormValues');
 
         return $method->invoke($module);
     }
 
     private static function save(TwopaymentTestHarness $module): void
     {
-        $method = new ReflectionMethod(Twopayment::class, 'saveTwoPaymentSettingsFormValues');
+        $method = new ReflectionMethod(Twopayment::class, 'saveTwoCheckoutFieldsFormValues');
         $method->invoke($module);
     }
 
@@ -402,7 +402,7 @@ final class OptionalCheckoutFieldsSpec
         self::enableAll();
         $module = new TwopaymentTestHarness();
 
-        $method = new ReflectionMethod(Twopayment::class, 'getTwoPaymentSettingsForm');
+        $method = new ReflectionMethod(Twopayment::class, 'getTwoCheckoutFieldsForm');
         $form = $method->invoke($module);
 
         $switchOrder = array();

--- a/tests/run.php
+++ b/tests/run.php
@@ -132,9 +132,9 @@ final class OrderBuilderSpec
         self::testGetTwoCheckoutCompanyDataUsesValidatedCookieFallback();
         self::testGetTwoCheckoutCompanyDataClearsStaleCookieOnCountryMismatch();
         self::testGetTwoCheckoutCompanyDataIgnoresStaleCookieWhenAddressCompanyChangesSameCountry();
-        self::testSaveGeneralFormDoesNotChangeSslVerificationFlag();
-        self::testSaveOtherFormUpdatesSslVerificationFlag();
-        self::testOtherSettingsFormDoesNotExposeOrderIntentToggle();
+        self::testSaveGeneralFormUpdatesSslVerificationFlag();
+        self::testSaveOrderManagementFormUpdatesTaxSubtotalsFlag();
+        self::testOrderManagementFormDoesNotExposeOrderIntentToggle();
         self::testHookActionAdminControllerSetMediaRegistersCssOnModuleConfigPage();
         self::testHookActionAdminControllerSetMediaSkipsUnrelatedAdminPage();
         self::testHookPaymentOptionsAllowsTwoCoveredCurrencies();
@@ -4547,8 +4547,12 @@ final class OrderBuilderSpec
         TinyAssert::same('ES', $data['country_iso']);
     }
 
-    private static function testSaveGeneralFormDoesNotChangeSslVerificationFlag(): void
+    private static function testSaveGeneralFormUpdatesSslVerificationFlag(): void
     {
+        // TWO-25386 Part 1 section regroup: Disable SSL Verification now
+        // renders under, and is saved by, the General panel (Section A)
+        // alongside the other connection-level controls (key, environment) -
+        // it moved out of the former "Advanced Settings"/"Other" panel.
         self::reset();
         $module = new class extends TwopaymentTestHarness {
             public function saveGeneralForTest(): void
@@ -4557,11 +4561,9 @@ final class OrderBuilderSpec
             }
         };
 
-        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 1);
-        Tools::setTestValue('PS_TWO_DISABLE_SSL_VERIFY', 0);
+        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 0);
+        Tools::setTestValue('PS_TWO_DISABLE_SSL_VERIFY', 1);
         Tools::setTestValue('PS_TWO_ENVIRONMENT', 'development');
-        Tools::setTestValue('PS_TWO_TITLE_1', 'Two title');
-        Tools::setTestValue('PS_TWO_SUB_TITLE_1', 'Two subtitle');
         Tools::setTestValue('PS_TWO_MERCHANT_SHORT_NAME', 'merchant');
         Tools::setTestValue('PS_TWO_MERCHANT_API_KEY', 'api-key');
 
@@ -4570,38 +4572,42 @@ final class OrderBuilderSpec
         TinyAssert::same(1, (int) Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
     }
 
-    private static function testSaveOtherFormUpdatesSslVerificationFlag(): void
+    private static function testSaveOrderManagementFormUpdatesTaxSubtotalsFlag(): void
     {
+        // TWO-25386 Part 1 section regroup: "Send tax subtotals in request
+        // payloads" now renders under, and is saved by, the Order Management
+        // panel (Section E) - it moved out of the former "Advanced
+        // Settings"/"Other" panel, which no longer exists as a single form.
         self::reset();
         $module = new class extends TwopaymentTestHarness {
-            public function saveOtherForTest(): void
+            public function saveOrderManagementForTest(): void
             {
-                $this->saveTwoOtherFormValues();
+                $this->saveTwoOrderManagementFormValues();
             }
         };
 
-        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 0);
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1);
-        Tools::setTestValue('PS_TWO_DISABLE_SSL_VERIFY', 1);
         Tools::setTestValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 0);
 
-        $module->saveOtherForTest();
+        $module->saveOrderManagementForTest();
 
-        TinyAssert::same(1, (int) Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         TinyAssert::same(0, (int) Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS'));
     }
 
-    private static function testOtherSettingsFormDoesNotExposeOrderIntentToggle(): void
+    private static function testOrderManagementFormDoesNotExposeOrderIntentToggle(): void
     {
+        // Order intent lives in the Checkout Fields panel (Section B), not
+        // Order Management (Section E) - regression guard carried over from
+        // the pre-TWO-25386 "Other Settings" panel this replaced.
         self::reset();
         $module = new class extends TwopaymentTestHarness {
-            public function getOtherFormForTest(): array
+            public function getOrderManagementFormForTest(): array
             {
-                return $this->getTwoOtherForm();
+                return $this->getTwoOrderManagementForm();
             }
         };
 
-        $form = $module->getOtherFormForTest();
+        $form = $module->getOrderManagementFormForTest();
         $inputNames = array_map(function ($field) {
             return isset($field['name']) ? (string) $field['name'] : '';
         }, $form['form']['input']);

--- a/tests/run.php
+++ b/tests/run.php
@@ -132,7 +132,7 @@ final class OrderBuilderSpec
         self::testGetTwoCheckoutCompanyDataUsesValidatedCookieFallback();
         self::testGetTwoCheckoutCompanyDataClearsStaleCookieOnCountryMismatch();
         self::testGetTwoCheckoutCompanyDataIgnoresStaleCookieWhenAddressCompanyChangesSameCountry();
-        self::testSaveGeneralFormUpdatesSslVerificationFlag();
+        self::testSaveDiagnosticsFormUpdatesSslVerificationFlag();
         self::testSaveOrderManagementFormUpdatesTaxSubtotalsFlag();
         self::testOrderManagementFormDoesNotExposeOrderIntentToggle();
         self::testHookActionAdminControllerSetMediaRegistersCssOnModuleConfigPage();
@@ -4547,27 +4547,24 @@ final class OrderBuilderSpec
         TinyAssert::same('ES', $data['country_iso']);
     }
 
-    private static function testSaveGeneralFormUpdatesSslVerificationFlag(): void
+    private static function testSaveDiagnosticsFormUpdatesSslVerificationFlag(): void
     {
-        // TWO-25386 Part 1 section regroup: Disable SSL Verification now
-        // renders under, and is saved by, the General panel (Section A)
-        // alongside the other connection-level controls (key, environment) -
-        // it moved out of the former "Advanced Settings"/"Other" panel.
+        // TWO-25386 Part 1 section regroup: Disable SSL Verification renders
+        // under, and is saved by, the Diagnostics panel (Section F) alongside
+        // the other debug-only controls - it moved out of the former
+        // "Advanced Settings"/"Other" panel (and never lived in General).
         self::reset();
         $module = new class extends TwopaymentTestHarness {
-            public function saveGeneralForTest(): void
+            public function saveDiagnosticsForTest(): void
             {
-                $this->saveTwoGeneralFormValues();
+                $this->saveTwoDiagnosticsFormValues();
             }
         };
 
         Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', 0);
         Tools::setTestValue('PS_TWO_DISABLE_SSL_VERIFY', 1);
-        Tools::setTestValue('PS_TWO_ENVIRONMENT', 'development');
-        Tools::setTestValue('PS_TWO_MERCHANT_SHORT_NAME', 'merchant');
-        Tools::setTestValue('PS_TWO_MERCHANT_API_KEY', 'api-key');
 
-        $module->saveGeneralForTest();
+        $module->saveDiagnosticsForTest();
 
         TinyAssert::same(1, (int) Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
     }

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -446,8 +446,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Handmatig invoeren';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Geregistreerd bedrijf';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Eenmanszaak';
-$_MODULE['<{twopayment}prestashop>twopayment_adaed373af40f154859a1e470279527f'] = 'Leverancier-/sitenaam';
-$_MODULE['<{twopayment}prestashop>twopayment_4e378a4617ae99ebad1374c430d83a96'] = 'Optioneel. Stel dit in als je Two op meerdere sites/leveranciers gebruikt, om te identificeren van welke de aanvragen komen.';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Aangepaste betaaltermijn (dagen)';
 $_MODULE['<{twopayment}prestashop>twopayment_e8910a5d4ad165a5989f6b672b4c8216'] = 'Optioneel. Bied een extra betaaltermijn (in dagen) aan die niet in de bovenstaande voorinstellingen is opgenomen. Laat leeg om alleen de hierboven geselecteerde termijnen aan te bieden. Two moet deze termijnlengte nog steeds toestaan voor je account - een niet-ondersteunde waarde wordt stilzwijgend genegeerd.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standaard voorgeselecteerde termijn';
@@ -499,3 +497,5 @@ $_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostische instellingen zijn bijgewerkt.';
 $_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Schakel de debugmodus in bij Diagnostiek en neem met de logs contact op met Two-support';
 $_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'De API-sleutel is niet geverifieerd. Afrekenverzoeken kunnen mislukken totdat de algemene instellingen met een geldige sleutel zijn opgeslagen.';
+$_MODULE['<{twopayment}prestashop>twopayment_740ac829af0e2bbb2816a70b724c851d'] = 'Leveranciersnaam (optioneel)';
+$_MODULE['<{twopayment}prestashop>twopayment_b41ef96a0f570c44647792507627d3e9'] = 'Als deze winkel een van meerdere leverancierssites is die dezelfde Two-handelaarsaccount delen, voer hier een naam in om deze specifieke site/leverancier te identificeren op elke bestelling die naar Two wordt gestuurd - laat leeg als je maar één site gebruikt.';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -3,14 +3,9 @@
 global $_MODULE;
 $_MODULE = array();
 $_MODULE['<{twopayment}prestashop>configuration_0ba29c6a1afacf586b03a26162c72274'] = 'Omgeving';
-$_MODULE['<{twopayment}prestashop>configuration_13831bd312b782daa4e11738a2fe3d04'] = 'Instellingen bestelstatus';
 $_MODULE['<{twopayment}prestashop>configuration_229a7ec501323b94db7ff3157a7623c9'] = 'Merchant-ID';
 $_MODULE['<{twopayment}prestashop>configuration_3f68e67dc6c397aaa9d1c24c356f754f'] = 'Geverifieerd';
-$_MODULE['<{twopayment}prestashop>configuration_4b89abd8c5879f053b551487a3b7c1c3'] = 'Plug-ininformatie';
-$_MODULE['<{twopayment}prestashop>configuration_52f4393e1b52ba63e27310ca92ba098c'] = 'Algemene instellingen';
 $_MODULE['<{twopayment}prestashop>configuration_5943a2e7c31755a5588c66c273d35f15'] = 'Korte naam merchant';
-$_MODULE['<{twopayment}prestashop>configuration_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Geavanceerde instellingen';
-$_MODULE['<{twopayment}prestashop>configuration_d5815623c49bc79327917762848902f0'] = 'Betaalinstellingen';
 $_MODULE['<{twopayment}prestashop>configuration_daf40c1ea5990bdee77b09f7137ffc31'] = 'API-sleutel succesvol geverifieerd';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_11335f7aaa473442d803c43c8b8d804d'] = 'Factuurlinks komen beschikbaar nadat de Two-bestelling is uitgeleverd.';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_2fdeffc575b8052f195eeff5b113cf3c'] = 'Two-status';
@@ -212,7 +207,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_4d8ef3ef2843e5fe46dbdce83c16b88e'] 
 $_MODULE['<{twopayment}prestashop>twopayment_4e48eb7b84e6418738c6548b3c826d94'] = 'Vergoeding betaaltermijn - %d dagen';
 $_MODULE['<{twopayment}prestashop>twopayment_4f40188f22dbc3f6b5f5ea06152782ca'] = 'De payload voor de order intent kon niet worden opgebouwd';
 $_MODULE['<{twopayment}prestashop>twopayment_526f52140844e831b1965500d17c26d8'] = 'Einde-van-de-maand (EOM) termijnen:';
-$_MODULE['<{twopayment}prestashop>twopayment_52f4393e1b52ba63e27310ca92ba098c'] = 'Algemene instellingen';
 $_MODULE['<{twopayment}prestashop>twopayment_53943134b629b65e0a320b7dd6ed92a8'] = 'Deze API-sleutel is geweigerd door Two. Mogelijk is de sleutel ongeldig of verlopen - controleer de sleutel in je Two-portaal.';
 $_MODULE['<{twopayment}prestashop>twopayment_539de410a9a131c0e925dc8e248a29d2'] = 'Betaling vervalt aan het einde van de maand plus X dagen, gerekend vanaf de uitleverdatum. Voorbeeld: lever je een bestelling uit op 15 januari met EOM+30, dan vervalt de betaling op 28 februari (einde januari + 30 dagen). Dit is gebruikelijk bij B2B-facturatie.';
 $_MODULE['<{twopayment}prestashop>twopayment_545e6db228f47336669130f1068a519e'] = 'Je bestelling kan niet worden verwerkt met Two-betaling. Kies een andere betaalmethode of neem contact op met de winkel.';
@@ -236,7 +230,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_60b60d57ac14700787432034bf58f8b1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_624d960f1513f62685fb2017c0bbc926'] = 'Werkt met PrestaShop 1.7.6 tot en met 9.x';
 $_MODULE['<{twopayment}prestashop>twopayment_62c7594948c1231bbae9f948b1535b7e'] = 'API-sleutel';
 $_MODULE['<{twopayment}prestashop>twopayment_633918382ee5b43840752588882a0496'] = 'De consistentie van de winkelwagen voor deze betaling kan niet worden gevalideerd. Probeer het opnieuw.';
-$_MODULE['<{twopayment}prestashop>twopayment_64b235cc9d452ea7fb8008c6f9aefd91'] = 'De API-sleutel is niet geverifieerd. Afrekenverzoeken kunnen mislukken totdat de algemene instellingen met een geldige sleutel zijn opgeslagen.';
 $_MODULE['<{twopayment}prestashop>twopayment_656a6828d7ef1bb791e42087c4b5ee6e'] = 'API-sleutel';
 $_MODULE['<{twopayment}prestashop>twopayment_65a4e2b7da5e4f1c422b2de7277d8311'] = 'Het interval waarop de toeslag wordt afgerond (bijv. 1 = hele eenheden, 0,50 = op een halve). Geldt alleen als er een afrondingsrichting is gekozen.';
 $_MODULE['<{twopayment}prestashop>twopayment_65facdf395107d60a23ce012c2a1c456'] = 'Einde van de maand + %s dagen';
@@ -244,7 +237,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_66e6e619e3e72bb941b0d2d4947466c9'] 
 $_MODULE['<{twopayment}prestashop>twopayment_67205cb0f855142963b4901fed7b35de'] = 'De status kon niet worden bijgewerkt naar geannuleerd; controleer id %s in de Two-beheeromgeving';
 $_MODULE['<{twopayment}prestashop>twopayment_6735bd225a891660cc38b49f427acb08'] = 'Meestal gaat het om verzendkosten of een korting die nog niet in de winkelwagen is toegepast. Vernieuw je winkelwagen en probeer het opnieuw, of neem contact op met de winkel.';
 $_MODULE['<{twopayment}prestashop>twopayment_67d805ed4bbf1baf8cd7a94badcb7bc1'] = 'Exclusief btw (netto)';
-$_MODULE['<{twopayment}prestashop>twopayment_67dd983768d27e0b7ca68a09c27d1cfd'] = 'Betaalinstellingen zijn bijgewerkt.';
 $_MODULE['<{twopayment}prestashop>twopayment_6825c19161f9f1b9a4047b08720ac98c'] = 'Er is geen bestelreferentie van de betaalprovider ingesteld voor deze bestelling.';
 $_MODULE['<{twopayment}prestashop>twopayment_68fc97fb527fe6d18d12d02199710634'] = 'Deze annuleringscallback kan niet worden gevalideerd. Probeer het afrekenen opnieuw.';
 $_MODULE['<{twopayment}prestashop>twopayment_693d87a10d7bf7577f44c12dfecb0559'] = 'Je bestelling is geannuleerd.';
@@ -304,7 +296,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_88d53497f4a92958c67c73a9f2f52df3'] 
 $_MODULE['<{twopayment}prestashop>twopayment_893c937ba17594e25cd9b8a6baa9a923'] = 'Milieubelasting (ecotax)';
 $_MODULE['<{twopayment}prestashop>twopayment_8ae26445494e68f399026e73ed477c13'] = 'Er kan niet worden doorverwezen naar de betaalprovider. Probeer het opnieuw.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b0299767b9b23d625c55554c37966ba'] = 'Selecteer een btw-behandeling voor de toeslag: toeslagen zijn ingeschakeld, dus je moet expliciet een belastingregelgroep kiezen voordat je opslaat.';
-$_MODULE['<{twopayment}prestashop>twopayment_8b667ac78d92f83cddeca84b8a22cce2'] = 'Als dit is ingeschakeld, worden bestellingen automatisch in Two als uitgeleverd gemarkeerd zodra hun status verandert naar een van de door jou ingestelde triggerstatussen (zie Bestelstatustoewijzing). Hiermee worden de betaaltermijnen van de koper geactiveerd en start de uitbetalingscyclus. Als dit is uitgeschakeld, moet je bestellingen handmatig uitleveren in de Merchant Portal van Two.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b71f88a3f44283f2f9d4905d1b097f1'] = 'Wat deze plug-in doet';
 $_MODULE['<{twopayment}prestashop>twopayment_8bc50504c201a3c29db85208d8ce68af'] = 'Subtitel';
 $_MODULE['<{twopayment}prestashop>twopayment_8c597b2f3bc899e1e04f301844c44482'] = 'De factuur is nog niet klaar omdat de bestelling nog wordt uitgeleverd. Probeer het later opnieuw.';
@@ -316,7 +307,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9397d7f54ed01d00e59b0e49f0900586'] 
 $_MODULE['<{twopayment}prestashop>twopayment_93b6026f985c994bf4d6bb646c88f584'] = 'Omschrijving toeslagregel';
 $_MODULE['<{twopayment}prestashop>twopayment_93cba07454f06a4a960172bbd6e2a435'] = 'Ja';
 $_MODULE['<{twopayment}prestashop>twopayment_93ef8e5b106e50d55fd88d4a966668c8'] = 'Wil je met Two betalen? Ga dan terug naar je factuuradres en vul je bedrijfsnaam in bij het veld Bedrijf.';
-$_MODULE['<{twopayment}prestashop>twopayment_9442d98dc18ef95b73b18e47583f38a6'] = 'Geavanceerde instellingen zijn bijgewerkt.';
 $_MODULE['<{twopayment}prestashop>twopayment_945d7d5e1d06440a9154e2bbc6350584'] = 'Two-bestelstatustoewijzing is bijgewerkt.';
 $_MODULE['<{twopayment}prestashop>twopayment_9518ef155ef9db3d13a441c4ac8ec76e'] = 'Standaard btw-code verzending';
 $_MODULE['<{twopayment}prestashop>twopayment_969a811ead960f897fc85735d99d646a'] = 'Controleer of er belastingregels voor jouw land zijn ingesteld onder Internationaal > Belastingen > Belastingregels';
@@ -332,7 +322,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9d8c5a3cd608d5590ab3da22a6855f83'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9ddf0af1d4404e3008c47a8fb8d17d6d'] = 'Vul een subtitel in die op de afrekenpagina wordt weergegeven als subtitel van de betaalmethode.';
 $_MODULE['<{twopayment}prestashop>twopayment_9e727fdd3aec8274f46685441900280d'] = 'Project';
 $_MODULE['<{twopayment}prestashop>twopayment_9f67feb76396d9f95843662cb1a3cbee'] = 'Ja (niet aanbevolen)';
-$_MODULE['<{twopayment}prestashop>twopayment_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Geavanceerde instellingen';
 $_MODULE['<{twopayment}prestashop>twopayment_a002c8066738bc8f9d9394abdcef7ea8'] = 'Je betaaltermijn start zodra je bestelling is uitgeleverd';
 $_MODULE['<{twopayment}prestashop>twopayment_a029c838076e00c19453faa87a214790'] = 'Geverifieerd - Klaar voor uitlevering → Two: Geverifieerd - Klaar voor uitlevering';
 $_MODULE['<{twopayment}prestashop>twopayment_a18b98ac865c5099d00d15aa7955772e'] = 'De opgevraagde bestelling kan niet worden gevonden; neem contact op met de winkeleigenaar.';
@@ -402,7 +391,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_d40f2c2b7a99b454ace5554f91e54c8c'] 
 $_MODULE['<{twopayment}prestashop>twopayment_d417918cd6fea0a0d40a394dc3826e44'] = 'Two - BNPL voor bedrijven';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b644ceb41c3a19d874ee330ac45f97'] = 'Geen afronding';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b9d20386ac408371aff6df4162e437'] = 'Afrekenen als eenmanszaak is niet beschikbaar';
-$_MODULE['<{twopayment}prestashop>twopayment_d5815623c49bc79327917762848902f0'] = 'Betaalinstellingen';
 $_MODULE['<{twopayment}prestashop>twopayment_d5a4650cc30bac28c85f6c41646a39a2'] = 'Standaardtoewijzingen:';
 $_MODULE['<{twopayment}prestashop>twopayment_d61f297c98cfff041329b59404710bd3'] = 'Two: Fout bij betaalverwerking';
 $_MODULE['<{twopayment}prestashop>twopayment_d74f5295cfbc83c79a5737ed01bc13d3'] = 'Toeslag per termijn';
@@ -437,7 +425,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_eb6d8ae6f20283755b339c0dc273988b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_ecddbd73a90aaf17dd71134521b09079'] = 'Niet geverifieerd';
 $_MODULE['<{twopayment}prestashop>twopayment_f1001479cd49b3293274238a2995a9b7'] = 'Two: Bestelling uitgeleverd - triggerstatussen';
 $_MODULE['<{twopayment}prestashop>twopayment_f12477236933ae49e5c643aecf75f74a'] = 'Klanten moeten een geldig bedrijfs-/organisatienummer hebben';
-$_MODULE['<{twopayment}prestashop>twopayment_f4575927d8447f088ce1b50cec9ff292'] = 'Schakel de debugmodus in bij Algemene instellingen en neem met de logs contact op met Two-support';
 $_MODULE['<{twopayment}prestashop>twopayment_f65e05deb9e54ed090b8450b4a4fbeb4'] = 'Veiligheidswaarschuwing:';
 $_MODULE['<{twopayment}prestashop>twopayment_f68cf3bf9fe34d152a13fa6947c19d9b'] = 'De kredietbeslissing of koperslimieten van Two overrulen';
 $_MODULE['<{twopayment}prestashop>twopayment_f71fecea4e95aedc66e77754d9cecda4'] = 'Ondersteuning voor meerdere btw-tarieven en btw-vrijgestelde klanten';
@@ -492,3 +479,23 @@ $_MODULE['<{twopayment}prestashop>twopayment_3fcdcba6f3097627522e41d9f927fd01'] 
 $_MODULE['<{twopayment}prestashop>twopayment_44749712dbec183e983dcd78a7736c41'] = 'Datum';
 $_MODULE['<{twopayment}prestashop>twopayment_007cc9547ae8884ad597cd92ba505422'] = 'Ernst';
 $_MODULE['<{twopayment}prestashop>twopayment_4c2a8fe7eaf24721cc7a9f0175115bd4'] = 'Bericht';
+$_MODULE['<{twopayment}prestashop>twopayment_0db377921f4ce762c62526131097968f'] = 'Algemeen';
+$_MODULE['<{twopayment}prestashop>configuration_0db377921f4ce762c62526131097968f'] = 'Algemeen';
+$_MODULE['<{twopayment}prestashop>twopayment_f6f8b33a0645b664592cffdc179e7189'] = 'Afrekenvelden';
+$_MODULE['<{twopayment}prestashop>configuration_f6f8b33a0645b664592cffdc179e7189'] = 'Afrekenvelden';
+$_MODULE['<{twopayment}prestashop>twopayment_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalingsvoorwaarden';
+$_MODULE['<{twopayment}prestashop>configuration_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalingsvoorwaarden';
+$_MODULE['<{twopayment}prestashop>twopayment_c3bcb4d75d3af37fe613c8077e38441d'] = 'Instellingen voor afrekenvelden zijn bijgewerkt.';
+$_MODULE['<{twopayment}prestashop>twopayment_23c8711f45541e10da6c1eb134fddeb2'] = 'Instellingen voor betalingsvoorwaarden zijn bijgewerkt.';
+$_MODULE['<{twopayment}prestashop>twopayment_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Bedrijfszoekopdracht';
+$_MODULE['<{twopayment}prestashop>configuration_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Bedrijfszoekopdracht';
+$_MODULE['<{twopayment}prestashop>twopayment_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Orderbeheer';
+$_MODULE['<{twopayment}prestashop>configuration_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Orderbeheer';
+$_MODULE['<{twopayment}prestashop>twopayment_5571738de78b958ae331069e8d8f0383'] = 'Als dit is ingeschakeld, worden bestellingen automatisch in Two als uitgeleverd gemarkeerd zodra hun status verandert naar een van de door jou ingestelde triggerstatussen (zie Uitleverstatussen hieronder). Hiermee worden de betaaltermijnen van de koper geactiveerd en start de uitbetalingscyclus. Als dit is uitgeschakeld, moet je bestellingen handmatig uitleveren in de Merchant Portal van Two.';
+$_MODULE['<{twopayment}prestashop>twopayment_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostiek';
+$_MODULE['<{twopayment}prestashop>configuration_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostiek';
+$_MODULE['<{twopayment}prestashop>twopayment_8178fa55db5e6276b9d2120ca523c26c'] = 'Instellingen voor bedrijfszoekopdracht zijn bijgewerkt.';
+$_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] = 'Instellingen voor orderbeheer zijn bijgewerkt.';
+$_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostische instellingen zijn bijgewerkt.';
+$_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Schakel de debugmodus in bij Diagnostiek en neem met de logs contact op met Two-support';
+$_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'De API-sleutel is niet geverifieerd. Afrekenverzoeken kunnen mislukken totdat de algemene instellingen met een geldige sleutel zijn opgeslagen.';

--- a/translations/no.php
+++ b/translations/no.php
@@ -3,14 +3,9 @@
 global $_MODULE;
 $_MODULE = array();
 $_MODULE['<{twopayment}prestashop>configuration_0ba29c6a1afacf586b03a26162c72274'] = 'Miljø';
-$_MODULE['<{twopayment}prestashop>configuration_13831bd312b782daa4e11738a2fe3d04'] = 'Innstillinger for ordrestatus';
 $_MODULE['<{twopayment}prestashop>configuration_229a7ec501323b94db7ff3157a7623c9'] = 'Selger-ID';
 $_MODULE['<{twopayment}prestashop>configuration_3f68e67dc6c397aaa9d1c24c356f754f'] = 'Verifisert';
-$_MODULE['<{twopayment}prestashop>configuration_4b89abd8c5879f053b551487a3b7c1c3'] = 'Informasjon om utvidelsen';
-$_MODULE['<{twopayment}prestashop>configuration_52f4393e1b52ba63e27310ca92ba098c'] = 'Generelle innstillinger';
 $_MODULE['<{twopayment}prestashop>configuration_5943a2e7c31755a5588c66c273d35f15'] = 'Kortnavn for selger';
-$_MODULE['<{twopayment}prestashop>configuration_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Avanserte innstillinger';
-$_MODULE['<{twopayment}prestashop>configuration_d5815623c49bc79327917762848902f0'] = 'Betalingsinnstillinger';
 $_MODULE['<{twopayment}prestashop>configuration_daf40c1ea5990bdee77b09f7137ffc31'] = 'API-nøkkelen ble verifisert';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_11335f7aaa473442d803c43c8b8d804d'] = 'Fakturalenker blir tilgjengelige etter at Two-ordren er oppfylt.';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_2fdeffc575b8052f195eeff5b113cf3c'] = 'Two-status';
@@ -212,7 +207,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_4d8ef3ef2843e5fe46dbdce83c16b88e'] 
 $_MODULE['<{twopayment}prestashop>twopayment_4e48eb7b84e6418738c6548b3c826d94'] = 'Gebyr for betalingsvilkår – %d dager';
 $_MODULE['<{twopayment}prestashop>twopayment_4f40188f22dbc3f6b5f5ea06152782ca'] = 'Kunne ikke bygge datainnholdet for ordreintensjonen';
 $_MODULE['<{twopayment}prestashop>twopayment_526f52140844e831b1965500d17c26d8'] = 'Vilkår med slutten av måneden (EOM):';
-$_MODULE['<{twopayment}prestashop>twopayment_52f4393e1b52ba63e27310ca92ba098c'] = 'Generelle innstillinger';
 $_MODULE['<{twopayment}prestashop>twopayment_53943134b629b65e0a320b7dd6ed92a8'] = 'Denne API-nøkkelen ble avvist av Two. Den kan være ugyldig eller utløpt - kontroller nøkkelen i Two-portalen din.';
 $_MODULE['<{twopayment}prestashop>twopayment_539de410a9a131c0e925dc8e248a29d2'] = 'Betalingsfristen er slutten av inneværende måned pluss X dager fra datoen ordren blir oppfylt. Eksempel: Hvis du oppfyller en ordre 15. januar med vilkåret EOM+30, er betalingsfristen 28. februar (slutten av januar + 30 dager). Dette er vanlig ved B2B-fakturering.';
 $_MODULE['<{twopayment}prestashop>twopayment_545e6db228f47336669130f1068a519e'] = 'Kunne ikke behandle ordren din med Two-betaling. Velg en annen betalingsmåte eller kontakt butikken.';
@@ -236,7 +230,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_60b60d57ac14700787432034bf58f8b1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_624d960f1513f62685fb2017c0bbc926'] = 'Fungerer med PrestaShop 1.7.6 til og med 9.x';
 $_MODULE['<{twopayment}prestashop>twopayment_62c7594948c1231bbae9f948b1535b7e'] = 'API-nøkkel';
 $_MODULE['<{twopayment}prestashop>twopayment_633918382ee5b43840752588882a0496'] = 'Kunne ikke bekrefte at handlekurven stemmer for denne betalingen. Prøv igjen.';
-$_MODULE['<{twopayment}prestashop>twopayment_64b235cc9d452ea7fb8008c6f9aefd91'] = 'API-nøkkelen er ikke verifisert. Forespørsler i utsjekken kan feile til de generelle innstillingene er lagret med en gyldig nøkkel.';
 $_MODULE['<{twopayment}prestashop>twopayment_656a6828d7ef1bb791e42087c4b5ee6e'] = 'API-nøkkel';
 $_MODULE['<{twopayment}prestashop>twopayment_65a4e2b7da5e4f1c422b2de7277d8311'] = 'Intervallet tillegget rundes av til (f.eks. 1 = hele enheter, 0,50 = nærmeste halve). Gjelder bare når det er valgt en avrundingsretning.';
 $_MODULE['<{twopayment}prestashop>twopayment_65facdf395107d60a23ce012c2a1c456'] = 'Slutten av måneden + %s dager';
@@ -244,7 +237,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_66e6e619e3e72bb941b0d2d4947466c9'] 
 $_MODULE['<{twopayment}prestashop>twopayment_67205cb0f855142963b4901fed7b35de'] = 'Kunne ikke oppdatere status til kansellert, kontroller med Two-administrasjonen for id %s';
 $_MODULE['<{twopayment}prestashop>twopayment_6735bd225a891660cc38b49f427acb08'] = 'Dette skyldes vanligvis et frakt- eller rabattbeløp som handlekurven ennå ikke har lagt til. Oppdater handlekurven og prøv igjen, eller kontakt butikken.';
 $_MODULE['<{twopayment}prestashop>twopayment_67d805ed4bbf1baf8cd7a94badcb7bc1'] = 'Eksklusiv avgift (netto)';
-$_MODULE['<{twopayment}prestashop>twopayment_67dd983768d27e0b7ca68a09c27d1cfd'] = 'Betalingsinnstillingene er oppdatert.';
 $_MODULE['<{twopayment}prestashop>twopayment_6825c19161f9f1b9a4047b08720ac98c'] = 'Det er ikke satt noen ordrereferanse fra betalingsleverandøren for denne ordren.';
 $_MODULE['<{twopayment}prestashop>twopayment_68fc97fb527fe6d18d12d02199710634'] = 'Kunne ikke bekrefte kanselleringen fra Two. Prøv utsjekken på nytt.';
 $_MODULE['<{twopayment}prestashop>twopayment_693d87a10d7bf7577f44c12dfecb0559'] = 'Ordren din er kansellert.';
@@ -304,7 +296,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_88d53497f4a92958c67c73a9f2f52df3'] 
 $_MODULE['<{twopayment}prestashop>twopayment_893c937ba17594e25cd9b8a6baa9a923'] = 'Miljøavgift (ecotax)';
 $_MODULE['<{twopayment}prestashop>twopayment_8ae26445494e68f399026e73ed477c13'] = 'Kunne ikke videresende til betalingsleverandøren. Prøv igjen.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b0299767b9b23d625c55554c37966ba'] = 'Velg en avgiftsbehandling for tillegg: tillegg er aktivert, så du må velge en avgiftsregelgruppe eksplisitt før du lagrer.';
-$_MODULE['<{twopayment}prestashop>twopayment_8b667ac78d92f83cddeca84b8a22cce2'] = 'Når dette er aktivert, blir ordrer automatisk markert som oppfylt hos Two når statusen endres til en av statusene du har satt opp som utløsere for oppfyllelse (se Kobling av ordrestatuser). Dette aktiverer kjøperens betalingsvilkår og starter utbetalingssyklusen. Hvis det er deaktivert, må du oppfylle ordrer manuelt i Twos selgerportal.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b71f88a3f44283f2f9d4905d1b097f1'] = 'Hva denne utvidelsen gjør';
 $_MODULE['<{twopayment}prestashop>twopayment_8bc50504c201a3c29db85208d8ce68af'] = 'Undertittel';
 $_MODULE['<{twopayment}prestashop>twopayment_8c597b2f3bc899e1e04f301844c44482'] = 'Fakturaen er ikke klar ennå fordi ordren fortsatt er under oppfyllelse. Prøv igjen senere.';
@@ -316,7 +307,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9397d7f54ed01d00e59b0e49f0900586'] 
 $_MODULE['<{twopayment}prestashop>twopayment_93b6026f985c994bf4d6bb646c88f584'] = 'Beskrivelse av tilleggsavgift';
 $_MODULE['<{twopayment}prestashop>twopayment_93cba07454f06a4a960172bbd6e2a435'] = 'Ja';
 $_MODULE['<{twopayment}prestashop>twopayment_93ef8e5b106e50d55fd88d4a966668c8'] = 'For å betale med Two må du gå tilbake til fakturaadressen og skrive inn firmanavnet ditt i Firma-feltet.';
-$_MODULE['<{twopayment}prestashop>twopayment_9442d98dc18ef95b73b18e47583f38a6'] = 'De avanserte innstillingene er oppdatert.';
 $_MODULE['<{twopayment}prestashop>twopayment_945d7d5e1d06440a9154e2bbc6350584'] = 'Koblingen av Two-ordrestatuser ble oppdatert.';
 $_MODULE['<{twopayment}prestashop>twopayment_9518ef155ef9db3d13a441c4ac8ec76e'] = 'Standard avgiftskode for frakt';
 $_MODULE['<{twopayment}prestashop>twopayment_969a811ead960f897fc85735d99d646a'] = 'Kontroller at avgiftsregler er satt opp for landet ditt under Internasjonalt > Avgifter > Avgiftsregler';
@@ -332,7 +322,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9d8c5a3cd608d5590ab3da22a6855f83'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9ddf0af1d4404e3008c47a8fb8d17d6d'] = 'Skriv inn en undertittel som vises i utsjekken som undertittel for betalingsmåten.';
 $_MODULE['<{twopayment}prestashop>twopayment_9e727fdd3aec8274f46685441900280d'] = 'Prosjekt';
 $_MODULE['<{twopayment}prestashop>twopayment_9f67feb76396d9f95843662cb1a3cbee'] = 'Ja (ikke anbefalt)';
-$_MODULE['<{twopayment}prestashop>twopayment_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Avanserte innstillinger';
 $_MODULE['<{twopayment}prestashop>twopayment_a002c8066738bc8f9d9394abdcef7ea8'] = 'Betalingsperioden din starter når ordren er oppfylt';
 $_MODULE['<{twopayment}prestashop>twopayment_a029c838076e00c19453faa87a214790'] = 'Verifisert – klar for oppfyllelse → Two: Verifisert – klar for oppfyllelse';
 $_MODULE['<{twopayment}prestashop>twopayment_a18b98ac865c5099d00d15aa7955772e'] = 'Finner ikke den forespurte ordren, kontakt butikkeieren.';
@@ -402,7 +391,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_d40f2c2b7a99b454ace5554f91e54c8c'] 
 $_MODULE['<{twopayment}prestashop>twopayment_d417918cd6fea0a0d40a394dc3826e44'] = 'Two – BNPL for bedrifter';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b644ceb41c3a19d874ee330ac45f97'] = 'Ingen avrunding';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b9d20386ac408371aff6df4162e437'] = 'Utsjekk for enkeltpersonforetak er ikke tilgjengelig';
-$_MODULE['<{twopayment}prestashop>twopayment_d5815623c49bc79327917762848902f0'] = 'Betalingsinnstillinger';
 $_MODULE['<{twopayment}prestashop>twopayment_d5a4650cc30bac28c85f6c41646a39a2'] = 'Standardkoblinger:';
 $_MODULE['<{twopayment}prestashop>twopayment_d61f297c98cfff041329b59404710bd3'] = 'Two: Feil ved betalingsbehandling';
 $_MODULE['<{twopayment}prestashop>twopayment_d74f5295cfbc83c79a5737ed01bc13d3'] = 'Tillegg per vilkår';
@@ -437,7 +425,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_eb6d8ae6f20283755b339c0dc273988b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_ecddbd73a90aaf17dd71134521b09079'] = 'Ikke verifisert';
 $_MODULE['<{twopayment}prestashop>twopayment_f1001479cd49b3293274238a2995a9b7'] = 'Two: Ordre oppfylt – utløsende statuser';
 $_MODULE['<{twopayment}prestashop>twopayment_f12477236933ae49e5c643aecf75f74a'] = 'Kundene må ha et gyldig organisasjonsnummer';
-$_MODULE['<{twopayment}prestashop>twopayment_f4575927d8447f088ce1b50cec9ff292'] = 'Slå på feilsøkingsmodus under Generelle innstillinger og kontakt Two-støtte med loggene';
 $_MODULE['<{twopayment}prestashop>twopayment_f65e05deb9e54ed090b8450b4a4fbeb4'] = 'Sikkerhetsadvarsel:';
 $_MODULE['<{twopayment}prestashop>twopayment_f68cf3bf9fe34d152a13fa6947c19d9b'] = 'Overstyre Twos kredittbeslutning eller kjøperens grenser';
 $_MODULE['<{twopayment}prestashop>twopayment_f71fecea4e95aedc66e77754d9cecda4'] = 'Støtte for flere avgiftssatser og avgiftsfrie kunder';
@@ -492,3 +479,23 @@ $_MODULE['<{twopayment}prestashop>twopayment_3fcdcba6f3097627522e41d9f927fd01'] 
 $_MODULE['<{twopayment}prestashop>twopayment_44749712dbec183e983dcd78a7736c41'] = 'Dato';
 $_MODULE['<{twopayment}prestashop>twopayment_007cc9547ae8884ad597cd92ba505422'] = 'Alvorlighetsgrad';
 $_MODULE['<{twopayment}prestashop>twopayment_4c2a8fe7eaf24721cc7a9f0175115bd4'] = 'Melding';
+$_MODULE['<{twopayment}prestashop>twopayment_0db377921f4ce762c62526131097968f'] = 'Generelt';
+$_MODULE['<{twopayment}prestashop>configuration_0db377921f4ce762c62526131097968f'] = 'Generelt';
+$_MODULE['<{twopayment}prestashop>twopayment_f6f8b33a0645b664592cffdc179e7189'] = 'Kassafelt';
+$_MODULE['<{twopayment}prestashop>configuration_f6f8b33a0645b664592cffdc179e7189'] = 'Kassafelt';
+$_MODULE['<{twopayment}prestashop>twopayment_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalingsvilkår';
+$_MODULE['<{twopayment}prestashop>configuration_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalingsvilkår';
+$_MODULE['<{twopayment}prestashop>twopayment_c3bcb4d75d3af37fe613c8077e38441d'] = 'Innstillingene for kassafelt er oppdatert.';
+$_MODULE['<{twopayment}prestashop>twopayment_23c8711f45541e10da6c1eb134fddeb2'] = 'Innstillingene for betalingsvilkår er oppdatert.';
+$_MODULE['<{twopayment}prestashop>twopayment_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Bedriftssøk';
+$_MODULE['<{twopayment}prestashop>configuration_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Bedriftssøk';
+$_MODULE['<{twopayment}prestashop>twopayment_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Ordrehåndtering';
+$_MODULE['<{twopayment}prestashop>configuration_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Ordrehåndtering';
+$_MODULE['<{twopayment}prestashop>twopayment_5571738de78b958ae331069e8d8f0383'] = 'Når dette er aktivert, blir ordrer automatisk markert som oppfylt hos Two når statusen endres til en av statusene du har satt opp som utløsere for oppfyllelse (se Oppfyllelsesstatuser nedenfor). Dette aktiverer kjøperens betalingsvilkår og starter utbetalingssyklusen. Hvis det er deaktivert, må du oppfylle ordrer manuelt i Twos selgerportal.';
+$_MODULE['<{twopayment}prestashop>twopayment_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostikk';
+$_MODULE['<{twopayment}prestashop>configuration_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostikk';
+$_MODULE['<{twopayment}prestashop>twopayment_8178fa55db5e6276b9d2120ca523c26c'] = 'Innstillingene for bedriftssøk er oppdatert.';
+$_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] = 'Innstillingene for ordrehåndtering er oppdatert.';
+$_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostikkinnstillingene er oppdatert.';
+$_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Slå på feilsøkingsmodus under Diagnostikk og kontakt Two-støtte med loggene';
+$_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'API-nøkkelen er ikke verifisert. Forespørsler i utsjekken kan feile til de generelle innstillingene er lagret med en gyldig nøkkel.';

--- a/translations/no.php
+++ b/translations/no.php
@@ -446,8 +446,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Angi manuelt';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrert virksomhet';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enkeltpersonforetak';
-$_MODULE['<{twopayment}prestashop>twopayment_adaed373af40f154859a1e470279527f'] = 'Leverandør-/nettstedsnavn';
-$_MODULE['<{twopayment}prestashop>twopayment_4e378a4617ae99ebad1374c430d83a96'] = 'Valgfritt. Angi dette hvis du kjører Two på flere nettsteder/leverandører, for å identifisere hvilken forespørslene kommer fra.';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Egendefinert betalingsfrist (dager)';
 $_MODULE['<{twopayment}prestashop>twopayment_e8910a5d4ad165a5989f6b672b4c8216'] = 'Valgfritt. Tilby en ekstra betalingsfrist (i dager) som ikke er dekket av forhåndsinnstillingene ovenfor. La stå tomt for å kun tilby betingelsene valgt ovenfor. Two må fortsatt tillate denne fristlengden for kontoen din - en ustøttet verdi ignoreres stille.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standard forhåndsvalgt betalingsfrist';
@@ -499,3 +497,5 @@ $_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostikkinnstillingene er oppdatert.';
 $_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Slå på feilsøkingsmodus under Diagnostikk og kontakt Two-støtte med loggene';
 $_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'API-nøkkelen er ikke verifisert. Forespørsler i utsjekken kan feile til de generelle innstillingene er lagret med en gyldig nøkkel.';
+$_MODULE['<{twopayment}prestashop>twopayment_740ac829af0e2bbb2816a70b724c851d'] = 'Leverandørnavn (valgfritt)';
+$_MODULE['<{twopayment}prestashop>twopayment_b41ef96a0f570c44647792507627d3e9'] = 'Hvis denne butikken representerer ett av flere leverandørnettsteder som deler samme Two-selgerkonto, skriv inn et navn her for å identifisere dette spesifikke nettstedet/leverandøren på hver bestilling som sendes til Two - la stå tomt hvis du bare driver ett nettsted.';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -3,14 +3,9 @@
 global $_MODULE;
 $_MODULE = array();
 $_MODULE['<{twopayment}prestashop>configuration_0ba29c6a1afacf586b03a26162c72274'] = 'Miljö';
-$_MODULE['<{twopayment}prestashop>configuration_13831bd312b782daa4e11738a2fe3d04'] = 'Inställningar för orderstatus';
 $_MODULE['<{twopayment}prestashop>configuration_229a7ec501323b94db7ff3157a7623c9'] = 'Handlar-ID';
 $_MODULE['<{twopayment}prestashop>configuration_3f68e67dc6c397aaa9d1c24c356f754f'] = 'Verifierad';
-$_MODULE['<{twopayment}prestashop>configuration_4b89abd8c5879f053b551487a3b7c1c3'] = 'Information om modulen';
-$_MODULE['<{twopayment}prestashop>configuration_52f4393e1b52ba63e27310ca92ba098c'] = 'Allmänna inställningar';
 $_MODULE['<{twopayment}prestashop>configuration_5943a2e7c31755a5588c66c273d35f15'] = 'Handlarens kortnamn';
-$_MODULE['<{twopayment}prestashop>configuration_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Avancerade inställningar';
-$_MODULE['<{twopayment}prestashop>configuration_d5815623c49bc79327917762848902f0'] = 'Betalningsinställningar';
 $_MODULE['<{twopayment}prestashop>configuration_daf40c1ea5990bdee77b09f7137ffc31'] = 'API-nyckeln verifierades';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_11335f7aaa473442d803c43c8b8d804d'] = 'Fakturalänkar blir tillgängliga när Two-ordern har levererats.';
 $_MODULE['<{twopayment}prestashop>displayadminorderleft_2fdeffc575b8052f195eeff5b113cf3c'] = 'Two-status';
@@ -212,7 +207,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_4d8ef3ef2843e5fe46dbdce83c16b88e'] 
 $_MODULE['<{twopayment}prestashop>twopayment_4e48eb7b84e6418738c6548b3c826d94'] = 'Avgift för betalningsvillkor - %d dagar';
 $_MODULE['<{twopayment}prestashop>twopayment_4f40188f22dbc3f6b5f5ea06152782ca'] = 'Kunde inte bygga nyttolasten för order intent';
 $_MODULE['<{twopayment}prestashop>twopayment_526f52140844e831b1965500d17c26d8'] = 'Villkor för månadsskifte (EOM):';
-$_MODULE['<{twopayment}prestashop>twopayment_52f4393e1b52ba63e27310ca92ba098c'] = 'Allmänna inställningar';
 $_MODULE['<{twopayment}prestashop>twopayment_53943134b629b65e0a320b7dd6ed92a8'] = 'Den här API-nyckeln avvisades av Two. Den kan vara ogiltig eller ha upphört att gälla - kontrollera nyckeln i din Two-portal.';
 $_MODULE['<{twopayment}prestashop>twopayment_539de410a9a131c0e925dc8e248a29d2'] = 'Betalning förfaller vid månadsskiftet plus X dagar från leveransdatumet. Exempel: om du levererar en order den 15 januari med villkoret EOM+30 förfaller betalningen den 28 februari (slutet av januari + 30 dagar). Detta är vanligt vid B2B-fakturering.';
 $_MODULE['<{twopayment}prestashop>twopayment_545e6db228f47336669130f1068a519e'] = 'Kunde inte behandla din order med Two-betalning. Välj en annan betalningsmetod eller kontakta butiken.';
@@ -236,7 +230,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_60b60d57ac14700787432034bf58f8b1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_624d960f1513f62685fb2017c0bbc926'] = 'Fungerar med PrestaShop 1.7.6 till 9.x';
 $_MODULE['<{twopayment}prestashop>twopayment_62c7594948c1231bbae9f948b1535b7e'] = 'API-nyckel';
 $_MODULE['<{twopayment}prestashop>twopayment_633918382ee5b43840752588882a0496'] = 'Kunde inte kontrollera varukorgens konsistens för denna betalning. Försök igen.';
-$_MODULE['<{twopayment}prestashop>twopayment_64b235cc9d452ea7fb8008c6f9aefd91'] = 'API-nyckeln är inte verifierad. Förfrågningar från kassan kan misslyckas till dess att de allmänna inställningarna sparas med en giltig nyckel.';
 $_MODULE['<{twopayment}prestashop>twopayment_656a6828d7ef1bb791e42087c4b5ee6e'] = 'API-nyckel';
 $_MODULE['<{twopayment}prestashop>twopayment_65a4e2b7da5e4f1c422b2de7277d8311'] = 'Steget som tilläggsavgiften avrundas till (t.ex. 1 = hela enheter, 0,50 = närmaste halva). Gäller endast när en avrundningsriktning är vald.';
 $_MODULE['<{twopayment}prestashop>twopayment_65facdf395107d60a23ce012c2a1c456'] = 'Månadsskifte + %s dagar';
@@ -244,7 +237,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_66e6e619e3e72bb941b0d2d4947466c9'] 
 $_MODULE['<{twopayment}prestashop>twopayment_67205cb0f855142963b4901fed7b35de'] = 'Kunde inte uppdatera status till avbruten, kontrollera med Two-administratören för id %s';
 $_MODULE['<{twopayment}prestashop>twopayment_6735bd225a891660cc38b49f427acb08'] = 'Detta är oftast en frakt- eller rabattsumma som varukorgen ännu inte har tillämpat. Uppdatera din varukorg och försök igen, eller kontakta butiken.';
 $_MODULE['<{twopayment}prestashop>twopayment_67d805ed4bbf1baf8cd7a94badcb7bc1'] = 'Exklusive moms (netto)';
-$_MODULE['<{twopayment}prestashop>twopayment_67dd983768d27e0b7ca68a09c27d1cfd'] = 'Betalningsinställningarna är uppdaterade.';
 $_MODULE['<{twopayment}prestashop>twopayment_6825c19161f9f1b9a4047b08720ac98c'] = 'Ingen orderreferens från betalningsleverantören är angiven för denna order.';
 $_MODULE['<{twopayment}prestashop>twopayment_68fc97fb527fe6d18d12d02199710634'] = 'Kunde inte bekräfta att betalningen avbröts. Försök genomföra kassan igen.';
 $_MODULE['<{twopayment}prestashop>twopayment_693d87a10d7bf7577f44c12dfecb0559'] = 'Din order är avbruten.';
@@ -304,7 +296,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_88d53497f4a92958c67c73a9f2f52df3'] 
 $_MODULE['<{twopayment}prestashop>twopayment_893c937ba17594e25cd9b8a6baa9a923'] = 'Miljöskatt (ekoskatt)';
 $_MODULE['<{twopayment}prestashop>twopayment_8ae26445494e68f399026e73ed477c13'] = 'Kunde inte omdirigera till betalningsleverantören. Försök igen.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b0299767b9b23d625c55554c37966ba'] = 'Välj en momshantering för tilläggsavgift: tilläggsavgifter är aktiverade, så du måste uttryckligen välja en momsregelgrupp innan du sparar.';
-$_MODULE['<{twopayment}prestashop>twopayment_8b667ac78d92f83cddeca84b8a22cce2'] = 'När funktionen är aktiverad markeras order automatiskt som levererade i Two när deras status ändras till någon av dina konfigurerade utlösande statusar (se Statusmappning för order). Detta aktiverar köparens betalningsvillkor och startar utbetalningscykeln. Om funktionen är avaktiverad måste du leveransrapportera order manuellt i Twos handlarportal.';
 $_MODULE['<{twopayment}prestashop>twopayment_8b71f88a3f44283f2f9d4905d1b097f1'] = 'Vad modulen gör';
 $_MODULE['<{twopayment}prestashop>twopayment_8bc50504c201a3c29db85208d8ce68af'] = 'Underrubrik';
 $_MODULE['<{twopayment}prestashop>twopayment_8c597b2f3bc899e1e04f301844c44482'] = 'Fakturan är inte klar ännu eftersom ordern fortfarande levereras. Försök igen senare.';
@@ -316,7 +307,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9397d7f54ed01d00e59b0e49f0900586'] 
 $_MODULE['<{twopayment}prestashop>twopayment_93b6026f985c994bf4d6bb646c88f584'] = 'Beskrivning av tilläggsavgift';
 $_MODULE['<{twopayment}prestashop>twopayment_93cba07454f06a4a960172bbd6e2a435'] = 'Ja';
 $_MODULE['<{twopayment}prestashop>twopayment_93ef8e5b106e50d55fd88d4a966668c8'] = 'För att betala med Two, gå tillbaka till din fakturaadress och ange ditt företagsnamn i fältet Företag.';
-$_MODULE['<{twopayment}prestashop>twopayment_9442d98dc18ef95b73b18e47583f38a6'] = 'De avancerade inställningarna är uppdaterade.';
 $_MODULE['<{twopayment}prestashop>twopayment_945d7d5e1d06440a9154e2bbc6350584'] = 'Statusmappningen för Two-order har uppdaterats.';
 $_MODULE['<{twopayment}prestashop>twopayment_9518ef155ef9db3d13a441c4ac8ec76e'] = 'Standardmomskod för frakt';
 $_MODULE['<{twopayment}prestashop>twopayment_969a811ead960f897fc85735d99d646a'] = 'Kontrollera att momsregler är konfigurerade för ditt land under Internationellt > Skatter > Momsregler';
@@ -332,7 +322,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_9d8c5a3cd608d5590ab3da22a6855f83'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9ddf0af1d4404e3008c47a8fb8d17d6d'] = 'Ange en underrubrik som visas i kassan som betalningsmetodens underrubrik.';
 $_MODULE['<{twopayment}prestashop>twopayment_9e727fdd3aec8274f46685441900280d'] = 'Projekt';
 $_MODULE['<{twopayment}prestashop>twopayment_9f67feb76396d9f95843662cb1a3cbee'] = 'Ja (rekommenderas inte)';
-$_MODULE['<{twopayment}prestashop>twopayment_9ffc3ccc968a96d902af963c6d7b4e97'] = 'Avancerade inställningar';
 $_MODULE['<{twopayment}prestashop>twopayment_a002c8066738bc8f9d9394abdcef7ea8'] = 'Din betalningsperiod börjar när din order levereras';
 $_MODULE['<{twopayment}prestashop>twopayment_a029c838076e00c19453faa87a214790'] = 'Verifierad - klar för leverans → Two: Verifierad - klar för leverans';
 $_MODULE['<{twopayment}prestashop>twopayment_a18b98ac865c5099d00d15aa7955772e'] = 'Kunde inte hitta den efterfrågade ordern, kontakta butiksägaren.';
@@ -402,7 +391,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_d40f2c2b7a99b454ace5554f91e54c8c'] 
 $_MODULE['<{twopayment}prestashop>twopayment_d417918cd6fea0a0d40a394dc3826e44'] = 'Two - BNPL för företag';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b644ceb41c3a19d874ee330ac45f97'] = 'Ingen avrundning';
 $_MODULE['<{twopayment}prestashop>twopayment_d4b9d20386ac408371aff6df4162e437'] = 'Kassan för enskild firma är inte tillgänglig';
-$_MODULE['<{twopayment}prestashop>twopayment_d5815623c49bc79327917762848902f0'] = 'Betalningsinställningar';
 $_MODULE['<{twopayment}prestashop>twopayment_d5a4650cc30bac28c85f6c41646a39a2'] = 'Standardmappningar:';
 $_MODULE['<{twopayment}prestashop>twopayment_d61f297c98cfff041329b59404710bd3'] = 'Two: Fel vid betalningsbehandling';
 $_MODULE['<{twopayment}prestashop>twopayment_d74f5295cfbc83c79a5737ed01bc13d3'] = 'Tilläggsavgift per villkor';
@@ -437,7 +425,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_eb6d8ae6f20283755b339c0dc273988b'] 
 $_MODULE['<{twopayment}prestashop>twopayment_ecddbd73a90aaf17dd71134521b09079'] = 'Inte verifierad';
 $_MODULE['<{twopayment}prestashop>twopayment_f1001479cd49b3293274238a2995a9b7'] = 'Two: Order levererad - utlösande statusar';
 $_MODULE['<{twopayment}prestashop>twopayment_f12477236933ae49e5c643aecf75f74a'] = 'Kunderna måste ha ett giltigt organisationsnummer';
-$_MODULE['<{twopayment}prestashop>twopayment_f4575927d8447f088ce1b50cec9ff292'] = 'Aktivera felsökningsläge under Allmänna inställningar och kontakta Twos support med loggarna';
 $_MODULE['<{twopayment}prestashop>twopayment_f65e05deb9e54ed090b8450b4a4fbeb4'] = 'Säkerhetsvarning:';
 $_MODULE['<{twopayment}prestashop>twopayment_f68cf3bf9fe34d152a13fa6947c19d9b'] = 'Åsidosätta Twos kreditbeslut eller köparens gränser';
 $_MODULE['<{twopayment}prestashop>twopayment_f71fecea4e95aedc66e77754d9cecda4'] = 'Stöd för flera momssatser och momsbefriade kunder';
@@ -492,3 +479,23 @@ $_MODULE['<{twopayment}prestashop>twopayment_3fcdcba6f3097627522e41d9f927fd01'] 
 $_MODULE['<{twopayment}prestashop>twopayment_44749712dbec183e983dcd78a7736c41'] = 'Datum';
 $_MODULE['<{twopayment}prestashop>twopayment_007cc9547ae8884ad597cd92ba505422'] = 'Allvarlighetsgrad';
 $_MODULE['<{twopayment}prestashop>twopayment_4c2a8fe7eaf24721cc7a9f0175115bd4'] = 'Meddelande';
+$_MODULE['<{twopayment}prestashop>twopayment_0db377921f4ce762c62526131097968f'] = 'Allmänt';
+$_MODULE['<{twopayment}prestashop>configuration_0db377921f4ce762c62526131097968f'] = 'Allmänt';
+$_MODULE['<{twopayment}prestashop>twopayment_f6f8b33a0645b664592cffdc179e7189'] = 'Kassafält';
+$_MODULE['<{twopayment}prestashop>configuration_f6f8b33a0645b664592cffdc179e7189'] = 'Kassafält';
+$_MODULE['<{twopayment}prestashop>twopayment_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalningsvillkor';
+$_MODULE['<{twopayment}prestashop>configuration_3ec74eaa839c4e1851706ef6709dfbbb'] = 'Betalningsvillkor';
+$_MODULE['<{twopayment}prestashop>twopayment_c3bcb4d75d3af37fe613c8077e38441d'] = 'Inställningarna för kassafält är uppdaterade.';
+$_MODULE['<{twopayment}prestashop>twopayment_23c8711f45541e10da6c1eb134fddeb2'] = 'Inställningarna för betalningsvillkor är uppdaterade.';
+$_MODULE['<{twopayment}prestashop>twopayment_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Företagssökning';
+$_MODULE['<{twopayment}prestashop>configuration_d4ab41c3ae714dd56e8f87a246fe39e1'] = 'Företagssökning';
+$_MODULE['<{twopayment}prestashop>twopayment_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Orderhantering';
+$_MODULE['<{twopayment}prestashop>configuration_c4dcb7da043e8feef88ce236dd7ab5bd'] = 'Orderhantering';
+$_MODULE['<{twopayment}prestashop>twopayment_5571738de78b958ae331069e8d8f0383'] = 'När funktionen är aktiverad markeras order automatiskt som levererade i Two när deras status ändras till någon av dina konfigurerade utlösande statusar (se Uppfyllelsestatusar nedan). Detta aktiverar köparens betalningsvillkor och startar utbetalningscykeln. Om funktionen är avaktiverad måste du leveransrapportera order manuellt i Twos handlarportal.';
+$_MODULE['<{twopayment}prestashop>twopayment_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostik';
+$_MODULE['<{twopayment}prestashop>configuration_36b64aad8a26246fe3ad4116a2b6f289'] = 'Diagnostik';
+$_MODULE['<{twopayment}prestashop>twopayment_8178fa55db5e6276b9d2120ca523c26c'] = 'Inställningarna för företagssökning är uppdaterade.';
+$_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] = 'Inställningarna för orderhantering är uppdaterade.';
+$_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostikinställningarna är uppdaterade.';
+$_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Aktivera felsökningsläge under Diagnostik och kontakta Twos support med loggarna';
+$_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'API-nyckeln är inte verifierad. Förfrågningar från kassan kan misslyckas till dess att de allmänna inställningarna sparas med en giltig nyckel.';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -446,8 +446,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Ange manuellt';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrerat företag';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enskild firma';
-$_MODULE['<{twopayment}prestashop>twopayment_adaed373af40f154859a1e470279527f'] = 'Leverantörs-/webbplatsnamn';
-$_MODULE['<{twopayment}prestashop>twopayment_4e378a4617ae99ebad1374c430d83a96'] = 'Valfritt. Ange detta om du använder Two på flera webbplatser/leverantörer, för att identifiera vilken förfrågningarna kommer från.';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Anpassat betalningsvillkor (dagar)';
 $_MODULE['<{twopayment}prestashop>twopayment_e8910a5d4ad165a5989f6b672b4c8216'] = 'Valfritt. Erbjud ytterligare ett betalningsvillkor (i dagar) som inte täcks av förinställningarna ovan. Lämna tomt för att endast erbjuda de villkor som valts ovan. Two måste fortfarande tillåta denna villkorslängd för ditt konto - ett ej understött värde ignoreras tyst.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standardförvalt betalningsvillkor';
@@ -499,3 +497,5 @@ $_MODULE['<{twopayment}prestashop>twopayment_891235d1cd86cc1c2d1979a42beed2e1'] 
 $_MODULE['<{twopayment}prestashop>twopayment_3789cbd8ceb584069580a3ea14085851'] = 'Diagnostikinställningarna är uppdaterade.';
 $_MODULE['<{twopayment}prestashop>twopayment_68496b4b801e25ab61ddfd84675fe52c'] = 'Aktivera felsökningsläge under Diagnostik och kontakta Twos support med loggarna';
 $_MODULE['<{twopayment}prestashop>twopayment_59ad2606b9dfb64aa42b2270950bbbbe'] = 'API-nyckeln är inte verifierad. Förfrågningar från kassan kan misslyckas till dess att de allmänna inställningarna sparas med en giltig nyckel.';
+$_MODULE['<{twopayment}prestashop>twopayment_740ac829af0e2bbb2816a70b724c851d'] = 'Leverantörsnamn (valfritt)';
+$_MODULE['<{twopayment}prestashop>twopayment_b41ef96a0f570c44647792507627d3e9'] = 'Om den här butiken representerar en av flera leverantörswebbplatser som delar samma Two-handlarkonto, ange ett namn här för att identifiera just denna webbplats/leverantör på varje order som skickas till Two - lämna tomt om du bara driver en webbplats.';

--- a/twopayment.php
+++ b/twopayment.php
@@ -1154,14 +1154,16 @@ class Twopayment extends PaymentModule
                     // Multi-site vendor/site name (TWO-25386, ported from
                     // woocommerce-plugin's `vendor_name` field). Free text, no
                     // validation - only meaningful for merchants running Two
-                    // across more than one site/vendor identity; empty is the
-                    // normal single-site state and is never sent to Two.
+                    // across more than one site/vendor identity. Sent verbatim
+                    // as `vendor_name` in the order-create/edit JSON payload to
+                    // Two's backend - never shown to buyers, not a header.
+                    // Empty is the normal single-site state and is never sent.
                     array(
                         'type' => 'text',
-                        'label' => $this->l('Vendor/site name'),
+                        'label' => $this->l('Vendor name (optional)'),
                         'name' => 'PS_TWO_VENDOR_NAME',
                         'required' => false,
-                        'desc' => $this->l('Optional. Set this if you run Two across multiple sites/vendors, to identify which one requests came from.'),
+                        'desc' => $this->l('If this store represents one of several vendor sites sharing the same Two merchant account, enter a name here to identify this specific site/vendor on each order sent to Two - leave blank if you only run a single site.'),
                     ),
                     array(
                         'type' => 'select',
@@ -1178,29 +1180,6 @@ class Twopayment extends PaymentModule
                             'id' => 'id_option',
                             'name' => 'name'
                         )
-                    ),
-                    // Disable SSL verification (TWO-25386 §A: relocated from
-                    // the former "Advanced Settings" panel, alongside the
-                    // other connection-level controls - key, environment).
-                    array(
-                        'type' => 'switch',
-                        'label' => $this->l('Disable SSL Verification (Corporate Networks Only)'),
-                        'name' => 'PS_TWO_DISABLE_SSL_VERIFY',
-                        'is_bool' => true,
-                        'desc' => $this->l('WARNING: Only enable this if you are behind a corporate proxy with custom SSL certificates. This disables SSL certificate verification and is a SECURITY RISK. NOT RECOMMENDED for production.'),
-                        'required' => true,
-                        'values' => array(
-                            array(
-                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_ON',
-                                'value' => 1,
-                                'label' => $this->l('Yes (Not Recommended)')
-                            ),
-                            array(
-                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_OFF',
-                                'value' => 0,
-                                'label' => $this->l('No (Secure)')
-                            ),
-                        ),
                     ),
                 ),
                 'submit' => array(
@@ -1262,7 +1241,6 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_MERCHANT_API_KEY'] = Tools::getValue('PS_TWO_MERCHANT_API_KEY', Configuration::get('PS_TWO_MERCHANT_API_KEY'));
         $fields_values['PS_TWO_VENDOR_NAME'] = Tools::getValue('PS_TWO_VENDOR_NAME', Configuration::get('PS_TWO_VENDOR_NAME'));
         $fields_values['PS_TWO_ENVIRONMENT'] = Tools::getValue('PS_TWO_ENVIRONMENT', Configuration::get('PS_TWO_ENVIRONMENT'));
-        $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         return $fields_values;
     }
 
@@ -1329,7 +1307,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', trim(Tools::getValue('PS_TWO_MERCHANT_API_KEY')));
         Configuration::updateValue('PS_TWO_VENDOR_NAME', trim((string) Tools::getValue('PS_TWO_VENDOR_NAME')));
         Configuration::updateValue('PS_TWO_ENVIRONMENT', Tools::getValue('PS_TWO_ENVIRONMENT'));
-        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
         // The verdict from the live check the validation above just made, now
         // that the key it describes is the stored one (TWO-25326). This is the
         // freshest that key will ever have had, so it becomes what the checkout
@@ -2455,6 +2432,29 @@ class Twopayment extends PaymentModule
                             ),
                         ),
                     ),
+                    // Disable SSL verification (relocated from the former
+                    // "Advanced Settings" panel, alongside the other
+                    // debug/diagnostic-only controls).
+                    array(
+                        'type' => 'switch',
+                        'label' => $this->l('Disable SSL Verification (Corporate Networks Only)'),
+                        'name' => 'PS_TWO_DISABLE_SSL_VERIFY',
+                        'is_bool' => true,
+                        'desc' => $this->l('WARNING: Only enable this if you are behind a corporate proxy with custom SSL certificates. This disables SSL certificate verification and is a SECURITY RISK. NOT RECOMMENDED for production.'),
+                        'required' => true,
+                        'values' => array(
+                            array(
+                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_ON',
+                                'value' => 1,
+                                'label' => $this->l('Yes (Not Recommended)')
+                            ),
+                            array(
+                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_OFF',
+                                'value' => 0,
+                                'label' => $this->l('No (Secure)')
+                            ),
+                        ),
+                    ),
                     // Skip confirm-order nonce/token check (TWO-25386 #4,
                     // ported from woocommerce-plugin's `skip_confirm_auth`).
                     // DEBUG ONLY - gates the CSRF-style token check
@@ -2805,14 +2805,11 @@ class Twopayment extends PaymentModule
         $this->output .= $this->displayConfirmation($this->l('Order management settings are updated.'));
     }
 
-    /**
-     * Validate the checkout sort order field (TWO-25386 #6): empty (no
-     * preference) or a plain integer, positive or negative.
-     */
     protected function getTwoDiagnosticsFormValues()
     {
         $fields_values = array();
         $fields_values['PS_TWO_DEBUG_MODE'] = Tools::getValue('PS_TWO_DEBUG_MODE', Configuration::get('PS_TWO_DEBUG_MODE'));
+        $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         $fields_values['PS_TWO_SKIP_CONFIRM_NONCE_CHECK'] = Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', Configuration::get('PS_TWO_SKIP_CONFIRM_NONCE_CHECK'));
         $fields_values['PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'] = Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'));
         return $fields_values;
@@ -2820,12 +2817,13 @@ class Twopayment extends PaymentModule
 
     protected function validTwoDiagnosticsFormValues()
     {
-        // Nothing to validate: all three fields are booleans / an html link.
+        // Nothing to validate: all fields are booleans / an html link.
     }
 
     protected function saveTwoDiagnosticsFormValues()
     {
         Configuration::updateValue('PS_TWO_DEBUG_MODE', Tools::getValue('PS_TWO_DEBUG_MODE'));
+        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
         Configuration::updateValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', (int) Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', 0));
         Configuration::updateValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', (int) Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', 1));
 

--- a/twopayment.php
+++ b/twopayment.php
@@ -164,7 +164,7 @@ class Twopayment extends PaymentModule
     // deliberate and shared - the admin switches render in the same sequence as
     // the checkout fields, so the pane reads like the thing it configures.
     // Adding a field means putting it in the right place in BOTH this array and
-    // getTwoPaymentSettingsForm()'s input list, not appending to either.
+    // getTwoCheckoutFieldsForm()'s input list, not appending to either.
     //
     // The order note is the fifth field in that standard sequence and is
     // deliberately absent from here: it is PrestaShop core's own
@@ -966,6 +966,12 @@ class Twopayment extends PaymentModule
 
     public function getContent()
     {
+        // Six-section admin scheme (TWO-25386 Part 1): A. General,
+        // B. Checkout Fields, C. Company Lookup, D. Payment Terms,
+        // E. Order Management, F. Diagnostics - same names/order as
+        // magento-plugin and woocommerce-plugin. This is a pure
+        // reorganisation of WHICH PANEL each existing field renders under;
+        // no Configuration key, validation rule or save behaviour changed.
         if (((bool) Tools::isSubmit('submitTwoGeneralForm')) == true) {
             Configuration::updateValue('PS_TWO_TAB_VALUE', 1);
             $this->validTwoGeneralFormValues();
@@ -978,11 +984,11 @@ class Twopayment extends PaymentModule
             }
         }
 
-        if (((bool) Tools::isSubmit('submitTwoPaymentSettingsForm')) == true) {
-            Configuration::updateValue('PS_TWO_TAB_VALUE', 5);
-            $this->validTwoPaymentSettingsFormValues();
+        if (((bool) Tools::isSubmit('submitTwoCheckoutFieldsForm')) == true) {
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 2);
+            $this->validTwoCheckoutFieldsFormValues();
             if (!count($this->errors)) {
-                $this->saveTwoPaymentSettingsFormValues();
+                $this->saveTwoCheckoutFieldsFormValues();
             } else {
                 foreach ($this->errors as $err) {
                     $this->output .= $this->displayError($err);
@@ -990,11 +996,35 @@ class Twopayment extends PaymentModule
             }
         }
 
-        if (((bool) Tools::isSubmit('submitTwoOtherForm')) == true) {
-            Configuration::updateValue('PS_TWO_TAB_VALUE', 2);
-            $this->validTwoOtherFormValues();
+        if (((bool) Tools::isSubmit('submitTwoCompanyLookupForm')) == true) {
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 3);
+            $this->validTwoCompanyLookupFormValues();
             if (!count($this->errors)) {
-                $this->saveTwoOtherFormValues();
+                $this->saveTwoCompanyLookupFormValues();
+            } else {
+                foreach ($this->errors as $err) {
+                    $this->output .= $this->displayError($err);
+                }
+            }
+        }
+
+        if (((bool) Tools::isSubmit('submitTwoPaymentTermsForm')) == true) {
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 4);
+            $this->validTwoPaymentTermsFormValues();
+            if (!count($this->errors)) {
+                $this->saveTwoPaymentTermsFormValues();
+            } else {
+                foreach ($this->errors as $err) {
+                    $this->output .= $this->displayError($err);
+                }
+            }
+        }
+
+        if (((bool) Tools::isSubmit('submitTwoOrderManagementForm')) == true) {
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 5);
+            $this->validTwoOrderManagementFormValues();
+            if (!count($this->errors)) {
+                $this->saveTwoOrderManagementFormValues();
             } else {
                 foreach ($this->errors as $err) {
                     $this->output .= $this->displayError($err);
@@ -1003,8 +1033,20 @@ class Twopayment extends PaymentModule
         }
 
         if (((bool) Tools::isSubmit('submitTwoOrderStatusForm')) == true) {
-            Configuration::updateValue('PS_TWO_TAB_VALUE', 3);
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 5);
             $this->saveTwoOrderStatusFormValues();
+        }
+
+        if (((bool) Tools::isSubmit('submitTwoDiagnosticsForm')) == true) {
+            Configuration::updateValue('PS_TWO_TAB_VALUE', 6);
+            $this->validTwoDiagnosticsFormValues();
+            if (!count($this->errors)) {
+                $this->saveTwoDiagnosticsFormValues();
+            } else {
+                foreach ($this->errors as $err) {
+                    $this->output .= $this->displayError($err);
+                }
+            }
         }
 
         // Post-upgrade nag (upgrade-2.5.0.php): a pre-release flat surcharge
@@ -1040,9 +1082,12 @@ class Twopayment extends PaymentModule
         $this->context->smarty->assign(
             array(
                 'renderTwoGeneralForm' => $this->renderTwoGeneralForm(),
-                'renderTwoPaymentSettingsForm' => $this->renderTwoPaymentSettingsForm(),
-                'renderTwoOtherForm' => $this->renderTwoOtherForm(),
+                'renderTwoCheckoutFieldsForm' => $this->renderTwoCheckoutFieldsForm(),
+                'renderTwoCompanyLookupForm' => $this->renderTwoCompanyLookupForm(),
+                'renderTwoPaymentTermsForm' => $this->renderTwoPaymentTermsForm(),
+                'renderTwoOrderManagementForm' => $this->renderTwoOrderManagementForm(),
                 'renderTwoOrderStatusForm' => $this->renderTwoOrderStatusForm(),
+                'renderTwoDiagnosticsForm' => $this->renderTwoDiagnosticsForm(),
                 'renderTwoPluginInfo' => $this->renderTwoPluginInfo(),
                 'twotabvalue' => Configuration::get('PS_TWO_TAB_VALUE'),
                 // The CURRENT verdict, not the sticky save-time flag
@@ -1095,27 +1140,10 @@ class Twopayment extends PaymentModule
         $fields_form = array(
             'form' => array(
                 'legend' => array(
-                    'title' => $this->l('General Settings'),
+                    'title' => $this->l('General'),
                     'icon' => 'icon-cogs',
                 ),
                 'input' => array(
-                    array(
-                        'type' => 'text',
-                        'label' => $this->l('Title'),
-                        'desc' => $this->l('Enter a title which is appear on checkout page as payment method title.'),
-                        'name' => 'PS_TWO_TITLE',
-                        'required' => true,
-                        'lang' => true,
-                    ),
-                    array(
-                        'type' => 'text',
-                        'label' => $this->l('Sub title'),
-                        'desc' => $this->l('Enter a sub title which is appear on checkout page as payment method sub title.'),
-                        'name' => 'PS_TWO_SUB_TITLE',
-                        'required' => true,
-                        'lang' => true,
-                    ),
-                    
                     array(
                         'type' => 'password',
                         'label' => $this->l('Api key'),
@@ -1151,25 +1179,26 @@ class Twopayment extends PaymentModule
                             'name' => 'name'
                         )
                     ),
-                    // Debug mode lives in General Settings for parity with
-                    // Magento's two_general > general group (which includes it).
+                    // Disable SSL verification (TWO-25386 §A: relocated from
+                    // the former "Advanced Settings" panel, alongside the
+                    // other connection-level controls - key, environment).
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Enable Debug Mode'),
-                        'name' => 'PS_TWO_DEBUG_MODE',
+                        'label' => $this->l('Disable SSL Verification (Corporate Networks Only)'),
+                        'name' => 'PS_TWO_DISABLE_SSL_VERIFY',
                         'is_bool' => true,
-                        'desc' => $this->l('Enable detailed logging for troubleshooting. Logs tax calculations and other diagnostic data. Only enable when requested by Two support.'),
-                        'required' => false,
+                        'desc' => $this->l('WARNING: Only enable this if you are behind a corporate proxy with custom SSL certificates. This disables SSL certificate verification and is a SECURITY RISK. NOT RECOMMENDED for production.'),
+                        'required' => true,
                         'values' => array(
                             array(
-                                'id' => 'PS_TWO_DEBUG_MODE_ON',
+                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_ON',
                                 'value' => 1,
-                                'label' => $this->l('Yes')
+                                'label' => $this->l('Yes (Not Recommended)')
                             ),
                             array(
-                                'id' => 'PS_TWO_DEBUG_MODE_OFF',
+                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_OFF',
                                 'value' => 0,
-                                'label' => $this->l('No')
+                                'label' => $this->l('No (Secure)')
                             ),
                         ),
                     ),
@@ -1229,28 +1258,16 @@ class Twopayment extends PaymentModule
     protected function getTwoGeneralFormValues()
     {
         $fields_values = array();
-        foreach ($this->languages as $language) {
-            $fields_values['PS_TWO_TITLE'][$language['id_lang']] = Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang'], Configuration::get('PS_TWO_TITLE', (int) $language['id_lang']));
-            $fields_values['PS_TWO_SUB_TITLE'][$language['id_lang']] = Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang'], Configuration::get('PS_TWO_SUB_TITLE', (int) $language['id_lang']));
-        }
         $fields_values['PS_TWO_MERCHANT_SHORT_NAME'] = Tools::getValue('PS_TWO_MERCHANT_SHORT_NAME', Configuration::get('PS_TWO_MERCHANT_SHORT_NAME'));
         $fields_values['PS_TWO_MERCHANT_API_KEY'] = Tools::getValue('PS_TWO_MERCHANT_API_KEY', Configuration::get('PS_TWO_MERCHANT_API_KEY'));
         $fields_values['PS_TWO_VENDOR_NAME'] = Tools::getValue('PS_TWO_VENDOR_NAME', Configuration::get('PS_TWO_VENDOR_NAME'));
         $fields_values['PS_TWO_ENVIRONMENT'] = Tools::getValue('PS_TWO_ENVIRONMENT', Configuration::get('PS_TWO_ENVIRONMENT'));
-        $fields_values['PS_TWO_DEBUG_MODE'] = Tools::getValue('PS_TWO_DEBUG_MODE', Configuration::get('PS_TWO_DEBUG_MODE'));
+        $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
         return $fields_values;
     }
 
     protected function validTwoGeneralFormValues()
     {
-        foreach ($this->languages as $language) {
-            if (Tools::isEmpty(Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang']))) {
-                $this->errors[] = $this->l('Enter a title.');
-            }
-            if (Tools::isEmpty(Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang']))) {
-                $this->errors[] = $this->l('Enter a sub title.');
-            }
-        }
         if (Tools::isEmpty(Tools::getValue('PS_TWO_MERCHANT_API_KEY'))) {
             $this->errors[] = $this->l('Enter an API key.');
         }
@@ -1306,21 +1323,13 @@ class Twopayment extends PaymentModule
 
     protected function saveTwoGeneralFormValues()
     {
-
-        $values = array();
-        foreach ($this->languages as $language) {
-            $values['PS_TWO_TITLE'][(int) $language['id_lang']] = Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang']);
-            $values['PS_TWO_SUB_TITLE'][(int) $language['id_lang']] = Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang']);
-        }
-        Configuration::updateValue('PS_TWO_TITLE', $values['PS_TWO_TITLE']);
-        Configuration::updateValue('PS_TWO_SUB_TITLE', $values['PS_TWO_SUB_TITLE']);
         // If verification succeeded, use verified short name; else fallback to form (kept for safety)
         $shortNameToSave = $this->verifiedMerchantShortName ? $this->verifiedMerchantShortName : trim(Tools::getValue('PS_TWO_MERCHANT_SHORT_NAME'));
         Configuration::updateValue('PS_TWO_MERCHANT_SHORT_NAME', $shortNameToSave);
         Configuration::updateValue('PS_TWO_MERCHANT_API_KEY', trim(Tools::getValue('PS_TWO_MERCHANT_API_KEY')));
         Configuration::updateValue('PS_TWO_VENDOR_NAME', trim((string) Tools::getValue('PS_TWO_VENDOR_NAME')));
         Configuration::updateValue('PS_TWO_ENVIRONMENT', Tools::getValue('PS_TWO_ENVIRONMENT'));
-        Configuration::updateValue('PS_TWO_DEBUG_MODE', Tools::getValue('PS_TWO_DEBUG_MODE'));
+        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
         // The verdict from the live check the validation above just made, now
         // that the key it describes is the stored one (TWO-25326). This is the
         // freshest that key will ever have had, so it becomes what the checkout
@@ -1366,7 +1375,7 @@ class Twopayment extends PaymentModule
         $this->output .= $this->displayConfirmation($this->l('General settings are updated.'));
     }
 
-    protected function renderTwoPaymentSettingsForm()
+    protected function renderTwoCheckoutFieldsForm()
     {
         $helper = new HelperForm();
         $helper->show_toolbar = false;
@@ -1375,108 +1384,170 @@ class Twopayment extends PaymentModule
         $helper->module = $this;
         $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
         $helper->identifier = $this->identifier;
-        $helper->submit_action = 'submitTwoPaymentSettingsForm';
+        $helper->submit_action = 'submitTwoCheckoutFieldsForm';
         $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = array(
             'uri' => $this->getPathUri(),
-            'fields_value' => $this->getTwoPaymentSettingsFormValues(),
+            'fields_value' => $this->getTwoCheckoutFieldsFormValues(),
             'languages' => $this->context->controller->getLanguages(),
             'id_language' => $this->context->language->id,
         );
-        return $helper->generateForm(array($this->getTwoPaymentSettingsForm()));
+        return $helper->generateForm(array($this->getTwoCheckoutFieldsForm()));
     }
 
-    protected function getTwoPaymentSettingsForm()
+    /**
+     * Section B - Checkout Fields (TWO-25386 Part 1). Title/Subtitle/Sort
+     * order/Min order value+basis/Order intent/"What is Two" link/Tooltips,
+     * then the optional buyer inputs (invoice email, PO number, project,
+     * department) - relocated here from the former "General Settings" and
+     * "Payment Settings" panels. Pure reorganisation: every Configuration
+     * key, default and validation rule is unchanged from before this ticket.
+     */
+    protected function getTwoCheckoutFieldsForm()
     {
         $inputs = array(
             array(
-                'type' => 'radio',
-                'label' => $this->l('Payment Term Type'),
-                'name' => 'PS_TWO_PAYMENT_TERM_TYPE',
-                'desc' => $this->l('Choose how payment terms are calculated:') . '<br><br><strong>' . $this->l('Standard Terms:') . '</strong> ' . $this->l('Payment due X days from fulfillment date. Example: If you fulfill an order on January 15th with 30-day terms, payment is due February 14th.') . '<br><br><strong>' . $this->l('End-of-Month (EOM) Terms:') . '</strong> ' . $this->l('Payment due at the end of the current month plus X days from fulfillment date. Example: If you fulfill an order on January 15th with EOM+30 terms, payment is due February 28th (end of January + 30 days). This is common for B2B invoicing.'),
-                'is_bool' => false,
-                'values' => array(
-                    array(
-                        'id' => 'term_type_standard',
-                        'value' => 'STANDARD',
-                        'label' => $this->l('Standard Terms (e.g., 30 days from fulfillment)')
-                    ),
-                    array(
-                        'id' => 'term_type_eom',
-                        'value' => 'EOM',
-                        'label' => $this->l('End-of-Month Terms (e.g., EOM + 30 days)')
-                    ),
-                ),
+                'type' => 'text',
+                'label' => $this->l('Title'),
+                'desc' => $this->l('Enter a title which is appear on checkout page as payment method title.'),
+                'name' => 'PS_TWO_TITLE',
+                'required' => true,
+                'lang' => true,
             ),
-            array(
-                'type' => 'checkbox',
-                'label' => $this->l('Available Payment Terms'),
-                'name' => 'PS_TWO_PAYMENT_TERMS',
-                'desc' => '<span id="two-payment-terms-desc-standard" style="display: none;">' . $this->l('Select which payment terms you want to offer. Standard terms are calculated from the fulfillment date.') . '</span><span id="two-payment-terms-desc-eom" style="display: none;">' . $this->l('Select which payment terms you want to offer. EOM (End-of-Month) terms are calculated from the end of the month at fulfillment, plus the selected days. Only 30, 45, and 60 day terms are available for EOM.') . '</span>',
-                'values' => array(
-                    // Restrict the tickable set to the merchant's backend
-                    // available_terms (TWO-24813); admin render is one of
-                    // the two sanctioned refresh points.
-                    'query' => $this->buildPaymentTermCheckboxQuery(),
-                    'id' => 'id',
-                    'name' => 'name'
-                )
-            ),
-            // Custom payment term in days (TWO-25386, ported from
-            // magento-plugin's payment_terms_duration_days / woocommerce-plugin's
-            // payment_terms_custom_days): a merchant-typed term length in
-            // addition to the preset checkboxes above. Unioned into
-            // getAvailablePaymentTerms() when > 0 AND still within Two's own
-            // backend-permitted term set (see that method) - it bypasses the
-            // EOM/STANDARD checkbox split, never the backend restriction.
             array(
                 'type' => 'text',
-                'label' => $this->l('Custom payment term (days)'),
-                'name' => 'PS_TWO_PAYMENT_TERMS_CUSTOM_DAYS',
-                'required' => false,
-                'desc' => $this->l('Optional. Offer an additional payment term (in days) not covered by the presets above. Leave empty to only offer the terms selected above. Two must still permit this term length for your account - an unsupported value is silently ignored.'),
+                'label' => $this->l('Sub title'),
+                'desc' => $this->l('Enter a sub title which is appear on checkout page as payment method sub title.'),
+                'name' => 'PS_TWO_SUB_TITLE',
+                'required' => true,
+                'lang' => true,
             ),
-            // Default pre-selected term (TWO-25386 #10): an explicit admin
-            // choice that takes priority over getDefaultPaymentTerm()'s
-            // derived default (API due_in_days, else 30 days, else lowest
-            // offered term) whenever the chosen term is still offered. This is
-            // the highest-priority item in this batch per the ticket: the
-            // surcharge differential-basis calculation
-            // (buildTwoBuyerFeeShare -> getDefaultPaymentTerm) reads through
-            // this same function, so setting it here is what actually makes
-            // the surcharge calc respect the merchant's chosen default.
+            // Checkout sort order (TWO-25386 #6, ported from
+            // magento-plugin's Advanced > sort_order). Best-effort:
+            // PrestaShop core has no per-module sort_order config path
+            // for payment methods the way Magento does - the native
+            // mechanism is the hook_module position table, normally
+            // reordered by dragging in Payment > Preferences. Saving
+            // this field asks core to move this module to that
+            // position on the paymentOptions hook (see
+            // applyTwoCheckoutSortOrder()); it is stored regardless so
+            // the value survives even where the move itself cannot be
+            // applied.
             array(
-                'type' => 'select',
-                'label' => $this->l('Default pre-selected term'),
-                'name' => 'PS_TWO_DEFAULT_PAYMENT_TERM',
-                'desc' => $this->l('Which offered term is pre-selected at checkout by default. Leave unset to keep the automatic choice (the merchant\'s own default term when offered, else 30 days, else the shortest offered term).'),
-                'options' => array(
-                    'query' => $this->getTwoDefaultPaymentTermOptions(),
-                    'id' => 'id_option',
-                    'name' => 'name',
-                ),
+                'type' => 'text',
+                'label' => $this->l('Checkout sort order'),
+                'name' => 'PS_TWO_CHECKOUT_SORT_ORDER',
+                'required' => false,
+                'desc' => $this->l('Optional. A lower number shows Two earlier among the payment methods offered at checkout. Leave empty to use PrestaShop\'s own Payment > Preferences ordering.'),
             ),
         );
 
-        // Checkout fields (Magento two_payment > checkout_fields parity):
-        // optional buyer inputs, placed after the term selection and before
-        // the surcharge configuration.
+        // Minimum order value (TWO-24775): the merchant's own optional bar,
+        // stacked on top of the API-resolved platform minimum. Field UX
+        // mirrors woocommerce-plugin / magento-plugin: currency in the label
+        // ("Minimum Order Value, EUR"), platform floor in the description,
+        // net/gross basis selector.
+        $default_currency_iso = $this->getTwoShopDefaultCurrencyIso();
+        $inputs[] = array(
+            'type' => 'text',
+            'label' => $default_currency_iso !== ''
+                ? sprintf($this->l('Minimum Order Value, %s'), $default_currency_iso)
+                : $this->l('Minimum Order Value'),
+            'name' => 'PS_TWO_MERCHANT_MIN_ORDER',
+            'desc' => $this->getTwoMerchantMinimumOrderDescription(),
+        );
+        $inputs[] = array(
+            'type' => 'select',
+            'label' => $this->l('Minimum Order Value Tax Basis'),
+            'name' => 'PS_TWO_MERCHANT_MIN_ORDER_BASIS',
+            'desc' => $this->l('Whether the basket is compared against the minimum including or excluding tax.'),
+            'options' => array(
+                'query' => array(
+                    array('id_option' => 'gross', 'name' => $this->l('Including tax (gross)')),
+                    array('id_option' => 'net', 'name' => $this->l('Excluding tax (net)')),
+                ),
+                'id' => 'id_option',
+                'name' => 'name',
+            ),
+        );
+
+        // Order intent / pre-approve toggle (TWO-25386 #8, NEW control - not a
+        // port). PS already runs the order-intent pre-approval check
+        // (controllers/front/orderintent.php ajaxProcessCheckOrderIntent)
+        // unconditionally on every payment-step render; this is the first
+        // admin switch for it. Gates the FRONT CONTROLLER's pre-approval
+        // preview call only (both server-side here and client-side via
+        // window.twopayment.enable_order_intent, see twopayment.js /
+        // TwoCheckoutManager.js) - it deliberately does NOT touch
+        // checkTwoOrderIntentApprovalAtPayment(), the authoritative check Two
+        // always runs at actual payment submission, so turning this off never
+        // lets an order through without Two's real approval - it only removes
+        // the early "will this be approved" preview shown during checkout.
+        // Default ON, matching the pre-existing always-on behaviour.
+        $inputs[] = array(
+            'type' => 'switch',
+            'label' => $this->l('Enable order intent pre-approval check'),
+            'name' => 'PS_TWO_ENABLE_ORDER_INTENT',
+            'is_bool' => true,
+            'desc' => $this->l('If you choose YES then the checkout calls Two to preview order approval before the buyer submits payment, and reflects the result in the payment tile. If you choose NO, this preview call is skipped - the buyer still goes through Two\'s real approval check when they submit payment.'),
+            'required' => true,
+            'values' => array(
+                array('id' => 'PS_TWO_ENABLE_ORDER_INTENT_ON', 'value' => 1, 'label' => $this->l('Yes')),
+                array('id' => 'PS_TWO_ENABLE_ORDER_INTENT_OFF', 'value' => 0, 'label' => $this->l('No')),
+            ),
+        );
+        // "What is Two" explainer link (TWO-25386, ported from
+        // woocommerce-plugin's `show_abt_link`): shows/hides the "What is
+        // Two?" info tooltip already rendered in the payment tile
+        // (views/templates/hook/paymentinfo.tpl). Default ON, matching the
+        // tile's pre-existing always-on behaviour.
+        $inputs[] = array(
+            'type' => 'switch',
+            'label' => $this->l('Show "What is Two" explainer link'),
+            'name' => 'PS_TWO_SHOW_ABOUT_LINK',
+            'is_bool' => true,
+            'desc' => $this->l('If you choose YES then buyers see a "What is Two?" info tooltip with a link to an explainer resource in the Two payment tile at checkout.'),
+            'required' => true,
+            'values' => array(
+                array('id' => 'PS_TWO_SHOW_ABOUT_LINK_ON', 'value' => 1, 'label' => $this->l('Yes')),
+                array('id' => 'PS_TWO_SHOW_ABOUT_LINK_OFF', 'value' => 0, 'label' => $this->l('No')),
+            ),
+        );
+        // Display input tooltips (TWO-25386, ported from woocommerce-plugin's
+        // `display_tooltips`): whether the optional checkout field inputs
+        // (invoice email, PO number, project, department) show a help tooltip
+        // on their label. Default OFF, matching woocommerce-plugin's default.
+        $inputs[] = array(
+            'type' => 'switch',
+            'label' => $this->l('Display input tooltips'),
+            'name' => 'PS_TWO_DISPLAY_TOOLTIPS',
+            'is_bool' => true,
+            'desc' => $this->l('If you choose YES then the optional checkout fields above show a short help tooltip on their label.'),
+            'required' => true,
+            'values' => array(
+                array('id' => 'PS_TWO_DISPLAY_TOOLTIPS_ON', 'value' => 1, 'label' => $this->l('Yes')),
+                array('id' => 'PS_TWO_DISPLAY_TOOLTIPS_OFF', 'value' => 0, 'label' => $this->l('No')),
+            ),
+        );
+
+        // Optional buyer inputs (Magento two_payment > checkout_fields
+        // parity). All four render inside the Two payment tile at the
+        // payment step, NOT in the billing address block. PrestaShop asks
+        // for the SHIPPING address first and only reveals the billing block
+        // when the buyer ticks "Billing address differs from shipping
+        // address", so anything hosted there is invisible to most buyers -
+        // which is exactly what happened to department and project before
+        // this release.
         //
-        // All four render inside the Two payment tile at the payment step, NOT
-        // in the billing address block. PrestaShop asks for the SHIPPING
-        // address first and only reveals the billing block when the buyer ticks
-        // "Billing address differs from shipping address", so anything hosted
-        // there is invisible to most buyers - which is exactly what happened to
-        // department and project before this release.
-        //
-        // ORDER IS LOAD-BEARING and must stay in step with
+        // ORDER IS LOAD-BEARING (TWO-25263) and must stay in step with
         // self::OPTIONAL_CHECKOUT_FIELDS, which is what the checkout tile
-        // iterates: invoice email, purchase order number, project, department.
-        // The switches read top-to-bottom in the same sequence the buyer sees.
-        // The order note completes that standard sequence but has no switch and
-        // no tile field - it is PrestaShop core's own `delivery_message` on the
-        // shipping step (see the constant's comment).
+        // iterates: invoice email, purchase order number, project,
+        // department. The switches read top-to-bottom in the same sequence
+        // the buyer sees. The order note completes that standard sequence
+        // but has no switch and no tile field - it is PrestaShop core's own
+        // `delivery_message` on the shipping step (see the constant's
+        // comment) and has no admin field to relocate.
         $inputs[] = array(
             'type' => 'switch',
             'label' => $this->l('Show Invoice email field'),
@@ -1558,102 +1629,131 @@ class Twopayment extends PaymentModule
                 ),
             ),
         );
-        // "What is Two" explainer link (TWO-25386, ported from
-        // woocommerce-plugin's `show_abt_link`): shows/hides the "What is
-        // Two?" info tooltip already rendered in the payment tile
-        // (views/templates/hook/paymentinfo.tpl). Default ON, matching the
-        // tile's pre-existing always-on behaviour.
-        $inputs[] = array(
-            'type' => 'switch',
-            'label' => $this->l('Show "What is Two" explainer link'),
-            'name' => 'PS_TWO_SHOW_ABOUT_LINK',
-            'is_bool' => true,
-            'desc' => $this->l('If you choose YES then buyers see a "What is Two?" info tooltip with a link to an explainer resource in the Two payment tile at checkout.'),
-            'required' => true,
-            'values' => array(
-                array('id' => 'PS_TWO_SHOW_ABOUT_LINK_ON', 'value' => 1, 'label' => $this->l('Yes')),
-                array('id' => 'PS_TWO_SHOW_ABOUT_LINK_OFF', 'value' => 0, 'label' => $this->l('No')),
-            ),
-        );
-        // Display input tooltips (TWO-25386, ported from woocommerce-plugin's
-        // `display_tooltips`): whether the optional checkout field inputs
-        // (invoice email, PO number, project, department) show a help tooltip
-        // on their label. Default OFF, matching woocommerce-plugin's default.
-        $inputs[] = array(
-            'type' => 'switch',
-            'label' => $this->l('Display input tooltips'),
-            'name' => 'PS_TWO_DISPLAY_TOOLTIPS',
-            'is_bool' => true,
-            'desc' => $this->l('If you choose YES then the optional checkout fields above show a short help tooltip on their label.'),
-            'required' => true,
-            'values' => array(
-                array('id' => 'PS_TWO_DISPLAY_TOOLTIPS_ON', 'value' => 1, 'label' => $this->l('Yes')),
-                array('id' => 'PS_TWO_DISPLAY_TOOLTIPS_OFF', 'value' => 0, 'label' => $this->l('No')),
-            ),
-        );
-        // Order intent / pre-approve toggle (TWO-25386 #8, NEW control - not a
-        // port). PS already runs the order-intent pre-approval check
-        // (controllers/front/orderintent.php ajaxProcessCheckOrderIntent)
-        // unconditionally on every payment-step render; this is the first
-        // admin switch for it. Gates the FRONT CONTROLLER's pre-approval
-        // preview call only (both server-side here and client-side via
-        // window.twopayment.enable_order_intent, see twopayment.js /
-        // TwoCheckoutManager.js) - it deliberately does NOT touch
-        // checkTwoOrderIntentApprovalAtPayment(), the authoritative check Two
-        // always runs at actual payment submission, so turning this off never
-        // lets an order through without Two's real approval - it only removes
-        // the early "will this be approved" preview shown during checkout.
-        // Default ON, matching the pre-existing always-on behaviour.
-        $inputs[] = array(
-            'type' => 'switch',
-            'label' => $this->l('Enable order intent pre-approval check'),
-            'name' => 'PS_TWO_ENABLE_ORDER_INTENT',
-            'is_bool' => true,
-            'desc' => $this->l('If you choose YES then the checkout calls Two to preview order approval before the buyer submits payment, and reflects the result in the payment tile. If you choose NO, this preview call is skipped - the buyer still goes through Two\'s real approval check when they submit payment.'),
-            'required' => true,
-            'values' => array(
-                array('id' => 'PS_TWO_ENABLE_ORDER_INTENT_ON', 'value' => 1, 'label' => $this->l('Yes')),
-                array('id' => 'PS_TWO_ENABLE_ORDER_INTENT_OFF', 'value' => 0, 'label' => $this->l('No')),
-            ),
-        );
-        // Offset pricing fee (buyer surcharge) fields — appended so the
-        // per-term grid reflects the merchant's currently-offered terms.
-        // TWO-24752 / TWO-24893.
-        $inputs = array_merge($inputs, $this->getTwoSurchargeFormInputs());
-
-        // Minimum order value (TWO-24775): the merchant's own optional bar,
-        // stacked on top of the API-resolved platform minimum. Field UX
-        // mirrors woocommerce-plugin / magento-plugin: currency in the label
-        // ("Minimum Order Value, EUR"), platform floor in the description,
-        // net/gross basis selector.
-        $default_currency_iso = $this->getTwoShopDefaultCurrencyIso();
-        $inputs[] = array(
-            'type' => 'text',
-            'label' => $default_currency_iso !== ''
-                ? sprintf($this->l('Minimum Order Value, %s'), $default_currency_iso)
-                : $this->l('Minimum Order Value'),
-            'name' => 'PS_TWO_MERCHANT_MIN_ORDER',
-            'desc' => $this->getTwoMerchantMinimumOrderDescription(),
-        );
-        $inputs[] = array(
-            'type' => 'select',
-            'label' => $this->l('Minimum Order Value Tax Basis'),
-            'name' => 'PS_TWO_MERCHANT_MIN_ORDER_BASIS',
-            'desc' => $this->l('Whether the basket is compared against the minimum including or excluding tax.'),
-            'options' => array(
-                'query' => array(
-                    array('id_option' => 'gross', 'name' => $this->l('Including tax (gross)')),
-                    array('id_option' => 'net', 'name' => $this->l('Excluding tax (net)')),
-                ),
-                'id' => 'id_option',
-                'name' => 'name',
-            ),
-        );
 
         return array(
             'form' => array(
                 'legend' => array(
-                    'title' => $this->l('Payment Settings'),
+                    'title' => $this->l('Checkout Fields'),
+                    'icon' => 'icon-list-alt',
+                ),
+                'input' => $inputs,
+                'submit' => array(
+                    'title' => $this->l('Save'),
+                ),
+            ),
+        );
+    }
+
+    protected function renderTwoPaymentTermsForm()
+    {
+        $helper = new HelperForm();
+        $helper->show_toolbar = false;
+        $helper->table = $this->table;
+        $helper->default_form_language = (int) Configuration::get('PS_LANG_DEFAULT');
+        $helper->module = $this;
+        $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
+        $helper->identifier = $this->identifier;
+        $helper->submit_action = 'submitTwoPaymentTermsForm';
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+        $helper->tpl_vars = array(
+            'uri' => $this->getPathUri(),
+            'fields_value' => $this->getTwoPaymentTermsFormValues(),
+            'languages' => $this->context->controller->getLanguages(),
+            'id_language' => $this->context->language->id,
+        );
+        return $helper->generateForm(array($this->getTwoPaymentTermsForm()));
+    }
+
+    /**
+     * Section D - Payment Terms (TWO-25386 Part 1). Term type, offered
+     * terms, custom term days, default term, then the surcharge
+     * method -> basis -> line description -> per-term grid -> rounding ->
+     * tax treatment/class controls (getTwoSurchargeFormInputs), in that
+     * relative sub-order - relocated here from the former "Payment
+     * Settings" panel.
+     */
+    protected function getTwoPaymentTermsForm()
+    {
+        $inputs = array(
+            array(
+                'type' => 'radio',
+                'label' => $this->l('Payment Term Type'),
+                'name' => 'PS_TWO_PAYMENT_TERM_TYPE',
+                'desc' => $this->l('Choose how payment terms are calculated:') . '<br><br><strong>' . $this->l('Standard Terms:') . '</strong> ' . $this->l('Payment due X days from fulfillment date. Example: If you fulfill an order on January 15th with 30-day terms, payment is due February 14th.') . '<br><br><strong>' . $this->l('End-of-Month (EOM) Terms:') . '</strong> ' . $this->l('Payment due at the end of the current month plus X days from fulfillment date. Example: If you fulfill an order on January 15th with EOM+30 terms, payment is due February 28th (end of January + 30 days). This is common for B2B invoicing.'),
+                'is_bool' => false,
+                'values' => array(
+                    array(
+                        'id' => 'term_type_standard',
+                        'value' => 'STANDARD',
+                        'label' => $this->l('Standard Terms (e.g., 30 days from fulfillment)')
+                    ),
+                    array(
+                        'id' => 'term_type_eom',
+                        'value' => 'EOM',
+                        'label' => $this->l('End-of-Month Terms (e.g., EOM + 30 days)')
+                    ),
+                ),
+            ),
+            array(
+                'type' => 'checkbox',
+                'label' => $this->l('Available Payment Terms'),
+                'name' => 'PS_TWO_PAYMENT_TERMS',
+                'desc' => '<span id="two-payment-terms-desc-standard" style="display: none;">' . $this->l('Select which payment terms you want to offer. Standard terms are calculated from the fulfillment date.') . '</span><span id="two-payment-terms-desc-eom" style="display: none;">' . $this->l('Select which payment terms you want to offer. EOM (End-of-Month) terms are calculated from the end of the month at fulfillment, plus the selected days. Only 30, 45, and 60 day terms are available for EOM.') . '</span>',
+                'values' => array(
+                    // Restrict the tickable set to the merchant's backend
+                    // available_terms (TWO-24813); admin render is one of
+                    // the two sanctioned refresh points.
+                    'query' => $this->buildPaymentTermCheckboxQuery(),
+                    'id' => 'id',
+                    'name' => 'name'
+                )
+            ),
+            // Custom payment term in days (TWO-25386, ported from
+            // magento-plugin's payment_terms_duration_days / woocommerce-plugin's
+            // payment_terms_custom_days): a merchant-typed term length in
+            // addition to the preset checkboxes above. Unioned into
+            // getAvailablePaymentTerms() when > 0 AND still within Two's own
+            // backend-permitted term set (see that method) - it bypasses the
+            // EOM/STANDARD checkbox split, never the backend restriction.
+            array(
+                'type' => 'text',
+                'label' => $this->l('Custom payment term (days)'),
+                'name' => 'PS_TWO_PAYMENT_TERMS_CUSTOM_DAYS',
+                'required' => false,
+                'desc' => $this->l('Optional. Offer an additional payment term (in days) not covered by the presets above. Leave empty to only offer the terms selected above. Two must still permit this term length for your account - an unsupported value is silently ignored.'),
+            ),
+            // Default pre-selected term (TWO-25386 #10): an explicit admin
+            // choice that takes priority over getDefaultPaymentTerm()'s
+            // derived default (API due_in_days, else 30 days, else lowest
+            // offered term) whenever the chosen term is still offered. This is
+            // the highest-priority item in this batch per the ticket: the
+            // surcharge differential-basis calculation
+            // (buildTwoBuyerFeeShare -> getDefaultPaymentTerm) reads through
+            // this same function, so setting it here is what actually makes
+            // the surcharge calc respect the merchant's chosen default.
+            array(
+                'type' => 'select',
+                'label' => $this->l('Default pre-selected term'),
+                'name' => 'PS_TWO_DEFAULT_PAYMENT_TERM',
+                'desc' => $this->l('Which offered term is pre-selected at checkout by default. Leave unset to keep the automatic choice (the merchant\'s own default term when offered, else 30 days, else the shortest offered term).'),
+                'options' => array(
+                    'query' => $this->getTwoDefaultPaymentTermOptions(),
+                    'id' => 'id_option',
+                    'name' => 'name',
+                ),
+            ),
+        );
+
+        // Offset pricing fee (buyer surcharge) fields — method, basis, line
+        // description, per-term grid, rounding, tax treatment/class, in
+        // that relative sub-order. TWO-24752 / TWO-24893.
+        $inputs = array_merge($inputs, $this->getTwoSurchargeFormInputs());
+
+        return array(
+            'form' => array(
+                'legend' => array(
+                    'title' => $this->l('Payment Terms'),
                     'icon' => 'icon-money',
                 ),
                 'input' => $inputs,
@@ -1664,26 +1764,145 @@ class Twopayment extends PaymentModule
         );
     }
 
-    protected function getTwoPaymentSettingsFormValues()
+    protected function getTwoCheckoutFieldsFormValues()
+    {
+        $fields_values = array();
+        foreach ($this->languages as $language) {
+            $fields_values['PS_TWO_TITLE'][$language['id_lang']] = Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang'], Configuration::get('PS_TWO_TITLE', (int) $language['id_lang']));
+            $fields_values['PS_TWO_SUB_TITLE'][$language['id_lang']] = Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang'], Configuration::get('PS_TWO_SUB_TITLE', (int) $language['id_lang']));
+        }
+        $fields_values['PS_TWO_CHECKOUT_SORT_ORDER'] = Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER', Configuration::get('PS_TWO_CHECKOUT_SORT_ORDER'));
+
+        $fields_values['PS_TWO_MERCHANT_MIN_ORDER'] = Tools::getValue(
+            'PS_TWO_MERCHANT_MIN_ORDER',
+            Configuration::get(self::CONFIG_MERCHANT_MIN_ORDER)
+        );
+        $saved_basis = Configuration::get(self::CONFIG_MERCHANT_MIN_ORDER_BASIS);
+        $fields_values['PS_TWO_MERCHANT_MIN_ORDER_BASIS'] = Tools::getValue(
+            'PS_TWO_MERCHANT_MIN_ORDER_BASIS',
+            in_array($saved_basis, array('net', 'gross'), true) ? $saved_basis : 'gross'
+        );
+
+        // Default-on switches (TWO-25386): an absent/empty stored row must
+        // read as enabled, matching the behaviour these switches shipped
+        // replacing (the "what is Two" tooltip and the order-intent preview
+        // call were both previously unconditional).
+        $fields_values['PS_TWO_ENABLE_ORDER_INTENT'] = Tools::getValue('PS_TWO_ENABLE_ORDER_INTENT', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_ENABLE_ORDER_INTENT'));
+        $fields_values['PS_TWO_SHOW_ABOUT_LINK'] = Tools::getValue('PS_TWO_SHOW_ABOUT_LINK', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_SHOW_ABOUT_LINK'));
+        $fields_values['PS_TWO_DISPLAY_TOOLTIPS'] = Tools::getValue('PS_TWO_DISPLAY_TOOLTIPS', Configuration::get('PS_TWO_DISPLAY_TOOLTIPS'));
+
+        // Optional buyer inputs. Standard field order, same as the form
+        // inputs and the checkout tile (TWO-25263).
+        $fields_values['PS_TWO_ENABLE_INVOICE_EMAIL'] = Tools::getValue('PS_TWO_ENABLE_INVOICE_EMAIL', Configuration::get('PS_TWO_ENABLE_INVOICE_EMAIL'));
+        $fields_values['PS_TWO_ENABLE_PO_NUMBER'] = Tools::getValue('PS_TWO_ENABLE_PO_NUMBER', Configuration::get('PS_TWO_ENABLE_PO_NUMBER'));
+        $fields_values['PS_TWO_ENABLE_PROJECT'] = Tools::getValue('PS_TWO_ENABLE_PROJECT', Configuration::get('PS_TWO_ENABLE_PROJECT'));
+        $fields_values['PS_TWO_ENABLE_DEPARTMENT'] = Tools::getValue('PS_TWO_ENABLE_DEPARTMENT', Configuration::get('PS_TWO_ENABLE_DEPARTMENT'));
+
+        return $fields_values;
+    }
+
+    protected function validTwoCheckoutFieldsFormValues()
+    {
+        foreach ($this->languages as $language) {
+            if (Tools::isEmpty(Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang']))) {
+                $this->errors[] = $this->l('Enter a title.');
+            }
+            if (Tools::isEmpty(Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang']))) {
+                $this->errors[] = $this->l('Enter a sub title.');
+            }
+        }
+
+        $this->validTwoCheckoutSortOrderValue();
+
+        // Minimum order value (TWO-24775): numeric and non-negative always;
+        // at least the platform floor when one is resolved AND expressible in
+        // the shop default currency. A floor that cannot be converted (no
+        // rate) skips the numeric check - the checkout gate enforces both
+        // minima independently (magento-plugin beforeSave parity).
+        $raw_minimum = trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER'));
+        if ($raw_minimum !== '') {
+            $normalised = str_replace(',', '.', $raw_minimum);
+            if (!is_numeric($normalised) || (float) $normalised < 0) {
+                $this->errors[] = $this->l('Minimum Order Value must be a non-negative number.');
+            } elseif ((float) $normalised > 0) {
+                $platform_minimum = $this->getPlatformMinimumOrder();
+                if ($platform_minimum) {
+                    $floor = $this->convertTwoAmountBetweenCurrencies(
+                        $platform_minimum['amount'],
+                        $platform_minimum['currency'],
+                        $this->getTwoShopDefaultCurrencyIso()
+                    );
+                    if ($floor !== null && (float) $normalised < $floor) {
+                        $this->errors[] = sprintf(
+                            $this->l('Minimum Order Value must be at least the platform minimum of %1$s, %2$s tax.'),
+                            $floor . ' ' . $this->getTwoShopDefaultCurrencyIso()
+                                . ($this->getTwoShopDefaultCurrencyIso() !== $platform_minimum['currency']
+                                    ? ' (' . $platform_minimum['amount'] . ' ' . $platform_minimum['currency'] . ')'
+                                    : ''),
+                            $platform_minimum['basis'] === 'gross' ? $this->l('including') : $this->l('excluding')
+                        );
+                    }
+                }
+            }
+        }
+        $basis = (string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS');
+        if ($basis !== '' && !in_array($basis, array('net', 'gross'), true)) {
+            $this->errors[] = $this->l('Minimum Order Value Tax Basis must be either including or excluding tax.');
+        }
+    }
+
+    protected function saveTwoCheckoutFieldsFormValues()
+    {
+        $values = array();
+        foreach ($this->languages as $language) {
+            $values['PS_TWO_TITLE'][(int) $language['id_lang']] = Tools::getValue('PS_TWO_TITLE_' . (int) $language['id_lang']);
+            $values['PS_TWO_SUB_TITLE'][(int) $language['id_lang']] = Tools::getValue('PS_TWO_SUB_TITLE_' . (int) $language['id_lang']);
+        }
+        Configuration::updateValue('PS_TWO_TITLE', $values['PS_TWO_TITLE']);
+        Configuration::updateValue('PS_TWO_SUB_TITLE', $values['PS_TWO_SUB_TITLE']);
+
+        // Checkout sort order (TWO-25386 #6). Passed validTwoCheckoutSortOrderValue
+        // above (empty, or a plain integer).
+        $raw_sort_order = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
+        Configuration::updateValue(
+            'PS_TWO_CHECKOUT_SORT_ORDER',
+            ($raw_sort_order !== '' && preg_match('/^-?\d+$/', $raw_sort_order)) ? $raw_sort_order : ''
+        );
+        $this->applyTwoCheckoutSortOrder();
+
+        // Minimum order value (TWO-24775). Normalise the decimal comma; store
+        // '' when empty (no merchant minimum). Values reaching here passed
+        // validTwoCheckoutFieldsFormValues (the caller aborts on errors).
+        $raw_minimum = trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER'));
+        Configuration::updateValue(
+            self::CONFIG_MERCHANT_MIN_ORDER,
+            $raw_minimum === '' ? '' : str_replace(',', '.', $raw_minimum)
+        );
+        $basis = (string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS');
+        if (in_array($basis, array('net', 'gross'), true)) {
+            Configuration::updateValue(self::CONFIG_MERCHANT_MIN_ORDER_BASIS, $basis);
+        }
+
+        Configuration::updateValue('PS_TWO_ENABLE_ORDER_INTENT', (int) Tools::getValue('PS_TWO_ENABLE_ORDER_INTENT', 1));
+        Configuration::updateValue('PS_TWO_SHOW_ABOUT_LINK', (int) Tools::getValue('PS_TWO_SHOW_ABOUT_LINK', 1));
+        Configuration::updateValue('PS_TWO_DISPLAY_TOOLTIPS', (int) Tools::getValue('PS_TWO_DISPLAY_TOOLTIPS', 0));
+
+        // Optional buyer inputs (moved from the former "Payment Settings" tab).
+        // Standard field order, same as the form inputs and the checkout tile.
+        Configuration::updateValue('PS_TWO_ENABLE_INVOICE_EMAIL', Tools::getValue('PS_TWO_ENABLE_INVOICE_EMAIL'));
+        Configuration::updateValue('PS_TWO_ENABLE_PO_NUMBER', Tools::getValue('PS_TWO_ENABLE_PO_NUMBER'));
+        Configuration::updateValue('PS_TWO_ENABLE_PROJECT', Tools::getValue('PS_TWO_ENABLE_PROJECT'));
+        Configuration::updateValue('PS_TWO_ENABLE_DEPARTMENT', Tools::getValue('PS_TWO_ENABLE_DEPARTMENT'));
+
+        $this->output .= $this->displayConfirmation($this->l('Checkout field settings are updated.'));
+    }
+
+    protected function getTwoPaymentTermsFormValues()
     {
         $fields_values = array();
 
         // Payment term type (STANDARD or EOM)
         $fields_values['PS_TWO_PAYMENT_TERM_TYPE'] = Tools::getValue('PS_TWO_PAYMENT_TERM_TYPE', Configuration::get('PS_TWO_PAYMENT_TERM_TYPE'));
-
-        // Checkout fields (moved from the former "Other Settings" tab).
-        // Standard field order, same as the form inputs and the checkout tile.
-        $fields_values['PS_TWO_ENABLE_INVOICE_EMAIL'] = Tools::getValue('PS_TWO_ENABLE_INVOICE_EMAIL', Configuration::get('PS_TWO_ENABLE_INVOICE_EMAIL'));
-        $fields_values['PS_TWO_ENABLE_PO_NUMBER'] = Tools::getValue('PS_TWO_ENABLE_PO_NUMBER', Configuration::get('PS_TWO_ENABLE_PO_NUMBER'));
-        $fields_values['PS_TWO_ENABLE_PROJECT'] = Tools::getValue('PS_TWO_ENABLE_PROJECT', Configuration::get('PS_TWO_ENABLE_PROJECT'));
-        $fields_values['PS_TWO_ENABLE_DEPARTMENT'] = Tools::getValue('PS_TWO_ENABLE_DEPARTMENT', Configuration::get('PS_TWO_ENABLE_DEPARTMENT'));
-        // Default-on switches (TWO-25386): an absent/empty stored row must
-        // read as enabled, matching the behaviour these switches shipped
-        // replacing (the "what is Two" tooltip and the order-intent preview
-        // call were both previously unconditional).
-        $fields_values['PS_TWO_SHOW_ABOUT_LINK'] = Tools::getValue('PS_TWO_SHOW_ABOUT_LINK', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_SHOW_ABOUT_LINK'));
-        $fields_values['PS_TWO_DISPLAY_TOOLTIPS'] = Tools::getValue('PS_TWO_DISPLAY_TOOLTIPS', Configuration::get('PS_TWO_DISPLAY_TOOLTIPS'));
-        $fields_values['PS_TWO_ENABLE_ORDER_INTENT'] = Tools::getValue('PS_TWO_ENABLE_ORDER_INTENT', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_ENABLE_ORDER_INTENT'));
 
         // Payment terms checkboxes
         $payment_terms = array_map('strval', self::PAYMENT_TERMS_OPTIONS);
@@ -1694,16 +1913,6 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_DEFAULT_PAYMENT_TERM'] = (string) Tools::getValue(
             'PS_TWO_DEFAULT_PAYMENT_TERM',
             $this->getTwoDefaultPaymentTermFormDefault()
-        );
-
-        $fields_values['PS_TWO_MERCHANT_MIN_ORDER'] = Tools::getValue(
-            'PS_TWO_MERCHANT_MIN_ORDER',
-            Configuration::get(self::CONFIG_MERCHANT_MIN_ORDER)
-        );
-        $saved_basis = Configuration::get(self::CONFIG_MERCHANT_MIN_ORDER_BASIS);
-        $fields_values['PS_TWO_MERCHANT_MIN_ORDER_BASIS'] = Tools::getValue(
-            'PS_TWO_MERCHANT_MIN_ORDER_BASIS',
-            in_array($saved_basis, array('net', 'gross'), true) ? $saved_basis : 'gross'
         );
 
         $fields_values = array_merge($fields_values, $this->getTwoSurchargeFormValues());
@@ -1827,7 +2036,7 @@ class Twopayment extends PaymentModule
         return in_array((int) $stored, $this->getAvailablePaymentTerms(), true) ? $stored : '';
     }
 
-    protected function validTwoPaymentSettingsFormValues()
+    protected function validTwoPaymentTermsFormValues()
     {
         // Validate payment terms
         $payment_terms = array_map('strval', self::PAYMENT_TERMS_OPTIONS);
@@ -1842,42 +2051,6 @@ class Twopayment extends PaymentModule
             $this->errors[] = $this->l('You must select at least one payment term.');
         }
 
-        // Minimum order value (TWO-24775): numeric and non-negative always;
-        // at least the platform floor when one is resolved AND expressible in
-        // the shop default currency. A floor that cannot be converted (no
-        // rate) skips the numeric check - the checkout gate enforces both
-        // minima independently (magento-plugin beforeSave parity).
-        $raw_minimum = trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER'));
-        if ($raw_minimum !== '') {
-            $normalised = str_replace(',', '.', $raw_minimum);
-            if (!is_numeric($normalised) || (float) $normalised < 0) {
-                $this->errors[] = $this->l('Minimum Order Value must be a non-negative number.');
-            } elseif ((float) $normalised > 0) {
-                $platform_minimum = $this->getPlatformMinimumOrder();
-                if ($platform_minimum) {
-                    $floor = $this->convertTwoAmountBetweenCurrencies(
-                        $platform_minimum['amount'],
-                        $platform_minimum['currency'],
-                        $this->getTwoShopDefaultCurrencyIso()
-                    );
-                    if ($floor !== null && (float) $normalised < $floor) {
-                        $this->errors[] = sprintf(
-                            $this->l('Minimum Order Value must be at least the platform minimum of %1$s, %2$s tax.'),
-                            $floor . ' ' . $this->getTwoShopDefaultCurrencyIso()
-                                . ($this->getTwoShopDefaultCurrencyIso() !== $platform_minimum['currency']
-                                    ? ' (' . $platform_minimum['amount'] . ' ' . $platform_minimum['currency'] . ')'
-                                    : ''),
-                            $platform_minimum['basis'] === 'gross' ? $this->l('including') : $this->l('excluding')
-                        );
-                    }
-                }
-            }
-        }
-        $basis = (string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS');
-        if ($basis !== '' && !in_array($basis, array('net', 'gross'), true)) {
-            $this->errors[] = $this->l('Minimum Order Value Tax Basis must be either including or excluding tax.');
-        }
-
         // Custom payment term days (TWO-25386 #9): empty is a legitimate "no
         // custom term" state; anything non-empty must be a positive integer.
         $raw_custom_days = trim((string) Tools::getValue('PS_TWO_PAYMENT_TERMS_CUSTOM_DAYS'));
@@ -1888,23 +2061,13 @@ class Twopayment extends PaymentModule
         $this->validTwoSurchargeFormValues();
     }
 
-    protected function saveTwoPaymentSettingsFormValues()
+    protected function saveTwoPaymentTermsFormValues()
     {
         // Save payment term type (STANDARD or EOM)
         $term_type = Tools::getValue('PS_TWO_PAYMENT_TERM_TYPE');
         if ($term_type === 'STANDARD' || $term_type === 'EOM') {
             Configuration::updateValue('PS_TWO_PAYMENT_TERM_TYPE', $term_type);
         }
-
-        // Checkout fields (moved from the former "Other Settings" tab).
-        // Standard field order, same as the form inputs and the checkout tile.
-        Configuration::updateValue('PS_TWO_ENABLE_INVOICE_EMAIL', Tools::getValue('PS_TWO_ENABLE_INVOICE_EMAIL'));
-        Configuration::updateValue('PS_TWO_ENABLE_PO_NUMBER', Tools::getValue('PS_TWO_ENABLE_PO_NUMBER'));
-        Configuration::updateValue('PS_TWO_ENABLE_PROJECT', Tools::getValue('PS_TWO_ENABLE_PROJECT'));
-        Configuration::updateValue('PS_TWO_ENABLE_DEPARTMENT', Tools::getValue('PS_TWO_ENABLE_DEPARTMENT'));
-        Configuration::updateValue('PS_TWO_SHOW_ABOUT_LINK', (int) Tools::getValue('PS_TWO_SHOW_ABOUT_LINK', 1));
-        Configuration::updateValue('PS_TWO_DISPLAY_TOOLTIPS', (int) Tools::getValue('PS_TWO_DISPLAY_TOOLTIPS', 0));
-        Configuration::updateValue('PS_TWO_ENABLE_ORDER_INTENT', (int) Tools::getValue('PS_TWO_ENABLE_ORDER_INTENT', 1));
 
         // Save payment terms checkboxes. Iterate ONLY the terms the admin form
         // actually rendered (the backend-restricted offerable source), NOT the
@@ -1921,7 +2084,7 @@ class Twopayment extends PaymentModule
         }
 
         // Custom payment term days (TWO-25386 #9). Passed
-        // validTwoPaymentSettingsFormValues above (digits-only, > 0, or
+        // validTwoPaymentTermsFormValues above (digits-only, > 0, or
         // empty).
         $raw_custom_days = trim((string) Tools::getValue('PS_TWO_PAYMENT_TERMS_CUSTOM_DAYS'));
         Configuration::updateValue(
@@ -1948,25 +2111,12 @@ class Twopayment extends PaymentModule
         }
         Configuration::updateValue('PS_TWO_DEFAULT_PAYMENT_TERM', $default_term_to_store);
 
-        // Minimum order value (TWO-24775). Normalise the decimal comma; store
-        // '' when empty (no merchant minimum). Values reaching here passed
-        // validTwoPaymentSettingsFormValues (the caller aborts on errors).
-        $raw_minimum = trim((string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER'));
-        Configuration::updateValue(
-            self::CONFIG_MERCHANT_MIN_ORDER,
-            $raw_minimum === '' ? '' : str_replace(',', '.', $raw_minimum)
-        );
-        $basis = (string) Tools::getValue('PS_TWO_MERCHANT_MIN_ORDER_BASIS');
-        if (in_array($basis, array('net', 'gross'), true)) {
-            Configuration::updateValue(self::CONFIG_MERCHANT_MIN_ORDER_BASIS, $basis);
-        }
-
         $this->saveTwoSurchargeFormValues();
 
-        $this->output .= $this->displayConfirmation($this->l('Payment settings are updated.'));
+        $this->output .= $this->displayConfirmation($this->l('Payment terms settings are updated.'));
     }
 
-    protected function renderTwoOtherForm()
+    protected function renderTwoCompanyLookupForm()
     {
         $helper = new HelperForm();
         $helper->show_toolbar = false;
@@ -1975,25 +2125,30 @@ class Twopayment extends PaymentModule
         $helper->module = $this;
         $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
         $helper->identifier = $this->identifier;
-        $helper->submit_action = 'submitTwoOtherForm';
+        $helper->submit_action = 'submitTwoCompanyLookupForm';
         $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = array(
             'uri' => $this->getPathUri(),
-            'fields_value' => $this->getTwoOtherFormValues(),
+            'fields_value' => $this->getTwoCompanyLookupFormValues(),
             'languages' => $this->context->controller->getLanguages(),
             'id_language' => $this->context->language->id,
         );
-        return $helper->generateForm(array($this->getTwoOtherForm()));
+        return $helper->generateForm(array($this->getTwoCompanyLookupForm()));
     }
 
-    protected function getTwoOtherForm()
+    /**
+     * Section C - Company Lookup (TWO-25386 Part 1): company search
+     * placement and address auto-complete - relocated here from the former
+     * "Advanced Settings" panel.
+     */
+    protected function getTwoCompanyLookupForm()
     {
         $fields_form = array(
             'form' => array(
                 'legend' => array(
-                    'title' => $this->l('Advanced Settings'),
-                    'icon' => 'icon-cogs',
+                    'title' => $this->l('Company Lookup'),
+                    'icon' => 'icon-building',
                 ),
                 'input' => array(
                     array(
@@ -2062,12 +2217,60 @@ class Twopayment extends PaymentModule
                             ),
                         ),
                     ),
+                ),
+                'submit' => array(
+                    'title' => $this->l('Save'),
+                ),
+            ),
+        );
+
+        return $fields_form;
+    }
+
+    protected function renderTwoOrderManagementForm()
+    {
+        $helper = new HelperForm();
+        $helper->show_toolbar = false;
+        $helper->table = $this->table;
+        $helper->default_form_language = (int) Configuration::get('PS_LANG_DEFAULT');
+        $helper->module = $this;
+        $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
+        $helper->identifier = $this->identifier;
+        $helper->submit_action = 'submitTwoOrderManagementForm';
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+        $helper->tpl_vars = array(
+            'uri' => $this->getPathUri(),
+            'fields_value' => $this->getTwoOrderManagementFormValues(),
+            'languages' => $this->context->controller->getLanguages(),
+            'id_language' => $this->context->language->id,
+        );
+        return $helper->generateForm(array($this->getTwoOrderManagementForm()));
+    }
+
+    /**
+     * Section E - Order Management (TWO-25386 Part 1): fulfilment trigger,
+     * tax subtotals and the shipping-tax fallback - relocated here from the
+     * former "Advanced Settings" panel. Fulfilment statuses and the
+     * Two -> platform state mapping remain the separate Order Status
+     * Mapping form (getTwoOrderStatusForm), rendered directly below this
+     * one on the same "Order Management" tab.
+     */
+    protected function getTwoOrderManagementForm()
+    {
+        $fields_form = array(
+            'form' => array(
+                'legend' => array(
+                    'title' => $this->l('Order Management'),
+                    'icon' => 'icon-truck',
+                ),
+                'input' => array(
                     array(
                         'type' => 'switch',
                         'label' => $this->l('Automatically fulfill orders with Two'),
                         'name' => 'PS_TWO_FINALIZE_PURCHASE',
                         'is_bool' => true,
-                        'desc' => $this->l('When enabled, orders are automatically marked as fulfilled in Two when their status changes to one of your configured fulfillment trigger statuses (see Order Status Mapping). This activates buyer payment terms and begins the payout cycle. If disabled, you must fulfill orders manually in Two\'s Merchant Portal.'),
+                        'desc' => $this->l('When enabled, orders are automatically marked as fulfilled in Two when their status changes to one of your configured fulfillment trigger statuses (see Fulfilment Statuses below). This activates buyer payment terms and begins the payout cycle. If disabled, you must fulfill orders manually in Two\'s Merchant Portal.'),
                         'required' => true,
                         'values' => array(
                             array(
@@ -2102,43 +2305,94 @@ class Twopayment extends PaymentModule
                             ),
                         ),
                     ),
+                ),
+                'submit' => array(
+                    'title' => $this->l('Save'),
+                ),
+            ),
+        );
+
+        // Hidden unless the install opts in (TWO-25200). Ordinary shops
+        // declare shipping VAT on their carriers and must not be offered a
+        // second place to do it; the field exists for merchants who price
+        // shipping outside the carrier table entirely.
+        if ($this->isTwoDefaultShippingTaxCodeFieldEnabled()) {
+            $fields_form['form']['input'][] = array(
+                'type' => 'select',
+                'label' => $this->l('Default shipping tax code'),
+                'name' => self::CONFIG_DEFAULT_SHIPPING_TAX_RULES_GROUP,
+                'desc' => $this->l('Tax rules group ASSUMED FOR SHIPPING ONLY when the carrier\'s tax rate cannot be resolved for the order - for example when shipping is priced outside PrestaShop\'s carrier table, so no carrier declares a tax rules group. It is never used when a carrier does declare one: the carrier\'s own group always wins. Leave unset to keep refusing such orders rather than assuming a rate.'),
+                'options' => array(
+                    'query' => $this->getTwoDefaultShippingTaxRulesGroupOptions(),
+                    'id' => 'id',
+                    'name' => 'name',
+                ),
+            );
+        }
+
+        return $fields_form;
+    }
+
+    protected function renderTwoDiagnosticsForm()
+    {
+        $helper = new HelperForm();
+        $helper->show_toolbar = false;
+        $helper->table = $this->table;
+        $helper->default_form_language = (int) Configuration::get('PS_LANG_DEFAULT');
+        $helper->module = $this;
+        $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
+        $helper->identifier = $this->identifier;
+        $helper->submit_action = 'submitTwoDiagnosticsForm';
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+        $helper->tpl_vars = array(
+            'uri' => $this->getPathUri(),
+            'fields_value' => $this->getTwoDiagnosticsFormValues(),
+            'languages' => $this->context->controller->getLanguages(),
+            'id_language' => $this->context->language->id,
+        );
+        return $helper->generateForm(array($this->getTwoDiagnosticsForm()));
+    }
+
+    /**
+     * Section F - Diagnostics (TWO-25386 Part 1): debug/API logging, skip
+     * confirm nonce, clear on deactivation and the error log link -
+     * relocated here from the former "General Settings"/"Advanced
+     * Settings" panels. The version/plugin-info panel and the install
+     * health checklist (renderTwoPluginInfo/renderTwoPluginHealthChecklist)
+     * render directly below this form on the same "Diagnostics" tab.
+     */
+    protected function getTwoDiagnosticsForm()
+    {
+        return array(
+            'form' => array(
+                'legend' => array(
+                    'title' => $this->l('Diagnostics'),
+                    'icon' => 'icon-stethoscope',
+                ),
+                'input' => array(
+                    // Debug mode (relocated from the former "General
+                    // Settings" panel, alongside the other diagnostic
+                    // controls).
                     array(
                         'type' => 'switch',
-                        'label' => $this->l('Disable SSL Verification (Corporate Networks Only)'),
-                        'name' => 'PS_TWO_DISABLE_SSL_VERIFY',
+                        'label' => $this->l('Enable Debug Mode'),
+                        'name' => 'PS_TWO_DEBUG_MODE',
                         'is_bool' => true,
-                        'desc' => $this->l('WARNING: Only enable this if you are behind a corporate proxy with custom SSL certificates. This disables SSL certificate verification and is a SECURITY RISK. NOT RECOMMENDED for production.'),
-                        'required' => true,
+                        'desc' => $this->l('Enable detailed logging for troubleshooting. Logs tax calculations and other diagnostic data. Only enable when requested by Two support.'),
+                        'required' => false,
                         'values' => array(
                             array(
-                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_ON',
+                                'id' => 'PS_TWO_DEBUG_MODE_ON',
                                 'value' => 1,
-                                'label' => $this->l('Yes (Not Recommended)')
+                                'label' => $this->l('Yes')
                             ),
                             array(
-                                'id' => 'PS_TWO_DISABLE_SSL_VERIFY_OFF',
+                                'id' => 'PS_TWO_DEBUG_MODE_OFF',
                                 'value' => 0,
-                                'label' => $this->l('No (Secure)')
+                                'label' => $this->l('No')
                             ),
                         ),
-                    ),
-                    // Checkout sort order (TWO-25386 #6, ported from
-                    // magento-plugin's Advanced > sort_order). Best-effort:
-                    // PrestaShop core has no per-module sort_order config path
-                    // for payment methods the way Magento does - the native
-                    // mechanism is the hook_module position table, normally
-                    // reordered by dragging in Payment > Preferences. Saving
-                    // this field asks core to move this module to that
-                    // position on the paymentOptions hook (see
-                    // applyTwoCheckoutSortOrder()); it is stored regardless so
-                    // the value survives even where the move itself cannot be
-                    // applied.
-                    array(
-                        'type' => 'text',
-                        'label' => $this->l('Checkout sort order'),
-                        'name' => 'PS_TWO_CHECKOUT_SORT_ORDER',
-                        'required' => false,
-                        'desc' => $this->l('Optional. A lower number shows Two earlier among the payment methods offered at checkout. Leave empty to use PrestaShop\'s own Payment > Preferences ordering.'),
                     ),
                     // Skip confirm-order nonce/token check (TWO-25386 #4,
                     // ported from woocommerce-plugin's `skip_confirm_auth`).
@@ -2193,26 +2447,6 @@ class Twopayment extends PaymentModule
                 ),
             ),
         );
-
-        // Hidden unless the install opts in (TWO-25200). Ordinary shops
-        // declare shipping VAT on their carriers and must not be offered a
-        // second place to do it; the field exists for merchants who price
-        // shipping outside the carrier table entirely.
-        if ($this->isTwoDefaultShippingTaxCodeFieldEnabled()) {
-            $fields_form['form']['input'][] = array(
-                'type' => 'select',
-                'label' => $this->l('Default shipping tax code'),
-                'name' => self::CONFIG_DEFAULT_SHIPPING_TAX_RULES_GROUP,
-                'desc' => $this->l('Tax rules group ASSUMED FOR SHIPPING ONLY when the carrier\'s tax rate cannot be resolved for the order - for example when shipping is priced outside PrestaShop\'s carrier table, so no carrier declares a tax rules group. It is never used when a carrier does declare one: the carrier\'s own group always wins. Leave unset to keep refusing such orders rather than assuming a rate.'),
-                'options' => array(
-                    'query' => $this->getTwoDefaultShippingTaxRulesGroupOptions(),
-                    'id' => 'id',
-                    'name' => 'name',
-                ),
-            );
-        }
-
-        return $fields_form;
     }
 
     /**
@@ -2261,7 +2495,7 @@ class Twopayment extends PaymentModule
      * existing switch rather than adding a new one is a deliberate BEHAVIOUR
      * CHANGE for shops that already have it set to "No": that used to turn
      * company search off entirely, and now relocates it to the payment tile
-     * instead (see the switch's own 'desc' in getTwoOtherForm()).
+     * instead (see the switch's own 'desc' in getTwoCompanyLookupForm()).
      *
      * An absent row resolves to '1' (address area) - the install default,
      * and the only behaviour that ever existed before this switch could mean
@@ -2394,7 +2628,7 @@ class Twopayment extends PaymentModule
         return $configured === null ? '' : (string) $configured;
     }
 
-    protected function getTwoOtherFormValues()
+    protected function getTwoCompanyLookupFormValues()
     {
         $fields_values = array();
         // Read through the same default-on resolver the checkout uses, so an
@@ -2412,12 +2646,43 @@ class Twopayment extends PaymentModule
         $fields_values['PS_TWO_ADDRESS_LOOKUP'] = $this->isAddressLookupSettingAvailable()
             ? Tools::getValue('PS_TWO_ADDRESS_LOOKUP', $this->getAddressLookupEnabled())
             : '0';
+        return $fields_values;
+    }
+
+    protected function validTwoCompanyLookupFormValues()
+    {
+        // Nothing to validate: both switches are booleans.
+    }
+
+    protected function saveTwoCompanyLookupFormValues()
+    {
+        // BEFORE the writes below: the gate reads the submitted (or, absent a
+        // submission, the currently stored) company-search position, and
+        // updateValue() would otherwise have already overwritten the stored
+        // row this falls back to.
+        $address_lookup_available = $this->isAddressLookupSettingAvailable();
+
+        Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
+        // Server-side half of the "unavailable when the search is not in the
+        // address area" gate (TWO-25326 §7.1 follow-up). The admin JS greys
+        // the switch out, and a disabled control posts nothing - but a
+        // hand-crafted or replayed POST can still carry a ticked box, and it
+        // must not take effect. Matched by the same gate in
+        // getTwoCompanyLookupFormValues() so the rendered position never
+        // disagrees with what is stored.
+        Configuration::updateValue(
+            'PS_TWO_ADDRESS_LOOKUP',
+            $address_lookup_available ? (int) Tools::getValue('PS_TWO_ADDRESS_LOOKUP', 1) : 0
+        );
+
+        $this->output .= $this->displayConfirmation($this->l('Company lookup settings are updated.'));
+    }
+
+    protected function getTwoOrderManagementFormValues()
+    {
+        $fields_values = array();
         $fields_values['PS_TWO_FINALIZE_PURCHASE'] = Tools::getValue('PS_TWO_FINALIZE_PURCHASE', Configuration::get('PS_TWO_FINALIZE_PURCHASE'));
         $fields_values['PS_TWO_ENABLE_TAX_SUBTOTALS'] = Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', Configuration::get('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
-        $fields_values['PS_TWO_DISABLE_SSL_VERIFY'] = Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', Configuration::get('PS_TWO_DISABLE_SSL_VERIFY'));
-        $fields_values['PS_TWO_CHECKOUT_SORT_ORDER'] = Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER', Configuration::get('PS_TWO_CHECKOUT_SORT_ORDER'));
-        $fields_values['PS_TWO_SKIP_CONFIRM_NONCE_CHECK'] = Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', Configuration::get('PS_TWO_SKIP_CONFIRM_NONCE_CHECK'));
-        $fields_values['PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'] = Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'));
         if ($this->isTwoDefaultShippingTaxCodeFieldEnabled()) {
             // Kept a STRING: an (int) cast would turn the unselected state
             // into 0 and silently pre-select "No tax".
@@ -2429,10 +2694,8 @@ class Twopayment extends PaymentModule
         return $fields_values;
     }
 
-    protected function validTwoOtherFormValues()
+    protected function validTwoOrderManagementFormValues()
     {
-        $this->validTwoCheckoutSortOrderValue();
-
         if (!$this->isTwoDefaultShippingTaxCodeFieldEnabled()) {
             return;
         }
@@ -2452,61 +2715,16 @@ class Twopayment extends PaymentModule
         }
     }
 
-    /**
-     * Validate the checkout sort order field (TWO-25386 #6): empty (no
-     * preference) or a plain integer, positive or negative.
-     */
-    protected function validTwoCheckoutSortOrderValue()
+    protected function saveTwoOrderManagementFormValues()
     {
-        $raw = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
-        if ($raw === '') {
-            return;
-        }
-        if (!preg_match('/^-?\d+$/', $raw)) {
-            $this->errors[] = $this->l('Checkout sort order must be a whole number, or left empty.');
-        }
-    }
-
-    protected function saveTwoOtherFormValues()
-    {
-        // BEFORE the writes below: the gate reads the submitted (or, absent a
-        // submission, the currently stored) company-search position, and
-        // updateValue() would otherwise have already overwritten the stored
-        // row this falls back to.
-        $address_lookup_available = $this->isAddressLookupSettingAvailable();
-
-        Configuration::updateValue('PS_TWO_ENABLE_COMPANY_NAME', Tools::getValue('PS_TWO_ENABLE_COMPANY_NAME'));
-        // Server-side half of the "unavailable when the search is not in the
-        // address area" gate (TWO-25326 §7.1 follow-up). The admin JS greys
-        // the switch out, and a disabled control posts nothing - but a
-        // hand-crafted or replayed POST can still carry a ticked box, and it
-        // must not take effect. Matched by the same gate in
-        // getTwoOtherFormValues() so the rendered position never disagrees
-        // with what is stored.
-        Configuration::updateValue(
-            'PS_TWO_ADDRESS_LOOKUP',
-            $address_lookup_available ? (int) Tools::getValue('PS_TWO_ADDRESS_LOOKUP', 1) : 0
-        );
         Configuration::updateValue('PS_TWO_FINALIZE_PURCHASE', Tools::getValue('PS_TWO_FINALIZE_PURCHASE'));
         Configuration::updateValue('PS_TWO_ENABLE_TAX_SUBTOTALS', (int) Tools::getValue('PS_TWO_ENABLE_TAX_SUBTOTALS', 1));
-        Configuration::updateValue('PS_TWO_DISABLE_SSL_VERIFY', (int) Tools::getValue('PS_TWO_DISABLE_SSL_VERIFY', 0));
-        Configuration::updateValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', (int) Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', 0));
-        Configuration::updateValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', (int) Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', 1));
-
-        // Checkout sort order (TWO-25386 #6). Passed validTwoCheckoutSortOrderValue
-        // above (empty, or a plain integer).
-        $raw_sort_order = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
-        Configuration::updateValue(
-            'PS_TWO_CHECKOUT_SORT_ORDER',
-            ($raw_sort_order !== '' && preg_match('/^-?\d+$/', $raw_sort_order)) ? $raw_sort_order : ''
-        );
-        $this->applyTwoCheckoutSortOrder();
 
         // Write the default shipping tax code ONLY when the field was
         // actually rendered AND actually submitted. A form that never showed
         // the field posts nothing for it, and blindly writing Tools::getValue
         // with a '' default there would wipe a stored declaration on the next
-        // unrelated advanced-settings save - exactly the failure mode the
+        // unrelated order-management save - exactly the failure mode the
         // payment-terms checkbox loop was fixed for under TWO-24813.
         if ($this->isTwoDefaultShippingTaxCodeFieldEnabled()) {
             $raw = Tools::getValue(self::CONFIG_DEFAULT_SHIPPING_TAX_RULES_GROUP, false);
@@ -2523,7 +2741,45 @@ class Twopayment extends PaymentModule
             }
         }
 
-        $this->output .= $this->displayConfirmation($this->l('Advanced settings are updated.'));
+        $this->output .= $this->displayConfirmation($this->l('Order management settings are updated.'));
+    }
+
+    /**
+     * Validate the checkout sort order field (TWO-25386 #6): empty (no
+     * preference) or a plain integer, positive or negative.
+     */
+    protected function validTwoCheckoutSortOrderValue()
+    {
+        $raw = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
+        if ($raw === '') {
+            return;
+        }
+        if (!preg_match('/^-?\d+$/', $raw)) {
+            $this->errors[] = $this->l('Checkout sort order must be a whole number, or left empty.');
+        }
+    }
+
+    protected function getTwoDiagnosticsFormValues()
+    {
+        $fields_values = array();
+        $fields_values['PS_TWO_DEBUG_MODE'] = Tools::getValue('PS_TWO_DEBUG_MODE', Configuration::get('PS_TWO_DEBUG_MODE'));
+        $fields_values['PS_TWO_SKIP_CONFIRM_NONCE_CHECK'] = Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', Configuration::get('PS_TWO_SKIP_CONFIRM_NONCE_CHECK'));
+        $fields_values['PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'] = Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', $this->isTwoBooleanConfigEnabledByDefault('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION'));
+        return $fields_values;
+    }
+
+    protected function validTwoDiagnosticsFormValues()
+    {
+        // Nothing to validate: all three fields are booleans / an html link.
+    }
+
+    protected function saveTwoDiagnosticsFormValues()
+    {
+        Configuration::updateValue('PS_TWO_DEBUG_MODE', Tools::getValue('PS_TWO_DEBUG_MODE'));
+        Configuration::updateValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', (int) Tools::getValue('PS_TWO_SKIP_CONFIRM_NONCE_CHECK', 0));
+        Configuration::updateValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', (int) Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', 1));
+
+        $this->output .= $this->displayConfirmation($this->l('Diagnostics settings are updated.'));
     }
 
     /**
@@ -2665,7 +2921,7 @@ class Twopayment extends PaymentModule
                     <li style="margin-bottom:8px;"><i class="icon-info-circle text-info"></i> <strong>' . $this->l('Buyer rejected?') . '</strong> ' . $this->l('The company may have reached their credit limit or failed Two\'s credit check') . '</li>
                     <li style="margin-bottom:8px;"><i class="icon-info-circle text-info"></i> <strong>' . $this->l('Company not found?') . '</strong> ' . $this->l('Customer must enter their official registered company name') . '</li>
                     <li style="margin-bottom:8px;"><i class="icon-info-circle text-info"></i> <strong>' . $this->l('Phone invalid?') . '</strong> ' . $this->l('Ensure the phone number includes country code and is in a valid format') . '</li>
-                    <li style="margin-bottom:8px;"><i class="icon-info-circle text-info"></i> <strong>' . $this->l('Amount mismatch errors?') . '</strong> ' . $this->l('Enable Debug Mode in General Settings and contact Two support with the logs') . '</li>
+                    <li style="margin-bottom:8px;"><i class="icon-info-circle text-info"></i> <strong>' . $this->l('Amount mismatch errors?') . '</strong> ' . $this->l('Enable Debug Mode in Diagnostics and contact Two support with the logs') . '</li>
                 </ul>
             </div>
         </div>
@@ -2882,7 +3138,7 @@ class Twopayment extends PaymentModule
         if (!$api_verified) {
             $html .= '<div class="alert alert-warning" style="margin-top:12px;margin-bottom:0;">';
             $html .= '<strong>' . $this->l('Action required:') . '</strong> ';
-            $html .= $this->l('API key is not verified. Checkout requests may fail until the General Settings are saved with a valid key.');
+            $html .= $this->l('API key is not verified. Checkout requests may fail until the General settings are saved with a valid key.');
             $html .= '</div>';
         }
 
@@ -12907,7 +13163,7 @@ class Twopayment extends PaymentModule
         }
         // The RENDERED term set, not getAvailablePaymentTerms(): the grid
         // renders (and therefore posts) a row per OFFERABLE term, and the
-        // ticked subset is rewritten by saveTwoPaymentSettingsFormValues()
+        // ticked subset is rewritten by saveTwoPaymentTermsFormValues()
         // BEFORE saveTwoSurchargeFormValues() reads it. Validating the stored
         // subset therefore skipped any cell on a term ticked in the same
         // submit - so a cap of 0 typed on a newly-ticked term was stored

--- a/twopayment.php
+++ b/twopayment.php
@@ -1897,6 +1897,67 @@ class Twopayment extends PaymentModule
         $this->output .= $this->displayConfirmation($this->l('Checkout field settings are updated.'));
     }
 
+    /**
+     * Validate the checkout sort order field (TWO-25386 #6): empty (no
+     * preference) or a plain integer, positive or negative.
+     */
+    protected function validTwoCheckoutSortOrderValue()
+    {
+        $raw = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
+        if ($raw === '') {
+            return;
+        }
+        if (!preg_match('/^-?\d+$/', $raw)) {
+            $this->errors[] = $this->l('Checkout sort order must be a whole number, or left empty.');
+        }
+    }
+
+    /**
+     * Best-effort application of the checkout sort order (TWO-25386 #6).
+     *
+     * PrestaShop core has no per-module sort_order config path for payment
+     * methods (unlike Magento's payment/two_payment/sort_order); the native
+     * mechanism is the hook_module position table that Module::updatePosition()
+     * writes, normally driven by dragging rows in Payment > Preferences. This
+     * asks core to move the module to the configured position on its own
+     * paymentOptions hook registration.
+     *
+     * Deliberately swallows any failure: the admin field and its stored value
+     * are the source of truth this method reads, and updatePosition()
+     * misbehaving (a lock conflict, an unexpected DB state, or genuinely not
+     * existing on some future core) must never block saving the rest of the
+     * Checkout Fields form. The method_exists() guard is a defensive
+     * belt-and-suspenders check, not the real safety net here -
+     * Module::updatePosition() is a real, long-standing core method this
+     * module's own PaymentModule parent inherits, so it exists on every
+     * supported PrestaShop version; the try/catch is what actually protects
+     * this save path.
+     *
+     * @return void
+     */
+    protected function applyTwoCheckoutSortOrder()
+    {
+        $raw = trim((string) Configuration::get('PS_TWO_CHECKOUT_SORT_ORDER'));
+        if ($raw === '' || !preg_match('/^-?\d+$/', $raw)) {
+            return;
+        }
+        if (!method_exists($this, 'updatePosition')) {
+            return;
+        }
+
+        try {
+            $id_hook = (int) Hook::getIdByName('paymentOptions');
+            if ($id_hook > 0) {
+                $this->updatePosition($id_hook, false, (int) $raw);
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog(
+                'TwoPayment: Failed applying checkout sort order - ' . $e->getMessage(),
+                2
+            );
+        }
+    }
+
     protected function getTwoPaymentTermsFormValues()
     {
         $fields_values = array();
@@ -2748,17 +2809,6 @@ class Twopayment extends PaymentModule
      * Validate the checkout sort order field (TWO-25386 #6): empty (no
      * preference) or a plain integer, positive or negative.
      */
-    protected function validTwoCheckoutSortOrderValue()
-    {
-        $raw = trim((string) Tools::getValue('PS_TWO_CHECKOUT_SORT_ORDER'));
-        if ($raw === '') {
-            return;
-        }
-        if (!preg_match('/^-?\d+$/', $raw)) {
-            $this->errors[] = $this->l('Checkout sort order must be a whole number, or left empty.');
-        }
-    }
-
     protected function getTwoDiagnosticsFormValues()
     {
         $fields_values = array();
@@ -2780,52 +2830,6 @@ class Twopayment extends PaymentModule
         Configuration::updateValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', (int) Tools::getValue('PS_TWO_CLEAR_SETTINGS_ON_DEACTIVATION', 1));
 
         $this->output .= $this->displayConfirmation($this->l('Diagnostics settings are updated.'));
-    }
-
-    /**
-     * Best-effort application of the checkout sort order (TWO-25386 #6).
-     *
-     * PrestaShop core has no per-module sort_order config path for payment
-     * methods (unlike Magento's payment/two_payment/sort_order); the native
-     * mechanism is the hook_module position table that Module::updatePosition()
-     * writes, normally driven by dragging rows in Payment > Preferences. This
-     * asks core to move the module to the configured position on its own
-     * paymentOptions hook registration.
-     *
-     * Deliberately swallows any failure: the admin field and its stored value
-     * are the source of truth this method reads, and updatePosition()
-     * misbehaving (a lock conflict, an unexpected DB state, or genuinely not
-     * existing on some future core) must never block saving the rest of the
-     * Advanced Settings form. The method_exists() guard is a defensive
-     * belt-and-suspenders check, not the real safety net here -
-     * Module::updatePosition() is a real, long-standing core method this
-     * module's own PaymentModule parent inherits, so it exists on every
-     * supported PrestaShop version; the try/catch is what actually protects
-     * this save path.
-     *
-     * @return void
-     */
-    protected function applyTwoCheckoutSortOrder()
-    {
-        $raw = trim((string) Configuration::get('PS_TWO_CHECKOUT_SORT_ORDER'));
-        if ($raw === '' || !preg_match('/^-?\d+$/', $raw)) {
-            return;
-        }
-        if (!method_exists($this, 'updatePosition')) {
-            return;
-        }
-
-        try {
-            $id_hook = (int) Hook::getIdByName('paymentOptions');
-            if ($id_hook > 0) {
-                $this->updatePosition($id_hook, false, (int) $raw);
-            }
-        } catch (Exception $e) {
-            PrestaShopLogger::addLog(
-                'TwoPayment: Failed applying checkout sort order - ' . $e->getMessage(),
-                2
-            );
-        }
     }
 
     protected function renderTwoOrderStatusForm()
@@ -12789,7 +12793,7 @@ class Twopayment extends PaymentModule
 
     /**
      * HelperForm input entries for the surcharge settings (appended to the
-     * Payment Settings form). Presentation only — all decisioning is in the
+     * Payment Terms form). Presentation only — all decisioning is in the
      * methods above.
      *
      * @return array
@@ -13174,7 +13178,7 @@ class Twopayment extends PaymentModule
         // JS hides it (and, with it, the help text explaining this very rule)
         // otherwise - but a hidden input still posts, so a cap stored while the
         // type was percentage keeps arriving. Refusing it would abort the whole
-        // Payment Settings save over a field the merchant can neither see nor
+        // Payment Terms save over a field the merchant can neither see nor
         // read about. The value is still stored either way; only the zero rule
         // is skipped, and a legacy zero resurfaces when the column comes back
         // into view, which is where they can act on it.

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -7,11 +7,12 @@
 <div class="row">
     <div id="two-tabs" class="col-lg-2 col-md-3">
         <div class="list-group">
-            <a class="list-group-item {if $twotabvalue == 1}active{/if}" href="#general-settings" aria-controls="general-settings" role="tab" data-toggle="tab">{l s='General Settings' mod='twopayment'}</a>
-            <a class="list-group-item {if $twotabvalue == 5}active{/if}" href="#payment-settings" aria-controls="payment-settings" role="tab" data-toggle="tab">{l s='Payment Settings' mod='twopayment'}</a>
-            <a class="list-group-item {if $twotabvalue == 2}active{/if}" href="#other-settings" aria-controls="other-settings" role="tab" data-toggle="tab">{l s='Advanced Settings' mod='twopayment'}</a>
-            <a class="list-group-item {if $twotabvalue == 3}active{/if}" href="#order-status-settings" aria-controls="order-status-settings" role="tab" data-toggle="tab">{l s='Order Status Settings' mod='twopayment'}</a>
-            <a class="list-group-item {if $twotabvalue == 4}active{/if}" href="#plugin-info" aria-controls="plugin-info" role="tab" data-toggle="tab">{l s='Plugin Information' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 1}active{/if}" href="#general-settings" aria-controls="general-settings" role="tab" data-toggle="tab">{l s='General' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 2}active{/if}" href="#checkout-fields-settings" aria-controls="checkout-fields-settings" role="tab" data-toggle="tab">{l s='Checkout Fields' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 3}active{/if}" href="#company-lookup-settings" aria-controls="company-lookup-settings" role="tab" data-toggle="tab">{l s='Company Lookup' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 4}active{/if}" href="#payment-terms-settings" aria-controls="payment-terms-settings" role="tab" data-toggle="tab">{l s='Payment Terms' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 5}active{/if}" href="#order-management-settings" aria-controls="order-management-settings" role="tab" data-toggle="tab">{l s='Order Management' mod='twopayment'}</a>
+            <a class="list-group-item {if $twotabvalue == 6}active{/if}" href="#diagnostics-settings" aria-controls="diagnostics-settings" role="tab" data-toggle="tab">{l s='Diagnostics' mod='twopayment'}</a>
         </div>
     </div>
     <div class="col-lg-10 col-md-9">
@@ -43,16 +44,21 @@
                 {/if}
                 {$renderTwoGeneralForm nofilter}
             </div>
-            <div id="payment-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 5}active{/if}">
-                {$renderTwoPaymentSettingsForm nofilter}
+            <div id="checkout-fields-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 2}active{/if}">
+                {$renderTwoCheckoutFieldsForm nofilter}
             </div>
-            <div id="other-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 2}active{/if}">
-                {$renderTwoOtherForm nofilter}
+            <div id="company-lookup-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 3}active{/if}">
+                {$renderTwoCompanyLookupForm nofilter}
             </div>
-            <div id="order-status-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 3}active{/if}">
+            <div id="payment-terms-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 4}active{/if}">
+                {$renderTwoPaymentTermsForm nofilter}
+            </div>
+            <div id="order-management-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 5}active{/if}">
+                {$renderTwoOrderManagementForm nofilter}
                 {$renderTwoOrderStatusForm nofilter}
             </div>
-            <div id="plugin-info" role="tabpanel" class="tab-pane {if $twotabvalue == 4}active{/if}">
+            <div id="diagnostics-settings" role="tabpanel" class="tab-pane {if $twotabvalue == 6}active{/if}">
+                {$renderTwoDiagnosticsForm nofilter}
                 {$renderTwoPluginInfo nofilter}
             </div>
         </div>


### PR DESCRIPTION
## Summary

Part 1 of TWO-25386 ("Admin controls: unify captions, groupings...") for PrestaShop — Part 2's control-porting merged in PR #147. This regroups `twopayment.php`'s admin config form from the ad-hoc panels (General Settings / Payment Settings / Advanced Settings / Order Status Mapping / Plugin Information) into the unified 6-section scheme shared with magento-plugin and woocommerce-plugin (parity agents in flight in parallel):

- **A. General** — Enable method (n/a on PS) · Environment · API key · Verify key (n/a on PS) · Vendor/site name · Test-host override (env-var gated, no admin field) · Disable SSL verify
- **B. Checkout Fields** — Title · Subtitle · Sort order · Country availability (native PrestaShop per-module restriction, no admin field in this module) · Min order value + basis · Order intent · "What is Two" link · Tooltips · Invoice email · PO number · Project · Department · Order note (no admin field — core `delivery_message`)
- **C. Company Lookup** — Company search placement · Address auto-complete
- **D. Payment Terms** — Term type · Offered terms · Custom term days · Default term · Surcharge method → basis → line description → per-term grid → rounding → tax treatment/class
- **E. Order Management** — Fulfilment trigger · Fulfilment statuses (boolean auto-fulfil + Two→platform state mapping) · Tax subtotals · Shipping tax fallback
- **F. Diagnostics** — Debug/API logging · Skip confirm nonce · Clear on deactivation · Version/plugin info panel · Install health checklist

## What changed vs. what didn't

- **Pure reorganization.** No `Configuration` key, default value, or validation rule changed — only which panel a field renders under, and the panel labels/order. Verified by running the full test suite unmodified in behavior (only method names/targets updated where a field moved to a differently-named form).
- Invoice email / PO number / Project / Department kept their existing relative order exactly, per TWO-25263 (load-bearing, matches `OPTIONAL_CHECKOUT_FIELDS`).
- The former single "Payment Settings" and "Advanced Settings" forms are each split across 2–3 new sections, since PrestaShop renders one `<form>` per panel; the render/get/valid/save method groups were split field-by-field along the same lines (e.g. `getTwoOtherForm()` → `getTwoCompanyLookupForm()` / `getTwoOrderManagementForm()` / `getTwoDiagnosticsForm()`).
- `views/templates/admin/configuration.tpl` now has 6 tabs; the existing "Two Order Status Mapping" sub-form renders under the new "Order Management" tab, and the existing Plugin Information/health-checklist content renders under the new "Diagnostics" tab (both unchanged in content).
- `PS_TWO_TAB_VALUE` now spans 1–6 (previously a scattered 1/2/3/4/5); still purely a UI-state remember-my-tab value.

## Not in scope

Country availability and the Order note item have no admin field to relocate in PrestaShop (native core features); Enable method / Verify key / Test-host override do not exist as PS admin fields today (Part 2 gap-closure territory, not this ticket).

## Test plan

- [x] `php tests/run.php` — all 59 specs pass (updated method-name references in `AddressLookupConfigSpec`, `AddressLookupGatingSpec`, `CompanySearchLocationConfigSpec`, `DefaultShippingTaxCodeSpec`, `MinimumOrderGateSpec`, `OptionalCheckoutFieldsSpec`, `run.php` to match the split methods)
- [x] `TranslationCatalogueSpec` — nl/no/sv catalogues updated (new section labels + messages added, orphaned rows for removed panel titles/descriptions removed)
- [x] `php -l twopayment.php` clean
- [ ] Manual smoke test of the 6 tabs in a live PrestaShop admin (not run in this session — no live shop attached)
