### PR TITLE
feat(dev): show resolved API/portal/checkout hosts in make install/run status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ install: clean
 		echo " Proxy admin:     $$PROXY_URL/admin-dev"; \
 	fi; \
 	echo " Credentials:      $(ADMIN_MAIL) / $(ADMIN_PASSWD)"; \
+	dev/print-resolved-hosts.sh $(CONTAINER) $(MODULE_NAME); \
 	echo "========================================="
 
 ## Update Two payment config (writes key + calls verify_api_key so the
@@ -122,6 +123,7 @@ run:
 		echo " Proxy admin:     $$PROXY_URL/admin-dev"; \
 	fi; \
 	echo " Credentials:      $(ADMIN_MAIL) / $(ADMIN_PASSWD)"; \
+	dev/print-resolved-hosts.sh $(CONTAINER) $(MODULE_NAME); \
 	echo "========================================="
 
 ## Start with PS_DEV_MODE on and caches cleared (hot reload)

--- a/README.md
+++ b/README.md
@@ -551,6 +551,11 @@ unset — `production` and `staging` have explicit hosts, everything else
 (The buyer portal login host has no override; it always follows the configured
 environment.)
 
+`make install` and `make run` print the resolved API / portal / checkout-page
+hosts (honouring the overrides above and the `_PS_MODE_DEV_` gate) in their
+status block, so you can see at a glance which real hosts your local instance
+will actually talk to without having to run `dev/probe-hosts.php` yourself.
+
 **Mind the two "checkouts".** `TWO_API_BASE_URL` is the one behind
 `getTwoCheckoutHostUrl()` and the `checkout_host` value handed to the browser —
 that is the **API**. `TWO_CHECKOUT_BASE_URL` is the hosted checkout-page **app**

--- a/dev/print-resolved-hosts.sh
+++ b/dev/print-resolved-hosts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Prints the API / merchant-portal / checkout-page hosts the RUNNING
+# container is actually configured to hit, by execing dev/probe-hosts.php
+# inside the container and reformatting three of its lines.
+#
+# Runs inside the container (not on the host) because _PS_MODE_DEV_ and the
+# TWO_*_BASE_URL overrides are read from the container's own process
+# environment, baked in at container creation - see "Service URL overrides"
+# in README.md. dev/probe-hosts.php is the one place that resolution logic
+# lives (Twopayment::getTwoCheckoutHostUrl/getTwoPortalUrl,
+# TwoSoleTrader::getSignupPageUrl); this script only parses its output, it
+# does not re-derive the override-vs-default logic.
+#
+# Usage: dev/print-resolved-hosts.sh <container-name> <module-name>
+# Prints nothing (and exits 0) if the container isn't reachable - callers
+# use this for a "nice to have" status block, not a hard dependency.
+set -euo pipefail
+
+CONTAINER="$1"
+MODULE_NAME="$2"
+
+DUMP=$(docker exec "$CONTAINER" php "/var/www/html/modules/$MODULE_NAME/dev/probe-hosts.php" 2>/dev/null) || exit 0
+
+API=$(sed -n 's/^getTwoCheckoutHostUrl(): //p' <<< "$DUMP")
+PORTAL=$(sed -n 's/^getTwoPortalUrl(): //p' <<< "$DUMP")
+CHECKOUT=$(sed -n 's/^TwoSoleTrader::getSignupPageUrl(): //p' <<< "$DUMP")
+
+[ -n "$API" ] && echo " API:               $API"
+[ -n "$PORTAL" ] && echo " Portal:            $PORTAL"
+[ -n "$CHECKOUT" ] && echo " Checkout (signup): $CHECKOUT"
+
+exit 0


### PR DESCRIPTION
## Summary
- `make install` / `make run` now print the API / merchant-portal / checkout-page-signup hosts the running container actually resolves to (overrides + `_PS_MODE_DEV_` gate honoured), in the same status block that already prints the shop URL.
- New `dev/print-resolved-hosts.sh` execs `dev/probe-hosts.php` inside the container and reformats three of its lines - all resolution logic still lives in `dev/probe-hosts.php` / `Twopayment`/`TwoSoleTrader`, this only parses and prints.
- README: short note under "Service URL overrides" pointing at the new status output.

## Why
A dev could not tell which real hosts (staging/sandbox/an override) their local shop was actually configured to hit without manually running `dev/probe-hosts.php`. This surfaces it automatically.

## Test plan
- [x] `php tests/run.php` (via `make test`) - green, no test covers `dev/probe-hosts.php`'s raw output format so nothing to update there
- [x] `make -n run` / `make -n install` - Makefile parses, new line appears in the right place
- [ ] Doug: spot-check `make run` output against a real container (needs `docker compose up`, not run in this sandbox)