### PR TITLE
fix(TWO-40): Sole Trader chip never got its own --selected class

### DIFF
--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -122,6 +122,35 @@ describe('activation', () => {
 
         expect(() => panelParts().soleTrader.trigger('click')).not.toThrow();
     });
+
+    /**
+     * Regression test: the handler correctly set `this._chipMode =
+     * 'sole_trader'` and started enrolment, but never called
+     * renderChipSelection() to reflect that onto the DOM - so
+     * "Registered Company" (the default) kept the `--selected` class
+     * forever and "Sole Trader" never got it, even though its own
+     * handler had just fired successfully. Asserting `startEnrollment`
+     * was called (as the test above does) does NOT catch this - the
+     * handler ran fine, only its cosmetic class write was missing.
+     * Checked directly against the DOM classes rather than `_chipMode`
+     * (an internal field a future refactor could rename) because the
+     * live bug this pins was observed exactly this way: DevTools reading
+     * `.className` on the real chip buttons.
+     */
+    test('marks itself selected and un-marks "Registered Company", even though the panel closes', () => {
+        stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+
+        const { registered, soleTrader, notListed } = panelParts();
+        expect(registered.hasClass('two-company-mode-chip--selected')).toBe(true);
+
+        soleTrader.trigger('click');
+
+        expect(soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(registered.hasClass('two-company-mode-chip--selected')).toBe(false);
+        expect(notListed.hasClass('two-company-mode-chip--selected')).toBe(false);
+    });
 });
 
 describe('reopening search cancels a pending enrolment (TWO-40)', () => {

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -861,6 +861,15 @@ class TwoCompanySearch {
                 event.preventDefault();
                 event.stopPropagation();
                 this._chipMode = 'sole_trader';
+                // Unlike "Registered Company" (below), this chip's own click
+                // handler is the only place `sole_trader` mode is entered, so
+                // it must render its own selection state rather than relying
+                // on a caller to. Must run BEFORE closeDropdown(true): the
+                // panel only hides via CSS (`display:none`/`hidden`), it
+                // never detaches the chip buttons, so the class write is not
+                // lost by closing - but doing it before keeps this handler's
+                // ordering symmetric with the other two.
+                this.renderChipSelection();
                 this.closeDropdown(true);
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {


### PR DESCRIPTION
## Summary
- Live-confirmed bug: clicking the "Sole Trader" chip correctly runs the sole-trader flow end to end (200 from the token endpoint, address write-back after PR #158), but the chip itself never visually shows selected - "Registered Company" stays marked selected forever.
- Root cause: the sole-trader click handler set `this._chipMode = 'sole_trader'` and started enrolment, but - unlike the "Registered Company" handler - never called `renderChipSelection()`, the method that actually writes the `--selected` class onto the three chip buttons. `closeDropdown()` only hides the panel via CSS, it never detaches the buttons, so the stale class from the last `openDropdown()` reset just sat there.
- Fix: call `renderChipSelection()` in the sole-trader click handler, mirroring how "Registered Company" already does it.

## Test plan
- Added a regression test in `tests/js/company-search-sole-trader-entry.test.js` that asserts the DOM class directly after the click (confirmed it fails on the pre-fix code, passes after).
- Full JS suite: `npx jest --config tests/js/jest.config.js` -> 27 suites / 712 tests passing.
- Live-verified on staging after confirming the served bundle matches this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)