### PR TITLE
fix(js): keep sole-trader spinner up until the signup popup closes

### DIFF
--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -104,6 +104,96 @@ test('a successful autofill (buyer match) fires the settle event', async () => {
     instance.destroy();
 });
 
+/**
+ * Adversarial review finding (Yoda): every OTHER test drives
+ * notifyEnrollmentSettled()'s popup-open guard through a path where
+ * `this._popup` is either never set or already nulled by the poll itself -
+ * none of them actually exercises the guard suppressing a call from a
+ * DIFFERENT terminal branch while a popup is still open. This does: a real
+ * OTP round trip (postMessage 'ACCEPTED') resolves through applyBuyer()'s
+ * success branch while the popup the buyer authenticated in is still open on
+ * screen - the spinner must not clear until they actually close it.
+ */
+test('a genuine OTP completion settles the buyer lookup but withholds the spinner until the still-open popup actually closes', async () => {
+    buildPaymentTile();
+    global.window.TwoCompanyNumber = { forDisplay: (v) => v };
+    global.window.TwoCheckoutManager_Instance = { setConfirmedCompanySelection: () => {} };
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='order-contact@example.test' />");
+
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+
+    let buyerLookupCalls = 0;
+    stubFetch({
+        buyer: () => {
+            buyerLookupCalls += 1;
+            if (buyerLookupCalls === 1) {
+                // Passive cookie-match check on the order's own checkout
+                // email - no match, so this falls through to the on-page
+                // prompt.
+                return Promise.resolve({ ok: false, status: 404 });
+            }
+            // The trusted lookup issued after a genuine OTP completion.
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({
+                    email: 'sole-trader-real-account@example.test',
+                    company_name: 'Sole Trader AS',
+                    organization_number: '923456789'
+                })
+            });
+        }
+    });
+    const { calls, handler } = recordSettled();
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            // No-match on the passive check - handed off to the on-page
+            // prompt (nothing left to wait on until the buyer clicks it).
+            expect(calls.length).toBe(1);
+
+            const prompt = document.querySelector('.two-sole-trader__prompt');
+            prompt.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+            expect(global.window.open).toHaveBeenCalledTimes(1);
+            expect(instance._popup).toBe(popup);
+            // Popup handed off to - must not have settled again yet.
+            expect(calls.length).toBe(1);
+
+            window.dispatchEvent(new window.MessageEvent('message', {
+                data: 'ACCEPTED',
+                origin: 'https://signup.example.test'
+            }));
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            // applyBuyer() succeeded - the buyer is enrolled - but the popup
+            // they just authenticated in is STILL open, so the guard must
+            // withhold the settle event.
+            expect(instance.enrolling).toBe(false);
+            expect(calls.length).toBe(1);
+
+            // Buyer now closes the popup.
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+
+            expect(calls.length).toBe(2);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
 test('a failed token mint fires the settle event', async () => {
     buildPaymentTile();
     stubFetch({ tokens: () => Promise.resolve({ json: () => Promise.resolve({ success: false }) }) });
@@ -262,6 +352,42 @@ test('a popup blocked outright (window.open() returns null) never starts a poll 
     }
     errorSpy.mockRestore();
     document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
+/**
+ * Adversarial review finding (Han): calling openPopup() a second time while
+ * the first popup from the SAME attempt is still open (e.g. the buyer
+ * double-clicks the on-page "sign up" prompt) used to open a SECOND browser
+ * window and silently retarget `this._popup` to it - orphaning the first
+ * window untracked, so a buyer closing the ORIGINAL window instead of the
+ * new one left the spinner stuck forever. openPopup() must refuse to open a
+ * second window while one is still tracked open and just refocus it.
+ */
+test('calling openPopup() again while a popup is already open refocuses it instead of opening a second window', () => {
+    buildAddressForm();
+    const popup = { closed: false, focus: jest.fn() };
+    const openSpy = jest.fn(() => popup);
+    global.window.open = openSpy;
+    stubFetch({});
+
+    const instance = build();
+    try {
+        instance.tokens = {
+            autofill_token: 'af-token',
+            delegation_token: 'del-token',
+            signup_url: 'https://signup.example.test/',
+            country: 'GB'
+        };
+        const first = instance.openPopup();
+        const second = instance.openPopup();
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(popup.focus).toHaveBeenCalledTimes(1);
+        expect(second).toBe(first);
+        expect(instance._popup).toBe(popup);
+    } finally {
+        instance.destroy();
+    }
 });
 
 /**

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -135,21 +135,187 @@ test('a network failure on the buyer lookup fires the settle event', async () =>
     instance.destroy();
 });
 
-test('a no-match buyer lookup handed off directly to the popup (address-editor page) fires the settle event', async () => {
+/**
+ * TWO-40 follow-up, Doug: the spinner was clearing as soon as window.open()
+ * returned, not when the popup itself closed. Pins the fixed behavior: the
+ * settle event stays held while the popup is open, and only fires once
+ * watchPopupUntilClosed()'s poll observes `popup.closed`.
+ */
+test('a no-match buyer lookup handed off directly to the popup (address-editor page) keeps the spinner up until the popup actually closes', async () => {
     buildAddressForm();
-    global.window.open = jest.fn(() => ({ closed: false }));
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
     stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
     const { calls, handler } = recordSettled();
 
-    const instance = build();
-    instance.startEnrollment();
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
 
-    expect(calls.length).toBe(1);
+            // Popup handed off to - the spinner must NOT settle yet, even
+            // though window.open() has already returned.
+            expect(calls.length).toBe(0);
+
+            // Buyer closes the popup (completes, cancels inside it, or just
+            // closes the window - all three read identically as `.closed`).
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+
+            expect(calls.length).toBe(1);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
     document.removeEventListener('two:sole-trader-flight-settled', handler);
-    instance.destroy();
+});
+
+test('the spinner stays held if the popup takes a few poll ticks to actually close', async () => {
+    buildAddressForm();
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            jest.advanceTimersByTime(500);
+            expect(calls.length).toBe(0);
+            jest.advanceTimersByTime(500);
+            expect(calls.length).toBe(0);
+
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+            expect(calls.length).toBe(1);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
+test('no popup poll interval survives a normal popup-close settle', async () => {
+    buildAddressForm();
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(jest.getTimerCount()).toBeGreaterThan(0);
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+            expect(jest.getTimerCount()).toBe(0);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('a popup blocked outright (window.open() returns null) never starts a poll and settles immediately', async () => {
+    buildAddressForm();
+    global.window.open = jest.fn(() => null);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(calls.length).toBe(1);
+            expect(jest.getTimerCount()).toBe(0);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+    errorSpy.mockRestore();
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
+/**
+ * cancelEnrollment() means the buyer moved on to a different search
+ * interaction, not the popup closing - it must stop the poll (no leaked
+ * interval) rather than leave it running against a popup nobody is tracking
+ * for this attempt any more.
+ */
+test('cancelEnrollment() while a popup is open stops the poll instead of leaking it', async () => {
+    buildAddressForm();
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(jest.getTimerCount()).toBeGreaterThan(0);
+            instance.cancelEnrollment();
+            expect(jest.getTimerCount()).toBe(0);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('destroy() while a popup is open stops the poll instead of leaking it', async () => {
+    buildAddressForm();
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(jest.getTimerCount()).toBeGreaterThan(0);
+        instance.destroy();
+        expect(jest.getTimerCount()).toBe(0);
+    } finally {
+        jest.useRealTimers();
+    }
 });
 
 test('a no-match buyer lookup handed off to the on-page prompt (payment step) fires the settle event', async () => {
@@ -238,7 +404,8 @@ test('cancelEnrollment() does NOT fire the settle event when there was nothing t
  */
 test('a mint that resolves after abandon-then-retry still resumes the buyer lookup for the current attempt', async () => {
     buildAddressForm();
-    global.window.open = jest.fn(() => ({ closed: false }));
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
     let resolveTokens;
     stubFetch({
         tokens: () => new Promise((resolve) => { resolveTokens = resolve; }),
@@ -246,37 +413,54 @@ test('a mint that resolves after abandon-then-retry still resumes the buyer look
     });
     const { calls, handler } = recordSettled();
 
-    const instance = build();
-    instance.startEnrollment(); // click 1: mint 1 starts, isFetchingTokens = true
-    const generationAtFirstClick = instance._enrollGeneration;
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment(); // click 1: mint 1 starts, isFetchingTokens = true
+            const generationAtFirstClick = instance._enrollGeneration;
 
-    instance.cancelEnrollment(); // buyer abandons - settles click 1
-    expect(calls.length).toBe(1);
+            instance.cancelEnrollment(); // buyer abandons - settles click 1
+            expect(calls.length).toBe(1);
 
-    instance.startEnrollment(); // click 2: fetchTokens() no-ops (still in flight)
-    expect(instance._enrollGeneration).not.toBe(generationAtFirstClick);
-    expect(instance.tokens).toBeNull();
+            instance.startEnrollment(); // click 2: fetchTokens() no-ops (still in flight)
+            expect(instance._enrollGeneration).not.toBe(generationAtFirstClick);
+            expect(instance.tokens).toBeNull();
 
-    // Mint 1 (the only request that ever went out) now resolves.
-    resolveTokens({
-        json: () => Promise.resolve({
-            success: true,
-            autofill_token: 'af-token',
-            delegation_token: 'del-token',
-            signup_url: 'https://signup.example.test/',
-            country: 'GB'
-        })
-    });
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
+            // Mint 1 (the only request that ever went out) now resolves.
+            resolveTokens({
+                json: () => Promise.resolve({
+                    success: true,
+                    autofill_token: 'af-token',
+                    delegation_token: 'del-token',
+                    signup_url: 'https://signup.example.test/',
+                    country: 'GB'
+                })
+            });
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
 
-    // Click 2 must have been resumed and settled on its own - not left
-    // hanging because the tokens landed under click 1's stale generation.
-    expect(instance.tokens).not.toBeNull();
-    expect(calls.length).toBe(2);
+            // Click 2 resumed and handed off to the popup - tokens landed,
+            // but the popup is still open, so click 2's own settle must not
+            // have fired yet (TWO-40 follow-up).
+            expect(instance.tokens).not.toBeNull();
+            expect(calls.length).toBe(1);
+
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+
+            // Click 2 must have been resumed and settled on its own once the
+            // popup closed - not left hanging because the tokens landed
+            // under click 1's stale generation.
+            expect(calls.length).toBe(2);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
     document.removeEventListener('two:sole-trader-flight-settled', handler);
-    instance.destroy();
 });
 
 /**
@@ -324,58 +508,76 @@ test('two concurrent getCurrentBuyer() calls only open one popup', async () => {
  */
 test('a buyer lookup that resolves after abandon-then-retry during the lookup stage still resumes for the current attempt', async () => {
     buildAddressForm();
-    global.window.open = jest.fn(() => ({ closed: false }));
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
     let resolveBuyer;
     stubFetch({
         buyer: () => new Promise((resolve) => { resolveBuyer = resolve; })
     });
     const { calls, handler } = recordSettled();
 
-    const instance = build();
-    instance.tokens = {
-        autofill_token: 'af-token',
-        delegation_token: 'del-token',
-        signup_url: 'https://signup.example.test/',
-        country: 'GB'
-    };
-    instance.enrolling = true;
-    instance.getCurrentBuyer(); // click 1: lookup 1 starts, isFetchingBuyer = true
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.tokens = {
+                autofill_token: 'af-token',
+                delegation_token: 'del-token',
+                signup_url: 'https://signup.example.test/',
+                country: 'GB'
+            };
+            instance.enrolling = true;
+            instance.getCurrentBuyer(); // click 1: lookup 1 starts, isFetchingBuyer = true
 
-    instance.cancelEnrollment(); // buyer abandons - settles click 1
-    expect(calls.length).toBe(1);
+            instance.cancelEnrollment(); // buyer abandons - settles click 1
+            expect(calls.length).toBe(1);
 
-    instance.enrolling = true; // as startEnrollment()'s "resume" branch would set it
-    instance.getCurrentBuyer(); // click 2: no-ops, lookup 1 still in flight
+            instance.enrolling = true; // as startEnrollment()'s "resume" branch would set it
+            instance.getCurrentBuyer(); // click 2: no-ops, lookup 1 still in flight
 
-    // Lookup 1 (the only request that ever went out) now resolves with a
-    // 404 - no match. superseded() is true (generation moved on from the
-    // abandon), so this settles into resumeIfStillEnrolling() rather than
-    // acting on it directly.
-    resolveBuyer({ ok: false, status: 404 });
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
-    // resumeIfStillEnrolling() defers via setTimeout(0) - flush the macrotask
-    // queue too, not just the microtask queue flushPromises() covers, so the
-    // resumed getCurrentBuyer() call actually runs and issues ITS OWN fetch
-    // (`buyer` factory is called again, rebinding `resolveBuyer` to that
-    // new promise's resolver below).
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await flushPromises();
+            // Lookup 1 (the only request that ever went out) now resolves with a
+            // 404 - no match. superseded() is true (generation moved on from the
+            // abandon), so this settles into resumeIfStillEnrolling() rather than
+            // acting on it directly.
+            resolveBuyer({ ok: false, status: 404 });
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+            // resumeIfStillEnrolling() defers via setTimeout(0) - advance the fake
+            // macrotask queue too, not just the microtask queue flushPromises()
+            // covers, so the resumed getCurrentBuyer() call actually runs and
+            // issues ITS OWN fetch (`buyer` factory is called again, rebinding
+            // `resolveBuyer` to that new promise's resolver below).
+            jest.advanceTimersByTime(0);
+            await flushPromises();
 
-    // The resumed lookup's own, SEPARATE request now resolves the same way
-    // - still no match, hands off to the popup on this containerless page.
-    resolveBuyer({ ok: false, status: 404 });
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
+            // The resumed lookup's own, SEPARATE request now resolves the same way
+            // - still no match, hands off to the popup on this containerless page.
+            resolveBuyer({ ok: false, status: 404 });
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
 
-    // Click 2 must have been resumed and settled on its own - not left
-    // hanging because the response landed under click 1's stale generation.
-    expect(global.window.open).toHaveBeenCalledTimes(1);
-    expect(calls.length).toBe(2);
+            // Click 2 was resumed and handed off to the popup - but the popup
+            // is still open, so its own settle must not have fired yet
+            // (TWO-40 follow-up).
+            expect(global.window.open).toHaveBeenCalledTimes(1);
+            expect(calls.length).toBe(1);
+
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+
+            // Click 2 must have been settled on its own once the popup
+            // closed - not left hanging because the response landed under
+            // click 1's stale generation.
+            expect(calls.length).toBe(2);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
     document.removeEventListener('two:sole-trader-flight-settled', handler);
-    instance.destroy();
 });
 
 /**

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -115,6 +115,14 @@ class TwoSoleTrader {
         this._tokensGeneration = 0;
         this.tokens = null;
         this.flowStarted = false;
+        // The handle returned by window.open() for the currently-open signup
+        // popup, and the setInterval id polling it - held so
+        // notifyEnrollmentSettled() can hold off until the popup actually
+        // closes rather than just handing off to it. See openPopup()/
+        // watchPopupUntilClosed() (TWO-40 follow-up, Doug: the query-field
+        // spinner was clearing as soon as window.open() returned).
+        this._popup = null;
+        this._popupPollInterval = null;
         // Set by startReplacement() ("Select a different sole trader"),
         // consumed by afterTokensReady() once tokens are ready. Tells that
         // point to skip getCurrentBuyer()'s silent-autofill check and go
@@ -359,6 +367,8 @@ class TwoSoleTrader {
      */
     destroy() {
         this.stopObserving();
+        this.stopPopupWatch();
+        this._popup = null;
         if (this._countryChangeHandler) {
             document.removeEventListener('change', this._countryChangeHandler);
             this._countryChangeHandler = null;
@@ -939,6 +949,12 @@ class TwoSoleTrader {
         // abandoned startReplacement() must not leave this set for whatever
         // ORDINARY flow resumes next.
         this._skipAutofillCheck = false;
+        // The buyer moved on to a different search interaction, not the
+        // popup itself closing - stop tracking it (no leaked poll interval)
+        // and clear the reference so the notify below isn't held back by
+        // notifyEnrollmentSettled()'s popup-open guard.
+        this.stopPopupWatch();
+        this._popup = null;
         if (!this.enrolling) {
             return;
         }
@@ -1729,13 +1745,54 @@ class TwoSoleTrader {
                 console.error('Two: sole-trader signup popup was blocked and no on-page error UI is available here.');
             }
         } else {
-            // Opened fine - this click's own round trip has handed off to
-            // the popup window, whether called directly from
-            // getCurrentBuyer() (no on-page prompt to show first) or from
-            // showPrompt()'s own click listener (TWO-40 round 4).
-            this.notifyEnrollmentSettled();
+            // Opened fine - hand off to the popup window, but do NOT settle
+            // the spinner yet (TWO-40 follow-up, Doug: it was clearing as
+            // soon as this line ran, not when the popup actually closed).
+            // watchPopupUntilClosed() settles it once `popup.closed` is
+            // actually true.
+            this._popup = popup;
+            this.watchPopupUntilClosed();
         }
         return popup;
+    }
+
+    /**
+     * Poll the popup handle until the buyer actually closes it - completes
+     * the signup, cancels inside it, or just closes the window. A
+     * cross-origin popup fires no event for any of those, so polling
+     * `.closed` is the only reliable signal; 500ms is frequent enough to
+     * feel immediate without hammering the main thread.
+     *
+     * Deliberately not "settled by the postMessage 'ACCEPTED' handler
+     * instead" - that message means the buyer authenticated, not that the
+     * popup has gone away, and the spinner must track the popup's own
+     * lifetime (see notifyEnrollmentSettled()'s guard).
+     */
+    watchPopupUntilClosed() {
+        this.stopPopupWatch();
+        const self = this;
+        this._popupPollInterval = window.setInterval(function () {
+            if (!self._popup || self._popup.closed) {
+                self._popup = null;
+                self.stopPopupWatch();
+                self.notifyEnrollmentSettled();
+            }
+        }, 500);
+    }
+
+    /**
+     * Clear the popup-close poll, if one is running, without touching
+     * `this._popup` - callers that already know the popup is gone clear that
+     * themselves first (see watchPopupUntilClosed()); callers tearing down a
+     * still-open popup's tracking (cancelEnrollment(), destroy()) clear it
+     * right after calling this. Idempotent, and every exit path calls it so
+     * no interval outlives its popup.
+     */
+    stopPopupWatch() {
+        if (this._popupPollInterval) {
+            window.clearInterval(this._popupPollInterval);
+            this._popupPollInterval = null;
+        }
     }
 
     /**
@@ -1879,18 +1936,34 @@ class TwoSoleTrader {
      * startEnrollment()'s call graph:
      *  - showError() (covers both fetchTokens() failure paths, the
      *    getCurrentBuyer() catch, and openPopup()'s popup-blocked branch)
-     *  - getCurrentBuyer()'s showPrompt()/openPopup() branches (no error,
-     *    but nothing left for the spinner to wait on - the flow has handed
-     *    off to on-page prompt UI or a popup window)
+     *  - getCurrentBuyer()'s showPrompt() branch (no error, but nothing left
+     *    for the spinner to wait on - the flow now waits on the buyer
+     *    clicking the on-page prompt)
      *  - applyBuyer()'s success branch
+     *  - watchPopupUntilClosed()'s poll, once a popup that WAS opened has
+     *    actually closed
      *
      * Deliberately NOT gated on `_enrollGeneration`: TwoCompanySearch.js's
      * listener is bound fresh per click and unbound on its own next close,
      * so a stale event from an abandoned attempt finding no listener left
      * to hear it is already a no-op, the same way a stale popup message
      * finding this object gone would be.
+     *
+     * Gated on `this._popup`, though (TWO-40 follow-up, Doug): while a
+     * signup popup is open, the spinner must wait for the popup itself to
+     * close - completed, cancelled inside it, or just closed by the buyer -
+     * not for whichever internal call happens to settle first. applyBuyer()'s
+     * success branch and showError() both still call this directly on every
+     * one of their own terminal paths; this guard is what makes those calls
+     * defer to watchPopupUntilClosed()'s poll instead of firing early
+     * whenever a popup is the thing still open. cancelEnrollment() clears
+     * `this._popup` itself first, since that path means the buyer moved on
+     * to a different search interaction, not the popup closing.
      */
     notifyEnrollmentSettled() {
+        if (this._popup && !this._popup.closed) {
+            return;
+        }
         document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
     }
 }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -1691,6 +1691,17 @@ class TwoSoleTrader {
         if (!this.tokens) {
             return null;
         }
+        if (this._popup && !this._popup.closed) {
+            // Round trip already handed off to a popup that is still open
+            // (adversarial review finding, Han + Vader independently) -
+            // opening a SECOND window here would orphan the first one,
+            // untracked: `this._popup` would move to the new popup and the
+            // poll would never learn the first window even existed, so a
+            // buyer who closes THAT one instead of the new one would leave
+            // the spinner stuck forever. Focus the existing popup instead.
+            this._popup.focus();
+            return this._popup;
+        }
         const ps = window.prestashop;
         const customer = (ps && ps.customer) || {};
         const firstName = document.querySelector("input[name='firstname']");


### PR DESCRIPTION
## Summary
- TWO-40 follow-up (Doug, live testing): the in-field spinner was clearing as soon as `window.open()` returned, not when the buyer actually closed the signup popup.
- `notifyEnrollmentSettled()` now defers to a poll on the popup handle's `.closed` state (no cross-origin close event exists); every exit path (popup close, `cancelEnrollment()`, `destroy()`) stops the poll so no interval leaks.

## Test plan
- [x] `npm run test:js` — 31 suites / 785 tests pass
- [x] New/updated coverage in `tests/js/sole-trader-flight-settled.test.js`: spinner stays up after `window.open()` returns, clears once `popup.closed` becomes true, settles immediately if the popup was blocked, no leaked poll interval on any exit path (close, cancel, destroy)
- [ ] Doug: live click-through on staging (checkout-critical UI, needs a real popup)