### PR TITLE
fix: widen sole trader popup to 700px

### DIFF
--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -277,6 +277,7 @@ describe('popup URL (c)', () => {
         const url = String(openSpy.mock.calls[0][0]);
         expect(url).toContain('businessToken=');
         expect(url).toContain('autoselect=false');
+        expect(String(openSpy.mock.calls[0][2])).toContain('width=700');
 
         instance.destroy();
     });
@@ -324,6 +325,7 @@ describe('popup URL (c)', () => {
         expect(buyerCurrentSpy).toHaveBeenCalledTimes(1);
         expect(openSpy).toHaveBeenCalledTimes(1);
         expect(String(openSpy.mock.calls[0][0])).not.toContain('autoselect=');
+        expect(String(openSpy.mock.calls[0][2])).toContain('width=700');
 
         instance.destroy();
     });

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -1674,7 +1674,7 @@ class TwoSoleTrader {
         const popup = window.open(
             url,
             '_blank',
-            'location=yes,resizable=yes,scrollbars=yes,status=yes,height=805,width=610'
+            'location=yes,resizable=yes,scrollbars=yes,status=yes,height=805,width=700'
         );
         if (!popup) {
             // Popup blocked despite opening from a click - surface it


### PR DESCRIPTION
## Summary
- Widens the sole trader signup popup from 610px to 700px (height=805 unchanged), per Doug's request.
- Single `window.open()` call site in `openPopup()` — both `startEnrollment()` and `startReplacement()` (PR #162) call through it, so both paths pick up the change.

## Test plan
- [x] `npm run test:js` — 30 suites / 750 tests pass
- [x] Added `width=700` assertions on the popup features string in `tests/js/sole-trader-select-different.test.js` (startReplacement + startEnrollment paths)