### PR TITLE
fix: sole-trader chip click dead-ends on address-editor page (TWO-40 follow-up)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -88,7 +88,12 @@ Reliable B2B invoice checkout via Two, with:
     is adopted server-side on first paint where the container IS present
     (TWO-25326), resolved over `soleTraderAvailability` otherwise, and cached
     both in memory and in localStorage per country (24h TTL, namespaced per
-    checkout environment) so a later page load can skip the round trip
+    checkout environment) so a later page load can skip the round trip.
+    Enrolment (`startEnrollment()`/`getCurrentBuyer()`) also has to work with
+    no container at all - on the address-editor page, where the chip lives
+    (`TwoCompanySearch.js`) but `.two-sole-trader` never renders - so a
+    no-match buyer lookup there calls `openPopup()` directly instead of the
+    payment-step's two-click `showPrompt()`->`openPopup()` (TWO-40 follow-up)
 - `views/js/modules/TwoOptionalFields.js`
   - Optional buyer reference fields in the payment tile: mirrors each visible
     input into its hidden twin inside the payment form (the tile is a sibling

--- a/tests/js/company-search-mode-chips.test.js
+++ b/tests/js/company-search-mode-chips.test.js
@@ -81,6 +81,25 @@ describe('the two unconditional chips', () => {
     });
 });
 
+describe('chip DOM order (TWO-40 follow-up: Doug wants Registered/Sole Trader/Enter Manually)', () => {
+    test('modeChips renders Registered Company, then Sole Trader, then Enter Manually', () => {
+        makeInstance();
+        openPanel();
+
+        const chips = panelParts().modeChips.children().toArray();
+        const classesInOrder = chips.map((el) => el.className);
+
+        expect(classesInOrder).toHaveLength(3);
+        expect(classesInOrder[0]).toContain('two-company-registered-entry');
+        expect(classesInOrder[1]).toContain('two-company-sole-trader-entry');
+        expect(classesInOrder[2]).toContain('two-company-not-listed');
+
+        // No `order:` CSS on these chips (views/css/two.css) - visual order
+        // is DOM order, so pinning the DOM sequence is sufficient; there is
+        // no separate flex/grid `order` property to also assert against.
+    });
+});
+
 describe('default selection (TWO-40: "Default selected chip: Registered Company")', () => {
     test('"Registered Company" carries the selected class on a fresh open', () => {
         makeInstance();

--- a/tests/js/sole-trader-containerless-popup.test.js
+++ b/tests/js/sole-trader-containerless-popup.test.js
@@ -1,0 +1,141 @@
+/**
+ * TWO-40 follow-up: PR #151 fixed the Sole Trader chip's VISIBILITY on the
+ * address-editor page but not its click behaviour. `.two-sole-trader` (and
+ * everything inside it - `.two-sole-trader__prompt`, `.two-sole-trader__status`,
+ * `.two-sole-trader__error`) is only ever rendered by
+ * views/templates/hook/paymentinfo.tpl, i.e. only on the payment step. On the
+ * address-editor page, getCurrentBuyer()'s no-match branch used to always call
+ * showPrompt(), which no-ops when `.two-sole-trader__prompt` cannot be found -
+ * so the buyer's click minted tokens, ran a buyer lookup, and then silently
+ * dead-ended with no popup and no error.
+ *
+ * Empirically verified in real Chrome against staging that a `window.open()`
+ * chained off two async hops (fetchTokens() then the buyer lookup) after a
+ * real click survives Chrome's transient-activation window under normal
+ * latency, so the fix is: when there is no `.two-sole-trader__prompt` to
+ * show, call openPopup() directly instead of falling through to a no-op.
+ *
+ * Payment-step behaviour, where the container and prompt element genuinely
+ * exist, must stay on the original two-click showPrompt()->openPopup() flow -
+ * see the "unchanged on payment step" test below.
+ */
+
+'use strict';
+
+const { loadSoleTrader, buildPaymentTile, buildAddressForm, flushPromises } = require('./ps-harness');
+
+let TwoSoleTrader;
+
+function build(overrides) {
+    return new TwoSoleTrader(Object.assign({
+        checkoutHost: 'https://api.example.test',
+        orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+        ajaxToken: 'test-token',
+        billingCountry: 'GB'
+    }, overrides || {}));
+}
+
+function stubFetch(buyerAnswer) {
+    global.window.fetch = (url) => {
+        if (String(url).includes('soleTraderAvailability')) {
+            return Promise.resolve({ json: () => Promise.resolve({ success: true, available: true }) });
+        }
+        if (String(url).includes('soleTraderTokens')) {
+            return Promise.resolve({
+                json: () => Promise.resolve({
+                    success: true,
+                    autofill_token: 'af-token',
+                    delegation_token: 'del-token',
+                    signup_url: 'https://signup.example.test/',
+                    country: 'GB'
+                })
+            });
+        }
+        if (String(url).includes('/autofill/v1/buyer/current')) {
+            return buyerAnswer();
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+    };
+    global.fetch = global.window.fetch;
+}
+
+/** No checkout email in the DOM - always a 404-shaped "no buyer" answer. */
+function noMatchAnswer() {
+    return Promise.resolve({ ok: false, status: 404 });
+}
+
+beforeEach(() => {
+    TwoSoleTrader = loadSoleTrader();
+});
+
+afterEach(() => {
+    delete global.fetch;
+    delete global.window.fetch;
+    delete global.window.TwoCompanyNumber;
+    delete global.window.open;
+    document.body.innerHTML = '';
+    global.window.localStorage.clear();
+});
+
+describe('address-editor page (no .two-sole-trader container at all)', () => {
+    test('a no-match buyer lookup opens the popup directly instead of dead-ending on showPrompt()', async () => {
+        buildAddressForm();
+        expect(document.querySelector('.two-sole-trader')).toBeNull();
+
+        const openSpy = jest.fn(() => ({ closed: false }));
+        global.window.open = openSpy;
+        stubFetch(noMatchAnswer);
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(String(openSpy.mock.calls[0][0])).toContain('businessToken=');
+        instance.destroy();
+    });
+
+    test('a blocked popup with no container logs to console.error instead of failing completely silently', async () => {
+        buildAddressForm();
+        global.window.open = jest.fn(() => null); // blocked
+        stubFetch(noMatchAnswer);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+        instance.destroy();
+    });
+});
+
+describe('payment step (.two-sole-trader container present) - unchanged', () => {
+    test('a no-match buyer lookup shows the prompt and does NOT open the popup until the prompt is clicked', async () => {
+        buildPaymentTile();
+        expect(document.querySelector('.two-sole-trader__prompt')).not.toBeNull();
+
+        const openSpy = jest.fn(() => ({ closed: false }));
+        global.window.open = openSpy;
+        stubFetch(noMatchAnswer);
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(openSpy).not.toHaveBeenCalled();
+        const prompt = document.querySelector('.two-sole-trader__prompt');
+        expect(prompt.style.display).toBe('inline');
+
+        prompt.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        instance.destroy();
+    });
+});

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -698,8 +698,8 @@ class TwoCompanySearch {
             .text(this.getSoleTraderEntryText());
 
         const modeChips = $('<div class="two-company-mode-chips"></div>')
-            .append(soleTraderEntry)
             .append(registeredEntry)
+            .append(soleTraderEntry)
             .append(notListed);
 
         // Positioned AFTER the results host, not before the query field

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -949,8 +949,24 @@ class TwoSoleTrader {
                     && String(buyer.email).toLowerCase() === entered);
                 if (matches) {
                     self.applyBuyer(buyer, generation);
-                } else {
+                } else if (self.container() && self.container().querySelector('.two-sole-trader__prompt')) {
                     self.showPrompt();
+                } else {
+                    // TWO-40 follow-up: on the address-editor page there is no
+                    // `.two-sole-trader` container at all (it is only rendered
+                    // by the payment-step template, paymentinfo.tpl), so
+                    // showPrompt()'s querySelector always comes back null and
+                    // the buyer's chip click dead-ends silently - tokens get
+                    // minted, this lookup fires, and nothing else happens.
+                    // Empirically verified in real Chrome against staging
+                    // (chained fetch()->fetch()->window.open() off a real
+                    // click survives Chrome's transient-activation window
+                    // under normal latency) that opening the popup directly
+                    // here, still async off the original click, is not
+                    // blocked in practice. Payment-step keeps the two-click
+                    // showPrompt()->openPopup() flow unchanged since its
+                    // container/prompt element exists there.
+                    self.openPopup();
                 }
             })
             .catch(function () {
@@ -1115,8 +1131,16 @@ class TwoSoleTrader {
         );
         if (!popup) {
             // Popup blocked despite opening from a click - surface it
-            // rather than failing silently.
+            // rather than failing silently. showError() itself no-ops
+            // without a `.two-sole-trader__error` element (containerless
+            // address-page path, TWO-40 follow-up) - console.error is the
+            // only signal left there, so it is not a completely silent
+            // dead end even in that edge case.
             this.showError();
+            if (!this.container()) {
+                // eslint-disable-next-line no-console
+                console.error('Two: sole-trader signup popup was blocked and no on-page error UI is available here.');
+            }
         }
         return popup;
     }


### PR DESCRIPTION
## Summary

PR #151 fixed the Sole Trader chip's *visibility* on the address-editor page. This fixes its *click behaviour*, which was still dead: `.two-sole-trader` (and the `__prompt`/`__status`/`__error` elements inside it) is only ever rendered by `paymentinfo.tpl` (payment step), so on the address-editor page `getCurrentBuyer()`'s no-match branch called `showPrompt()`, which silently no-ops when it can't find `.two-sole-trader__prompt` - the click minted tokens, ran a buyer lookup, and then dead-ended with nothing visible.

- When no prompt element is available, `getCurrentBuyer()`'s no-match branch now calls `openPopup()` directly instead of falling through to a no-op `showPrompt()`.
- Empirically verified in real Chrome against staging: `window.open()` chained off two async hops (token mint, then the buyer lookup) following a real click is **not** blocked by Chrome's transient-activation window under normal latency.
- Payment-step keeps its original two-click `showPrompt()` -> `openPopup()` flow, completely unchanged.
- Added a `console.error` fallback for the rare case a popup IS blocked with no container to show an on-page error in - not a completely silent dead end even then.
- Reorders the three mode chips per request: Registered Company, Sole Trader, Enter Manually (was Sole Trader first). No `order:` CSS override exists on these chips, so the DOM-order change alone controls visual order.

## Test plan

- [x] New Jest suite `tests/js/sole-trader-containerless-popup.test.js`: no-match lookup on a containerless page (`buildAddressForm()`) opens the popup directly; a blocked popup with no container logs to console.error; payment-step behaviour (`buildPaymentTile()`) is unchanged (shows prompt, popup only opens on prompt click).
- [x] New DOM-order test in `tests/js/company-search-mode-chips.test.js` pinning Registered/Sole-Trader/Enter-Manually order.
- [x] Full JS suite: `21 passed, 500 passed` (`npm run test:js`).
- [x] Empirical popup-blocker check in real Chrome against staging (see PR comment).
