### PR TITLE
TWO-40: Select a different sole trader + Magento/WooCommerce porting note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ tests/e2e/playwright-report/
 
 # Deploy-time commit stamp (written by package-release.sh / git-sync, never committed)
 .two-deployed-commit
+.review/

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -133,6 +133,88 @@ describe('click behaviour (b)', () => {
         document.body.removeEventListener('click', ancestorHandler);
         instance.destroy();
     });
+
+    test('a rapid double-click only calls startReplacement() once (re-entrancy guard, TWO-40 review finding)', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        const startReplacement = jest.fn();
+        global.window.TwoSoleTrader_Instance = { startReplacement: startReplacement };
+
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(startReplacement).toHaveBeenCalledTimes(1);
+
+        instance.destroy();
+    });
+
+    test('the guard releases on the settle event, so a LATER click (after the flight settled) works again', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        const startReplacement = jest.fn();
+        global.window.TwoSoleTrader_Instance = { startReplacement: startReplacement };
+
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+        expect(startReplacement).toHaveBeenCalledTimes(1);
+
+        // Simulate the popup-opened (or blocked/failed) settle signal
+        // TwoSoleTrader.js's notifyEnrollmentSettled() fires from every
+        // terminal branch of startReplacement()'s call graph.
+        document.dispatchEvent(new window.CustomEvent('two:sole-trader-flight-settled'));
+
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+        expect(startReplacement).toHaveBeenCalledTimes(2);
+
+        instance.destroy();
+    });
+
+    test('a missing/malformed TwoSoleTrader_Instance logs visibly instead of a silent no-op', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        delete global.window.TwoSoleTrader_Instance;
+
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+        instance.destroy();
+    });
+});
+
+describe('stale link removal on a real registered-company selection (d)', () => {
+    test('onCompanySelected() with an organisation number removes a stale "Select a different sole trader" link', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        expect(document.querySelector('.two-company-select-different-sole-trader')).not.toBeNull();
+
+        instance.onCompanySelected(
+            { preventDefault: () => {} },
+            { item: { value: 'Real Registered Co', organization_number: '923456789' } }
+        );
+
+        expect(document.querySelector('.two-company-select-different-sole-trader')).toBeNull();
+        instance.destroy();
+    });
+
+    test('onCompanySelected() with NO organisation number (clearSelectedCompany() path) also removes it', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        expect(document.querySelector('.two-company-select-different-sole-trader')).not.toBeNull();
+
+        instance.onCompanySelected(
+            { preventDefault: () => {} },
+            { item: { value: 'Some Result With No Number' } }
+        );
+
+        expect(document.querySelector('.two-company-select-different-sole-trader')).toBeNull();
+        instance.destroy();
+    });
 });
 
 describe('popup URL (c)', () => {

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -356,3 +356,24 @@ describe('country change abandons an in-flight replacement flow (e, round-2 revi
         instance.destroy();
     });
 });
+
+describe('destroy() abandons an in-flight replacement flow too (f, round-3 review finding)', () => {
+    test('destroy() calls TwoSoleTrader_Instance.cancelEnrollment() - covers updatedAddressForm rebuilds, not just a country change', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        const cancelEnrollment = jest.fn();
+        global.window.TwoSoleTrader_Instance = {
+            startReplacement: jest.fn(),
+            cancelEnrollment: cancelEnrollment
+        };
+
+        // TwoCheckoutManager.handleAddressFormUpdate() destroys and rebuilds
+        // this instance on EVERY `updatedAddressForm` firing (not only a
+        // country change - that's the round-2 fix's gap) - destroy() itself
+        // is the one choke point common to all of those triggers.
+        instance.destroy();
+
+        expect(cancelEnrollment).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -328,3 +328,31 @@ describe('popup URL (c)', () => {
         instance.destroy();
     });
 });
+
+describe('country change abandons an in-flight replacement flow (e, round-2 review finding)', () => {
+    test('changing the billing country calls TwoSoleTrader_Instance.cancelEnrollment()', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        const cancelEnrollment = jest.fn();
+        global.window.TwoSoleTrader_Instance = {
+            startReplacement: jest.fn(),
+            cancelEnrollment: cancelEnrollment
+        };
+
+        // Simulate the buyer having clicked "Select a different sole
+        // trader" (a mint/lookup is now conceptually in flight for the OLD
+        // country) - this test targets the country-change listener itself,
+        // not startReplacement(), so the click is not required to exercise
+        // the fix; the point is that cancelEnrollment() fires REGARDLESS of
+        // whether a flow is actually in flight, exactly like the
+        // "Registered Company" chip handler and openDropdown() already do.
+        const countryField = document.querySelector("select[name='id_country']");
+        expect(countryField).not.toBeNull();
+        countryField.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+        expect(cancelEnrollment).toHaveBeenCalledTimes(1);
+
+        instance.destroy();
+    });
+});

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -1,0 +1,248 @@
+/**
+ * TWO-40 follow-up: "Select a different sole trader".
+ *
+ * A completed sole-trader enrolment writes the buyer's identity into the
+ * company field (TwoCompanySearch.adoptSoleTraderBuyer(), see
+ * sole-trader-writeback.test.js) but previously left no way back into the
+ * hosted signup other than reloading the page. This adds a reverse link,
+ * same slot/pattern as the existing "Search for company" link
+ * (renderBackToSearchLink()), that reopens the popup directly - skipping
+ * getCurrentBuyer()'s silent-autofill check, since the buyer is explicitly
+ * asking to replace an identity that check would just hand straight back -
+ * with `autoselect=false` appended so the hosted signup does not silently
+ * re-apply the same registration.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    loadSoleTrader,
+    buildAddressForm,
+    flushPromises
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+
+const NAMED_BUYER = {
+    company_name: 'Sole Trader Test Co',
+    organization_number: 'TWO:ST123456789012',
+    email: 'buyer@example.test',
+    billing_address: null,
+    shipping_address: null
+};
+
+let TwoCompanySearch;
+
+function makeSearchInstance(config) {
+    return new TwoCompanySearch(Object.assign({ checkoutHost: CHECKOUT_HOST }, config || {}));
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    buildAddressForm();
+});
+
+afterEach(() => {
+    delete global.window.TwoSoleTrader_Instance;
+    delete global.fetch;
+    delete global.window.fetch;
+    delete global.window.open;
+    document.body.innerHTML = '';
+});
+
+describe('rendering (a)', () => {
+    test('the link renders under the company field once a named sole-trader identity lands', () => {
+        const instance = makeSearchInstance();
+
+        expect(document.querySelector('.two-company-select-different-sole-trader')).toBeNull();
+
+        const wrote = instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        expect(wrote).toBe(true);
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        expect(link).not.toBeNull();
+        expect(link.tagName).toBe('BUTTON');
+        expect(link.getAttribute('type')).toBe('button');
+        expect(link.textContent).toBe('Select a different sole trader');
+
+        // Same slot as "Search for company": a sibling of the company field
+        // that comes AFTER it in document order, not folded into some other
+        // row (e.g. the org-number hint span company search also appends).
+        const companyField = document.querySelector("input[name='company']");
+        expect(companyField.parentNode).toBe(link.parentNode);
+        // eslint-disable-next-line no-bitwise
+        expect(companyField.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+        instance.destroy();
+    });
+
+    test('a nameless sole trader (no trading name) does not render the link - nothing to "replace" visibly', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(Object.assign({}, NAMED_BUYER, { company_name: '' }));
+
+        expect(document.querySelector('.two-company-select-different-sole-trader')).toBeNull();
+        instance.destroy();
+    });
+
+    test('clearSelectedCompany() removes the link again, mirroring the reverse link\'s own gating', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        expect(document.querySelector('.two-company-select-different-sole-trader')).not.toBeNull();
+
+        instance.clearSelectedCompany();
+
+        expect(document.querySelector('.two-company-select-different-sole-trader')).toBeNull();
+        instance.destroy();
+    });
+});
+
+describe('click behaviour (b)', () => {
+    test('clicking the link calls TwoSoleTrader_Instance.startReplacement(), not startEnrollment()', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        const startReplacement = jest.fn();
+        const startEnrollment = jest.fn();
+        global.window.TwoSoleTrader_Instance = { startReplacement: startReplacement, startEnrollment: startEnrollment };
+
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(startReplacement).toHaveBeenCalledTimes(1);
+        expect(startEnrollment).not.toHaveBeenCalled();
+
+        instance.destroy();
+    });
+
+    test('the click does not bubble into a delegated ancestor handler (same accordion-toggle guard as the reverse link)', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        global.window.TwoSoleTrader_Instance = { startReplacement: jest.fn() };
+
+        const ancestorHandler = jest.fn();
+        document.body.addEventListener('click', ancestorHandler);
+
+        const link = document.querySelector('.two-company-select-different-sole-trader');
+        link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(ancestorHandler).not.toHaveBeenCalled();
+
+        document.body.removeEventListener('click', ancestorHandler);
+        instance.destroy();
+    });
+});
+
+describe('popup URL (c)', () => {
+    let TwoSoleTrader;
+
+    beforeEach(() => {
+        TwoSoleTrader = loadSoleTrader();
+    });
+
+    function buildTrader(overrides) {
+        return new TwoSoleTrader(Object.assign({
+            checkoutHost: CHECKOUT_HOST,
+            orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+            ajaxToken: 'test-token',
+            billingCountry: 'GB'
+        }, overrides || {}));
+    }
+
+    function stubFetch() {
+        const buyerCurrentSpy = jest.fn();
+        global.window.fetch = (url) => {
+            if (String(url).includes('soleTraderAvailability')) {
+                return Promise.resolve({ json: () => Promise.resolve({ success: true, available: true }) });
+            }
+            if (String(url).includes('soleTraderTokens')) {
+                return Promise.resolve({
+                    json: () => Promise.resolve({
+                        success: true,
+                        autofill_token: 'af-token',
+                        delegation_token: 'del-token',
+                        signup_url: 'https://signup.example.test/',
+                        country: 'GB'
+                    })
+                });
+            }
+            if (String(url).includes('/autofill/v1/buyer/current')) {
+                buyerCurrentSpy(url);
+                return Promise.resolve({ ok: false, status: 404 });
+            }
+            return Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+        };
+        global.fetch = global.window.fetch;
+        return buyerCurrentSpy;
+    }
+
+    test('startReplacement() mints tokens, skips getCurrentBuyer(), and opens the popup with autoselect=false', async () => {
+        buildAddressForm();
+        const buyerCurrentSpy = stubFetch();
+        const openSpy = jest.fn(() => ({ closed: false }));
+        global.window.open = openSpy;
+
+        const instance = buildTrader();
+        instance.startReplacement();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(buyerCurrentSpy).not.toHaveBeenCalled();
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        const url = String(openSpy.mock.calls[0][0]);
+        expect(url).toContain('businessToken=');
+        expect(url).toContain('autoselect=false');
+
+        instance.destroy();
+    });
+
+    test('startReplacement() on an instance with tokens already minted opens the popup directly (no re-mint, no autofill check)', async () => {
+        buildAddressForm();
+        const buyerCurrentSpy = stubFetch();
+        const openSpy = jest.fn(() => ({ closed: false }));
+        global.window.open = openSpy;
+
+        const instance = buildTrader();
+        // Simulate an already-completed ordinary enrolment: tokens minted,
+        // flow started, buyer lookup already resolved once.
+        instance.flowStarted = true;
+        instance.tokens = {
+            success: true,
+            autofill_token: 'af-token',
+            delegation_token: 'del-token',
+            signup_url: 'https://signup.example.test/',
+            country: 'GB'
+        };
+
+        instance.startReplacement();
+        await flushPromises();
+
+        expect(buyerCurrentSpy).not.toHaveBeenCalled();
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(String(openSpy.mock.calls[0][0])).toContain('autoselect=false');
+
+        instance.destroy();
+    });
+
+    test('an ordinary startEnrollment() (unaffected) still runs the autofill check and does not carry autoselect=false', async () => {
+        buildAddressForm();
+        const buyerCurrentSpy = stubFetch();
+        const openSpy = jest.fn(() => ({ closed: false }));
+        global.window.open = openSpy;
+
+        const instance = buildTrader();
+        instance.startEnrollment();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(buyerCurrentSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(String(openSpy.mock.calls[0][0])).not.toContain('autoselect=');
+
+        instance.destroy();
+    });
+});

--- a/translations/es.php
+++ b/translations/es.php
@@ -416,3 +416,4 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Introducir manualmente';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Empresa registrada';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Autónomo';
+$_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Seleccionar otro autónomo';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -447,6 +447,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Handmatig invoeren';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Geregistreerd bedrijf';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Eenmanszaak';
+$_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Selecteer een andere eenmanszaak';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Aangepaste betaaltermijn (dagen)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Optioneel. Bied een extra betaaltermijn (in dagen) aan die niet in de bovenstaande voorinstellingen is opgenomen. Laat leeg om alleen de hierboven geselecteerde termijnen aan te bieden. %s moet deze termijnlengte nog steeds toestaan voor je account - een niet-ondersteunde waarde wordt stilzwijgend genegeerd.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standaard voorgeselecteerde termijn';

--- a/translations/no.php
+++ b/translations/no.php
@@ -447,6 +447,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Angi manuelt';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrert virksomhet';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enkeltpersonforetak';
+$_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Velg et annet enkeltpersonforetak';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Egendefinert betalingsfrist (dager)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Valgfritt. Tilby en ekstra betalingsfrist (i dager) som ikke er dekket av forhåndsinnstillingene ovenfor. La stå tomt for å kun tilby betingelsene valgt ovenfor. %s må fortsatt tillate denne fristlengden for kontoen din - en ustøttet verdi ignoreres stille.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standard forhåndsvalgt betalingsfrist';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -447,6 +447,7 @@ $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] 
 $_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Ange manuellt';
 $_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrerat företag';
 $_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enskild firma';
+$_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Välj en annan enskild firma';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Anpassat betalningsvillkor (dagar)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Valfritt. Erbjud ytterligare ett betalningsvillkor (i dagar) som inte täcks av förinställningarna ovan. Lämna tomt för att endast erbjuda de villkor som valts ovan. %s måste fortfarande tillåta denna villkorslängd för ditt konto - ett ej understött värde ignoreras tyst.';
 $_MODULE['<{twopayment}prestashop>twopayment_3ac5c697efd1c21abb77ab72a59fd256'] = 'Standardförvalt betalningsvillkor';

--- a/twopayment.php
+++ b/twopayment.php
@@ -4452,6 +4452,13 @@ class Twopayment extends PaymentModule
             // above: that one is a first-person prompt to START enrolling,
             // this is a noun phrase describing what the buyer already IS.
             'sole_trader_status_label' => $this->l('Sole trader'),
+            // Reverse link out of a COMPLETED sole-trader enrolment (TWO-40
+            // follow-up), same slot/pattern as `company_search_back_to_search`
+            // above but for the sole-trader identity rather than manual entry.
+            // Reopens the hosted signup popup directly - it offers both
+            // "pick a different registration" and "register as new" inside
+            // its own UI, so this plugin does not need to distinguish them.
+            'company_search_select_different_sole_trader' => $this->l('Select a different sole trader'),
         );
 
         // Checkout media render is a sanctioned refresh point for the backend

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -1613,7 +1613,8 @@
  * The way back out of manual entry. A real <button>, so every one of the
  * browser's button defaults has to be undone to make it read as a link.
  */
-.two-company-search-back {
+.two-company-search-back,
+.two-company-select-different-sole-trader {
     /*
      * §3: right-aligned under the company-name field. A block with
      * `width: fit-content` and an auto inline-start margin, rather than a
@@ -1646,7 +1647,8 @@
     cursor: pointer;
 }
 
-.two-company-search-back:focus {
+.two-company-search-back:focus,
+.two-company-select-different-sole-trader:focus {
     outline: 2px solid #1976d2;
     outline-offset: 2px;
 }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -229,6 +229,11 @@ class TwoCompanySearch {
         // the panel is being kept open with the query-field spinner showing
         // for a Sole Trader click's autofill round trip (TWO-40 round 4).
         this._soleTraderLoading = false;
+        // Re-entrancy guard for the "Select a different sole trader" link's
+        // click handler (TWO-40 follow-up) - same shape as
+        // `_soleTraderLoading` above, released on the same settle event, but
+        // its own flag/namespace since the two buttons/flows are independent.
+        this._selectDifferentSoleTraderLoading = false;
         // Per-instance event namespace suffix. The `mouseup` guard has to be
         // bound on `document` (a drag can end anywhere, including outside the
         // panel), and `document` is a page-wide singleton - so unbinding by
@@ -4128,9 +4133,49 @@ class TwoCompanySearch {
             // sibling inside the address step's markup, not something the
             // theme's delegated collapse handler is meant to hear from.
             event.stopPropagation();
-            if (window.TwoSoleTrader_Instance
-                && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
-                window.TwoSoleTrader_Instance.startReplacement();
+            // Re-entrancy guard (adversarial review finding, TWO-40 follow-
+            // up - Han/Vader independently caught this): THIS button only
+            // ever renders once tokens already exist from an earlier
+            // enrolment, which is exactly the branch of
+            // TwoSoleTrader.startReplacement() that opens the popup
+            // SYNCHRONOUSLY with no guard of its own (unlike
+            // getCurrentBuyer()'s `isFetchingBuyer`) - without this, a
+            // double-click reliably opened two signup popups from one
+            // gesture, the exact defect class `isFetchingBuyer`/
+            // `_soleTraderLoading` already exist elsewhere in this flow to
+            // close.
+            if (this._selectDifferentSoleTraderLoading) {
+                return;
+            }
+            this._selectDifferentSoleTraderLoading = true;
+            // Released on TwoSoleTrader.js's own settle event - fired from
+            // EVERY terminal branch of startReplacement()'s call graph
+            // (popup opened, popup blocked, mint failed, or abandoned via a
+            // cancelEnrollment() elsewhere) - same event
+            // beginSoleTraderLoading() already relies on for the "Sole
+            // Trader" chip, own namespace so the two guards never interfere.
+            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
+                .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
+                    this._selectDifferentSoleTraderLoading = false;
+                });
+            try {
+                if (window.TwoSoleTrader_Instance
+                    && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
+                    window.TwoSoleTrader_Instance.startReplacement();
+                } else {
+                    // Same shape as the "Sole Trader" chip's own missing-
+                    // instance branch: nothing is going to fire the settle
+                    // event for this click, so release the guard here rather
+                    // than leaving it stuck and log visibly rather than a
+                    // completely silent no-op (adversarial review finding).
+                    // eslint-disable-next-line no-console
+                    console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
+                    this._selectDifferentSoleTraderLoading = false;
+                    $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+                }
+            } catch (e) {
+                this._selectDifferentSoleTraderLoading = false;
+                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
             }
         });
 
@@ -4157,6 +4202,15 @@ class TwoCompanySearch {
             this._selectDifferentSoleTraderLink = null;
         }
         $('.two-company-select-different-sole-trader').off('.twoSoleTraderReplace').remove();
+        // Belt-and-braces: release the re-entrancy guard and its settle
+        // listener too, in case this runs while a flight it started is still
+        // outstanding (e.g. clearSelectedCompany() firing mid-flight) - a
+        // stuck-true guard would otherwise silently no-op every future click
+        // on a FUTURE re-rendered link, exactly the failure shape
+        // fetchTokens()'s own try/catch elsewhere in this flow exists to
+        // avoid.
+        this._selectDifferentSoleTraderLoading = false;
+        $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
     }
 
     /**
@@ -5029,6 +5083,19 @@ class TwoCompanySearch {
         if (!ui.item) {
             return false;
         }
+
+        // A REAL registered-company selection (TWO-40 follow-up, review
+        // finding): unconditionally, before either branch below, whether or
+        // not this result carries an organisation number yet. The no-org-
+        // number branch already tears this down via clearSelectedCompany(),
+        // but the org-number branch writes the company field directly and
+        // never calls it - without this, a buyer who completed sole-trader
+        // enrolment and THEN picked a real company here kept a stale
+        // "Select a different sole trader" link pointing at the OLD tokens.
+        // Clicking it would reopen the abandoned signup popup, and its
+        // eventual completion silently overwrites the just-picked registered
+        // company with the sole-trader identity.
+        this.removeSelectDifferentSoleTraderLink();
 
         // TWO-25326: the buyer has now actually picked a company from the
         // search results - the moment TwoCheckoutManager's tile-mode gate

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -5665,6 +5665,29 @@ class TwoCompanySearch {
         } catch (e) {
             // no-op
         }
+        // Its own try, same reason (adversarial review round 3, TWO-40
+        // follow-up - Vader finding): `TwoCheckoutManager.handleAddressFormUpdate()`
+        // destroys and rebuilds this instance on EVERY `updatedAddressForm`
+        // firing, not only on a country change - PrestaShop emits that event
+        // for far more than country changes (see the comment at its own call
+        // site). The country-select listener's own `cancelEnrollment()` call
+        // (round 2) only covers the country-change trigger; this covers every
+        // OTHER address-form replacement too. Without it, a sole-trader
+        // enrolment started against THIS instance, still in flight when the
+        // form gets replaced, resolves later against whatever instance is
+        // mounted then - `TwoSoleTrader.applyBuyer()` resolves
+        // `TwoCheckoutManager_Instance.companySearch` fresh, not a captured
+        // reference - silently adopting the identity into an address context
+        // the buyer has since moved on from, ungated because no generation
+        // bump ever ran for this trigger.
+        try {
+            if (window.TwoSoleTrader_Instance
+                && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
+                window.TwoSoleTrader_Instance.cancelEnrollment();
+            }
+        } catch (e) {
+            // no-op
+        }
         // Its own try for the same reason as the reverse link: the panel
         // carries live click/keydown/focus handlers on nodes that would
         // otherwise outlive this instance.

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -5492,6 +5492,24 @@ class TwoCompanySearch {
                 // leaving it be.
                 this.closeDropdown(false);
 
+                // Abandon any sole-trader enrolment in flight for the
+                // PREVIOUS country (adversarial review round 2, TWO-40
+                // follow-up - Han finding). Same call `openDropdown()`/the
+                // "Registered Company" chip handler already make before
+                // doing anything else - this listener was the one path that
+                // could reach `startReplacement()` (via the "Select a
+                // different sole trader" link, which is NOT gated behind an
+                // open dropdown the way the "Sole Trader" chip is) without
+                // it. Without this, a mint/lookup started for the old
+                // country resolves with `_enrollGeneration` never bumped,
+                // reads as still-current, and can pop a signup popup - or
+                // worse, silently publish a completed enrolment - for a
+                // country the buyer has already moved off.
+                if (window.TwoSoleTrader_Instance
+                    && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
+                    window.TwoSoleTrader_Instance.cancelEnrollment();
+                }
+
                 if (this.companyField && this.companyField.length > 0) {
                     this.companyField.val('');
                 }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -180,6 +180,10 @@ class TwoCompanySearch {
         // the field turns it back off.
         this._manualEntry = false;
         this._backToSearchLink = null;
+        // "Select a different sole trader" reverse link (TWO-40 follow-up) -
+        // same shape as `_backToSearchLink` above, for a completed
+        // sole-trader enrolment instead of manual entry.
+        this._selectDifferentSoleTraderLink = null;
 
         // The anchored dropdown panel (TWO-25326 §1). Supersedes the
         // click-to-reveal chip TWO-25288 element 2 shipped.
@@ -3892,6 +3896,11 @@ class TwoCompanySearch {
         // intent would keep credit-checking a company the buyer has explicitly
         // moved off, and would do it in preference to the cleared cookie.
         this.publishConfirmedSelection('', '');
+        // FIFTH half (TWO-40 follow-up): whatever sole-trader identity this
+        // clear is walking away from, the "Select a different sole trader"
+        // link is the inverse of a POPULATED identity and must go with it -
+        // same reasoning as renderBackToSearchLink()'s companion removal.
+        this.removeSelectDifferentSoleTraderLink();
     }
 
     /**
@@ -4080,6 +4089,74 @@ class TwoCompanySearch {
             this._backToSearchLink = null;
         }
         $('.two-company-search-back').off('.twoManualEntry').remove();
+    }
+
+    /**
+     * @returns {string} caption for renderSelectDifferentSoleTraderLink()
+     */
+    getSelectDifferentSoleTraderText() {
+        return (window.twopayment && window.twopayment.i18n
+                && window.twopayment.i18n.company_search_select_different_sole_trader)
+            || 'Select a different sole trader';
+    }
+
+    /**
+     * Render the "Select a different sole trader" link below the company
+     * field (TWO-40 follow-up) - same slot, same styling/gating shape as
+     * renderBackToSearchLink() above, but for a COMPLETED sole-trader
+     * enrolment rather than manual entry. Called by adoptSoleTraderBuyer()
+     * once a named identity has actually landed in the company field.
+     *
+     * A real `<button type="button">` for the same reason
+     * renderBackToSearchLink() is one: focusable, Enter/Space-activated,
+     * announced as a button, and `type="button"` so it cannot submit the
+     * address form it sits inside.
+     */
+    renderSelectDifferentSoleTraderLink() {
+        if (!this.companyField || this.companyField.length === 0) {
+            return;
+        }
+        this.removeSelectDifferentSoleTraderLink();
+
+        const link = $('<button type="button"></button>')
+            .addClass('two-company-select-different-sole-trader')
+            .text(this.getSelectDifferentSoleTraderText());
+        link.on('click.twoSoleTraderReplace', (event) => {
+            event.preventDefault();
+            // Same accordion-toggle reason as renderBackToSearchLink()'s own
+            // stopPropagation (#30.x.14 bug 2.5): this button is a plain
+            // sibling inside the address step's markup, not something the
+            // theme's delegated collapse handler is meant to hear from.
+            event.stopPropagation();
+            if (window.TwoSoleTrader_Instance
+                && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
+                window.TwoSoleTrader_Instance.startReplacement();
+            }
+        });
+
+        // Same placement as renderBackToSearchLink(): appended to the field
+        // wrapper so it lands below the org-number hint and the (hidden
+        // here) dropdown panel that share that wrapper.
+        const wrapper = this.companyField.parent();
+        if (wrapper.length && wrapper.hasClass('two-company-field-wrap')) {
+            wrapper.append(link);
+        } else {
+            this.companyField.after(link);
+        }
+        this._selectDifferentSoleTraderLink = link;
+    }
+
+    /**
+     * Remove the "Select a different sole trader" link and unbind it. Same
+     * class-wide-sweep reasoning as removeBackToSearchLink().
+     */
+    removeSelectDifferentSoleTraderLink() {
+        if (this._selectDifferentSoleTraderLink) {
+            this._selectDifferentSoleTraderLink.off('.twoSoleTraderReplace');
+            this._selectDifferentSoleTraderLink.remove();
+            this._selectDifferentSoleTraderLink = null;
+        }
+        $('.two-company-select-different-sole-trader').off('.twoSoleTraderReplace').remove();
     }
 
     /**
@@ -5495,6 +5572,14 @@ class TwoCompanySearch {
         } catch (e) {
             // no-op
         }
+        // Its own try for the same reason as the reverse link above (TWO-40
+        // follow-up): a live listener on a node that outlives this instance
+        // otherwise.
+        try {
+            this.removeSelectDifferentSoleTraderLink();
+        } catch (e) {
+            // no-op
+        }
         // Its own try for the same reason as the reverse link: the panel
         // carries live click/keydown/focus handlers on nodes that would
         // otherwise outlive this instance.
@@ -5849,6 +5934,14 @@ class TwoCompanySearch {
         this.syncNotListedVisibility();
         this.syncSoleTraderEntryVisibility();
         this.syncRegisteredEntryVisibility();
+
+        // "Select a different sole trader" (TWO-40 follow-up): only once a
+        // NAMED identity actually landed in the company field above - the
+        // nameless branch earlier in this method clears that field instead,
+        // and there is nothing to offer to "replace" in that case.
+        if (name) {
+            this.renderSelectDifferentSoleTraderLink();
+        }
 
         return wrote;
     }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -822,9 +822,14 @@ class TwoSoleTrader {
             this.flowStarted = true;
             this.fetchTokens();
         } else {
+            // Same "explicit resume" re-stamp as startEnrollment()'s own
+            // resume branch, then straight through afterTokensReady() rather
+            // than inlining its own openPopup() call (review finding,
+            // TWO-40 follow-up) - one place consumes `_skipAutofillCheck`,
+            // not two, so a future change to what "tokens ready" means only
+            // has one call site to update.
             this._tokensGeneration = this._enrollGeneration;
-            this._skipAutofillCheck = false;
-            this.openPopup({ autoselect: 'false' });
+            this.afterTokensReady();
         }
     }
 
@@ -1471,9 +1476,11 @@ class TwoSoleTrader {
         // PORTING NOTE (future Magento/WooCommerce port of this sole-trader
         // flow): brand resolution here is PrestaShop-only and has NO brand
         // dimension. `this.tokens.signup_url` comes from
-        // TwoSoleTrader::getSignupPageUrl() (classes/TwoSoleTrader.php:93-96,
-        // :419-432), which maps ONLY environment -> host - it does not know
-        // ABN or any other brand exists. Magento/WooCommerce resolve brand
+        // TwoSoleTrader::getSignupPageUrl() (classes/TwoSoleTrader.php - see
+        // its `$signup_hosts` property and the method itself; deliberately
+        // not citing line numbers here, they drift), which maps ONLY
+        // environment -> host - it does not know ABN or any other brand
+        // exists. Magento/WooCommerce resolve brand
         // via a per-brand `checkout_url_template` (a distinct hostname per
         // brand, e.g. `achterafbetalen.abnamro.nl` for ABN) with a
         // `?brand=<tag>&brandVersion=<ver>` query-string fallback used ONLY

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -115,6 +115,11 @@ class TwoSoleTrader {
         this._tokensGeneration = 0;
         this.tokens = null;
         this.flowStarted = false;
+        // Set by startReplacement() ("Select a different sole trader"),
+        // consumed by afterTokensReady() once tokens are ready. Tells that
+        // point to skip getCurrentBuyer()'s silent-autofill check and go
+        // straight to the popup - see startReplacement()'s own comment.
+        this._skipAutofillCheck = false;
         this.messageListenerBound = false;
         // Held so destroy() can detach it. See bindPopupMessageListener().
         this._messageHandler = null;
@@ -797,6 +802,51 @@ class TwoSoleTrader {
     }
 
     /**
+     * "Select a different sole trader" entry point (TWO-40 follow-up).
+     * Reuses startEnrollment()'s token-minting, but deliberately SKIPS
+     * getCurrentBuyer()'s silent-autofill check and goes straight to the
+     * hosted signup popup - the buyer already HAS a sole-trader identity on
+     * screen and is explicitly asking to replace it, so re-running the
+     * same-email autofill match would just hand back the identity they are
+     * trying to get away from. Covers both "pick a different registration"
+     * and "register as new" - that choice happens inside the popup's own
+     * UI, this plugin does not distinguish them.
+     *
+     * `autoselect=false` on the popup URL is not interpreted server-side
+     * yet (handled elsewhere); it is appended unconditionally regardless.
+     */
+    startReplacement() {
+        this.enrolling = true;
+        this._skipAutofillCheck = true;
+        if (!this.flowStarted || !this.tokens) {
+            this.flowStarted = true;
+            this.fetchTokens();
+        } else {
+            this._tokensGeneration = this._enrollGeneration;
+            this._skipAutofillCheck = false;
+            this.openPopup({ autoselect: 'false' });
+        }
+    }
+
+    /**
+     * Continuation once tokens are ready (a fresh mint or an existing set),
+     * shared by fetchTokens()'s success branches. Ordinary flow proceeds to
+     * the silent-autofill check; startReplacement() sets `_skipAutofillCheck`
+     * to bypass it and open the popup directly instead. Consumed (reset)
+     * here rather than left set, so a LATER ordinary startEnrollment() call
+     * on the same instance is not silently affected by an earlier
+     * replacement click.
+     */
+    afterTokensReady() {
+        if (this._skipAutofillCheck) {
+            this._skipAutofillCheck = false;
+            this.openPopup({ autoselect: 'false' });
+            return;
+        }
+        this.getCurrentBuyer();
+    }
+
+    /**
      * Abandon an in-progress enrolment without discarding minted tokens -
      * re-entering via startEnrollment() resumes rather than re-mints. Called
      * when the buyer goes back to ordinary company search (opening the
@@ -827,6 +877,10 @@ class TwoSoleTrader {
      */
     cancelEnrollment() {
         this._enrollGeneration += 1;
+        // Belt-and-braces alongside afterTokensReady()'s own reset: an
+        // abandoned startReplacement() must not leave this set for whatever
+        // ORDINARY flow resumes next.
+        this._skipAutofillCheck = false;
         if (!this.enrolling) {
             return;
         }
@@ -943,7 +997,7 @@ class TwoSoleTrader {
                         // runs AFTER this point but before the tokens are
                         // acted on, the stamp must already read as stale.
                         self._tokensGeneration = generation;
-                        self.getCurrentBuyer();
+                        self.afterTokensReady();
                     } else if (self.enrolling) {
                         // TWO-40 round 5 (adversarial review finding, Han +
                         // Yoda independently): THIS mint's own generation is
@@ -964,7 +1018,7 @@ class TwoSoleTrader {
                         // requested the mint - mirrors startEnrollment()'s
                         // own "resume" branch below for the same tokens.
                         self._tokensGeneration = self._enrollGeneration;
-                        self.getCurrentBuyer();
+                        self.afterTokensReady();
                     }
                     // Else: genuinely abandoned, nobody enrolling right now.
                     // cancelEnrollment() already notified whichever click
@@ -1395,7 +1449,11 @@ class TwoSoleTrader {
         return btoa(unescape(encodeURIComponent(JSON.stringify(data))));
     }
 
-    openPopup() {
+    /**
+     * @param {Object} [extraParams] additional query params appended to the
+     *   popup URL verbatim (encoded key/value pairs), e.g. `autoselect`.
+     */
+    openPopup(extraParams) {
         if (!this.tokens) {
             return null;
         }
@@ -1410,11 +1468,29 @@ class TwoSoleTrader {
             last_name: (lastName && lastName.value) || customer.lastname || '',
             phone_number: phone ? phone.value : ''
         };
+        // PORTING NOTE (future Magento/WooCommerce port of this sole-trader
+        // flow): brand resolution here is PrestaShop-only and has NO brand
+        // dimension. `this.tokens.signup_url` comes from
+        // TwoSoleTrader::getSignupPageUrl() (classes/TwoSoleTrader.php:93-96,
+        // :419-432), which maps ONLY environment -> host - it does not know
+        // ABN or any other brand exists. Magento/WooCommerce resolve brand
+        // via a per-brand `checkout_url_template` (a distinct hostname per
+        // brand, e.g. `achterafbetalen.abnamro.nl` for ABN) with a
+        // `?brand=<tag>&brandVersion=<ver>` query-string fallback used ONLY
+        // on shared non-prod domains. Porting this popup-launch URL
+        // construction to those platforms must go through THAT existing
+        // mechanism, not this environment-keyed host map - PrestaShop has no
+        // brand-overlay support today and this file must not invent one.
         const url =
             this.tokens.signup_url +
             '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
             '&autofillToken=' + encodeURIComponent(this.tokens.autofill_token) +
-            '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill));
+            '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill)) +
+            (extraParams && typeof extraParams === 'object'
+                ? Object.keys(extraParams).map(function (key) {
+                    return '&' + encodeURIComponent(key) + '=' + encodeURIComponent(extraParams[key]);
+                }).join('')
+                : '');
         const popup = window.open(
             url,
             '_blank',


### PR DESCRIPTION
## Summary
- Adds a "Select a different sole trader" link under the company field, same slot/pattern as the existing "Search for company" link, visible once a named sole-trader identity has been adopted via `adoptSoleTraderBuyer()`.
- Clicking it calls a new `TwoSoleTrader.startReplacement()`, which mints/reuses tokens and opens the hosted signup popup directly, deliberately skipping `getCurrentBuyer()`'s silent-autofill check, with `autoselect=false` appended to the popup URL. `autoselect` is not interpreted server-side yet (handled separately) - wired through unconditionally here.
- Covers both "pick a different existing registration" and "register as new" - that choice happens inside the popup's own UI, so this plugin does not need to distinguish them itself.
- Adds a factual comment at the popup-launch site (`TwoSoleTrader.openPopup()`) documenting that a future Magento/WooCommerce port must resolve brand through those platforms' existing `checkout_url_template` / `brand`+`brandVersion` mechanism, not this plugin's brand-less environment-keyed host map. No PrestaShop-side brand-overlay support is added - out of scope per this round.

## Test plan
- [x] `npm run test:js` - full suite green (29 suites / 739 tests)
- [x] New regression test `tests/js/sole-trader-select-different.test.js`: link renders under the company field once a named identity lands, is removed by `clearSelectedCompany()`, click calls `startReplacement()` (not `startEnrollment()`) and does not bubble, and the resulting popup URL carries `autoselect=false` while an ordinary `startEnrollment()` flow is unaffected.
- [ ] Live-verify on prestashop-dev.staging.two.inc: link placement + popup URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)