### PR TITLE
TWO-40: sole-trader chip state parity on reopen

### DIFF
--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -638,7 +638,7 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
         expect(notListed().parent().parent().is('.two-company-dropdown')).toBe(true);
         expect(notListed().parent().prev().is('.two-company-dropdown__results')).toBe(true);
         expect(notListed().text()).toBe(instance.getManualEntryText());
-        expect(instance.getManualEntryText()).toBe('Enter Manually');
+        expect(instance.getManualEntryText()).toBe('Enter manually');
         expect(shown(notListed())).toBe(true);
     });
 
@@ -3026,7 +3026,7 @@ describe('the custom fallback used when jQuery UI is absent', () => {
             expect(button.attr('role')).toBeUndefined();
             expect(button.attr('tabindex')).toBeUndefined();
             // Its accessible name is its text content; nothing else supplies one.
-            expect(button.text()).toBe('Enter Manually');
+            expect(button.text()).toBe('Enter manually');
             // NOT disabled and NOT aria-disabled, unlike the message rows.
             expect(button.prop('disabled')).toBe(false);
             expect(button.attr('aria-disabled')).toBeUndefined();

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -71,7 +71,7 @@ describe('visibility', () => {
         openPanel();
 
         expect(shown(panelParts().soleTrader)).toBe(true);
-        expect(panelParts().soleTrader.text()).toBe('Sole Trader');
+        expect(panelParts().soleTrader.text()).toBe('Sole trader');
     });
 
     test('is hidden when TwoSoleTrader says the country is not eligible', () => {

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -1,0 +1,222 @@
+/**
+ * TWO-40 follow-up, Doug live-test findings (2026-08-19):
+ *
+ *  1. Reopening the dropdown while a sole trader is adopted must show the
+ *     "Sole Trader" chip selected, not silently fall back to "Registered
+ *     Company" (openDropdown() previously reset `_chipMode` unconditionally
+ *     on every open).
+ *  2. The free-text query input must not be usable while the Sole Trader
+ *     chip is selected - there is deliberately only one way to pick a
+ *     different company in that state (item 3 below), typing a query is
+ *     not it.
+ *  3. Re-clicking the "Sole Trader" chip while already adopted must behave
+ *     EXACTLY like the standalone "Select a different sole trader" link
+ *     (triggerSelectDifferentSoleTrader()/startReplacement()), not start a
+ *     fresh enrolment and not no-op.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    buildAddressForm,
+    installStylesheet,
+    stubAjax,
+    releaseWidgets,
+    panelParts,
+    openPanel,
+    typeQuery,
+    shown
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+
+const NAMED_BUYER = {
+    company_name: 'Sole Trader Test Co',
+    organization_number: 'TWO:ST123456789012',
+    email: 'buyer@example.test',
+    billing_address: null,
+    shipping_address: null
+};
+
+let TwoCompanySearch;
+let $;
+
+function makeInstance(config) {
+    return new TwoCompanySearch(Object.assign({ checkoutHost: CHECKOUT_HOST }, config || {}));
+}
+
+function stubSoleTrader() {
+    const instance = {
+        isAvailableForCurrentCountry: jest.fn(() => true),
+        startEnrollment: jest.fn(),
+        startReplacement: jest.fn(),
+        cancelEnrollment: jest.fn()
+    };
+    global.window.TwoSoleTrader_Instance = instance;
+    return instance;
+}
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    buildAddressForm();
+    installStylesheet('views/css/two.css');
+    stubAjax($);
+});
+
+afterEach(() => {
+    releaseWidgets($);
+    jest.useRealTimers();
+    delete global.window.TwoSoleTrader_Instance;
+});
+
+describe('reopening while sole-trader-adopted (item 1)', () => {
+    test('shows the "Sole Trader" chip selected, not "Registered Company"', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        // Close, then reopen exactly as a buyer clicking back into the
+        // (readonly) company field would.
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(panelParts().registered.hasClass('two-company-mode-chip--selected')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('a fresh instance with no adoption still defaults to "Registered Company"', () => {
+        const instance = makeInstance();
+        openPanel();
+
+        expect(panelParts().registered.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(false);
+
+        instance.destroy();
+    });
+});
+
+describe('query input suppressed while Sole Trader is selected (item 2)', () => {
+    test('the query field is readonly on a reopen while adopted', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        expect(panelParts().query.prop('readonly')).toBe(true);
+
+        instance.destroy();
+    });
+
+    test('typing into the (readonly) query field triggers no search request', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const ajaxStub = stubAjax($);
+        typeQuery('Some Other Company');
+        jest.runAllTimers();
+
+        expect(ajaxStub.calls.length).toBe(0);
+
+        instance.destroy();
+    });
+
+    test('the query field is editable again once "Registered Company" is clicked', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+        expect(panelParts().query.prop('readonly')).toBe(true);
+
+        panelParts().registered.trigger('click');
+
+        expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('a fresh, never-adopted open leaves the query field editable', () => {
+        const instance = makeInstance();
+        openPanel();
+
+        expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+});
+
+describe('re-clicking "Sole Trader" while adopted (item 3)', () => {
+    test('calls startReplacement(), not startEnrollment() - same as the standalone link', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const soleTrader = stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startReplacement).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startEnrollment).not.toHaveBeenCalled();
+
+        instance.destroy();
+    });
+
+    test('a rapid double-click only calls startReplacement() once (shares the link\'s re-entrancy guard)', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const soleTrader = stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startReplacement).toHaveBeenCalledTimes(1);
+
+        instance.destroy();
+    });
+
+    test('the chip still shows selected after routing through startReplacement()', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+
+        instance.destroy();
+    });
+});
+
+describe('unaffected: a fresh (non-adopted) "Sole Trader" click still enrolls normally', () => {
+    test('calls startEnrollment(), not startReplacement()', () => {
+        const instance = makeInstance();
+        const soleTrader = stubSoleTrader();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startReplacement).not.toHaveBeenCalled();
+
+        instance.destroy();
+    });
+});

--- a/twopayment.php
+++ b/twopayment.php
@@ -4425,7 +4425,7 @@ class Twopayment extends PaymentModule
             // deliberately DIVERGES from the other three plugins' current
             // wording for this affordance, pending their own rollout of the
             // same three-chip pattern.
-            'company_search_manual_entry' => $this->l('Enter Manually'),
+            'company_search_manual_entry' => $this->l('Enter manually'),
             'company_search_back_to_search' => $this->l('Search for company'),
             // Zero-result wording (TWO-25326 §1). EXACT across all four
             // plugins - "No results found" is a different string and the
@@ -4438,14 +4438,14 @@ class Twopayment extends PaymentModule
             // The three-chip mode selector (TWO-40 design revision). Shown
             // immediately on interacting with the search control, no
             // upfront choice OUTSIDE the control any more, no waiting for
-            // characters to be typed. "Registered Company" is the default;
-            // "Enter Manually" (above) is always visible alongside it;
-            // "Sole Trader" is added to the set only when the registry says
+            // characters to be typed. "Registered company" is the default;
+            // "Enter manually" (above) is always visible alongside it;
+            // "Sole trader" is added to the set only when the registry says
             // the currently-selected billing country supports sole traders
             // (TwoSoleTrader::isAvailable), and removed again live if the
             // buyer changes the country selector to one that does not.
-            'company_search_registered_entry' => $this->l('Registered Company'),
-            'company_search_sole_trader_entry' => $this->l('Sole Trader'),
+            'company_search_registered_entry' => $this->l('Registered company'),
+            'company_search_sole_trader_entry' => $this->l('Sole trader'),
             // Fallback status label shown once enrolment succeeds but the
             // registration carries no displayable company name or number
             // (TwoCompanyNumber.forDisplay() answers '' for both a blank name

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -909,6 +909,18 @@ class TwoCompanySearch {
                 // lost by closing - but doing it before keeps this handler's
                 // ordering symmetric with the other two.
                 this.renderChipSelection();
+                // Re-clicking this chip while a sole trader is already
+                // adopted (TWO-40 follow-up, Doug's explicit ruling: an
+                // earlier round made this a no-op, treating the standalone
+                // "select a different sole trader" link/button as the only
+                // entry point - that was wrong). Route through the exact
+                // same call the link uses rather than starting a fresh
+                // enrolment, which would re-mint tokens for an identity
+                // that's already adopted.
+                if (this.isSoleTraderAdopted()) {
+                    this.triggerSelectDifferentSoleTrader();
+                    return;
+                }
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {
                     // Keep the panel OPEN and show the query field's own
@@ -1289,11 +1301,17 @@ class TwoCompanySearch {
         this._dropdown.removeAttr('hidden').show();
         this.setDropdownExpandedState();
         // Every FRESH open starts at the default chip (TWO-40: "Default
-        // selected chip: Registered Company"). Not reachable from manual
-        // entry (early-returns above), so the only mode this could be
-        // carrying over from is 'sole_trader' - and cancelEnrollment() just
-        // above already reversed that.
-        this._chipMode = 'registered';
+        // selected chip: Registered Company") - UNLESS a sole trader is
+        // currently adopted (TWO-40 follow-up, Doug live-test finding). The
+        // earlier version of this comment reasoned that cancelEnrollment()
+        // above already reverses the only other source of 'sole_trader',
+        // which is true for an in-flight ENROLMENT but not for an already-
+        // ADOPTED identity: cancelEnrollment() only cancels a signup in
+        // progress, it does not un-adopt a completed one. A sole trader IS
+        // what's currently selected in that state, so the reopened panel
+        // must show that chip selected, not silently fall back to
+        // "Registered Company".
+        this._chipMode = this.isSoleTraderAdopted() ? 'sole_trader' : 'registered';
         this.renderChipSelection();
         this.syncNotListedVisibility();
         this.syncSoleTraderEntryVisibility();
@@ -1470,6 +1488,40 @@ class TwoCompanySearch {
                 button.toggleClass('two-company-mode-chip--selected', this._chipMode === mode);
             }
         });
+        this.syncQueryFieldSuppression();
+    }
+
+    /**
+     * Suppress the free-text query input while the Sole Trader chip is the
+     * selected one (TWO-40 follow-up, Doug live-test finding). There is
+     * deliberately only one way to pick a different company while a sole
+     * trader is selected - the chip/link re-launching the signup flow (see
+     * triggerSelectDifferentSoleTrader()) - typing a fresh live-search query
+     * is not it. `readonly`, not `disabled`: the field must stay focusable
+     * and part of the dropdown's own tab order, it just must not accept
+     * typed input. Called from renderChipSelection() so every place the chip
+     * selection changes - a fresh open, either chip's click handler - stays
+     * in sync with no separate call site to remember.
+     */
+    syncQueryFieldSuppression() {
+        if (!this._queryField || !this._queryField.length) {
+            return;
+        }
+        this._queryField.prop('readonly', this._chipMode === 'sole_trader');
+    }
+
+    /**
+     * Whether a sole-trader identity is currently adopted into the form
+     * (TWO-40 follow-up). The "Select a different sole trader" link/button
+     * only ever exists for exactly this state (see
+     * renderSelectDifferentSoleTraderLink()/removeSelectDifferentSoleTraderLink()),
+     * so its presence is the single source of truth rather than a second,
+     * independently-maintained flag that could drift from it.
+     *
+     * @returns {boolean}
+     */
+    isSoleTraderAdopted() {
+        return !!(this._selectDifferentSoleTraderLink && this._selectDifferentSoleTraderLink.length);
     }
 
     /**
@@ -1658,8 +1710,15 @@ class TwoCompanySearch {
             this.openDropdown();
             // The character that opened the panel belongs in the query field,
             // not lost. Only for a real printable character - `key` is a
-            // single code point exactly when the keypress produced text.
-            if (key && key.length === 1 && this._queryField && this._queryField.length) {
+            // single code point exactly when the keypress produced text. Not
+            // forwarded while the Sole Trader chip is selected (TWO-40
+            // follow-up): openDropdown() just set that chip mode when a
+            // sole trader is adopted, and the query field is `readonly` in
+            // that state (syncQueryFieldSuppression()) - `.val()` would
+            // still write through a readonly attribute, so this has to check
+            // explicitly rather than relying on the attribute alone.
+            if (key && key.length === 1 && this._chipMode !== 'sole_trader'
+                && this._queryField && this._queryField.length) {
                 this._queryField.val(key);
                 this._queryField.trigger('input');
             }
@@ -3520,6 +3579,16 @@ class TwoCompanySearch {
                         response([]);
                         return;
                     }
+                    // Sole Trader selected (TWO-40 follow-up): the query field
+                    // is `readonly` in this state (syncQueryFieldSuppression())
+                    // so no real keystroke reaches here, but this is the same
+                    // "defence in depth" posture as the manual-entry check
+                    // above - a programmatic `input`/`search` trigger must not
+                    // run a live search while a sole trader is what's selected.
+                    if (this._chipMode === 'sole_trader') {
+                        response([]);
+                        return;
+                    }
                     // Too short to search on - INCLUDING the empty query the
                     // panel opens with. No search is made and no row is
                     // rendered for this any more (TWO-40 follow-up): the
@@ -3865,7 +3934,7 @@ class TwoCompanySearch {
      */
     getManualEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_manual_entry)
-            || 'Enter Manually';
+            || 'Enter manually';
     }
 
     /**
@@ -3875,7 +3944,7 @@ class TwoCompanySearch {
      */
     getRegisteredEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_registered_entry)
-            || 'Registered Company';
+            || 'Registered company';
     }
 
     /**
@@ -3883,7 +3952,7 @@ class TwoCompanySearch {
      */
     getSoleTraderEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_sole_trader_entry)
-            || 'Sole Trader';
+            || 'Sole trader';
     }
 
     /**
@@ -4141,6 +4210,55 @@ class TwoCompanySearch {
     }
 
     /**
+     * Relaunch the sole-trader signup/re-selection flow (TWO-40 follow-up).
+     * The single shared call for BOTH entry points that mean "pick a
+     * different sole trader" - the standalone link/button below the company
+     * field, and re-clicking the "Sole Trader" mode chip while a sole
+     * trader is already adopted (Doug's ruling: the two must behave
+     * identically, not one being a no-op).
+     *
+     * Re-entrancy guard (adversarial review finding, TWO-40 follow-up -
+     * Han/Vader independently caught this): `TwoSoleTrader.startReplacement()`
+     * opens the popup SYNCHRONOUSLY with no guard of its own (unlike
+     * getCurrentBuyer()'s `isFetchingBuyer`) - without this, a double-click
+     * reliably opened two signup popups from one gesture.
+     */
+    triggerSelectDifferentSoleTrader() {
+        if (this._selectDifferentSoleTraderLoading) {
+            return;
+        }
+        this._selectDifferentSoleTraderLoading = true;
+        // Released on TwoSoleTrader.js's own settle event - fired from
+        // EVERY terminal branch of startReplacement()'s call graph (popup
+        // opened, popup blocked, mint failed, or abandoned via a
+        // cancelEnrollment() elsewhere) - same event beginSoleTraderLoading()
+        // already relies on for the "Sole Trader" chip's fresh-enrolment
+        // path, own namespace so the two guards never interfere.
+        $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
+            .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
+                this._selectDifferentSoleTraderLoading = false;
+            });
+        try {
+            if (window.TwoSoleTrader_Instance
+                && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
+                window.TwoSoleTrader_Instance.startReplacement();
+            } else {
+                // Nothing is going to fire the settle event for this click,
+                // so release the guard here rather than leaving it stuck and
+                // log visibly rather than a completely silent no-op
+                // (adversarial review finding).
+                // eslint-disable-next-line no-console
+                console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
+                this._selectDifferentSoleTraderLoading = false;
+                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+            }
+        } catch (e) {
+            this._selectDifferentSoleTraderLoading = false;
+            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+        }
+    }
+
+    /**
      * Render the "Select a different sole trader" link below the company
      * field (TWO-40 follow-up) - same slot, same styling/gating shape as
      * renderBackToSearchLink() above, but for a COMPLETED sole-trader
@@ -4168,50 +4286,7 @@ class TwoCompanySearch {
             // sibling inside the address step's markup, not something the
             // theme's delegated collapse handler is meant to hear from.
             event.stopPropagation();
-            // Re-entrancy guard (adversarial review finding, TWO-40 follow-
-            // up - Han/Vader independently caught this): THIS button only
-            // ever renders once tokens already exist from an earlier
-            // enrolment, which is exactly the branch of
-            // TwoSoleTrader.startReplacement() that opens the popup
-            // SYNCHRONOUSLY with no guard of its own (unlike
-            // getCurrentBuyer()'s `isFetchingBuyer`) - without this, a
-            // double-click reliably opened two signup popups from one
-            // gesture, the exact defect class `isFetchingBuyer`/
-            // `_soleTraderLoading` already exist elsewhere in this flow to
-            // close.
-            if (this._selectDifferentSoleTraderLoading) {
-                return;
-            }
-            this._selectDifferentSoleTraderLoading = true;
-            // Released on TwoSoleTrader.js's own settle event - fired from
-            // EVERY terminal branch of startReplacement()'s call graph
-            // (popup opened, popup blocked, mint failed, or abandoned via a
-            // cancelEnrollment() elsewhere) - same event
-            // beginSoleTraderLoading() already relies on for the "Sole
-            // Trader" chip, own namespace so the two guards never interfere.
-            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
-                .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
-                    this._selectDifferentSoleTraderLoading = false;
-                });
-            try {
-                if (window.TwoSoleTrader_Instance
-                    && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
-                    window.TwoSoleTrader_Instance.startReplacement();
-                } else {
-                    // Same shape as the "Sole Trader" chip's own missing-
-                    // instance branch: nothing is going to fire the settle
-                    // event for this click, so release the guard here rather
-                    // than leaving it stuck and log visibly rather than a
-                    // completely silent no-op (adversarial review finding).
-                    // eslint-disable-next-line no-console
-                    console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
-                    this._selectDifferentSoleTraderLoading = false;
-                    $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
-                }
-            } catch (e) {
-                this._selectDifferentSoleTraderLoading = false;
-                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
-            }
+            this.triggerSelectDifferentSoleTrader();
         });
 
         // Same placement as renderBackToSearchLink(): appended to the field
@@ -4663,6 +4738,12 @@ class TwoCompanySearch {
             const term = inputEl.value || '';
             clearTimeout(debounce.id);
             if (this._manualEntry) {
+                debounce.id = null;
+                return;
+            }
+            // Sole Trader selected (TWO-40 follow-up) - same defence-in-depth
+            // reasoning as the jQuery UI `source` callback's own check.
+            if (this._chipMode === 'sole_trader') {
                 debounce.id = null;
                 return;
             }


### PR DESCRIPTION
## Summary

Doug live-tested and found three cross-platform chip-state bugs on TWO-40's sole-trader mode-chip UI (PrestaShop side), plus a wording mismatch vs WooCommerce:

1. **Wrong chip selected on reopen.** `openDropdown()` unconditionally reset the mode chip to "Registered Company" on every open, even when a sole trader was already adopted. Fixed: it now checks whether a sole trader is currently adopted (presence of the "Select a different sole trader" button) and selects the "Sole Trader" chip in that case.
2. **Free-text query usable while adopted.** The query field is now suppressed (`readonly` plus defence-in-depth guards on both the jQuery UI and fallback search paths) whenever the "Sole Trader" chip is selected, since typing a query is not a supported way to replace an adopted sole trader.
3. **Re-clicking the "Sole Trader" chip while adopted was a no-op.** Doug's ruling: it must behave exactly like the standalone "Select a different sole trader" button. Extracted the button's handler into `triggerSelectDifferentSoleTrader()` and routed the chip's click through the same call when already adopted.

Also updates the three mode-chip labels to sentence case ("Registered company" / "Sole trader" / "Enter manually") to match WooCommerce's existing wording, at the PHP translation-string source (`twopayment.php`) and the JS fallback literals.

## Test plan

- [x] New `tests/js/sole-trader-chip-adopted-state.test.js` covers all three behavior fixes with real repro coverage (reopen chip selection, query suppression + re-enable on "Registered Company", chip-click routing to `startReplacement()`, re-entrancy guard, unaffected fresh-enrollment path).
- [x] Updated two existing exact-text assertions for the new sentence-case wording.
- [x] Full JS suite: `npm run test:js` - 33 suites / 809 tests passing.
- [x] `php -l twopayment.php` clean.
