### PR TITLE
fix(TWO-40): live-verified chip-selection paint fix + Sole Trader autofill spinner

### DIFF
--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -158,7 +158,7 @@ describe('activation', () => {
         expect(panelParts().query.hasClass('two-company-search-loading')).toBe(false);
     });
 
-    test('does nothing destructive if TwoSoleTrader_Instance is missing', () => {
+    test('does nothing destructive if TwoSoleTrader_Instance is missing, and still closes (after a paint) rather than dead-ending open', () => {
         stubSoleTrader(true);
         makeInstance();
         openPanel();
@@ -167,6 +167,19 @@ describe('activation', () => {
         delete global.window.TwoSoleTrader_Instance;
 
         expect(() => panelParts().soleTrader.trigger('click')).not.toThrow();
+
+        // TWO-40 round 5 (adversarial review, round 2 follow-up): this
+        // fallback branch does not go through beginSoleTraderLoading()'s
+        // keep-open window at all, so it needs its OWN paint-timing fix
+        // (deferred by one requestAnimationFrame) - round 1's review caught
+        // that the round-4 rewrite had silently dropped it here, reopening
+        // the exact same-tick "renderChipSelection() then closeDropdown()"
+        // bug this whole PR chain exists to fix. This assertion is what
+        // that fix's own regression test was missing: not just "doesn't
+        // throw", but "actually closes, deferred, rather than staying open
+        // forever with nothing left to close it".
+        jest.advanceTimersByTime(20);
+        expect(shown(panelParts().panel)).toBe(false);
     });
 
     /**

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -100,24 +100,6 @@ describe('visibility', () => {
 });
 
 describe('activation', () => {
-    test('clicking it starts sole-trader enrolment and closes the panel after a paint', () => {
-        const soleTrader = stubSoleTrader(true);
-        makeInstance();
-        openPanel();
-        typeQuery('exa');
-
-        panelParts().soleTrader.trigger('click');
-
-        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
-        // Not synchronous any more (TWO-40 round 3 paint-timing fix) - see the
-        // regression test below for why.
-        expect(shown(panelParts().panel)).toBe(true);
-
-        jest.advanceTimersByTime(20);
-
-        expect(shown(panelParts().panel)).toBe(false);
-    });
-
     /**
      * Regression test (TWO-40 round 3, live-verified against a real browser -
      * see .ai/decisions.md): PR #159 added renderChipSelection() but called it
@@ -126,12 +108,13 @@ describe('activation', () => {
      * panel's `display:none` hid it again - zero rendered frames ever showed
      * the selection to a buyer, even though jsdom (which has no render/paint
      * step) reported the class as set immediately and PR #159's own test
-     * passed on exactly that basis. This pins the actual requirement: the
-     * panel must still be visibly OPEN, with the class already applied, for
-     * at least one tick after the click - not merely "the DOM node eventually
-     * carries the class, in a document nobody was watching".
+     * passed on exactly that basis. Superseded functionally by the round-4
+     * keep-open behaviour below (the panel now stays open far longer than one
+     * frame), but pinned in its own right: the selection must be visible
+     * WHILE the panel is still open, not merely "eventually true in a
+     * document nobody was watching".
      */
-    test('the selected chip stays visibly open for at least one frame before the panel closes', () => {
+    test('the selected chip is visibly applied while the panel is still open, not only after it closes', () => {
         stubSoleTrader(true);
         makeInstance();
         openPanel();
@@ -139,14 +122,40 @@ describe('activation', () => {
         const { soleTrader } = panelParts();
         soleTrader.trigger('click');
 
-        // Still open AND already showing the selection - this is the frame a
-        // real buyer would actually see.
         expect(shown(panelParts().panel)).toBe(true);
         expect(soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+    });
 
-        jest.advanceTimersByTime(20);
+    /**
+     * TWO-40 round 4, Doug's explicit request: "keep the company search
+     * control open, show spinner in query field" for the duration of the
+     * Sole Trader autofill round trip. Driven by the REAL settle event
+     * TwoSoleTrader.js's notifyEnrollmentSettled() fires (see
+     * TwoSoleTrader.js), not a fixed timeout - the panel must stay open for
+     * however long the actual call takes, and no longer.
+     */
+    test('clicking it starts sole-trader enrolment, keeps the panel open with the query-field spinner, and only closes when the flight settles', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+        typeQuery('exa');
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+
+        // No fixed timeout closes it - it would still be open five seconds
+        // later if the real call were still out.
+        jest.advanceTimersByTime(5000);
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+
+        document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
 
         expect(shown(panelParts().panel)).toBe(false);
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(false);
     });
 
     test('does nothing destructive if TwoSoleTrader_Instance is missing', () => {

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -100,7 +100,7 @@ describe('visibility', () => {
 });
 
 describe('activation', () => {
-    test('clicking it closes the panel and starts sole-trader enrolment', () => {
+    test('clicking it starts sole-trader enrolment and closes the panel after a paint', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         openPanel();
@@ -108,8 +108,45 @@ describe('activation', () => {
 
         panelParts().soleTrader.trigger('click');
 
-        expect(shown(panelParts().panel)).toBe(false);
         expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        // Not synchronous any more (TWO-40 round 3 paint-timing fix) - see the
+        // regression test below for why.
+        expect(shown(panelParts().panel)).toBe(true);
+
+        jest.advanceTimersByTime(20);
+
+        expect(shown(panelParts().panel)).toBe(false);
+    });
+
+    /**
+     * Regression test (TWO-40 round 3, live-verified against a real browser -
+     * see .ai/decisions.md): PR #159 added renderChipSelection() but called it
+     * in the SAME synchronous tick as closeDropdown(), so a real browser never
+     * painted a single frame with the `--selected` class applied before the
+     * panel's `display:none` hid it again - zero rendered frames ever showed
+     * the selection to a buyer, even though jsdom (which has no render/paint
+     * step) reported the class as set immediately and PR #159's own test
+     * passed on exactly that basis. This pins the actual requirement: the
+     * panel must still be visibly OPEN, with the class already applied, for
+     * at least one tick after the click - not merely "the DOM node eventually
+     * carries the class, in a document nobody was watching".
+     */
+    test('the selected chip stays visibly open for at least one frame before the panel closes', () => {
+        stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+
+        const { soleTrader } = panelParts();
+        soleTrader.trigger('click');
+
+        // Still open AND already showing the selection - this is the frame a
+        // real buyer would actually see.
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+
+        jest.advanceTimersByTime(20);
+
+        expect(shown(panelParts().panel)).toBe(false);
     });
 
     test('does nothing destructive if TwoSoleTrader_Instance is missing', () => {

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -170,6 +170,64 @@ describe('activation', () => {
     });
 
     /**
+     * Regression test (TWO-40 round 5, adversarial review finding - Han and
+     * Vader independently caught this): round 4 keeps the chip clickable for
+     * the WHOLE round trip instead of closing on the first click, which
+     * newly makes a second click reachable while the first is still
+     * waiting. Without a guard, the second click re-entered
+     * startEnrollment() and could fire a second, concurrent buyer lookup -
+     * on the no-match path, that meant TWO signup popup windows from one
+     * buyer gesture.
+     */
+    test('a second click while already loading does not start a second enrolment attempt', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+        panelParts().soleTrader.trigger('click');
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+    });
+
+    test('a fresh click after the flight has settled is allowed to start a new attempt', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+        document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
+        // Re-open - the panel closed when the flight settled, same as any
+        // other close.
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * Regression test (TWO-40 round 5, Vader finding): startEnrollment() is
+     * foreign-module code called with no try/catch before this fix - a
+     * synchronous throw left the panel open with the spinner running and
+     * nothing left to ever settle it, since beginSoleTraderLoading() had
+     * already run.
+     */
+    test('a synchronous throw from startEnrollment() does not leave the panel stuck open with the spinner running', () => {
+        const soleTrader = stubSoleTrader(true);
+        soleTrader.startEnrollment.mockImplementation(() => {
+            throw new Error('boom');
+        });
+        makeInstance();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(shown(panelParts().panel)).toBe(false);
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(false);
+    });
+
+    /**
      * Regression test: the handler correctly set `this._chipMode =
      * 'sole_trader'` and started enrolment, but never called
      * renderChipSelection() to reflect that onto the DOM - so

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -186,3 +186,124 @@ test('a blocked popup still fires the settle event exactly once (not twice, desp
     document.removeEventListener('two:sole-trader-flight-settled', handler);
     instance.destroy();
 });
+
+/**
+ * TWO-40 round 5, adversarial review finding (Leia): cancelEnrollment() only
+ * bumped the generation counter and hid the prompt - it never told
+ * TwoCompanySearch.js's spinner/listener that the flight it was watching is
+ * over. apply() calls cancelEnrollment() directly off a live billing-country
+ * change while enrolling, not just from a click handler, so this is a real
+ * path, not a hypothetical.
+ */
+test('cancelEnrollment() fires the settle event when it actually cancels an in-progress enrolment', () => {
+    buildPaymentTile();
+    stubFetch({});
+    const instance = build();
+    const { calls, handler } = recordSettled();
+
+    instance.enrolling = true; // as startEnrollment() would have set it
+    instance.cancelEnrollment();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('cancelEnrollment() does NOT fire the settle event when there was nothing to cancel', () => {
+    buildPaymentTile();
+    stubFetch({});
+    const instance = build();
+    const { calls, handler } = recordSettled();
+
+    expect(instance.enrolling).toBe(false);
+    instance.cancelEnrollment();
+
+    expect(calls.length).toBe(0);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+/**
+ * TWO-40 round 5, adversarial review finding (Han + Yoda, independently):
+ * abandon-then-retry while the FIRST mint is still outstanding used to leave
+ * the second attempt's spinner running forever. Sequence: click Sole Trader
+ * (mint 1 in flight) -> buyer abandons (cancelEnrollment() bumps the
+ * generation) -> buyer clicks Sole Trader again. Because fetchTokens() has a
+ * single in-flight guard, the SECOND click's startEnrollment() rides mint
+ * 1's request rather than issuing its own - there is only ever one mint in
+ * flight. When that shared mint resolves successfully, the fix must resume
+ * the buyer lookup for whichever generation is CURRENT, not silently drop
+ * newly-minted tokens because they no longer match the STALE generation
+ * that originally requested them.
+ */
+test('a mint that resolves after abandon-then-retry still resumes the buyer lookup for the current attempt', async () => {
+    buildAddressForm();
+    global.window.open = jest.fn(() => ({ closed: false }));
+    let resolveTokens;
+    stubFetch({
+        tokens: () => new Promise((resolve) => { resolveTokens = resolve; }),
+        buyer: () => Promise.resolve({ ok: false, status: 404 })
+    });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment(); // click 1: mint 1 starts, isFetchingTokens = true
+    const generationAtFirstClick = instance._enrollGeneration;
+
+    instance.cancelEnrollment(); // buyer abandons - settles click 1
+    expect(calls.length).toBe(1);
+
+    instance.startEnrollment(); // click 2: fetchTokens() no-ops (still in flight)
+    expect(instance._enrollGeneration).not.toBe(generationAtFirstClick);
+    expect(instance.tokens).toBeNull();
+
+    // Mint 1 (the only request that ever went out) now resolves.
+    resolveTokens({
+        json: () => Promise.resolve({
+            success: true,
+            autofill_token: 'af-token',
+            delegation_token: 'del-token',
+            signup_url: 'https://signup.example.test/',
+            country: 'GB'
+        })
+    });
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    // Click 2 must have been resumed and settled on its own - not left
+    // hanging because the tokens landed under click 1's stale generation.
+    expect(instance.tokens).not.toBeNull();
+    expect(calls.length).toBe(2);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+/**
+ * TWO-40 round 5, adversarial review finding (Han + Vader, independently):
+ * getCurrentBuyer() had no in-flight guard of its own (unlike fetchTokens()'s
+ * isFetchingTokens) - a second concurrent lookup on the no-match path opened
+ * a second signup popup from one buyer gesture.
+ */
+test('two concurrent getCurrentBuyer() calls only open one popup', async () => {
+    buildAddressForm();
+    const openSpy = jest.fn(() => ({ closed: false }));
+    global.window.open = openSpy;
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+
+    const instance = build();
+    instance.tokens = {
+        autofill_token: 'af-token',
+        delegation_token: 'del-token',
+        signup_url: 'https://signup.example.test/',
+        country: 'GB'
+    };
+    instance.getCurrentBuyer();
+    instance.getCurrentBuyer();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    instance.destroy();
+});

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -307,3 +307,134 @@ test('two concurrent getCurrentBuyer() calls only open one popup', async () => {
     expect(openSpy).toHaveBeenCalledTimes(1);
     instance.destroy();
 });
+
+/**
+ * TWO-40 round 5 follow-up, adversarial review round 2 finding (Han): the
+ * abandon-then-retry resume fixed above for the MINT stage had no
+ * equivalent for the BUYER-LOOKUP stage - getCurrentBuyer() got the exact
+ * same isFetchingBuyer single-flight guard in the same commit, but its own
+ * superseded() branches just bare-returned, one call deeper than the bug
+ * this whole PR chain exists to fix. Sequence: click 1 mints fast and its
+ * buyer lookup is outstanding -> buyer abandons (cancelEnrollment() bumps
+ * the generation) -> buyer clicks Sole Trader again; tokens already exist,
+ * so click 2 goes straight to getCurrentBuyer(), which no-ops on
+ * isFetchingBuyer (click 1's lookup still out). When click 1's lookup
+ * resolves, the fix must resume for whichever generation is CURRENT rather
+ * than dropping the result with nothing left to ever settle click 2.
+ */
+test('a buyer lookup that resolves after abandon-then-retry during the lookup stage still resumes for the current attempt', async () => {
+    buildAddressForm();
+    global.window.open = jest.fn(() => ({ closed: false }));
+    let resolveBuyer;
+    stubFetch({
+        buyer: () => new Promise((resolve) => { resolveBuyer = resolve; })
+    });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.tokens = {
+        autofill_token: 'af-token',
+        delegation_token: 'del-token',
+        signup_url: 'https://signup.example.test/',
+        country: 'GB'
+    };
+    instance.enrolling = true;
+    instance.getCurrentBuyer(); // click 1: lookup 1 starts, isFetchingBuyer = true
+
+    instance.cancelEnrollment(); // buyer abandons - settles click 1
+    expect(calls.length).toBe(1);
+
+    instance.enrolling = true; // as startEnrollment()'s "resume" branch would set it
+    instance.getCurrentBuyer(); // click 2: no-ops, lookup 1 still in flight
+
+    // Lookup 1 (the only request that ever went out) now resolves with a
+    // 404 - no match. superseded() is true (generation moved on from the
+    // abandon), so this settles into resumeIfStillEnrolling() rather than
+    // acting on it directly.
+    resolveBuyer({ ok: false, status: 404 });
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+    // resumeIfStillEnrolling() defers via setTimeout(0) - flush the macrotask
+    // queue too, not just the microtask queue flushPromises() covers, so the
+    // resumed getCurrentBuyer() call actually runs and issues ITS OWN fetch
+    // (`buyer` factory is called again, rebinding `resolveBuyer` to that
+    // new promise's resolver below).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushPromises();
+
+    // The resumed lookup's own, SEPARATE request now resolves the same way
+    // - still no match, hands off to the popup on this containerless page.
+    resolveBuyer({ ok: false, status: 404 });
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    // Click 2 must have been resumed and settled on its own - not left
+    // hanging because the response landed under click 1's stale generation.
+    expect(global.window.open).toHaveBeenCalledTimes(1);
+    expect(calls.length).toBe(2);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+/**
+ * TWO-40 round 5 follow-up, adversarial review round 2 finding (Vader): the
+ * synchronous stretch between setting isFetchingTokens/isFetchingBuyer true
+ * and the fetch() call actually starting was unprotected. A throw there
+ * left the guard stuck true FOREVER - unlike a throw from
+ * TwoSoleTrader_Instance.startEnrollment() itself (which
+ * TwoCompanySearch.js's own try/catch recovers), this one has no recovery
+ * at all: every future click silently no-ops on the guard for the rest of
+ * the page's life, with nothing ever in flight and no settle event to ever
+ * close a THEN-open panel/spinner.
+ */
+test('a synchronous throw building the token-mint request does not permanently wedge fetchTokens()', () => {
+    buildPaymentTile();
+    stubFetch({});
+    const instance = build();
+    const { handler } = recordSettled();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Force a synchronous throw from inside fetchTokens()'s own pre-fetch
+    // setup, the same way a malformed billingCountry() config could.
+    const originalBillingCountry = instance.billingCountry;
+    instance.billingCountry = () => { throw new Error('boom'); };
+
+    expect(() => instance.startEnrollment()).not.toThrow();
+    expect(instance.isFetchingTokens).toBe(false);
+
+    // The guard must not be stuck - a later, working call proceeds.
+    instance.billingCountry = originalBillingCountry;
+    global.window.fetch = () => Promise.resolve({ json: () => Promise.resolve({ success: false }) });
+    global.fetch = global.window.fetch;
+    instance.nextRetryAt = 0; // skip the retry cooldown the failed attempt armed
+    instance.startEnrollment();
+    expect(instance.isFetchingTokens).toBe(true);
+
+    errorSpy.mockRestore();
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a synchronous throw building the buyer-lookup request does not permanently wedge getCurrentBuyer()', () => {
+    buildAddressForm();
+    stubFetch({});
+    const instance = build();
+
+    // this.tokens is null - the exact shape of throw Vader flagged
+    // (`this.tokens.autofill_token` reads off null).
+    expect(instance.tokens).toBeNull();
+
+    expect(() => instance.getCurrentBuyer()).not.toThrow();
+    expect(instance.isFetchingBuyer).toBe(false);
+
+    // The guard must not be stuck - a later, working call proceeds.
+    instance.tokens = { autofill_token: 'af-token' };
+    global.window.fetch = () => new Promise(() => {}); // never resolves; just prove it starts
+    global.fetch = global.window.fetch;
+    instance.getCurrentBuyer();
+    expect(instance.isFetchingBuyer).toBe(true);
+
+    instance.destroy();
+});

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -379,6 +379,61 @@ test('a buyer lookup that resolves after abandon-then-retry during the lookup st
 });
 
 /**
+ * TWO-40 round 7, adversarial review round 3 finding (Han): resumeIfStillEnrolling()
+ * checked `enrolling` once, at SCHEDULE time, then deferred via setTimeout(0)
+ * - the real time gap between scheduling and firing is exactly wide enough
+ * for a SECOND abandonment to land in it. Without a re-check at fire time,
+ * the deferred callback ran a full, unwanted buyer lookup for someone who
+ * had already walked away from the flow a second time - on the no-match
+ * path, popping a signup window nobody asked for any more.
+ */
+test('a second abandonment landing during the deferred resume window does not fire an unwanted lookup', async () => {
+    buildAddressForm();
+    const openSpy = jest.fn(() => ({ closed: false }));
+    global.window.open = openSpy;
+    let resolveBuyer;
+    stubFetch({
+        buyer: () => new Promise((resolve) => { resolveBuyer = resolve; })
+    });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.tokens = {
+        autofill_token: 'af-token',
+        delegation_token: 'del-token',
+        signup_url: 'https://signup.example.test/',
+        country: 'GB'
+    };
+    instance.enrolling = true;
+    instance.getCurrentBuyer(); // click 1: lookup 1 starts
+
+    instance.cancelEnrollment(); // abandon #1
+    instance.enrolling = true; // resumed, as startEnrollment() would set it
+    instance.getCurrentBuyer(); // click 2: no-ops, lookup 1 still in flight
+
+    resolveBuyer({ ok: false, status: 404 }); // lookup 1 settles, superseded
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    // A SECOND abandonment, landing in the gap before the deferred resume's
+    // setTimeout(0) has fired - `enrolling` is false again by the time it does.
+    instance.cancelEnrollment();
+    expect(instance.enrolling).toBe(false);
+
+    // Now let the deferred macrotask actually fire.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushPromises();
+    await flushPromises();
+
+    // No lookup should have run for the abandoned second attempt - no fetch
+    // issued, no popup opened.
+    expect(openSpy).not.toHaveBeenCalled();
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+/**
  * TWO-40 round 5 follow-up, adversarial review round 2 finding (Vader): the
  * synchronous stretch between setting isFetchingTokens/isFetchingBuyer true
  * and the fetch() call actually starting was unprotected. A throw there
@@ -415,6 +470,37 @@ test('a synchronous throw building the token-mint request does not permanently w
     errorSpy.mockRestore();
     document.removeEventListener('two:sole-trader-flight-settled', handler);
     instance.destroy();
+});
+
+/**
+ * TWO-40 round 7, adversarial review round 3 finding (Vader): the retry
+ * cooldown (`nextRetryAt`) predates the round-4 "keep panel open until
+ * settle" redesign and was never wired into it. Unlike the isFetchingTokens
+ * branch (where a request really is out and will eventually resume this
+ * click), a click landing inside the cooldown window has NOTHING in flight
+ * to ever settle it - the panel/spinner used to be stuck open indefinitely,
+ * recoverable only by an unrelated action (Escape, reopening, switching
+ * chips). A buyer clicking "I'm a sole trader" again within 5 seconds of a
+ * failed attempt - "did that work? let me retry" - is an entirely ordinary
+ * gesture, not an edge case.
+ */
+test('a click landing inside the retry cooldown still settles its own flight, rather than dead-ending open', () => {
+    buildPaymentTile();
+    stubFetch({ tokens: () => Promise.resolve({ json: () => Promise.resolve({ success: false }) }) });
+    const instance = build();
+    const { calls, handler } = recordSettled();
+
+    instance.startEnrollment(); // click 1: mint fails, arms the cooldown
+    return flushPromises().then(() => flushPromises()).then(() => {
+        expect(instance.nextRetryAt).toBeGreaterThan(Date.now());
+        expect(calls.length).toBe(1);
+
+        instance.startEnrollment(); // click 2: lands inside the cooldown
+
+        expect(calls.length).toBe(2);
+        document.removeEventListener('two:sole-trader-flight-settled', handler);
+        instance.destroy();
+    });
 });
 
 test('a synchronous throw building the buyer-lookup request does not permanently wedge getCurrentBuyer()', () => {

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -1,0 +1,188 @@
+/**
+ * TWO-40 round 4, Doug's explicit request: "keep the company search control
+ * open, show spinner in query field" for the duration of a Sole Trader
+ * click's real autofill round trip.
+ *
+ * TwoCompanySearch.js needs to know when that round trip is DONE - whatever
+ * the outcome - so it can stop the spinner and close the panel. This pins
+ * the signal it listens for: TwoSoleTrader.js's notifyEnrollmentSettled(),
+ * which fires `document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'))`
+ * from every terminal branch of startEnrollment()'s call graph. Each test
+ * below drives one branch and asserts the event actually fires from it -
+ * a fixed timeout in TwoCompanySearch.js would pass every one of these
+ * trivially without ever wiring the real signal, which is exactly the
+ * class of bug this file exists to rule out.
+ */
+
+'use strict';
+
+const { loadSoleTrader, buildPaymentTile, buildAddressForm, flushPromises } = require('./ps-harness');
+
+let TwoSoleTrader;
+
+function build(overrides) {
+    return new TwoSoleTrader(Object.assign({
+        checkoutHost: 'https://api.example.test',
+        orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+        ajaxToken: 'test-token',
+        billingCountry: 'GB'
+    }, overrides || {}));
+}
+
+function stubFetch(handlers) {
+    global.window.fetch = (url) => {
+        if (String(url).includes('soleTraderAvailability')) {
+            return Promise.resolve({ json: () => Promise.resolve({ success: true, available: true }) });
+        }
+        if (String(url).includes('soleTraderTokens')) {
+            return handlers.tokens
+                ? handlers.tokens()
+                : Promise.resolve({
+                    json: () => Promise.resolve({
+                        success: true,
+                        autofill_token: 'af-token',
+                        delegation_token: 'del-token',
+                        signup_url: 'https://signup.example.test/',
+                        country: 'GB'
+                    })
+                });
+        }
+        if (String(url).includes('/autofill/v1/buyer/current')) {
+            return handlers.buyer ? handlers.buyer() : Promise.resolve({ ok: false, status: 404 });
+        }
+        if (String(url).includes('saveCompany')) {
+            return handlers.save ? handlers.save() : Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+    };
+    global.fetch = global.window.fetch;
+}
+
+/** Records every `two:sole-trader-flight-settled` document dispatch. */
+function recordSettled() {
+    const calls = [];
+    const handler = () => calls.push(true);
+    document.addEventListener('two:sole-trader-flight-settled', handler);
+    return { calls, handler };
+}
+
+beforeEach(() => {
+    TwoSoleTrader = loadSoleTrader();
+});
+
+afterEach(() => {
+    delete global.fetch;
+    delete global.window.fetch;
+    delete global.window.TwoCompanyNumber;
+    delete global.window.open;
+    delete global.window.TwoCheckoutManager_Instance;
+    document.body.innerHTML = '';
+    global.window.localStorage.clear();
+});
+
+test('a successful autofill (buyer match) fires the settle event', async () => {
+    buildPaymentTile();
+    global.window.TwoCompanyNumber = { forDisplay: (v) => v };
+    global.window.TwoCheckoutManager_Instance = { setConfirmedCompanySelection: () => {} };
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='buyer@example.test' />");
+    stubFetch({
+        buyer: () => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ email: 'buyer@example.test', company_name: 'Sole Trader AS', organization_number: '923456789' })
+        })
+    });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a failed token mint fires the settle event', async () => {
+    buildPaymentTile();
+    stubFetch({ tokens: () => Promise.resolve({ json: () => Promise.resolve({ success: false }) }) });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a network failure on the buyer lookup fires the settle event', async () => {
+    buildPaymentTile();
+    stubFetch({ buyer: () => Promise.reject(new Error('network down')) });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a no-match buyer lookup handed off directly to the popup (address-editor page) fires the settle event', async () => {
+    buildAddressForm();
+    global.window.open = jest.fn(() => ({ closed: false }));
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a no-match buyer lookup handed off to the on-page prompt (payment step) fires the settle event', async () => {
+    buildPaymentTile();
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});
+
+test('a blocked popup still fires the settle event exactly once (not twice, despite openPopup() also reaching showError())', async () => {
+    buildAddressForm();
+    global.window.open = jest.fn(() => null); // blocked
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(calls.length).toBe(1);
+    errorSpy.mockRestore();
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+    instance.destroy();
+});

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -874,6 +874,22 @@ class TwoCompanySearch {
             this._soleTraderButton.on('click.twoDropdown', (event) => {
                 event.preventDefault();
                 event.stopPropagation();
+                // Re-entrancy guard (TWO-40 round 5, adversarial review
+                // finding - Han/Vader both independently caught this): round
+                // 4 keeps this button clickable for the WHOLE round trip
+                // rather than closing on the first click, which newly makes
+                // a second click reachable while the first is still waiting.
+                // TwoSoleTrader.js's own guards only cover the token-mint
+                // stage (`isFetchingTokens`); a second click landing during
+                // the buyer-lookup stage re-entered startEnrollment()'s
+                // "resume" branch and fired a second concurrent
+                // getCurrentBuyer() - on the no-match path that opened TWO
+                // signup popups from one buyer gesture. `_soleTraderLoading`
+                // is exactly "a flight for this click is already in
+                // progress", so bail out rather than starting a second one.
+                if (this._soleTraderLoading) {
+                    return;
+                }
                 this._chipMode = 'sole_trader';
                 // Unlike "Registered Company" (below), this chip's own click
                 // handler is the only place `sole_trader` mode is entered, so
@@ -899,11 +915,29 @@ class TwoCompanySearch {
                     // work; see their own comments for the event contract
                     // with TwoSoleTrader.js.
                     this.beginSoleTraderLoading();
-                    window.TwoSoleTrader_Instance.startEnrollment();
+                    try {
+                        // TWO-40 round 5 (Vader finding): startEnrollment() is
+                        // foreign-module code called with no try/catch
+                        // before this - a synchronous throw would leave the
+                        // spinner open with nothing left to ever settle it.
+                        window.TwoSoleTrader_Instance.startEnrollment();
+                    } catch (e) {
+                        this.endSoleTraderLoading();
+                        this.closeDropdown(true);
+                    }
                 } else {
                     // Nothing to wait on - close the same way "Registered
-                    // Company"/"Enter Manually" do.
-                    this.closeDropdown(true);
+                    // Company"/"Enter Manually" do. Deferred by one
+                    // requestAnimationFrame (the round-3 paint-timing fix,
+                    // reinstated here TWO-40 round 5 - adversarial review
+                    // finding): this branch does not go through
+                    // beginSoleTraderLoading()'s keep-open window at all, so
+                    // without this it is the exact same "renderChipSelection()
+                    // and closeDropdown() in the same synchronous tick, zero
+                    // painted frames" bug the rest of this handler exists to
+                    // fix. Only reachable when the global instance is
+                    // missing/malformed.
+                    window.requestAnimationFrame(() => this.closeDropdown(true));
                 }
             });
         }
@@ -923,15 +957,21 @@ class TwoCompanySearch {
                 if (this._manualEntry) {
                     this.exitManualEntryMode();
                 }
+                // BEFORE cancelEnrollment() (TWO-40 round 5, adversarial
+                // review finding), not after - see the reasoning at
+                // notifyEnrollmentSettled() in TwoSoleTrader.js:
+                // cancelEnrollment() now fires the SAME settle event that
+                // beginSoleTraderLoading()'s own listener reacts to by
+                // calling closeDropdown(true). This handler wants to STAY
+                // OPEN, not close - so its own listener must already be
+                // unbound before cancelEnrollment() can dispatch, or this
+                // click would immediately close the very panel it is trying
+                // to keep open.
+                this.endSoleTraderLoading();
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
                     window.TwoSoleTrader_Instance.cancelEnrollment();
                 }
-                // Same reasoning as "Enter Manually" above: this handler does
-                // not go through closeDropdown() either, and cancelEnrollment()
-                // only marks the flight stale server-generation-wise - it does
-                // not know about, or clear, this control's own spinner.
-                this.endSoleTraderLoading();
                 this.renderChipSelection();
                 if (this._queryField && this._queryField.length) {
                     this._queryField.trigger('focus');
@@ -1212,6 +1252,13 @@ class TwoCompanySearch {
             || !this._queryField || !this._queryField.length) {
             return;
         }
+        // BEFORE cancelEnrollment() (TWO-40 round 5, adversarial review
+        // finding - same reasoning as the "Registered Company" handler):
+        // cancelEnrollment() now fires the settle event too, and this
+        // method's own listener reacting to it would call closeDropdown(true)
+        // from INSIDE openDropdown() itself, re-closing the very panel this
+        // call is in the middle of opening. Unbind first.
+        this.endSoleTraderLoading();
         // Reopening the search control is the buyer choosing ordinary company
         // search over an "I'm a sole trader" row they may have clicked
         // moments earlier (TWO-40). Cancel any not-yet-completed enrolment -
@@ -1221,11 +1268,6 @@ class TwoCompanySearch {
             && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
             window.TwoSoleTrader_Instance.cancelEnrollment();
         }
-        // Same reasoning as cancelEnrollment() just above, for this
-        // control's own spinner/listener rather than TwoSoleTrader's
-        // bookkeeping (TWO-40 round 4) - a re-open reachable while a Sole
-        // Trader wait is still showing must not leave it spinning forever.
-        this.endSoleTraderLoading();
         clearTimeout(this._closeTimerId);
         this._closeTimerId = null;
         // Cleared on every open: the flag is otherwise only reset by a
@@ -1450,7 +1492,10 @@ class TwoCompanySearch {
         }
         $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs)
             .on('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs, () => {
-                this.endSoleTraderLoading();
+                // closeDropdown() itself calls endSoleTraderLoading() as its
+                // own first line (TWO-40 round 5 cleanup, Yoda finding) - no
+                // need to call it again here too, and this keeps every close
+                // path funnelled through the one centralized call.
                 this.closeDropdown(true);
             });
     }
@@ -1458,9 +1503,11 @@ class TwoCompanySearch {
     /**
      * Reverse beginSoleTraderLoading(): drop the spinner and the listener.
      * Called from closeDropdown() itself (so EVERY way the panel closes -
-     * the settle event, Escape, or anything else - leaves no listener or
-     * spinner behind) as well as from the settle handler above, which is
-     * why this is idempotent rather than assuming it is only ever called
+     * the settle event routes through there too now - Escape, reopening,
+     * "Registered Company"/"Enter Manually", or anything else leaves no
+     * listener or spinner behind), and also called directly (not via a
+     * close) from those same chip handlers and openDropdown(), which is why
+     * this stays idempotent rather than assuming it is only ever called
      * once.
      */
     endSoleTraderLoading() {
@@ -1569,6 +1616,13 @@ class TwoCompanySearch {
         this.companyField.off('.twoCompanyOpen');
 
         this.companyField.on('mousedown.twoCompanyOpen', (event) => {
+            // NOT guarded on `this._dropdownOpen` (considered and reverted,
+            // TWO-40 round 5): clicking the company field again - even while
+            // the panel is already open, e.g. with a Sole Trader wait in
+            // progress - is the buyer's own deliberate way back to ordinary
+            // search (see openDropdown()'s own comment and the "reopening
+            // search cancels a pending enrolment" tests). Adding the guard
+            // broke that intentional, already-tested behaviour.
             if (this._destroyed || this._manualEntry) {
                 return;
             }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -221,6 +221,10 @@ class TwoCompanySearch {
         // freezeResultsHeight().
         this._resultsHeightFrozen = false;
         this._resultsFreezeReleaseId = null;
+        // True between beginSoleTraderLoading() and endSoleTraderLoading() -
+        // the panel is being kept open with the query-field spinner showing
+        // for a Sole Trader click's autofill round trip (TWO-40 round 4).
+        this._soleTraderLoading = false;
         // Per-instance event namespace suffix. The `mouseup` guard has to be
         // bound on `document` (a drag can end anywhere, including outside the
         // panel), and `document` is a page-wide singleton - so unbinding by
@@ -751,6 +755,10 @@ class TwoCompanySearch {
      * link can afford a document-wide sweep; a focus-moving control cannot.
      */
     removeDropdown() {
+        // Same reasoning as closeDropdown()'s own call to this - a full
+        // teardown must not leave the settle listener bound past the panel
+        // it would have called closeDropdown() on (TWO-40 round 4).
+        this.endSoleTraderLoading();
         clearTimeout(this._closeTimerId);
         this._closeTimerId = null;
         this._dropdownOpen = false;
@@ -846,6 +854,12 @@ class TwoCompanySearch {
                 // reads a stray click as "collapse this step".
                 event.stopPropagation();
                 this._chipMode = 'manual';
+                // Abandons any Sole Trader wait in progress (TWO-40 round 4)
+                // - this handler does not go through closeDropdown(), so
+                // without this the query-field spinner would keep spinning
+                // and the settle listener would stay bound past the flow the
+                // buyer just walked away from.
+                this.endSoleTraderLoading();
                 this.enterManualEntryMode();
             });
         }
@@ -870,25 +884,26 @@ class TwoCompanySearch {
                 // lost by closing - but doing it before keeps this handler's
                 // ordering symmetric with the other two.
                 this.renderChipSelection();
-                // Deferred by one animation frame - NOT tidying (live-verified
-                // root cause of "the chip never looks selected", TWO-40 round
-                // 2). renderChipSelection() and closeDropdown() used to run in
-                // the very same synchronous tick of this one click handler, so
-                // the browser never got a chance to PAINT a frame with
-                // `--selected` applied before the panel's `display:none` wiped
-                // it back out - zero rendered frames showed the selection, even
-                // though the DOM write itself was correct and durable (it
-                // survives the hide, see closeDropdown()'s own comment). PR
-                // #159's regression test could not catch this because jsdom has
-                // no rendering/paint step at all: reading `.className`
-                // synchronously after the click always "sees" the class there,
-                // whether or not a real browser would ever have shown a frame
-                // with it. requestAnimationFrame() guarantees at least one paint
-                // of the selected state before the panel disappears.
-                window.requestAnimationFrame(() => this.closeDropdown(true));
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {
+                    // Keep the panel OPEN and show the query field's own
+                    // spinner for the actual duration of this click's
+                    // autofill round trip (Doug, TWO-40 round 4), instead of
+                    // closing immediately. This also subsumes the round-3
+                    // paint-timing fix that used to defer closeDropdown() by
+                    // one requestAnimationFrame: the panel now stays open for
+                    // the whole flight - far longer than one frame - so the
+                    // `--selected` state a buyer actually sees is no longer a
+                    // timing accident, it is the real in-progress state.
+                    // beginSoleTraderLoading()/endSoleTraderLoading() do the
+                    // work; see their own comments for the event contract
+                    // with TwoSoleTrader.js.
+                    this.beginSoleTraderLoading();
                     window.TwoSoleTrader_Instance.startEnrollment();
+                } else {
+                    // Nothing to wait on - close the same way "Registered
+                    // Company"/"Enter Manually" do.
+                    this.closeDropdown(true);
                 }
             });
         }
@@ -912,6 +927,11 @@ class TwoCompanySearch {
                     && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
                     window.TwoSoleTrader_Instance.cancelEnrollment();
                 }
+                // Same reasoning as "Enter Manually" above: this handler does
+                // not go through closeDropdown() either, and cancelEnrollment()
+                // only marks the flight stale server-generation-wise - it does
+                // not know about, or clear, this control's own spinner.
+                this.endSoleTraderLoading();
                 this.renderChipSelection();
                 if (this._queryField && this._queryField.length) {
                     this._queryField.trigger('focus');
@@ -1201,6 +1221,11 @@ class TwoCompanySearch {
             && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
             window.TwoSoleTrader_Instance.cancelEnrollment();
         }
+        // Same reasoning as cancelEnrollment() just above, for this
+        // control's own spinner/listener rather than TwoSoleTrader's
+        // bookkeeping (TWO-40 round 4) - a re-open reachable while a Sole
+        // Trader wait is still showing must not leave it spinning forever.
+        this.endSoleTraderLoading();
         clearTimeout(this._closeTimerId);
         this._closeTimerId = null;
         // Cleared on every open: the flag is otherwise only reset by a
@@ -1239,6 +1264,12 @@ class TwoCompanySearch {
      *   browser has already moved focus somewhere else of its own accord.
      */
     closeDropdown(returnFocus) {
+        // Every way the panel closes must leave no sole-trader spinner or
+        // stray settle-listener behind, not only the settle event's own
+        // path back into here (TWO-40 round 4) - Escape, for instance, goes
+        // straight to closeDropdown() without going through
+        // endSoleTraderLoading() otherwise.
+        this.endSoleTraderLoading();
         clearTimeout(this._closeTimerId);
         this._closeTimerId = null;
         this._dropdownOpen = false;
@@ -1388,6 +1419,59 @@ class TwoCompanySearch {
                 button.toggleClass('two-company-mode-chip--selected', this._chipMode === mode);
             }
         });
+    }
+
+    /**
+     * Keep the panel open and show the query field's own spinner for the
+     * duration of a Sole Trader click's real autofill round trip (TWO-40
+     * round 4, Doug's explicit request: "keep the company search control
+     * open, show spinner in query field"). Reuses the SAME spinner the
+     * ordinary search path already shows - `.two-company-dropdown__spinner`,
+     * toggled by the `two-company-search-loading` class on the query field
+     * (see two.css) - rather than inventing a second one; §1 already settled
+     * where an in-field spinner on this control lives.
+     *
+     * Bound to a single, namespaced `document` listener for
+     * `two:sole-trader-flight-settled` - the event TwoSoleTrader.js's
+     * notifyEnrollmentSettled() fires from every terminal branch of
+     * startEnrollment()'s call graph (success, failure, or a hand-off to the
+     * on-page prompt/popup). One-shot in effect: endSoleTraderLoading()
+     * unbinds it as its first act, so a second, unrelated settle (there
+     * should not be one for a single click, but nothing here depends on
+     * that) is a no-op rather than a second close.
+     */
+    beginSoleTraderLoading() {
+        if (this._soleTraderLoading) {
+            return;
+        }
+        this._soleTraderLoading = true;
+        if (this._queryField && this._queryField.length) {
+            this._queryField.addClass('two-company-search-loading');
+        }
+        $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs)
+            .on('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs, () => {
+                this.endSoleTraderLoading();
+                this.closeDropdown(true);
+            });
+    }
+
+    /**
+     * Reverse beginSoleTraderLoading(): drop the spinner and the listener.
+     * Called from closeDropdown() itself (so EVERY way the panel closes -
+     * the settle event, Escape, or anything else - leaves no listener or
+     * spinner behind) as well as from the settle handler above, which is
+     * why this is idempotent rather than assuming it is only ever called
+     * once.
+     */
+    endSoleTraderLoading() {
+        if (!this._soleTraderLoading) {
+            return;
+        }
+        this._soleTraderLoading = false;
+        $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs);
+        if (this._queryField && this._queryField.length) {
+            this._queryField.removeClass('two-company-search-loading');
+        }
     }
 
     /**

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -870,7 +870,22 @@ class TwoCompanySearch {
                 // lost by closing - but doing it before keeps this handler's
                 // ordering symmetric with the other two.
                 this.renderChipSelection();
-                this.closeDropdown(true);
+                // Deferred by one animation frame - NOT tidying (live-verified
+                // root cause of "the chip never looks selected", TWO-40 round
+                // 2). renderChipSelection() and closeDropdown() used to run in
+                // the very same synchronous tick of this one click handler, so
+                // the browser never got a chance to PAINT a frame with
+                // `--selected` applied before the panel's `display:none` wiped
+                // it back out - zero rendered frames showed the selection, even
+                // though the DOM write itself was correct and durable (it
+                // survives the hide, see closeDropdown()'s own comment). PR
+                // #159's regression test could not catch this because jsdom has
+                // no rendering/paint step at all: reading `.className`
+                // synchronously after the click always "sees" the class there,
+                // whether or not a real browser would ever have shown a frame
+                // with it. requestAnimationFrame() guarantees at least one paint
+                // of the selected state before the panel disappears.
+                window.requestAnimationFrame(() => this.closeDropdown(true));
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {
                     window.TwoSoleTrader_Instance.startEnrollment();

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -869,24 +869,45 @@ class TwoSoleTrader {
         // again the instant they land, defeating bindPopupMessageListener()'s
         // whole check.
         const generation = this._enrollGeneration;
-        // Post the country the buyer currently has selected (TWO-40). The
-        // server prefers THIS over anything it holds: the invoice-address tier
-        // that used to outrank it was deleted, not demoted, so the posted
-        // country wins outright and the cart's DELIVERY address is consulted
-        // only when no usable country was posted at all. It re-checks the
-        // registry either way.
-        //
-        // Deliberately billingCountry(): that is the SAME resolver
-        // isAvailableForCurrentCountry() answers the chip's visibility from,
-        // so the country the mint is authorised against and the country the
-        // chip was shown for cannot disagree by construction. Sent
-        // urlencoded, the way applyBuyer() posts to saveCompany.
-        const body = new URLSearchParams({ country: this.billingCountry() });
-        fetch(this.moduleUrl('soleTraderTokens'), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
-        })
+        // Everything from here down to the fetch() call starting is
+        // synchronous and, before this try (TWO-40 round 5 follow-up, Vader
+        // finding round 2), unprotected: a throw anywhere in it - e.g.
+        // billingCountry() or moduleUrl() reading a malformed config - left
+        // `isFetchingTokens` stuck `true` forever. Every later click would
+        // then silently no-op on that guard for the rest of the page's
+        // life, with nothing ever in flight and no settle event to ever
+        // close a THEN-open panel/spinner - the try/catch TwoCompanySearch.js
+        // has around calling startEnrollment() only protects the FIRST such
+        // click, not the ones after it. Treated exactly like a network
+        // failure once caught.
+        let request;
+        try {
+            // Post the country the buyer currently has selected (TWO-40).
+            // The server prefers THIS over anything it holds: the invoice-
+            // address tier that used to outrank it was deleted, not
+            // demoted, so the posted country wins outright and the cart's
+            // DELIVERY address is consulted only when no usable country was
+            // posted at all. It re-checks the registry either way.
+            //
+            // Deliberately billingCountry(): that is the SAME resolver
+            // isAvailableForCurrentCountry() answers the chip's visibility
+            // from, so the country the mint is authorised against and the
+            // country the chip was shown for cannot disagree by
+            // construction. Sent urlencoded, the way applyBuyer() posts to
+            // saveCompany.
+            const body = new URLSearchParams({ country: this.billingCountry() });
+            request = fetch(this.moduleUrl('soleTraderTokens'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            });
+        } catch (e) {
+            this.isFetchingTokens = false;
+            this.nextRetryAt = Date.now() + this.retryCooldownMs;
+            this.showError();
+            return;
+        }
+        request
             .then(function (response) { return response.json(); })
             .then(function (json) {
                 if (json && json.success && json.autofill_token) {
@@ -965,6 +986,38 @@ class TwoSoleTrader {
     }
 
     /**
+     * Re-run getCurrentBuyer() for whichever generation is CURRENT, called
+     * from getCurrentBuyer()'s own superseded branches when `enrolling` is
+     * still true - i.e. a later click abandoned-then-resumed while THIS
+     * lookup was outstanding, riding it via the isFetchingBuyer single-
+     * flight guard rather than issuing its own (TWO-40 round 5 follow-up,
+     * Han finding round 2).
+     *
+     * Deferred to a macrotask (`setTimeout(..., 0)`), not called directly.
+     * This runs from INSIDE the `.then()`/`.catch()` handler of the request
+     * that just finished - `isFetchingBuyer` is still true at that point,
+     * because the `.finally()` chained after it has not run yet, and won't
+     * until this handler returns. Calling getCurrentBuyer() synchronously
+     * here would race that pending `.finally()`: whichever of "the resumed
+     * call sets isFetchingBuyer back to true" or "the original chain's
+     * finally resets it to false" runs SECOND would win, and the finally
+     * runs second by construction (it is queued as this handler returns),
+     * so a synchronous call was getting its own re-entrancy flag reset out
+     * from under it moments after starting. Deferring to a macrotask runs
+     * this after that finally has already settled the flag, so the resumed
+     * call's own true/false bracketing is undisturbed.
+     */
+    resumeIfStillEnrolling() {
+        if (!this.enrolling) {
+            return;
+        }
+        const self = this;
+        setTimeout(function () {
+            self.getCurrentBuyer();
+        }, 0);
+    }
+
+    /**
      * Autofill from the buyer's current Two sole-trader business. A 404,
      * a missing checkout email, or an email mismatch means no usable
      * registration yet - show the signup prompt instead. The email match
@@ -1000,10 +1053,26 @@ class TwoSoleTrader {
         const superseded = function () {
             return self._enrollGeneration !== generation;
         };
-        fetch(this.config.checkoutHost + '/autofill/v1/buyer/current', {
-            credentials: 'include',
-            headers: { 'two-delegated-authority-token': this.tokens.autofill_token }
-        })
+        // Same reasoning as fetchTokens()'s own try/catch around its
+        // pre-fetch setup (TWO-40 round 5 follow-up, Vader finding round 2):
+        // `this.tokens.autofill_token` below throws synchronously if
+        // `this.tokens` is ever null when this runs, and nothing before
+        // this fix protected `isFetchingBuyer` against that - a stuck-true
+        // guard here silently no-ops every future click for the rest of
+        // the page's life, the exact failure mode this whole PR chain
+        // exists to close.
+        let request;
+        try {
+            request = fetch(this.config.checkoutHost + '/autofill/v1/buyer/current', {
+                credentials: 'include',
+                headers: { 'two-delegated-authority-token': this.tokens.autofill_token }
+            });
+        } catch (e) {
+            this.isFetchingBuyer = false;
+            this.showError();
+            return;
+        }
+        request
             .then(function (response) {
                 if (response.ok) {
                     return response.json();
@@ -1015,6 +1084,22 @@ class TwoSoleTrader {
             })
             .then(function (buyer) {
                 if (superseded()) {
+                    // TWO-40 round 5 follow-up (Han finding, round 2): the
+                    // SAME abandon-then-retry shape fetchTokens()'s success
+                    // branch was fixed for above, one stage deeper. This
+                    // lookup's own single-flight guard (isFetchingBuyer)
+                    // means a click that arrived while this request was
+                    // already out never issued its own lookup - it is riding
+                    // this one. If this generation is now stale but
+                    // something is still enrolling, re-run the lookup for
+                    // whichever generation IS current rather than dropping
+                    // this result on the floor with nothing left to ever
+                    // settle the resumed click's spinner. Deliberately a
+                    // fresh getCurrentBuyer() call (not just falling through
+                    // with the stale `buyer`/`generation` closures) - a
+                    // buyer lookup, unlike a token mint, must be re-run for
+                    // the current identity/generation, not replayed.
+                    self.resumeIfStillEnrolling();
                     return;
                 }
                 const entered = self.checkoutEmail().trim().toLowerCase();
@@ -1050,6 +1135,16 @@ class TwoSoleTrader {
             })
             .catch(function () {
                 if (superseded()) {
+                    // Same reasoning as the success branch above (round 5
+                    // follow-up, Han finding round 2): a resumed click may
+                    // be riding this exact request. A network failure on it
+                    // is a real failure for that resumed click too, not just
+                    // for the stale one that originally issued it - retry
+                    // once for the current generation rather than dropping
+                    // it silently. (The retry itself can fail again, but
+                    // that failure will correctly reach showError()/notify
+                    // for the then-current generation on its own terms.)
+                    self.resumeIfStillEnrolling();
                     return;
                 }
                 self.showError();

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -968,6 +968,10 @@ class TwoSoleTrader {
                     self.applyBuyer(buyer, generation);
                 } else if (self.container() && self.container().querySelector('.two-sole-trader__prompt')) {
                     self.showPrompt();
+                    // No error, but nothing left for this click's own round
+                    // trip to wait on - the flow now waits on the buyer
+                    // clicking the on-page prompt, a separate user action.
+                    self.notifyEnrollmentSettled();
                 } else {
                     // TWO-40 follow-up: on the address-editor page there is no
                     // `.two-sole-trader` container at all (it is only rendered
@@ -982,7 +986,9 @@ class TwoSoleTrader {
                     // here, still async off the original click, is not
                     // blocked in practice. Payment-step keeps the two-click
                     // showPrompt()->openPopup() flow unchanged since its
-                    // container/prompt element exists there.
+                    // container/prompt element exists there. openPopup()
+                    // itself notifies from both of its own branches (opened
+                    // fine, or blocked) - see there.
                     self.openPopup();
                 }
             })
@@ -1103,6 +1109,7 @@ class TwoSoleTrader {
                     self.enrolling = false;
                     self.stopObserving();
                     document.dispatchEvent(new CustomEvent('two:sole-trader-ready'));
+                    self.notifyEnrollmentSettled();
                 } else {
                     self.showError();
                 }
@@ -1226,12 +1233,20 @@ class TwoSoleTrader {
             // without a `.two-sole-trader__error` element (containerless
             // address-page path, TWO-40 follow-up) - console.error is the
             // only signal left there, so it is not a completely silent
-            // dead end even in that edge case.
+            // dead end even in that edge case. showError() also notifies
+            // (TWO-40 round 4) - do not ALSO notify below, or a blocked
+            // popup would fire the settle event twice for one click.
             this.showError();
             if (!this.container()) {
                 // eslint-disable-next-line no-console
                 console.error('Two: sole-trader signup popup was blocked and no on-page error UI is available here.');
             }
+        } else {
+            // Opened fine - this click's own round trip has handed off to
+            // the popup window, whether called directly from
+            // getCurrentBuyer() (no on-page prompt to show first) or from
+            // showPrompt()'s own click listener (TWO-40 round 4).
+            this.notifyEnrollmentSettled();
         }
         return popup;
     }
@@ -1338,6 +1353,35 @@ class TwoSoleTrader {
         if (error) {
             error.style.display = 'inline';
         }
+        // Every showError() call site is the LAST thing its branch does - a
+        // terminal state for whichever round trip led here (token mint,
+        // buyer lookup, or a blocked popup) - so this single spot covers
+        // every failure exit without a notify at each call site. See
+        // notifyEnrollmentSettled() for what this is for.
+        this.notifyEnrollmentSettled();
+    }
+
+    /**
+     * Tell TwoCompanySearch.js's in-flight spinner (TWO-40 round 4) that
+     * THIS click's own round trip has reached a terminal state, whatever
+     * that state is - a completed autofill, a signup prompt/popup handed
+     * off to, or a failure. Fired from every terminal branch of
+     * startEnrollment()'s call graph:
+     *  - showError() (covers both fetchTokens() failure paths, the
+     *    getCurrentBuyer() catch, and openPopup()'s popup-blocked branch)
+     *  - getCurrentBuyer()'s showPrompt()/openPopup() branches (no error,
+     *    but nothing left for the spinner to wait on - the flow has handed
+     *    off to on-page prompt UI or a popup window)
+     *  - applyBuyer()'s success branch
+     *
+     * Deliberately NOT gated on `_enrollGeneration`: TwoCompanySearch.js's
+     * listener is bound fresh per click and unbound on its own next close,
+     * so a stale event from an abandoned attempt finding no listener left
+     * to hear it is already a no-op, the same way a stale popup message
+     * finding this object gone would be.
+     */
+    notifyEnrollmentSettled() {
+        document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
     }
 }
 

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -163,6 +163,9 @@ class TwoSoleTrader {
         this.isFetchingTokens = false;
         this.nextRetryAt = 0;
         this.retryCooldownMs = 5000;
+        // Same shape as isFetchingTokens above, for getCurrentBuyer()
+        // (TWO-40 round 5, adversarial review finding) - see its own guard.
+        this.isFetchingBuyer = false;
 
         // TWO-25326 bug 9, round 3: take the availability answer the SERVER
         // already resolved as this instance's settled state, before init()
@@ -829,6 +832,18 @@ class TwoSoleTrader {
         }
         this.enrolling = false;
         this.hidePrompt();
+        // TWO-40 round 5 (adversarial review finding): a genuine cancellation
+        // - `enrolling` really was true - is itself a terminal state for
+        // whichever click started the flight being cancelled, exactly like a
+        // success or a failure. Without this, TwoCompanySearch.js's spinner/
+        // listener only got cleared because every ONE of its own callers
+        // happens to also call endSoleTraderLoading() directly in the same
+        // tick - a coincidence of two files' invariants staying in lockstep,
+        // not an enforced contract. See TwoCompanySearch.js's own callers of
+        // cancelEnrollment(), all of which now unbind their listener BEFORE
+        // calling this, so this dispatch reaching an already-unbound
+        // listener there is the expected, harmless case.
+        this.notifyEnrollmentSettled();
     }
 
     /**
@@ -883,16 +898,41 @@ class TwoSoleTrader {
                     // correctly reads as stale; bindPopupMessageListener()'s
                     // check (and a resumed startEnrollment()'s own re-stamp)
                     // are what bring it current again, never this callback.
-                    self._tokensGeneration = generation;
                     self.bindPopupMessageListener();
-                    // Only auto-continue into the buyer lookup if nothing
-                    // has cancelled since this mint was requested. A
-                    // superseded mint still keeps its tokens (an explicit
-                    // resume works off them without re-minting), it just
-                    // does not act on them unasked.
                     if (self._enrollGeneration === generation) {
+                        // Ordinary case: nothing has cancelled since this
+                        // mint was requested. Stamp with the CAPTURED
+                        // generation, not the current one - if cancelEnrollment()
+                        // runs AFTER this point but before the tokens are
+                        // acted on, the stamp must already read as stale.
+                        self._tokensGeneration = generation;
+                        self.getCurrentBuyer();
+                    } else if (self.enrolling) {
+                        // TWO-40 round 5 (adversarial review finding, Han +
+                        // Yoda independently): THIS mint's own generation is
+                        // stale (cancelEnrollment() ran while it was out -
+                        // e.g. the buyer abandoned via "Registered Company"
+                        // then clicked "Sole Trader" again before this
+                        // resolved). But `fetchTokens()`'s own re-entry
+                        // guard (isFetchingTokens, above) means the SECOND
+                        // click's startEnrollment() call rode along on this
+                        // exact request rather than firing a new one - there
+                        // is only ever one mint in flight at a time. If
+                        // `enrolling` is true, a later click IS still
+                        // waiting on exactly these tokens; silently dropping
+                        // them here (the previous behaviour) left that
+                        // click's spinner and open panel with nothing left
+                        // to ever settle it. Stamp and resume for whichever
+                        // generation is CURRENT, not the stale one that
+                        // requested the mint - mirrors startEnrollment()'s
+                        // own "resume" branch below for the same tokens.
+                        self._tokensGeneration = self._enrollGeneration;
                         self.getCurrentBuyer();
                     }
+                    // Else: genuinely abandoned, nobody enrolling right now.
+                    // cancelEnrollment() already notified whichever click
+                    // started this mint that its wait is over; these tokens
+                    // are simply kept for a future explicit resume.
                 } else {
                     self.tokens = null;
                     self.nextRetryAt = Date.now() + self.retryCooldownMs;
@@ -931,6 +971,22 @@ class TwoSoleTrader {
      * is case-insensitive and required.
      */
     getCurrentBuyer() {
+        // Re-entrancy guard (TWO-40 round 5, adversarial review finding -
+        // Han + Vader independently caught this): unlike fetchTokens()
+        // (isFetchingTokens), this had no guard of its own before. A second
+        // click while a lookup was already outstanding fired a second,
+        // concurrent lookup - on the no-match path each one independently
+        // reaches openPopup(), so a buyer clicking twice got TWO signup
+        // popup windows from one gesture. TwoCompanySearch.js's own click
+        // handler now guards on `_soleTraderLoading`, but this is kept as a
+        // second, symmetric layer: bindPopupMessageListener()'s resumed
+        // lookup (a genuinely separate caller, off a real user action in
+        // another window) goes through here too, and should not be able to
+        // race a lookup already running for the same reason.
+        if (this.isFetchingBuyer) {
+            return;
+        }
+        this.isFetchingBuyer = true;
         const self = this;
         // Captured BEFORE the request starts (round 2 adversarial review
         // finding). cancelEnrollment() bumps this on every call, including
@@ -997,6 +1053,9 @@ class TwoSoleTrader {
                     return;
                 }
                 self.showError();
+            })
+            .finally(function () {
+                self.isFetchingBuyer = false;
             });
     }
 

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -855,7 +855,23 @@ class TwoSoleTrader {
      * click.
      */
     fetchTokens() {
-        if (this.isFetchingTokens || Date.now() < this.nextRetryAt) {
+        if (this.isFetchingTokens) {
+            // A request IS already out - this click is riding it, and its
+            // own resolution (the `else if (self.enrolling)` resume branch
+            // below) is what settles this click, not this return.
+            return;
+        }
+        if (Date.now() < this.nextRetryAt) {
+            // Round 7 adversarial review finding (Vader): unlike the
+            // isFetchingTokens branch above, NOTHING is in flight to ever
+            // resume this click - the cooldown predates the round-4 "keep
+            // panel open until settle" redesign and was never wired into
+            // it. A click landing inside the cooldown window used to
+            // dead-end with the panel/spinner stuck open indefinitely -
+            // TwoCompanySearch.js's listener had nothing left to ever hear.
+            // showError() also notifies (see its own comment), settling
+            // THIS click exactly as a real failed mint would.
+            this.showError();
             return;
         }
         this.isFetchingTokens = true;
@@ -1006,6 +1022,16 @@ class TwoSoleTrader {
      * from under it moments after starting. Deferring to a macrotask runs
      * this after that finally has already settled the flag, so the resumed
      * call's own true/false bracketing is undisturbed.
+     *
+     * Assumes `this` outlives the deferred macrotask - true today only
+     * because `window.TwoSoleTrader_Instance` is created exactly once
+     * (views/js/twopayment.js) and never destroyed/recreated in production.
+     * A future refactor that DOES tear down and rebuild the instance
+     * mid-page needs to clear any pending timer from this method in its
+     * own destroy(), the same way removeDropdown()/closeDropdown() already
+     * clear TwoCompanySearch.js's own timers - round 3 adversarial review
+     * observation (Vader), not fixed here because the precondition it
+     * guards against does not exist in this codebase today.
      */
     resumeIfStillEnrolling() {
         if (!this.enrolling) {
@@ -1013,6 +1039,19 @@ class TwoSoleTrader {
         }
         const self = this;
         setTimeout(function () {
+            // Re-check at FIRE time, not just at schedule time (round 7
+            // adversarial review finding, Han): the gap between scheduling
+            // this macrotask and it actually running is real time in a real
+            // browser, and a second abandon can land in it - a second
+            // "Registered Company"/"Enter Manually" click, or another
+            // country change, calling cancelEnrollment() again before this
+            // fires. Without re-checking, this ran a full, unwanted lookup
+            // for a buyer who had already walked away from the flow a
+            // second time - on the no-match path, popping an unwanted
+            // signup window.
+            if (!self.enrolling) {
+                return;
+            }
             self.getCurrentBuyer();
         }, 0);
     }


### PR DESCRIPTION
## Summary

PR #159 fixed the DOM state (`renderChipSelection()` was missing from the Sole Trader click handler) but a real Chrome click-through still showed nothing selected. Live-verified against `prestashop-dev.staging.two.inc` with a cache-busted asset check first, to rule out a deploy/cache problem.

- **Root cause**: `renderChipSelection()` and `closeDropdown()` ran in the same synchronous tick of the click handler, so a real browser never painted a frame with `--selected` applied before the panel's `display:none` hid it again. Zero rendered frames ever showed the selection to a buyer. jsdom has no render/paint step, so PR #159's own regression test (reading `.className` synchronously after the click) could not see this - it passed regardless of whether any real browser would ever have shown a frame with the class applied.
- **Fix, commit 1**: defer `closeDropdown()` by one `requestAnimationFrame`, guaranteeing at least one real paint of the selected state.
- **Fix, commit 2** (feature, Doug's explicit request): "keep the company search control open, show spinner in query field" for the actual duration of the Sole Trader autofill round trip, rather than closing immediately. This supersedes commit 1's one-frame fix for the normal path (the panel now stays open far longer than one frame) while commit 1 still stands on its own. Reuses the existing `.two-company-dropdown__spinner` / `two-company-search-loading` in-field spinner (two.css §1) rather than inventing a new one. `TwoSoleTrader.js` gains `notifyEnrollmentSettled()`, dispatching `two:sole-trader-flight-settled` from every terminal branch of `startEnrollment()`'s call graph (success, failed token mint, failed buyer lookup, hand-off to the on-page prompt, hand-off to the signup popup - opened or blocked). `TwoCompanySearch.js` closes the panel only when that event fires - not on a fixed timeout.

## Live verification

- Chrome-driven repro against `prestashop-dev.staging.two.inc/gb/` (guest checkout, address step, Sole Trader chip click) before this fix: DOM class only becomes correct ~1.2s after click, after the panel is already hidden - confirming zero painted frames of the selected state.
- Full JS suite green locally (28 suites / 719 tests) after both commits.
- Cache-busted `curl ...?ver=` re-check of the deployed asset planned before merge, per the standing "don't trust a bare unversioned URL" lesson from this same investigation.

## Test plan

- [x] `npx jest --config tests/js/jest.config.js` - 28 suites / 719 tests green
- [x] New regression test pinning the paint-timing bug (panel visibly open + class applied, not just eventually true)
- [x] New regression test pinning the keep-open/spinner/settle-driven-close behaviour, including "no fixed timeout closes it"
- [x] New `sole-trader-flight-settled.test.js` covering every terminal branch of `startEnrollment()`'s call graph fires the settle event exactly once
- [ ] Live re-verification on staging with the DOM class array check, before merge
