### PR TITLE
fix(dev): stop probe-hosts.php leaving var/cache/dev root-owned

### DIFF
--- a/dev/print-resolved-hosts.sh
+++ b/dev/print-resolved-hosts.sh
@@ -20,7 +20,13 @@ set -euo pipefail
 CONTAINER="$1"
 MODULE_NAME="$2"
 
-DUMP=$(docker exec "$CONTAINER" php "/var/www/html/modules/$MODULE_NAME/dev/probe-hosts.php" 2>/dev/null) || exit 0
+# -u www-data: probe-hosts.php bootstraps config/config.inc.php, which
+# compiles/warms the Symfony `dev` container cache on a cold cache. Run as
+# the default docker-exec user (root) that leaves var/cache/dev owned by
+# root, 0755 - unwritable by the www-data Apache workers that serve every
+# real request, which then fail with Symfony's rename() IOException the
+# next time the container needs recompiling.
+DUMP=$(docker exec -u www-data "$CONTAINER" php "/var/www/html/modules/$MODULE_NAME/dev/probe-hosts.php" 2>/dev/null) || exit 0
 
 API=$(sed -n 's/^getTwoCheckoutHostUrl(): //p' <<< "$DUMP")
 PORTAL=$(sed -n 's/^getTwoPortalUrl(): //p' <<< "$DUMP")


### PR DESCRIPTION
## Summary
- `dev/print-resolved-hosts.sh` execs `dev/probe-hosts.php` with the default docker-exec user (root). That script bootstraps `config/config.inc.php`, which compiles/warms the Symfony `dev` container cache on a cold cache — so a fresh `make install`/`make run` left `var/cache/dev` owned `root:root`, mode `0755`, unwritable by the `www-data` Apache workers that serve real requests.
- The next cache recompile then failed `rename()` with Symfony's `IOException` ("Cannot rename ... FrontContainer.php ..."), breaking the shop until the directory was manually `chown`'d.
- Fix: run `probe-hosts.php` as `www-data`, matching every other `docker exec` against the PHP process in this repo.

## Test plan
- [x] Root-caused via `docker exec`/`stat`/`lsattr` on a running container: confirmed `/tmp` and `var/cache/dev` are the same overlay filesystem (ruled out cross-device `rename`/`EXDEV`), and that `var/cache/dev` was root-owned + unwritable by `www-data` — matching the reported IOException exactly on manual reproduction.
- [x] Traced the root-owned directory to `print-resolved-hosts.sh`'s unguarded `docker exec` of `probe-hosts.php`.
- [x] Applied the fix, ran a full `make install` end-to-end, confirmed `var/cache/dev` is `www-data:www-data` afterward.
- [x] Forced a cache-clear + recompile and hit the shop through the real FRP tunnel (`https://prestashop-doug.frp.staging.two.inc/`) — `HTTP 200`, no `Fatal error`/`IOException` in the response body.
- No PHP test surface — this is a one-line dev-tooling shell script fix, not application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)