### PR TITLE
feat(js): refresh delegated auth tokens every 30 minutes while checkout is open

### DIFF
--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -317,7 +317,10 @@ test('no popup poll interval survives a normal popup-close settle', async () => 
             expect(jest.getTimerCount()).toBeGreaterThan(0);
             popup.closed = true;
             jest.advanceTimersByTime(500);
-            expect(jest.getTimerCount()).toBe(0);
+            // 1, not 0: the poll interval is gone, but TWO-40's 30-minute
+            // background token-refresh interval is a real timer that
+            // legitimately outlives the settle - only destroy() clears it.
+            expect(jest.getTimerCount()).toBe(1);
         } finally {
             instance.destroy();
         }
@@ -343,7 +346,10 @@ test('a popup blocked outright (window.open() returns null) never starts a poll 
             await flushPromises();
 
             expect(calls.length).toBe(1);
-            expect(jest.getTimerCount()).toBe(0);
+            // 1, not 0: the mint still succeeded (openPopup() itself is what
+            // fails here), so TWO-40's background token-refresh interval is
+            // legitimately running.
+            expect(jest.getTimerCount()).toBe(1);
         } finally {
             instance.destroy();
         }
@@ -413,7 +419,11 @@ test('cancelEnrollment() while a popup is open stops the poll instead of leaking
 
             expect(jest.getTimerCount()).toBeGreaterThan(0);
             instance.cancelEnrollment();
-            expect(jest.getTimerCount()).toBe(0);
+            // 1, not 0: cancelEnrollment() deliberately does not discard
+            // `tokens` (resumable by design, see its own comment), so
+            // TWO-40's background refresh interval keeps them alive too -
+            // only destroy() clears it.
+            expect(jest.getTimerCount()).toBe(1);
         } finally {
             instance.destroy();
         }

--- a/tests/js/sole-trader-token-refresh.test.js
+++ b/tests/js/sole-trader-token-refresh.test.js
@@ -430,15 +430,58 @@ test('a popup opened while a background mint is still in flight is not orphaned 
  * again to clear it.
  */
 test('a mint that resolves after destroy() does not arm a background-refresh interval', async () => {
-    let resolveMint;
-    stubFetch(() => new Promise((resolve) => { resolveMint = resolve; }));
+    // Round 3 adversarial review (Vader finding): `_tokenRefreshIntervalId`
+    // is a proxy the code under test writes itself - a mutant that armed a
+    // REAL setInterval() without recording its handle there would still
+    // read null here. jest.getTimerCount() proves no timer, of any kind,
+    // was actually scheduled.
+    jest.useFakeTimers();
+    try {
+        let resolveMint;
+        stubFetch(() => new Promise((resolve) => { resolveMint = resolve; }));
+
+        const instance = build();
+        instance.startEnrollment();
+        instance.destroy();
+
+        resolveMint({ json: () => Promise.resolve(tokenPayload('late')) });
+        await flushPromises();
+
+        expect(instance._tokenRefreshIntervalId).toBeNull();
+        expect(jest.getTimerCount()).toBe(0);
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+/**
+ * Round 3 adversarial review (Leia/Yoda, convergent): fetchTokens()'s own
+ * success branch checks `_destroyed` before touching `this.tokens` -
+ * refreshTokens()'s should too, for the same reason (this instance is gone,
+ * nothing is safe to act on), even though it arms nothing that could leak.
+ */
+test('a background mint that resolves after destroy() does not write to a torn-down instance', async () => {
+    let mintCalls = 0;
+    let resolveSecondMint;
+    stubFetch(() => {
+        mintCalls += 1;
+        if (mintCalls === 1) {
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload('1')) });
+        }
+        return new Promise((resolve) => { resolveSecondMint = resolve; });
+    });
 
     const instance = build();
     instance.startEnrollment();
-    instance.destroy();
+    await flushPromises();
+    expect(mintCalls).toBe(1);
 
-    resolveMint({ json: () => Promise.resolve(tokenPayload('late')) });
+    instance.refreshTokens();
+    expect(mintCalls).toBe(2);
+
+    instance.destroy();
+    resolveSecondMint({ json: () => Promise.resolve(tokenPayload('2')) });
     await flushPromises();
 
-    expect(instance._tokenRefreshIntervalId).toBeNull();
+    expect(instance.tokens.autofill_token).toBe('af-token-1');
 });

--- a/tests/js/sole-trader-token-refresh.test.js
+++ b/tests/js/sole-trader-token-refresh.test.js
@@ -243,3 +243,130 @@ test('destroy() clears the timer - no further mint after teardown', async () => 
         jest.useRealTimers();
     }
 });
+
+test('the interval fires repeatedly, not just once - two consecutive successful ticks re-mint twice', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+        expect(mintCalls).toBe(2);
+        expect(instance.tokens.autofill_token).toBe('af-token-2');
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+        expect(mintCalls).toBe(3);
+        expect(instance.tokens.autofill_token).toBe('af-token-3');
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+/**
+ * Adversarial review round 1 BLOCKER (Han/Vader/Yoda, independently):
+ * openPopup() bakes `this.tokens` into the popup's own URL at open time: a
+ * background tick that swaps `this.tokens` while that popup is still open
+ * would authenticate the popup's eventual 'ACCEPTED' completion against a
+ * token pair the buyer's OTP flow never actually ran through.
+ */
+test('a tick is skipped while a signup popup opened against the current tokens is still open', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+        const popup = { closed: false };
+        global.window.open = jest.fn(() => popup);
+
+        const instance = build();
+        instance.startEnrollment();
+        // Mint succeeds; the immediate buyer lookup (404, no match) hands
+        // off to the on-page prompt rather than opening the popup itself.
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+
+        const prompt = document.querySelector('.two-sole-trader__prompt');
+        prompt.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        expect(global.window.open).toHaveBeenCalledTimes(1);
+        expect(instance._popup).toBe(popup);
+
+        const mintedTokens = instance.tokens;
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+
+        // Popup still open - the tick must have been skipped outright.
+        expect(mintCalls).toBe(1);
+        expect(instance.tokens).toBe(mintedTokens);
+
+        // Buyer closes the popup; watchPopupUntilClosed()'s own poll clears
+        // `this._popup` on its next 500ms tick.
+        popup.closed = true;
+        jest.advanceTimersByTime(500);
+        await flushPromises();
+        expect(instance._popup).toBeNull();
+
+        // A later tick is no longer held back.
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+        expect(mintCalls).toBe(2);
+        expect(instance.tokens.autofill_token).toBe('af-token-2');
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+/**
+ * Adversarial review round 1 BUG (Vader): fetchTokens()'s own mint keeps the
+ * posted country and the eligibility-check country in agreement "by
+ * construction" (see its own comment) - a background refresh minting for a
+ * DIFFERENT country than the one `this.tokens` currently belongs to would
+ * silently break that agreement.
+ */
+test('a tick is skipped if the billing country has diverged from the country the current tokens were minted for', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+
+        const instance = build({ billingCountry: 'GB' });
+        instance.startEnrollment();
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+        expect(instance.tokens.country).toBe('GB');
+
+        // The buyer changes billing country mid-enrolment WITHOUT it
+        // becoming ineligible (config-time billingCountry() fallback can't
+        // move on its own, so this pins the guard directly rather than
+        // simulating a country-select change).
+        instance.config.billingCountry = 'SE';
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+
+        expect(mintCalls).toBe(1);
+        expect(instance.tokens.autofill_token).toBe('af-token-1');
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});

--- a/tests/js/sole-trader-token-refresh.test.js
+++ b/tests/js/sole-trader-token-refresh.test.js
@@ -1,0 +1,245 @@
+/**
+ * TWO-40 follow-up, Doug: delegated auth tokens can expire server-side if a
+ * buyer sits on checkout too long, breaking autofill and the sole-trader
+ * flow. Pins the fixed behaviour: a 30-minute background re-mint, started
+ * only once a real mint has actually succeeded, reusing fetchTokens()'s own
+ * `isFetchingTokens` guard rather than a second, uncoordinated mint path.
+ */
+
+'use strict';
+
+const { loadSoleTrader, buildPaymentTile, flushPromises } = require('./ps-harness');
+
+let TwoSoleTrader;
+
+function build(overrides) {
+    return new TwoSoleTrader(Object.assign({
+        checkoutHost: 'https://api.example.test',
+        orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+        ajaxToken: 'test-token',
+        billingCountry: 'GB'
+    }, overrides || {}));
+}
+
+function tokenPayload(suffix) {
+    return {
+        success: true,
+        autofill_token: 'af-token-' + suffix,
+        delegation_token: 'del-token-' + suffix,
+        signup_url: 'https://signup.example.test/',
+        country: 'GB'
+    };
+}
+
+/**
+ * Stubs fetch(), routing soleTraderTokens calls through `mintHandler` (so
+ * tests can hand back a fresh payload, a pending Promise, or a failure per
+ * call) and answering every other endpoint (availability, buyer lookup)
+ * inertly so they cannot interfere with what each test is asserting.
+ */
+function stubFetch(mintHandler) {
+    global.window.fetch = (url) => {
+        if (String(url).includes('soleTraderAvailability')) {
+            return Promise.resolve({ json: () => Promise.resolve({ success: true, available: true }) });
+        }
+        if (String(url).includes('soleTraderTokens')) {
+            return mintHandler();
+        }
+        if (String(url).includes('/autofill/v1/buyer/current')) {
+            return Promise.resolve({ ok: false, status: 404 });
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+    };
+    global.fetch = global.window.fetch;
+}
+
+beforeEach(() => {
+    buildPaymentTile();
+    TwoSoleTrader = loadSoleTrader();
+});
+
+afterEach(() => {
+    delete global.fetch;
+    delete global.window.fetch;
+    delete global.window.TwoCompanyNumber;
+    delete global.window.open;
+    delete global.window.TwoCheckoutManager_Instance;
+    document.body.innerHTML = '';
+    global.window.localStorage.clear();
+});
+
+test('the refresh interval does not start before any mint has ever succeeded', () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload('never-called')) });
+        });
+
+        // Constructed but never enrolled - a buyer who has not touched the
+        // sole-trader flow has no tokens, so nothing should be scheduled.
+        const instance = build();
+        jest.advanceTimersByTime(60 * 60 * 1000);
+
+        expect(mintCalls).toBe(0);
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('a real mint starts the interval, which re-mints via the guarded fetchTokens() path at the 30-minute mark', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+
+        expect(mintCalls).toBe(1);
+        expect(instance.tokens.autofill_token).toBe('af-token-1');
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+
+        expect(mintCalls).toBe(2);
+        expect(instance.tokens.autofill_token).toBe('af-token-2');
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('a tick is skipped, not queued, while a mint is already in flight', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        let resolveSecondMint;
+        stubFetch(() => {
+            mintCalls += 1;
+            if (mintCalls === 1) {
+                return Promise.resolve({ json: () => Promise.resolve(tokenPayload('1')) });
+            }
+            // The buyer clicks "select a different sole trader" right as the
+            // 30-minute tick fires - a real mint is genuinely in flight.
+            return new Promise((resolve) => { resolveSecondMint = resolve; });
+        });
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+
+        instance.isFetchingTokens = true;
+        instance.refreshTokens();
+        // The guard skips the tick outright - no second request queued
+        // behind the in-flight one.
+        expect(mintCalls).toBe(1);
+
+        instance.isFetchingTokens = false;
+        resolveSecondMint = null;
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('a failed refresh tick leaves the existing tokens in place for the next scheduled retry', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            if (mintCalls === 1) {
+                return Promise.resolve({ json: () => Promise.resolve(tokenPayload('good')) });
+            }
+            return Promise.reject(new Error('network down'));
+        });
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        const mintedTokens = instance.tokens;
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+
+        expect(mintCalls).toBe(2);
+        // Unlike fetchTokens()'s own failure handling (which nulls tokens
+        // out), a failed background refresh must not break autofill for a
+        // buyer who still has valid, not-yet-expired tokens.
+        expect(instance.tokens).toBe(mintedTokens);
+        expect(instance.isFetchingTokens).toBe(false);
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('a refresh tick after cancelEnrollment() still silently replaces the tokens, without re-entering the enrolment flow', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+        global.window.open = jest.fn();
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+
+        // Buyer abandons the flow - bumps `_enrollGeneration`, but does NOT
+        // discard `tokens` (see cancelEnrollment()'s own comment).
+        instance.cancelEnrollment();
+
+        jest.advanceTimersByTime(30 * 60 * 1000);
+        await flushPromises();
+
+        // The tick still re-minted (tokens are kept alive regardless of
+        // enrolment state), but did not act on them: no popup, no new
+        // buyer lookup - refreshTokens() never calls afterTokensReady().
+        expect(mintCalls).toBe(2);
+        expect(instance.tokens.autofill_token).toBe('af-token-2');
+        expect(global.window.open).not.toHaveBeenCalled();
+
+        instance.destroy();
+    } finally {
+        jest.useRealTimers();
+    }
+});
+
+test('destroy() clears the timer - no further mint after teardown', async () => {
+    jest.useFakeTimers();
+    try {
+        let mintCalls = 0;
+        stubFetch(() => {
+            mintCalls += 1;
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload(String(mintCalls))) });
+        });
+
+        const instance = build();
+        instance.startEnrollment();
+        await flushPromises();
+        expect(mintCalls).toBe(1);
+
+        instance.destroy();
+
+        jest.advanceTimersByTime(60 * 60 * 1000);
+        await flushPromises();
+
+        expect(mintCalls).toBe(1);
+    } finally {
+        jest.useRealTimers();
+    }
+});

--- a/tests/js/sole-trader-token-refresh.test.js
+++ b/tests/js/sole-trader-token-refresh.test.js
@@ -370,3 +370,75 @@ test('a tick is skipped if the billing country has diverged from the country the
         jest.useRealTimers();
     }
 });
+
+/**
+ * Round 2 adversarial review (Han finding): the entry guard on `this._popup`
+ * only proves no popup was open when the tick STARTED - it says nothing
+ * about a popup opened WHILE that tick's mint POST is still out.
+ * openPopup() (via the on-page prompt's click handler) has no
+ * `isFetchingTokens` guard of its own, so this is a real, if narrow, window.
+ */
+test('a popup opened while a background mint is still in flight is not orphaned by that mint landing', async () => {
+    let mintCalls = 0;
+    let resolveSecondMint;
+    stubFetch(() => {
+        mintCalls += 1;
+        if (mintCalls === 1) {
+            return Promise.resolve({ json: () => Promise.resolve(tokenPayload('1')) });
+        }
+        return new Promise((resolve) => { resolveSecondMint = resolve; });
+    });
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+
+    const instance = build();
+    instance.startEnrollment();
+    // Mint succeeds; the buyer lookup (404, no match) hands off to the
+    // on-page prompt.
+    await flushPromises();
+    expect(mintCalls).toBe(1);
+
+    // A background tick starts - no popup open yet, so the entry guard lets
+    // it through - and its mint is still in flight.
+    instance.refreshTokens();
+    expect(mintCalls).toBe(2);
+
+    // The buyer clicks the prompt WHILE that mint is out, baking the
+    // (still-old) tokens into a brand new popup.
+    const prompt = document.querySelector('.two-sole-trader__prompt');
+    prompt.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(global.window.open).toHaveBeenCalledTimes(1);
+    expect(instance._popup).toBe(popup);
+
+    // NOW the background tick's mint resolves.
+    resolveSecondMint({ json: () => Promise.resolve(tokenPayload('2')) });
+    await flushPromises();
+
+    // Must not have overwritten the tokens the just-opened popup was baked
+    // against - the re-check inside refreshTokens()'s own .then() catches
+    // what the entry guard alone could not.
+    expect(instance.tokens.autofill_token).toBe('af-token-1');
+
+    instance.destroy();
+});
+
+/**
+ * Round 2 adversarial review (Leia finding): a mint still outstanding when
+ * destroy() runs (e.g. PrestaShop swaps in a fresh instance for a replaced
+ * payment fragment) must not arm a NEW setInterval on the now-dead instance
+ * when it eventually resolves - nothing will ever call destroy() on it
+ * again to clear it.
+ */
+test('a mint that resolves after destroy() does not arm a background-refresh interval', async () => {
+    let resolveMint;
+    stubFetch(() => new Promise((resolve) => { resolveMint = resolve; }));
+
+    const instance = build();
+    instance.startEnrollment();
+    instance.destroy();
+
+    resolveMint({ json: () => Promise.resolve(tokenPayload('late')) });
+    await flushPromises();
+
+    expect(instance._tokenRefreshIntervalId).toBeNull();
+});

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -78,6 +78,13 @@ class TwoSoleTrader {
     // the delegated auth tokens to expire server-side loses autofill and the
     // sole-trader flow entirely. See startTokenRefreshInterval()/
     // refreshTokens().
+    //
+    // Unlike `_AVAILABILITY_CACHE_TTL_MS` above, there is no local server-side
+    // constant to cite here: the delegated tokens' own TTL is set upstream, by
+    // whatever mints delegation_token/autofill_token (classes/TwoSoleTrader.php's
+    // mint call), not by this module or its immediate PHP counterpart. 30
+    // minutes is Doug's own considered figure (this ticket's ask verbatim),
+    // not derived from a constant this file can point at.
     static _TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
     constructor(config) {
@@ -1216,16 +1223,22 @@ class TwoSoleTrader {
      * invariant that has nothing to do with `_enrollGeneration` but that this
      * call can still break silently.
      *
-     * Known residual gap (round 2 adversarial review, Vader finding,
+     * Known residual gap (round 2/3 adversarial review, Vader finding,
      * accepted): while a popup stays open, EVERY tick is skipped, so tokens
      * baked into that popup's URL at open time are never refreshed for as
      * long as it stays open. A popup left open past the server's own token
      * TTL still hits the expiry this file exists to fix - just narrowed from
      * "always broken past 30 minutes" to "broken only if the buyer leaves
-     * the popup open that long", which is judged an acceptable trade against
-     * the alternative (silently authenticating against a token pair the
-     * popup's own OTP flow never ran through - the round-1 bug). Not fixed
-     * here; a popup-resume re-mint would be a separate change.
+     * the popup open that long". A "re-mint the moment the popup closes"
+     * fix would NOT meaningfully narrow this further: the dominant
+     * completion path is the OTP 'ACCEPTED' postMessage
+     * (bindPopupMessageListener() -> getCurrentBuyer()), which fires and
+     * reads `this.tokens.autofill_token` BEFORE the popup close is ever
+     * observed - watchPopupUntilClosed()'s poll runs after, not before,
+     * that read. So the accepted trade is specifically against the
+     * round-1 bug (silently authenticating against a token pair the
+     * popup's own OTP flow never ran through), not a placeholder for an
+     * easy popup-close-triggered fix. Not fixed here.
      *
      * Unlike fetchTokens()'s OWN failure handling, a failed refresh leaves
      * `this.tokens` exactly as it was rather than nulling it out: the existing
@@ -1289,6 +1302,14 @@ class TwoSoleTrader {
         request
             .then(function (response) { return response.json(); })
             .then(function (json) {
+                if (self._destroyed) {
+                    // Same reasoning as fetchTokens()'s own success branch -
+                    // this instance is gone, nothing below is safe to act on.
+                    // Arms nothing here (unlike that branch), but writing
+                    // `self.tokens` on a torn-down instance is still not a
+                    // legitimate effect to have.
+                    return;
+                }
                 // Re-checked, not just checked at entry (round 2 adversarial
                 // review, Han finding): the guard above only proves no popup
                 // was open when this tick STARTED. The buyer can still click

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -74,6 +74,12 @@ class TwoSoleTrader {
     // finding) - this is read by nobody outside readPersistedAvailability().
     static _AVAILABILITY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+    // TWO-40 follow-up, Doug: a buyer who sits on checkout long enough for
+    // the delegated auth tokens to expire server-side loses autofill and the
+    // sole-trader flow entirely. See startTokenRefreshInterval()/
+    // refreshTokens().
+    static _TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+
     constructor(config) {
         this.config = {
             checkoutHost: '',
@@ -184,6 +190,11 @@ class TwoSoleTrader {
         // already true for a different call (TWO-40 round 8, adversarial
         // review finding, Han) - see getCurrentBuyer()'s own .finally().
         this._pendingTrustedResume = false;
+        // The setInterval handle for the 30-minute background token refresh
+        // (TWO-40 follow-up) - held so destroy() can clear it. Started once,
+        // by fetchTokens()'s own success branch, on the first real mint; see
+        // startTokenRefreshInterval().
+        this._tokenRefreshIntervalId = null;
 
         // TWO-25326 bug 9, round 3: take the availability answer the SERVER
         // already resolved as this instance's settled state, before init()
@@ -368,6 +379,7 @@ class TwoSoleTrader {
     destroy() {
         this.stopObserving();
         this.stopPopupWatch();
+        this.stopTokenRefreshInterval();
         this._popup = null;
         if (this._countryChangeHandler) {
             document.removeEventListener('change', this._countryChangeHandler);
@@ -1056,6 +1068,11 @@ class TwoSoleTrader {
             .then(function (json) {
                 if (json && json.success && json.autofill_token) {
                     self.tokens = json;
+                    // Idempotent (see its own guard) - started on the FIRST
+                    // real mint, not eagerly in the constructor, since a
+                    // buyer who has never touched the sole-trader flow has
+                    // no tokens to keep alive (TWO-40 follow-up).
+                    self.startTokenRefreshInterval();
                     // Stamp with the CAPTURED generation, not the current
                     // one - see the comment above. If cancelEnrollment() ran
                     // while this request was out, `generation` is already
@@ -1108,6 +1125,103 @@ class TwoSoleTrader {
                 self.tokens = null;
                 self.nextRetryAt = Date.now() + self.retryCooldownMs;
                 self.showError();
+            })
+            .finally(function () {
+                self.isFetchingTokens = false;
+            });
+    }
+
+    /**
+     * Start the 30-minute background re-mint (TWO-40 follow-up, Doug: a
+     * buyer who sits on checkout too long can outlast the delegated auth
+     * tokens' server-side lifetime, breaking autofill and the sole-trader
+     * flow entirely). Idempotent - a resumed enrolment (startEnrollment()'s/
+     * startReplacement()'s "else" branches) re-enters fetchTokens()'s success
+     * branch without ever needing a second interval.
+     *
+     * A single setInterval, not a recursive setTimeout chain: refreshTokens()
+     * has no per-tick backoff to carry between calls, so there is nothing a
+     * chain would buy here over a fixed 30-minute cadence.
+     *
+     * @returns {void}
+     */
+    startTokenRefreshInterval() {
+        if (this._tokenRefreshIntervalId) {
+            return;
+        }
+        const self = this;
+        this._tokenRefreshIntervalId = setInterval(function () {
+            self.refreshTokens();
+        }, TwoSoleTrader._TOKEN_REFRESH_INTERVAL_MS);
+    }
+
+    /**
+     * @returns {void}
+     */
+    stopTokenRefreshInterval() {
+        if (this._tokenRefreshIntervalId) {
+            clearInterval(this._tokenRefreshIntervalId);
+            this._tokenRefreshIntervalId = null;
+        }
+    }
+
+    /**
+     * One periodic re-mint tick (TWO-40 follow-up). Reuses fetchTokens()'s own
+     * `isFetchingTokens` guard rather than a second, uncoordinated one: if a
+     * user-driven mint is already out when this fires, that mint will land
+     * and refresh `this.tokens` itself - issuing a second concurrent request
+     * here would break the "exactly one mint in flight" invariant fetchTokens()'s
+     * own comments document at length. This tick is simply skipped; the next
+     * scheduled one will try again.
+     *
+     * Deliberately NOT gated on `_enrollGeneration`/`_tokensGeneration`: unlike
+     * fetchTokens()'s success branch, this call does not ACT on the tokens -
+     * no afterTokensReady(), no popup, no getCurrentBuyer() - it only replaces
+     * the token VALUES a later, generation-checked call will read. Which
+     * enrolment attempt (if any) those values belong to is unaffected by
+     * refreshing them, so there is nothing here for a generation check to
+     * protect.
+     *
+     * Unlike fetchTokens()'s OWN failure handling, a failed refresh leaves
+     * `this.tokens` exactly as it was rather than nulling it out: the existing
+     * (not-yet-expired) tokens are still the buyer's best option until a
+     * later tick actually replaces them, and nulling them on a transient
+     * failure would break autofill immediately instead of waiting for the
+     * next scheduled retry.
+     *
+     * @returns {void}
+     */
+    refreshTokens() {
+        if (this.isFetchingTokens || !this.tokens) {
+            return;
+        }
+        this.isFetchingTokens = true;
+        const self = this;
+        let request;
+        try {
+            // Same synchronous-throw protection as fetchTokens()'s own try -
+            // billingCountry()/moduleUrl() reading a malformed config must
+            // not leave `isFetchingTokens` stuck true forever.
+            const body = new URLSearchParams({ country: this.billingCountry() });
+            request = fetch(this.moduleUrl('soleTraderTokens'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            });
+        } catch (e) {
+            this.isFetchingTokens = false;
+            return;
+        }
+        request
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                if (json && json.success && json.autofill_token) {
+                    self.tokens = json;
+                }
+                // Else: leave the existing tokens in place, see doc above.
+            })
+            .catch(function () {
+                // Transport failure - leave the existing tokens in place.
             })
             .finally(function () {
                 self.isFetchingTokens = false;

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -195,6 +195,14 @@ class TwoSoleTrader {
         // by fetchTokens()'s own success branch, on the first real mint; see
         // startTokenRefreshInterval().
         this._tokenRefreshIntervalId = null;
+        // Set by destroy() (TWO-40 follow-up, round 2 adversarial review,
+        // Leia finding): a fetchTokens() mint still outstanding when
+        // destroy() runs (e.g. PrestaShop swaps in a fresh instance for a
+        // replaced payment fragment) must not arm a NEW setInterval on the
+        // now-dead instance when it resolves - nothing will ever call
+        // destroy() on it again to clear it. Checked at the top of
+        // fetchTokens()'s success branch.
+        this._destroyed = false;
 
         // TWO-25326 bug 9, round 3: take the availability answer the SERVER
         // already resolved as this instance's settled state, before init()
@@ -377,6 +385,7 @@ class TwoSoleTrader {
      * @returns {void}
      */
     destroy() {
+        this._destroyed = true;
         this.stopObserving();
         this.stopPopupWatch();
         this.stopTokenRefreshInterval();
@@ -1077,6 +1086,14 @@ class TwoSoleTrader {
         request
             .then(function (response) { return response.json(); })
             .then(function (json) {
+                if (self._destroyed) {
+                    // Round 2 adversarial review (Leia): this instance is
+                    // gone - nothing below is safe to act on, and arming a
+                    // NEW setInterval here would leak it (destroy() already
+                    // ran, so nothing will ever call stopTokenRefreshInterval()
+                    // on this instance again).
+                    return;
+                }
                 if (json && json.success && json.autofill_token) {
                     self.tokens = json;
                     // Idempotent (see its own guard) - started on the FIRST
@@ -1199,6 +1216,17 @@ class TwoSoleTrader {
      * invariant that has nothing to do with `_enrollGeneration` but that this
      * call can still break silently.
      *
+     * Known residual gap (round 2 adversarial review, Vader finding,
+     * accepted): while a popup stays open, EVERY tick is skipped, so tokens
+     * baked into that popup's URL at open time are never refreshed for as
+     * long as it stays open. A popup left open past the server's own token
+     * TTL still hits the expiry this file exists to fix - just narrowed from
+     * "always broken past 30 minutes" to "broken only if the buyer leaves
+     * the popup open that long", which is judged an acceptable trade against
+     * the alternative (silently authenticating against a token pair the
+     * popup's own OTP flow never ran through - the round-1 bug). Not fixed
+     * here; a popup-resume re-mint would be a separate change.
+     *
      * Unlike fetchTokens()'s OWN failure handling, a failed refresh leaves
      * `this.tokens` exactly as it was rather than nulling it out: the existing
      * (not-yet-expired) tokens are still the buyer's best option until a
@@ -1261,6 +1289,19 @@ class TwoSoleTrader {
         request
             .then(function (response) { return response.json(); })
             .then(function (json) {
+                // Re-checked, not just checked at entry (round 2 adversarial
+                // review, Han finding): the guard above only proves no popup
+                // was open when this tick STARTED. The buyer can still click
+                // the on-page prompt - openPopup() has no isFetchingTokens
+                // guard of its own and bakes whatever `this.tokens` holds
+                // RIGHT NOW into its URL - while this mint's POST is still
+                // out. Applying `json` after that would silently orphan the
+                // just-opened popup's tokens exactly as the entry guard was
+                // built to prevent, just through the async gap instead of a
+                // stale read at tick-start.
+                if (self._popup && !self._popup.closed) {
+                    return;
+                }
                 if (json && json.success && json.autofill_token) {
                     self.tokens = json;
                 }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -987,6 +987,35 @@ class TwoSoleTrader {
     }
 
     /**
+     * The actual mint POST, shared by fetchTokens() and refreshTokens()
+     * (TWO-40 follow-up) so a future change to this request has one call
+     * site, not two.
+     *
+     * Deliberately billingCountry(): that is the SAME resolver
+     * isAvailableForCurrentCountry() answers the chip's visibility from, so
+     * the country the mint is authorised against and the country the chip
+     * was shown for cannot disagree by construction. Sent urlencoded, the
+     * way applyBuyer() posts to saveCompany.
+     *
+     * The server prefers this posted country over anything it holds: the
+     * invoice-address tier that used to outrank it was deleted, not
+     * demoted, so the posted country wins outright and the cart's DELIVERY
+     * address is consulted only when no usable country was posted at all.
+     * It re-checks the registry either way.
+     *
+     * @param {string} country
+     * @returns {Promise} the fetch() promise
+     */
+    mintTokensRequest(country) {
+        const body = new URLSearchParams({ country: country });
+        return fetch(this.moduleUrl('soleTraderTokens'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+        });
+    }
+
+    /**
      * Mint tokens, guarded against a request storm: refuses re-entry
      * while a request is already outstanding (isFetchingTokens) and
      * enforces a minimum gap between attempts after a failure
@@ -1038,25 +1067,7 @@ class TwoSoleTrader {
         // failure once caught.
         let request;
         try {
-            // Post the country the buyer currently has selected (TWO-40).
-            // The server prefers THIS over anything it holds: the invoice-
-            // address tier that used to outrank it was deleted, not
-            // demoted, so the posted country wins outright and the cart's
-            // DELIVERY address is consulted only when no usable country was
-            // posted at all. It re-checks the registry either way.
-            //
-            // Deliberately billingCountry(): that is the SAME resolver
-            // isAvailableForCurrentCountry() answers the chip's visibility
-            // from, so the country the mint is authorised against and the
-            // country the chip was shown for cannot disagree by
-            // construction. Sent urlencoded, the way applyBuyer() posts to
-            // saveCompany.
-            const body = new URLSearchParams({ country: this.billingCountry() });
-            request = fetch(this.moduleUrl('soleTraderTokens'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: body.toString()
-            });
+            request = this.mintTokensRequest(this.billingCountry());
         } catch (e) {
             this.isFetchingTokens = false;
             this.nextRetryAt = Date.now() + this.retryCooldownMs;
@@ -1135,9 +1146,10 @@ class TwoSoleTrader {
      * Start the 30-minute background re-mint (TWO-40 follow-up, Doug: a
      * buyer who sits on checkout too long can outlast the delegated auth
      * tokens' server-side lifetime, breaking autofill and the sole-trader
-     * flow entirely). Idempotent - a resumed enrolment (startEnrollment()'s/
-     * startReplacement()'s "else" branches) re-enters fetchTokens()'s success
-     * branch without ever needing a second interval.
+     * flow entirely). Idempotent - a mint that FAILS after the interval is
+     * already running (a later click retries fetchTokens(), which reaches
+     * this same success branch a second time) must not arm a second,
+     * duplicate interval.
      *
      * A single setInterval, not a recursive setTimeout chain: refreshTokens()
      * has no per-tick backoff to carry between calls, so there is nothing a
@@ -1182,6 +1194,11 @@ class TwoSoleTrader {
      * refreshing them, so there is nothing here for a generation check to
      * protect.
      *
+     * IS gated on the open-popup and country checks below (adversarial
+     * review, round 1 - Han/Vader/Yoda independently) - both protect an
+     * invariant that has nothing to do with `_enrollGeneration` but that this
+     * call can still break silently.
+     *
      * Unlike fetchTokens()'s OWN failure handling, a failed refresh leaves
      * `this.tokens` exactly as it was rather than nulling it out: the existing
      * (not-yet-expired) tokens are still the buyer's best option until a
@@ -1195,21 +1212,50 @@ class TwoSoleTrader {
         if (this.isFetchingTokens || !this.tokens) {
             return;
         }
+        // A popup opened against the CURRENT `this.tokens` (openPopup() bakes
+        // `delegation_token`/`autofill_token`/`signup_url` into its URL at
+        // open time, not read live) is still tracked open and awaiting its
+        // own 'ACCEPTED' completion. Swapping `this.tokens` under it would
+        // authenticate that completion's buyer lookup
+        // (bindPopupMessageListener() -> getCurrentBuyer() ->
+        // `this.tokens.autofill_token`) against a pair the buyer's OTP flow
+        // never actually ran through - exactly the "real auth, rejected"
+        // failure class this file has hardened against elsewhere. Skip the
+        // tick; watchPopupUntilClosed() clears `this._popup` once it closes,
+        // letting a later tick through.
+        if (this._popup && !this._popup.closed) {
+            return;
+        }
+        // The buyer may have changed billing country since these tokens were
+        // minted without the country becoming ineligible (which would have
+        // routed through cancelEnrollment() instead). fetchTokens()'s own
+        // mint deliberately keeps the posted country and the eligibility
+        // country in agreement "by construction" (see its own comment) -
+        // re-minting here for a country that no longer matches
+        // `this.tokens.country` would mint fresh tokens for a country the
+        // buyer's on-screen enrolment no longer belongs to. Skip the tick
+        // rather than silently disagree with it.
+        if (this.tokens.country && this.billingCountry() !== this.tokens.country) {
+            return;
+        }
         this.isFetchingTokens = true;
         const self = this;
         let request;
         try {
             // Same synchronous-throw protection as fetchTokens()'s own try -
             // billingCountry()/moduleUrl() reading a malformed config must
-            // not leave `isFetchingTokens` stuck true forever.
-            const body = new URLSearchParams({ country: this.billingCountry() });
-            request = fetch(this.moduleUrl('soleTraderTokens'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: body.toString()
-            });
+            // not leave `isFetchingTokens` stuck true forever. Unlike that
+            // failure branch, there is no showError() here (nothing user-
+            // facing to interrupt on a background tick) - but a persistent
+            // throw would otherwise go completely unsignalled forever, so
+            // this gets the same console.error breadcrumb as the other
+            // background failure this file has no on-page UI for (see
+            // openPopup()'s blocked-popup branch).
+            request = this.mintTokensRequest(this.billingCountry());
         } catch (e) {
             this.isFetchingTokens = false;
+            // eslint-disable-next-line no-console
+            console.error('Two: background sole-trader token refresh failed to build its request.', e);
             return;
         }
         request


### PR DESCRIPTION
## Summary
- TWO-40 follow-up (Doug): delegated auth tokens can expire server-side if a buyer sits on checkout too long, breaking autofill and the sole-trader flow. Adds a 30-minute background re-mint, started only after the first real mint succeeds, reusing fetchTokens()'s own `isFetchingTokens` guard so it never races a user-driven mint.
- PrestaShop only; a parallel PR covers WooCommerce.

## Test plan
- [x] `npm run test:js` - 32 suites / 793 tests pass, including new `tests/js/sole-trader-token-refresh.test.js` (interval starts only after a real mint, fires and re-mints at 30 min, skips a tick when a mint is in flight, leaves tokens in place on a failed tick, doesn't re-enter the enrolment flow, timer cleared on destroy()).
