### PR TITLE
fix(js): the sole-trader chip never rendered for a supported country (TWO-40 follow-up)

### DIFF
--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -1,0 +1,440 @@
+# Sole-trader / company-search: porting guide (PrestaShop → Magento / WooCommerce)
+
+Source of truth: `two-inc/prestashop-plugin` `staging`, PRs #153–#168 (TWO-40). This
+guide is the distilled design + gotcha list for reimplementing the same behavior on
+another platform. Read it before writing code — most of the entries exist because a
+naive first attempt on PrestaShop got it wrong and had to be corrected, often more
+than once, sometimes reversing an earlier decision entirely.
+
+## 0. The mode chips are DOM children of the search dropdown, not a separate widget
+
+**This was missing from earlier drafts of this guide, and its absence caused the same
+wrong port to happen twice independently** (once in an initial WooCommerce audit that
+called existing tile-only placement "already correct," once in an unrelated from-scratch
+reimplementation that reasoned "the guide specifies how each placement must read, not
+that a placement must be added" and left the chips as a separate persistent tile
+element). Both were wrong for the same reason: the guide talked about *placement*
+(§1 below) without ever stating the one fact that actually constrains chip markup.
+
+Confirmed directly from PrestaShop's live DOM (the staging dev shop, GB
+address step, real click-and-type interaction — not forced attribute manipulation,
+not inferred from source). This section was itself wrong on two details in an earlier
+draft and has now been corrected against real evidence a third time; treat every
+claim below as DOM-verified, cited by the actual structure captured live:
+
+- **Real nesting** — `div.two-company-dropdown` has exactly three direct children:
+  `.two-company-dropdown__search` (query input + spinner), `.two-company-dropdown__results`
+  (the autocomplete `<ul>`), and `.two-company-mode-chips` (the three
+  `.two-company-mode-chip` buttons). The chips are NOT direct children/siblings of the
+  search input — there is one intermediate wrapper (`.two-company-mode-chips`) between
+  the dropdown panel and the individual chip buttons. Two levels: chip →
+  `.two-company-mode-chips` → `.two-company-dropdown`.
+- **Visibility is purely inherited, confirmed with zero independent chip state.** Every
+  chip's `style` attribute is present but empty (`element.style.display === ''` in
+  every observed state); there is exactly one visibility switch in the whole
+  structure — the `hidden` attribute on `.two-company-dropdown` itself. Open it, all
+  three chips become visible; close it, all three become invisible; nothing about an
+  individual chip's presence is ever toggled independently. (Which chip is
+  *selected* — `.two-company-mode-chip--selected` — is a separate, purely cosmetic
+  class change, not a visibility mechanism.)
+- Consequence for porting: **do not build the chips as an always-visible element
+  fixed in the payment tile or address form.** Whatever placement §1 resolves to
+  (a.1/a.2/a.3), the chips render *inside that placement's own search-dropdown panel*,
+  as children of one intermediate wrapper, appear only while it's open, and disappear
+  when it closes — exactly like the search results they sit next to. A platform whose
+  company-search control has no dropdown panel concept at all needs one added; that is
+  in scope for this port, not an acceptable reduction of it.
+- The old "my company is not on the list" link-style fallback is NOT additional UI
+  alongside the chips — it no longer exists as separate copy on PrestaShop (confirmed:
+  zero occurrences of "not on the list" or "my company" anywhere in the page, in any
+  state). It has been fully absorbed into the third chip, class
+  `two-company-not-listed`, visible label "Enter Manually." A port that keeps its own
+  platform's old fallback link *and* adds the chips as a second, separate mechanism
+  has not implemented this design — it has implemented two overlapping ones.
+- **Chip selection must survive a reopen — was a live PrestaShop bug, now FIXED
+  (`1c1b3d7`), so port the fixed behaviour, not the old one.** Reopening the panel
+  used to reset `--selected` to "Registered Company" every time, whatever was last
+  chosen. The root cause is worth knowing because the wrong fix is tempting: the
+  reopen handler reset the mode unconditionally, reasoning that cancelling an
+  in-flight enrolment on reopen had already reversed the only other way the mode
+  could be `sole_trader`. That is true of an in-flight ENROLMENT and false of an
+  already-ADOPTED identity — cancelling a signup in progress does not un-adopt a
+  completed one. Derive the reopened selection from whether an identity is adopted
+  (PrestaShop reads the presence of the "select a different sole trader" element as
+  the single source of truth, rather than a second flag that can drift from it), not
+  from a mode variable the reopen path is free to clobber. Full rules in §11.
+- **Chip labels are sentence case** — "Registered company", "Sole trader", "Enter
+  manually" (`1c1b3d7` aligned PrestaShop onto WooCommerce's existing wording). Not
+  Title Case, on any platform.
+- **The "select a different sole trader" element is OUTSIDE the dropdown, not inside
+  it — this corrects an earlier wrong edit to this guide.** It is a `<button>`
+  (`.two-company-select-different-sole-trader`), appended as the LAST child of the
+  outer field wrapper (`.two-company-field-wrap`), landing as a following SIBLING of
+  `.two-company-dropdown` — never a descendant of the dropdown panel or of
+  `.two-company-mode-chips`. It renders only after a sole-trader identity has been
+  adopted, in normal block flow below the company field, deliberately never
+  overlapping the (possibly-open) dropdown or the org-number hint that shares the
+  same wrapper. There is NO equivalent element for an adopted *registered* company at
+  all — re-searching a registered company is done by clicking the (readonly) company
+  input itself, which reopens the dropdown; only the sole-trader case gets an
+  explicit standalone "pick a different one" affordance.
+
+## 1. Two independent "which country/company" questions
+
+Never conflate these two. They were originally 3-way (then 4-way) mirrored across
+different resolvers on PrestaShop and that duplication was the root cause of several
+bugs — resolve country/company ONE way, reuse it everywhere.
+
+- **(a) Chip visibility + workflow input** — what drives whether the sole-trader
+  chip renders, and what country/company feeds the enrollment/signup/token-mint
+  calls.
+- **(b) Order intent / order data** — whatever actually gets submitted with the
+  order. Out of scope for this porting pass; whatever already resolves it keeps
+  doing so unchanged. The only place (a) and (b) must agree: the org-number/company
+  name persisted for admin/webhook-time use (§6) must come from (b)'s resolution.
+
+Case (a) splits into three placement scenarios — phrase these by ROLE
+(billing/invoice vs shipping/delivery), never by "primary/secondary": PrestaShop,
+Magento/Luma, and Hyvä default shipping-first (shipping is the always-shown
+"primary" form); **WooCommerce defaults billing-first** — a real inversion, not a
+naming quirk. A naive port of PrestaShop's shipping-first logic reads/writes the
+wrong block on WooCommerce every time.
+
+1. **(a.1) delivery/shipping address form.** Chip visibility + workflow
+   country/company read LIVE from that same form's own current fields — never a
+   committed/saved value, never a different address.
+2. **(a.2) invoice/billing address form.** Same rule, same live-local read.
+3. **(a.3) payment tile** (no address fields of its own). Read explicitly from
+   whichever address plays the billing/invoice ROLE — never "whichever address is
+   primary" as a shortcut. If billing/invoice is the platform's non-default
+   ("secondary") form, that value comes from the sync mechanism (§2), not an
+   independent read.
+
+**Security note, already investigated and disproven on PrestaShop, don't re-litigate
+it per-platform without cause:** the token-mint call takes no country parameter at
+all — country only feeds an availability-gate lookup, which has no security
+consequence either way (a client can already query availability for any country
+directly). Preferring the live in-page value over a committed one is a pure
+correctness win, not a security tradeoff.
+
+## 2. Two-address model: editable + synced, never locked
+
+**Rejected design, don't reintroduce it:** making the non-default ("secondary")
+address's company/country read-only, mirroring the default one. Real business case
+that killed it: a company based in NI with an RoI branch — same legal entity, no
+separate registration, but a genuinely different valid local country/company
+pairing on the second address.
+
+**Current rules:**
+
+1. The non-default address stays fully editable, always.
+2. Default behavior: changing country/company on the default address propagates to
+   the non-default one.
+3. **Sync-stop is a pure content-match check, not a discrete flag.** Before writing
+   a mirrored value into any field, compare (trimmed, case-insensitive) its current
+   content against what the mirror would write. Still matches → still "synced",
+   overwrite freely. Even ONE field not matching → the **whole address** (not just
+   that field) is buyer-edited and pinned. This whole-address granularity was an
+   explicit ruling — don't scope the pin per-field.
+4. **No dedicated "resume sync" control.** The match check in (3) handles resumption
+   automatically — collapsing back to one address and reopening naturally re-matches
+   the mirror's expected state. An earlier, more complex "explicit flag tied to UI
+   events" design was deliberately dropped in favor of this.
+5. **Track every field the mirror can write**, for the pin-check, not just
+   country/company: also address line 2 and the state/region field. A first attempt
+   left these out reasoning they were "safe" — wrong; a buyer typing into address2 is
+   exactly as strong a signal of independent editing as typing into city.
+6. **Field-routing when writing an address from an external payload** (autofill,
+   registered-company search — same rule for both, don't special-case sole trader
+   here):
+   - `building`/`apartment` present → line 1; `street` → line 2.
+   - `building`/`apartment` absent → `street` → line 1, line 2 untouched.
+   - **No dedup check** between the two even if textually identical — some real
+     addresses legitimately have matching first/second lines.
+   - `region`: write to a state/county field if the address format has one
+     (best-effort text→id match, inherently lossy but attempted); otherwise append
+     to `city` with a comma (`"Ashford, Kent"`).
+7. **Company/org-number requirement scope:** required ONLY on whichever address
+   plays the billing/invoice ROLE (§1's a.3 resolution) — never on a shipping-only
+   address. Reuse the same role-resolution logic; don't build a second one.
+
+## 3. `TWO:`-prefixed identifiers: exactly one special case, and it's cosmetic
+
+**Rejected design:** treating internal (`TWO:`-prefixed) identifiers — sole trader
+OR registered-company (confirmed: also issued to some US companies with no separate
+public registration, not sole-trader-exclusive) — as special anywhere in
+storage/pairing/validation/routing. This caused two real bugs: a mismatched
+name/number pair surviving a validation refusal, and a "name must always travel with
+its number" invariant broken by design (could hard-block a buyer whose country
+requires an identification field).
+
+**Corrected rule:** a `TWO:` value goes through the exact same single write/pairing/
+mirror/validation/submission path as any other org number — no branch anywhere.
+**The only exception is display**: hide it wherever the org-number field is shown to
+the buyer, on the containing form-group (`display:none`), not just the input — hiding
+only the input orphans its label.
+
+**The one real, unavoidable platform wrinkle:** if the target platform has a native
+"identification number"-style field with its own format validation (PrestaShop's
+Spain-format `dni`: rejects a colon, 16-char cap), a `TWO:` value can fail to save
+there outright. **Fix by never routing to that one field, not by stripping the
+prefix** — the prefix is meaningful to the API and must never be stripped, anywhere,
+for any reason. Check the target platform for an equivalent trap before assuming it's
+safe (WooCommerce/Magento's own persistence fields had no such trap when checked —
+that's not proof the next platform won't).
+
+## 4. Cross-platform persistence check (why this matters)
+
+WooCommerce and Magento already persist org number + company name durably,
+independent of session/cookie state: WooCommerce via order meta (`company_id`,
+unprefixed key, `TWO:` values stored raw) + user meta; Magento via a genuine EAV
+attribute on the customer-address entity (varchar(255), no validation) + the order
+payment's `additional_information` JSON blob. Neither platform's admin order screen
+actually surfaces it, though (matches the corrected PrestaShop state).
+
+**PrestaShop's own equivalent, shipped this session (§6):** two new columns on the
+module's own order-keyed table, following the exact precedent already in that table
+for a different "checkout-time value needed later at admin/webhook time with no
+session available" problem (`two_day_on_invoice`/`$storedTerm` in
+`getTwoUpdateOrderData()`). If the target platform already has durable order-scoped
+storage (it does, per above) — reuse it, don't build a parallel mechanism.
+
+## 5. Write-back state machine — the recurring root cause
+
+This was the single most repeated bug source this session. Any platform's sole-trader
+implementation needs the equivalent of:
+
+- **A pairing tag**, recording which org-number selection a given company-name value
+  was chosen under. On the next input/change to the company field, if the tag is
+  absent or doesn't match, wipe the org number and any dependent state — this stops a
+  stale org number silently surviving a retype.
+- **A single write-path helper** that sets the company-id/org-number field AND its
+  pairing tag atomically, in one call. Any code that sets the org-number field
+  without going through this helper gets silently wiped by the guard above on the
+  very next interaction. This bit multiple PRs this session (write-backs, mirror
+  writes, sole-trader adoption) before the pattern was fixed into one shared helper.
+- **A provenance marker**, separate from the pairing tag, recording that a given
+  field's current value was written by the plugin (vs typed by the buyer) — needed
+  by the pin/mirror logic in §2 to distinguish "still what we wrote" from "buyer
+  edited this."
+- **The write-back function must NOT be gated on the same "is address-lookup enabled"
+  switch that gates an ordinary company-search selection's address write.** On
+  PrestaShop, `adoptSoleTraderBuyer()` initially routed through the same
+  `autoFillAddress()`/`writeOrganizationToAddressIdentifiers()`/`autoFillRegion()`
+  methods an ordinary search-result selection uses — all three early-return when that
+  switch is off (which it legitimately is whenever company-search isn't mounted in
+  the address area). Sole-trader signup completion must write regardless of where
+  company search is mounted; add an explicit bypass parameter rather than trying to
+  make the switch context-aware.
+- **A real browser paints on a delay; a synchronous DOM-class assertion in a test
+  harness does not.** A "chip shows as selected" fix that sets a CSS class and closes
+  a dropdown in the same synchronous tick can pass its own unit test (no render step
+  in a virtual DOM) while never actually painting a visible frame in a real browser
+  before the dropdown hides. If a visual-state fix's own test passes on the first
+  try, don't trust it alone — verify with a real browser and watch the timing, not
+  just the end DOM state.
+- **Order-intent / any other side-effect call triggered by the write-back must not
+  fire before the buyer reaches the step that's supposed to trigger it.** Check
+  whatever gates the platform's ordinary intent-creation flow (usually "buyer reaches
+  and selects a payment method") and make sure the sole-trader path is gated by the
+  exact same condition — don't let a signup-completion callback call intent-creation
+  directly.
+
+## 6. Order-scoped persistence pattern (Option A + C from this session)
+
+If the target platform's native org-number-carrying field has the validation trap in
+§3: skip writing to that field for `TWO:` values (Option A) AND persist org number +
+company name on the platform's own order-scoped storage (Option C — reuse an
+existing durable per-order store, per §4; on Magento/WooCommerce this likely means no
+new storage at all, just make sure the sole-trader write-back path populates the
+SAME field the ordinary flow already uses for this, and audit whether any admin/
+webhook-time PUT-style code path can send an empty value where a resolved one should
+be — this exact bug existed on PrestaShop's admin-edit and tracking-number-update
+paths before Option C).
+
+The value persisted must be **the resolved billing/invoice address's org number
+specifically** — the same value driving order-intent/order-data (§1's out-of-scope
+case (b)) — not whichever address the sole-trader UI happened to run in.
+
+## 7. UX additions, implement alongside the core flow, not as an afterthought
+
+- **In-flight spinner:** while the sole-trader autofill/token-fetch/signup-check
+  round trip is running, keep the company-search control OPEN (don't close it) and
+  show a spinner inside the query/search input field itself — not a separate overlay.
+  Wire it to the real async duration (resolve on an actual "flight settled" event
+  fired from every terminal branch of the async call graph — success, failure,
+  retry-exhausted, abandoned), never a fixed timeout. Adversarial review on this
+  exact feature found real races on every iteration (stuck-forever spinners on two
+  different abandon/retry paths, a missing re-entrancy guard causing double signup
+  popups, a guard released too early) — budget for multiple review rounds, don't
+  expect to get this right in one pass.
+- **"Select a different sole trader" link** — placement per §0's corrected finding,
+  behaviour once adopted per §11 (it is one of exactly two entry points into the same
+  relaunch call, not the only one). Concretely:
+  this is a standalone button appended as the LAST child of the company field's
+  outer wrapper, landing as a SIBLING AFTER the dropdown panel — not inside it, not
+  inside the chip group. Only renders once a sole-trader identity has been adopted;
+  there is deliberately no equivalent for an adopted registered company (that case
+  reuses clicking the field itself to reopen search). Clicking it must skip the
+  normal cookie/silent-autofill pre-check and launch the popup directly with an extra
+  flag appended (PrestaShop used `autoselect=false`, currently unread by the backend —
+  just wire the parameter through unconditionally, no client-side branching on its
+  value). The single popup/link covers BOTH "pick a different existing registration"
+  and "register a new one" — that choice happens inside the third-party popup's own
+  UI once it's open; the plugin doesn't need to distinguish the two cases itself.
+- **Popup window size:** `700×805` (width×height) — not narrower; a too-narrow popup
+  clips the hosted signup flow's own layout.
+- **Popup mechanism stays `window.open()`, not an iframe.** The signup/OTP flow
+  depends on a third party that only works in a real popup window — don't attempt an
+  iframe-in-overlay rewrite even though it would sidestep popup-blocker risk; that
+  tradeoff was explicitly evaluated and rejected. Keep the `window.open()` call
+  synchronous with the click event that triggers it — an async-delayed
+  `window.open()` risks being blocked by the browser regardless of platform.
+- **Branding on the popup URL:** DO NOT build brand-overlay support pre-emptively —
+  but leave a comment at the popup-launch call site (wherever the final URL is
+  assembled) noting the real, confirmed precedent: Magento/WooCommerce resolve brand
+  via a **per-brand hostname template** (`checkout_url_template`) — a distinct
+  hostname per brand, so the host itself conveys the brand in production, rather than
+  the base host. There's also a `?brand=<tag>&brandVersion=
+  <ver>` query-string fallback, but it's explicitly documented as dev-loop-only, for
+  when multiple brands temporarily share one non-prod domain — don't treat it as the
+  primary mechanism to copy.
+
+## 8. Email/identity trust levels — don't reuse a passive check on an authenticated path
+
+A buyer-identity lookup that's correct for a PASSIVE, pre-auth context (matching the
+current checkout form's email against a cookie/session, no proof of identity yet) is
+WRONG if reused unchanged on a POST-AUTHENTICATION callback (e.g. the popup's OTP
+step just succeeded — the server has already told the browser who the buyer is,
+possibly under a different email than the checkout form's). Reusing the passive
+check on the authenticated path causes a real, confirmed bug: a legitimate buyer
+completes OTP successfully, then the same stale email-match heuristic silently
+disagrees with the server and reopens the same popup, forever. Fix pattern: thread an
+explicit "this identity is already authenticated" flag through to the buyer-lookup
+function and have it skip the match check on that path — the email the buyer
+authenticated with should drive lookup, full stop, with NO requirement to match
+whatever's sitting in the order's contact-email field.
+
+## 9. Local-dev tooling — this session added it to PrestaShop, may need building on WC
+
+Independent dev-mode env-var overrides for all three service hosts a plugin talks
+to — checkout/merchant API, merchant portal, and the hosted checkout-page app
+(sole-trader signup + company search) — each falling back independently to its
+platform-appropriate default, and ALL gated so a production instance can never
+accidentally honor one even if the env var somehow leaks into its process
+environment. Magento already has this (`TWO_API_BASE_URL`/`TWO_CHECKOUT_BASE_URL`,
+gated on developer mode, documented in its README) — mirror that pattern rather than
+inventing a new one. WooCommerce has NOT been audited for this yet as of this
+session — check before assuming it needs building from scratch.
+
+For a remote/non-local shop needing to reach a developer's laptop-hosted
+checkout-page specifically (not the API/portal, which the shop's own server-side
+process can usually reach via a normal Docker network alias): the browser is what
+opens the popup, so the override host has to be one the BROWSER can resolve — an FRP
+reverse tunnel exposing the local checkout-page dev server works and is what this
+session used; don't assume `localhost`/`host.docker.internal` alone is sufficient
+once the shop itself is remote (e.g. GKE-hosted), since neither resolves anything
+useful to a browser pointed at a remote domain.
+
+## 10. Process notes, not code, but save real time
+
+- **Never trust a fix's own test as proof it worked live**, especially for anything
+  visual/timing-sensitive. This session shipped a "fixed" chip-selection PR whose own
+  regression test passed while the fix did nothing in a real browser (§5's paint-
+  timing entry) — caught only by live re-testing after merge.
+- **A round of adversarial review whose only findings are artifacts of the PREVIOUS
+  round's own fix is oscillating, not clean** — don't merge on it, run another round
+  against the latest fix specifically.
+- **Live-verifying against a cached/CDN'd asset needs a cache-busted URL** — a bare,
+  unversioned URL request can return a stale cached response even when the real
+  deployed asset is already correct, producing a false "not deployed yet" read.
+- Every "obvious" root cause on this feature turned out to need at least one
+  correction once tested against real production-shaped data (a real buyer's
+  existing address, a real merchant's registry answer, a real popped-open browser
+  window) — budget live-verification time into every port, not just the initial
+  unit-test pass.
+
+## 11. Adoption is a MODE, not a populated field
+
+All three rules below are Doug's, from live testing on 2026-08-19, and are now
+implemented on both platforms: PrestaShop `1c1b3d7`, WooCommerce `38bc49a` +
+`48edd08`. They are one design, not three fixes: **once a sole trader is adopted,
+that is the state of the control**, and every surface has to agree with it.
+
+1. **A passive autofill/prefetch adoption on first load is a FULL adoption.** If the
+   cookie-driven prefetch that runs on initial checkout load resolves to a sole
+   trader and populates the company name, it must also set the mode to sole-trader
+   and render the "select a different sole trader" affordance immediately — not defer
+   either until some later explicit user action. Writing only the display value is
+   the bug, and it is silent: the name looks right, then reopening the dropdown shows
+   "Registered company" selected, and a signup completing later is dropped on the
+   floor because the mode it needed was never set. The trap is structural, so look
+   for it by call site rather than by symptom: on WooCommerce the restore path wrote
+   straight to the capture layer and bypassed `setCompany()` — the ONE function that
+   sets mode/adopted and syncs the link — so any path that can populate the company
+   field must either go through that single function or set the same state itself.
+   Corollary, same commit: once adopted, a LATER prefetch for a re-edited email must
+   not revert the adoption. The email field stays editable by design; a non-match
+   there means "the autofill cookie disagrees with a settled adoption", not "abandon
+   sole trader". Adoption is a one-way latch until the buyer explicitly asks for a
+   different company.
+2. **Reopening the dropdown once adopted offers no free-text query.** The Sole trader
+   chip shows as selected (§0), and the query input must not accept typed input —
+   `readonly`, not `disabled` and not unbound: the click that opens the panel must
+   still land, and the field must stay focusable and in the tab order. There is
+   exactly ONE way to change company from that state: the explicit "select a
+   different" affordance. That is deliberately two entry points into one call — the
+   standalone link, and re-clicking the Sole trader chip — and re-clicking the chip
+   must route through the IDENTICAL relaunch call the link uses. Not a no-op (an
+   earlier round on both platforms made it one; Doug reversed that explicitly), and
+   not a fresh enrolment either, which would re-mint tokens for an identity already
+   adopted, and can re-adopt the same prefetched match with no popup at all — the
+   opposite of what "select a different" means. Shared entry points need a shared
+   re-entrancy guard: the relaunch opens the popup SYNCHRONOUSLY with no guard of its
+   own, so without one a double-click reliably opens two signup popups.
+3. **Clicking back to "Registered company" keeps the dropdown OPEN with focus in the
+   query field.** Unlike the other two chips, this one is not a hand-off to another
+   flow — it means "stay here, search normally" — so it must not close the panel, and
+   the query field must become typable again in the same click. Implemented on
+   PrestaShop (`1c1b3d7`, pinned by tests): the handler reverses manual-entry and
+   cancels any enrolment, re-renders the chip selection (which is also what clears
+   the `readonly` from rule 2), and focuses the query field, with no close call
+   anywhere in it. One ordering trap, worth copying rather than rediscovering:
+   cancelling the enrolment fires the same "flight settled" event that the keep-open
+   spinner's own listener answers by CLOSING the panel, so that listener has to be
+   unbound before the cancel can dispatch, or this click closes the very panel it is
+   trying to keep open. **Not verified on WooCommerce as of this session** — its
+   business-chip branch calls `setMode("business")` and leaves the widget's own
+   open/close and focus behaviour to select2; check it against this rule rather than
+   assuming it inherits it.
+
+## 12. Chip visibility is PUSHED from the availability answer, never only pulled
+
+The chip's gate is the registry's per-country answer, resolved asynchronously
+(§1a). The control that draws the chip reads that answer at the moments IT
+re-evaluates — panel open, address-form re-render, adoption — so an answer landing
+after the panel is already open reaches nothing. Push it: the module that owns the
+availability answer must tell the search control to re-sync its chip every time it
+applies one. WooCommerce already did this; PrestaShop did not, which is why the chip
+could be missing entirely for a supported country (GB, live-reported by Doug
+2026-08-19) — the address step has no server-rendered answer to adopt, so on a first
+visit every panel opened inside the round trip painted with no chip and nothing added
+one afterwards.
+
+Two caching rules fall out of the same bug, and they generalise to any platform that
+caches this answer:
+
+- **`success: false` is not an answer.** The availability endpoint replies HTTP 200
+  with a JSON error body for a stale/absent ajax token or an unknown action, so it
+  never reaches a transport-failure branch. Flattening that into "not available" and
+  caching it turns one expired token into a chip that is gone for the cache's whole
+  lifetime, with nothing that re-asks. Treat a declined request exactly like a
+  transport failure: cache nothing, let the next trigger re-ask.
+- **Never persist a NEGATIVE answer across page loads.** A cross-load cache exists so
+  an available chip paints without waiting out a round trip; there is nothing to paint
+  faster for a country with no chip, so storing "no" buys nothing and costs a full TTL
+  of staleness after the answer behind it changes (a country being enrolled, an
+  environment being fixed). REMOVE the stored entry on a negative rather than skipping
+  the write — skipping leaves an earlier "yes" standing after the country stops being
+  eligible, the same bug pointing the other way. Keep caching the answer in memory for
+  the page's life either way, so no extra request is made per page.

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -359,7 +359,9 @@ useful to a browser pointed at a remote domain.
 All three rules below are Doug's, from live testing on 2026-08-19. They are one
 design, not three fixes: **once a sole trader is adopted, that is the state of the
 control**, and every surface has to agree with it. Rules 2 and 3 are implemented on
-both platforms (PrestaShop `1c1b3d7`, WooCommerce `38bc49a` + `48edd08`); rule 1 is
+both platforms (PrestaShop `1c1b3d7`, WooCommerce `38bc49a` + `48edd08`) — but rule
+2's first round on both was readonly-only, which Doug rejected on re-test; it is
+corrected on PrestaShop and still open on WooCommerce, see the rule. Rule 1 is
 implemented on WooCommerce and is a **known open gap on PrestaShop** — see its own
 entry.
 
@@ -390,14 +392,50 @@ entry.
    renders the "select a different sole trader" element, which is the single source of
    truth for "adopted" (§0) — so on such a load the field looks right while the control
    is still in registered-company mode: reopening shows the wrong chip selected and a
-   typable query. Not fixed as of this writing; the fix is the same shape as
+   visible, typable query. Not fixed as of this writing; the fix is the same shape as
    WooCommerce's — recognise a `TWO:`-prefixed seeded number on that path and enter the
    adopted state from it.
 2. **Reopening the dropdown once adopted offers no free-text query.** The Sole trader
-   chip shows as selected (§0), and the query input must not accept typed input —
-   `readonly`, not `disabled` and not unbound: the click that opens the panel must
-   still land, and the field must stay focusable and in the tab order. There is
-   exactly ONE way to change company from that state: the explicit "select a
+   chip shows as selected (§0), and the query input is **not rendered at all**.
+
+   **`readonly` is NOT an acceptable reading of this rule — it was an incomplete
+   implementation of it.** The first round on PrestaShop (`1c1b3d7`) made the field
+   readonly and left it on screen; Doug's correction on re-test was verbatim: "the
+   field should not be *visible*. I did not tell you it was editable, I told you it
+   was visible." A search box that is painted but inert reads as a search box that
+   has broken, which is worse than one that is absent. Hide it — `display:none` or
+   the `hidden` attribute, **not** `visibility:hidden`/`opacity:0`, which leave it in
+   the tab order for a keyboard buyer to land on something they cannot see. Keeping
+   `readonly` on as well costs nothing and is worth it as defence in depth against a
+   programmatic write, but it satisfies nothing on its own.
+
+   **WooCommerce has this gap too, as of `8af86d4`** — its select2 search input is
+   made readonly on the adopted state and stays on screen, which is the exact
+   implementation Doug rejected here. Fix it there rather than porting the readonly.
+
+   Two consequences that are easy to miss, both found by review rather than by
+   testing the happy path:
+
+   - **Hide the query field's whole ROW, not the input.** The in-field spinner is an
+     absolutely-positioned sibling *inside* that row, so hiding the input alone
+     collapses the row to zero height and strands the spinner at its top edge. And
+     the hide has to stand down for the duration of a sole-trader flight, because
+     that same spinner in that same field IS the in-progress state the keep-open
+     window exists to show (rule 3's ordering trap lives next door to this).
+   - **Something else in the panel has to take focus on open.** The open path focuses
+     the query field; `.focus()` on a `display:none` element silently does nothing,
+     leaving focus on the company-name field — *outside* the panel, and the panel is
+     where Escape-to-close and close-on-focus-leave are bound. A keyboard buyer would
+     have opened a panel they cannot close. Focus the selected chip instead, with the
+     always-visible Registered company chip as the fallback for the one state where
+     the Sole trader chip is itself hidden (adopted, then the registry stops offering
+     that country).
+
+   Drop any query term on the way out, too: it describes a company the buyer then did
+   not pick, and restoring it above results that no longer match it is worse than an
+   empty field.
+
+   There is exactly ONE way to change company from that state: the explicit "select a
    different" affordance. That is deliberately two entry points into one call — the
    standalone link, and re-clicking the Sole trader chip — and re-clicking the chip
    must route through the IDENTICAL relaunch call the link uses. Not a no-op (an
@@ -412,9 +450,10 @@ entry.
    flow — it means "stay here, search normally" — so it must not close the panel, and
    the query field must become typable again in the same click. Implemented on
    PrestaShop (`1c1b3d7`, pinned by tests): the handler reverses manual-entry and
-   cancels any enrolment, re-renders the chip selection (which is also what clears
-   the `readonly` from rule 2), and focuses the query field, with no close call
-   anywhere in it. One ordering trap, worth copying rather than rediscovering:
+   cancels any enrolment, re-renders the chip selection (which is also what brings
+   the query field back from rule 2's hide, readonly and all), and focuses the query
+   field, with no close call anywhere in it. One ordering trap, worth copying rather
+   than rediscovering:
    cancelling the enrolment fires the same "flight settled" event that the keep-open
    spinner's own listener answers by CLOSING the panel, so that listener has to be
    unbound before the cancel can dispatch, or this click closes the very panel it is

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -48,7 +48,7 @@ claim below as DOM-verified, cited by the actual structure captured live:
   alongside the chips — it no longer exists as separate copy on PrestaShop (confirmed:
   zero occurrences of "not on the list" or "my company" anywhere in the page, in any
   state). It has been fully absorbed into the third chip, class
-  `two-company-not-listed`, visible label "Enter Manually." A port that keeps its own
+  `two-company-not-listed`, visible label "Enter manually." A port that keeps its own
   platform's old fallback link *and* adds the chips as a second, separate mechanism
   has not implemented this design — it has implemented two overlapping ones.
 - **Chip selection must survive a reopen — was a live PrestaShop bug, now FIXED

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -356,10 +356,12 @@ useful to a browser pointed at a remote domain.
 
 ## 11. Adoption is a MODE, not a populated field
 
-All three rules below are Doug's, from live testing on 2026-08-19, and are now
-implemented on both platforms: PrestaShop `1c1b3d7`, WooCommerce `38bc49a` +
-`48edd08`. They are one design, not three fixes: **once a sole trader is adopted,
-that is the state of the control**, and every surface has to agree with it.
+All three rules below are Doug's, from live testing on 2026-08-19. They are one
+design, not three fixes: **once a sole trader is adopted, that is the state of the
+control**, and every surface has to agree with it. Rules 2 and 3 are implemented on
+both platforms (PrestaShop `1c1b3d7`, WooCommerce `38bc49a` + `48edd08`); rule 1 is
+implemented on WooCommerce and is a **known open gap on PrestaShop** — see its own
+entry.
 
 1. **A passive autofill/prefetch adoption on first load is a FULL adoption.** If the
    cookie-driven prefetch that runs on initial checkout load resolves to a sole
@@ -378,6 +380,19 @@ that is the state of the control**, and every surface has to agree with it.
    there means "the autofill cookie disagrees with a settled adoption", not "abandon
    sole trader". Adoption is a one-way latch until the buyer explicitly asks for a
    different company.
+
+   **Open on PrestaShop — don't port the gap, and don't treat PrestaShop as the
+   reference for this rule.** PrestaShop has no load-time autofill prefetch at all (its
+   buyer lookup runs only from an explicit enrolment click or a signup completion), but
+   it has the same shape of restore: the checkout manager seeds the confirmed company
+   name and org number from the server on init, and a returning buyer's saved address
+   carries an adopted sole trader's name plus its `TWO:` number. Nothing on that path
+   renders the "select a different sole trader" element, which is the single source of
+   truth for "adopted" (§0) — so on such a load the field looks right while the control
+   is still in registered-company mode: reopening shows the wrong chip selected and a
+   typable query. Not fixed as of this writing; the fix is the same shape as
+   WooCommerce's — recognise a `TWO:`-prefixed seeded number on that path and enter the
+   adopted state from it.
 2. **Reopening the dropdown once adopted offers no free-text query.** The Sole trader
    chip shows as selected (§0), and the query input must not accept typed input —
    `readonly`, not `disabled` and not unbound: the click that opens the panel must

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -359,6 +359,14 @@ The server half is in `tests/SoleTraderTokenPreconditionSpec.php`, which drives 
 action through the controller's own switch: the tier ordering, the shape check on the posted
 country, and that a posted country is still gated by the registry rather than trusted.
 
+`sole-trader-chip-visibility.test.js` — why the "Sole trader" chip did not render for GB
+at all (Doug, 2026-08-19). The only suite that runs the REAL `TwoSoleTrader` beside the
+real search control: all three defects live in the seam between the module that resolves
+the availability answer and the one that draws the chip, so a stub on either side hides
+them. Covers the answer landing while the panel is already open, every declined-request
+body shape (`success: false` and friends, all HTTP 200, so none reaches the transport
+catch), and that a negative answer is never persisted across page loads.
+
 ## Known gaps
 
 Deliberately out of scope for this suite, which covers company-search resilience and

--- a/tests/js/company-search-rerender.test.js
+++ b/tests/js/company-search-rerender.test.js
@@ -638,7 +638,7 @@ describe('the manual-entry affordance on the jQuery UI path (TWO-25326 §2)', ()
         expect(notListed().parent().parent().is('.two-company-dropdown')).toBe(true);
         expect(notListed().parent().prev().is('.two-company-dropdown__results')).toBe(true);
         expect(notListed().text()).toBe(instance.getManualEntryText());
-        expect(instance.getManualEntryText()).toBe('Enter Manually');
+        expect(instance.getManualEntryText()).toBe('Enter manually');
         expect(shown(notListed())).toBe(true);
     });
 
@@ -3026,7 +3026,7 @@ describe('the custom fallback used when jQuery UI is absent', () => {
             expect(button.attr('role')).toBeUndefined();
             expect(button.attr('tabindex')).toBeUndefined();
             // Its accessible name is its text content; nothing else supplies one.
-            expect(button.text()).toBe('Enter Manually');
+            expect(button.text()).toBe('Enter manually');
             // NOT disabled and NOT aria-disabled, unlike the message rows.
             expect(button.prop('disabled')).toBe(false);
             expect(button.attr('aria-disabled')).toBeUndefined();

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -71,7 +71,7 @@ describe('visibility', () => {
         openPanel();
 
         expect(shown(panelParts().soleTrader)).toBe(true);
-        expect(panelParts().soleTrader.text()).toBe('Sole Trader');
+        expect(panelParts().soleTrader.text()).toBe('Sole trader');
     });
 
     test('is hidden when TwoSoleTrader says the country is not eligible', () => {

--- a/tests/js/ps-harness.js
+++ b/tests/js/ps-harness.js
@@ -884,6 +884,9 @@ function panelParts() {
     return {
         panel: $('.two-company-dropdown'),
         query: $('.two-company-dropdown__query'),
+        // The query field's row - the unit that is hidden while the Sole
+        // trader chip is selected, since the spinner is a sibling inside it.
+        searchRow: $('.two-company-dropdown__search'),
         results: $('.two-company-dropdown__results'),
         // The three-chip mode selector (TWO-40 design revision).
         modeChips: $('.two-company-mode-chips'),

--- a/tests/js/sole-trader-availability-cache.test.js
+++ b/tests/js/sole-trader-availability-cache.test.js
@@ -363,11 +363,16 @@ describe('a transport failure is never persisted to the cache', () => {
         second.destroy();
     });
 
-    test('a genuine "success: false" server answer (not a transport failure) IS persisted as false', async () => {
-        // Distinct from the catch()/reject path: the fetch resolved, the
-        // server responded, it just said "not available" (or malformed
-        // success). That is a real answer, not a blip - see the comment in
-        // TwoSoleTrader.js's refreshAvailability() fetch handler.
+    test('a "success: false" server answer is NOT an answer, and is cached nowhere', async () => {
+        // Reverses what this test asserted before (TWO-40 follow-up, Doug
+        // live-test finding - the GB chip disappearing). The fetch resolving is
+        // not the same as the server ANSWERING: `success: false` is what this
+        // endpoint says for a stale ajax token and for an unknown action, HTTP
+        // 200 with a JSON body either way, so the catch() below never sees it.
+        // Treating it as "this country does not do sole traders" cached a
+        // declined request as a real answer - for the page in memory, and for
+        // 24h in localStorage on every later load, with nothing that re-asks
+        // inside the TTL. Full coverage in sole-trader-chip-visibility.test.js.
         global.window.fetch = (url) => {
             fetchCalls.push(url);
             return Promise.resolve({ json: () => Promise.resolve({ success: false }) });
@@ -381,9 +386,8 @@ describe('a transport failure is never persisted to the cache', () => {
 
         expect(fetchCalls).toHaveLength(1);
         expect(instance.isAvailableForCurrentCountry()).toBe(false);
-        expect(window.localStorage.getItem(storageKey('GB'))).not.toBeNull();
-        const cached = JSON.parse(window.localStorage.getItem(storageKey('GB')));
-        expect(cached.available).toBe(false);
+        expect(instance.availabilityByCountry.GB).toBeUndefined();
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
         instance.destroy();
     });
 });
@@ -511,8 +515,10 @@ describe('a superseded in-flight request is not resurrected by a concurrent cach
         buildPaymentTileWithSoleTraderAnswer('0', 'GB');
         await flushPromises();
         expect(instance.isAvailableForCurrentCountry()).toBe(false);
-        const afterAdopt = JSON.parse(window.localStorage.getItem(storageKey('GB')));
-        expect(afterAdopt.available).toBe(false);
+        // A negative answer is REMOVED from the persisted cache rather than
+        // stored in it (TWO-40 follow-up) - there was nothing here to remove,
+        // so the assertion is simply that it still holds no answer.
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
 
         // The original request now resolves with the OPPOSITE answer. It
         // must not win in memory (pre-existing invariant) OR overwrite the
@@ -522,8 +528,7 @@ describe('a superseded in-flight request is not resurrected by a concurrent cach
         await drain();
 
         expect(instance.isAvailableForCurrentCountry()).toBe(false);
-        const afterSettle = JSON.parse(window.localStorage.getItem(storageKey('GB')));
-        expect(afterSettle.available).toBe(false);
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
         instance.destroy();
     });
 });

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -104,12 +104,93 @@ describe('reopening while sole-trader-adopted (item 1)', () => {
 });
 
 describe('query input suppressed while Sole Trader is selected (item 2)', () => {
-    test('the query field is readonly on a reopen while adopted', () => {
+    /**
+     * HIDDEN, not merely readonly (Doug, 2026-08-19, second live round on this
+     * same rule): "the field should not be VISIBLE. I did not tell you it was
+     * editable, I told you it was visible." A readonly-but-painted search box
+     * reads as a search box that has stopped working, so the readonly
+     * assertions below are kept only as the defence-in-depth half - the
+     * visibility ones are the requirement.
+     */
+    function adoptAndReopen() {
         const instance = makeInstance();
         openPanel();
         instance.adoptSoleTraderBuyer(NAMED_BUYER);
         instance.closeDropdown(false);
         $("input[name='company']").trigger('mousedown');
+        return instance;
+    }
+
+    /** Focusable panel controls, in document order, that are actually rendered. */
+    function tabStops() {
+        return panelParts().panel.find('input, button, a[href], [tabindex]')
+            .filter(function () { return $(this).attr('tabindex') !== '-1'; })
+            .get()
+            .filter((node) => shown(node));
+    }
+
+    test('the query field is not VISIBLE on a reopen while adopted', () => {
+        const instance = adoptAndReopen();
+
+        expect(shown(panelParts().query)).toBe(false);
+        // The whole row, spinner included - a lone absolutely-positioned
+        // spinner in a collapsed row is not "hidden", it is misplaced.
+        expect(shown(panelParts().searchRow)).toBe(false);
+        // The panel itself is still open around it.
+        expect(shown(panelParts().panel)).toBe(true);
+
+        instance.destroy();
+    });
+
+    test('a hidden query field is out of the tab order, not just unpainted', () => {
+        const instance = adoptAndReopen();
+
+        // `display:none` removes it; `visibility:hidden`/`opacity:0` would
+        // not, and a keyboard-only buyer would tab into an invisible input.
+        expect(tabStops()).not.toContain(panelParts().query.get(0));
+        // The chips it sits above are still reachable, so this is the field
+        // leaving the tab order rather than the panel doing so.
+        expect(tabStops()).toContain(panelParts().registered.get(0));
+
+        instance.destroy();
+    });
+
+    test('focus opens on the selected chip, INSIDE the panel, so Escape can still close it', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        // The field openDropdown() normally focuses is not rendered, and
+        // focusing a `display:none` element is a no-op - which would strand
+        // focus on the company-name field, outside the panel, where neither
+        // the Escape handler nor the close-on-focus-leave one ever sees a
+        // keystroke.
+        expect(document.activeElement).toBe(panelParts().soleTrader.get(0));
+
+        $(document.activeElement).trigger($.Event('keydown', { key: 'Escape' }));
+
+        expect(shown(panelParts().panel)).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('falls back to the Registered company chip when the Sole trader chip is itself hidden', () => {
+        // Adopted, but the registry no longer offers this country - the one
+        // state where the selected chip is not on screen to receive focus.
+        const instance = adoptAndReopen();
+
+        expect(shown(panelParts().soleTrader)).toBe(false);
+        expect(document.activeElement).toBe(panelParts().registered.get(0));
+        expect(panelParts().panel.get(0).contains(document.activeElement)).toBe(true);
+
+        instance.destroy();
+    });
+
+    test('the query field is readonly too, on top of being hidden', () => {
+        const instance = adoptAndReopen();
 
         expect(panelParts().query.prop('readonly')).toBe(true);
 
@@ -132,26 +213,61 @@ describe('query input suppressed while Sole Trader is selected (item 2)', () => 
         instance.destroy();
     });
 
-    test('the query field is editable again once "Registered Company" is clicked', () => {
-        const instance = makeInstance();
-        openPanel();
-        instance.adoptSoleTraderBuyer(NAMED_BUYER);
-        instance.closeDropdown(false);
-        $("input[name='company']").trigger('mousedown');
-        expect(panelParts().query.prop('readonly')).toBe(true);
+    test('the query field is visible and editable again once "Registered Company" is clicked', () => {
+        const instance = adoptAndReopen();
+        stubSoleTrader();
+        expect(shown(panelParts().query)).toBe(false);
 
         panelParts().registered.trigger('click');
 
+        expect(shown(panelParts().query)).toBe(true);
+        expect(shown(panelParts().searchRow)).toBe(true);
+        expect(tabStops()).toContain(panelParts().query.get(0));
         expect(panelParts().query.prop('readonly')).toBe(false);
 
         instance.destroy();
     });
 
-    test('a fresh, never-adopted open leaves the query field editable', () => {
+    test('a term half-typed before picking Sole trader does not come back with the field', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        typeQuery('Half A Compa');
+
+        // Driven WITHOUT a close in between, deliberately: closeDropdown()
+        // empties the field on its own, so a route through it would leave
+        // this passing whatever the hide does with the term.
+        panelParts().soleTrader.trigger('click');
+        panelParts().registered.trigger('click');
+
+        // A query describing a company the buyer then did NOT pick, restored
+        // above results that no longer match it, is worse than an empty field.
+        expect(panelParts().query.val()).toBe('');
+
+        instance.destroy();
+    });
+
+    test('a fresh, never-adopted open leaves the query field visible and editable', () => {
         const instance = makeInstance();
         openPanel();
 
+        expect(shown(panelParts().query)).toBe(true);
         expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('the field stays visible for the flight of a FIRST sole-trader click, spinner and all', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        // Round 4's keep-open window: the spinner lives IN this field, so
+        // hiding the row for the duration would leave nothing to spin.
+        expect(shown(panelParts().query)).toBe(true);
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
 
         instance.destroy();
     });

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -26,10 +26,18 @@ const {
     panelParts,
     openPanel,
     typeQuery,
+    resultTexts,
     shown
 } = require('./ps-harness');
 
 const CHECKOUT_HOST = 'https://api.example.test';
+
+const SEARCH_RESPONSE = {
+    items: [
+        { name: 'Example Trading Ltd', lookup_id: 'lk-1', national_identifier: { id: '11111111' } },
+        { name: 'Example Holdings Ltd', lookup_id: 'lk-2', national_identifier: { id: '22222222' } }
+    ]
+};
 
 const NAMED_BUYER = {
     company_name: 'Sole Trader Test Co',
@@ -41,6 +49,7 @@ const NAMED_BUYER = {
 
 let TwoCompanySearch;
 let $;
+let ajax;
 
 function makeInstance(config) {
     return new TwoCompanySearch(Object.assign({ checkoutHost: CHECKOUT_HOST }, config || {}));
@@ -66,7 +75,7 @@ beforeEach(() => {
     $ = loaded.$;
     buildAddressForm();
     installStylesheet('views/css/two.css');
-    stubAjax($);
+    ajax = stubAjax($);
 });
 
 afterEach(() => {
@@ -268,6 +277,79 @@ describe('query input suppressed while Sole Trader is selected (item 2)', () => 
         // hiding the row for the duration would leave nothing to spin.
         expect(shown(panelParts().query)).toBe(true);
         expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+
+        instance.destroy();
+    });
+});
+
+/**
+ * Cross-round gap (final review before merge): item 1 made a reopen land in
+ * sole-trader mode, item 2 blanked the query field on the way into that mode -
+ * and nothing emptied the RESULT ROWS the blanked term had produced. jQuery
+ * UI's `response([])` only runs `_close()`, which hides the menu without
+ * emptying it, and this mode is the one that keeps the panel OPEN (manual entry
+ * closes it), so those rows stayed painted and clickable: registered companies
+ * still on offer for a term the field no longer held, next to a search row that
+ * is not even rendered.
+ */
+describe('no stale result rows survive into sole-trader mode', () => {
+    function searchAndSettle(term) {
+        typeQuery(term);
+        jest.advanceTimersByTime(400);
+        const pending = ajax.last();
+        if (pending) {
+            pending.succeed(SEARCH_RESPONSE);
+        }
+        jest.advanceTimersByTime(50);
+    }
+
+    test('reopening while adopted does not re-offer the previous search\'s results', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        searchAndSettle('Example');
+        expect(resultTexts().length).toBeGreaterThan(0);
+
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        // The field is hidden and blank here (see item 2 above), so a list of
+        // registered companies above it belongs to nothing the buyer can see.
+        expect(resultTexts()).toEqual([]);
+
+        instance.destroy();
+    });
+
+    test('picking the chip mid-search clears the rows that search produced', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        searchAndSettle('Example');
+
+        panelParts().soleTrader.trigger('click');
+
+        // The panel stays open for the flight (round 4's keep-open window), so
+        // this is on screen, not merely in the DOM.
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(resultTexts()).toEqual([]);
+
+        instance.destroy();
+    });
+
+    test('coming back to "Registered company" starts from an empty list, not the old one', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        searchAndSettle('Example');
+
+        panelParts().soleTrader.trigger('click');
+        panelParts().registered.trigger('click');
+
+        // The term went with the trip into sole-trader mode; results matching
+        // it must not outlive it.
+        expect(panelParts().query.val()).toBe('');
+        expect(resultTexts()).toEqual([]);
 
         instance.destroy();
     });

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -1,0 +1,222 @@
+/**
+ * TWO-40 follow-up, Doug live-test findings (2026-08-19):
+ *
+ *  1. Reopening the dropdown while a sole trader is adopted must show the
+ *     "Sole Trader" chip selected, not silently fall back to "Registered
+ *     Company" (openDropdown() previously reset `_chipMode` unconditionally
+ *     on every open).
+ *  2. The free-text query input must not be usable while the Sole Trader
+ *     chip is selected - there is deliberately only one way to pick a
+ *     different company in that state (item 3 below), typing a query is
+ *     not it.
+ *  3. Re-clicking the "Sole Trader" chip while already adopted must behave
+ *     EXACTLY like the standalone "Select a different sole trader" link
+ *     (triggerSelectDifferentSoleTrader()/startReplacement()), not start a
+ *     fresh enrolment and not no-op.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    buildAddressForm,
+    installStylesheet,
+    stubAjax,
+    releaseWidgets,
+    panelParts,
+    openPanel,
+    typeQuery,
+    shown
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://api.example.test';
+
+const NAMED_BUYER = {
+    company_name: 'Sole Trader Test Co',
+    organization_number: 'TWO:ST123456789012',
+    email: 'buyer@example.test',
+    billing_address: null,
+    shipping_address: null
+};
+
+let TwoCompanySearch;
+let $;
+
+function makeInstance(config) {
+    return new TwoCompanySearch(Object.assign({ checkoutHost: CHECKOUT_HOST }, config || {}));
+}
+
+function stubSoleTrader() {
+    const instance = {
+        isAvailableForCurrentCountry: jest.fn(() => true),
+        startEnrollment: jest.fn(),
+        startReplacement: jest.fn(),
+        cancelEnrollment: jest.fn()
+    };
+    global.window.TwoSoleTrader_Instance = instance;
+    return instance;
+}
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    buildAddressForm();
+    installStylesheet('views/css/two.css');
+    stubAjax($);
+});
+
+afterEach(() => {
+    releaseWidgets($);
+    jest.useRealTimers();
+    delete global.window.TwoSoleTrader_Instance;
+});
+
+describe('reopening while sole-trader-adopted (item 1)', () => {
+    test('shows the "Sole Trader" chip selected, not "Registered Company"', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+
+        // Close, then reopen exactly as a buyer clicking back into the
+        // (readonly) company field would.
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(panelParts().registered.hasClass('two-company-mode-chip--selected')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('a fresh instance with no adoption still defaults to "Registered Company"', () => {
+        const instance = makeInstance();
+        openPanel();
+
+        expect(panelParts().registered.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(false);
+
+        instance.destroy();
+    });
+});
+
+describe('query input suppressed while Sole Trader is selected (item 2)', () => {
+    test('the query field is readonly on a reopen while adopted', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        expect(panelParts().query.prop('readonly')).toBe(true);
+
+        instance.destroy();
+    });
+
+    test('typing into the (readonly) query field triggers no search request', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const ajaxStub = stubAjax($);
+        typeQuery('Some Other Company');
+        jest.runAllTimers();
+
+        expect(ajaxStub.calls.length).toBe(0);
+
+        instance.destroy();
+    });
+
+    test('the query field is editable again once "Registered Company" is clicked', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+        expect(panelParts().query.prop('readonly')).toBe(true);
+
+        panelParts().registered.trigger('click');
+
+        expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('a fresh, never-adopted open leaves the query field editable', () => {
+        const instance = makeInstance();
+        openPanel();
+
+        expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+});
+
+describe('re-clicking "Sole Trader" while adopted (item 3)', () => {
+    test('calls startReplacement(), not startEnrollment() - same as the standalone link', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const soleTrader = stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startReplacement).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startEnrollment).not.toHaveBeenCalled();
+
+        instance.destroy();
+    });
+
+    test('a rapid double-click only calls startReplacement() once (shares the link\'s re-entrancy guard)', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        const soleTrader = stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startReplacement).toHaveBeenCalledTimes(1);
+
+        instance.destroy();
+    });
+
+    test('the chip still shows selected after routing through startReplacement()', () => {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+
+        stubSoleTrader();
+        panelParts().soleTrader.trigger('click');
+
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+
+        instance.destroy();
+    });
+});
+
+describe('unaffected: a fresh (non-adopted) "Sole Trader" click still enrolls normally', () => {
+    test('calls startEnrollment(), not startReplacement()', () => {
+        const instance = makeInstance();
+        const soleTrader = stubSoleTrader();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startReplacement).not.toHaveBeenCalled();
+
+        instance.destroy();
+    });
+});

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -206,6 +206,50 @@ describe('re-clicking "Sole Trader" while adopted (item 3)', () => {
     });
 });
 
+describe('clicking back to "Registered company" while adopted (item 4)', () => {
+    /**
+     * The way out of the adopted state without launching a signup: the
+     * "Registered company" chip is deliberately NOT a hand-off to another
+     * flow, so it must leave the panel open with the buyer able to type a
+     * query immediately. Pinned here rather than assumed - the sole-trader
+     * chip's own handler closes the panel on one of its branches, and this
+     * one runs cancelEnrollment(), which fires the same settle event another
+     * listener answers by closing.
+     */
+    function adoptAndReopen() {
+        const instance = makeInstance();
+        openPanel();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        instance.closeDropdown(false);
+        $("input[name='company']").trigger('mousedown');
+        stubSoleTrader();
+        return instance;
+    }
+
+    test('the panel stays OPEN, with the "Registered company" chip selected', () => {
+        const instance = adoptAndReopen();
+
+        panelParts().registered.trigger('click');
+
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(panelParts().registered.hasClass('two-company-mode-chip--selected')).toBe(true);
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(false);
+
+        instance.destroy();
+    });
+
+    test('focus lands in the query field, which is typable again', () => {
+        const instance = adoptAndReopen();
+
+        panelParts().registered.trigger('click');
+
+        expect(document.activeElement).toBe(panelParts().query.get(0));
+        expect(panelParts().query.prop('readonly')).toBe(false);
+
+        instance.destroy();
+    });
+});
+
 describe('unaffected: a fresh (non-adopted) "Sole Trader" click still enrolls normally', () => {
     test('calls startEnrollment(), not startReplacement()', () => {
         const instance = makeInstance();

--- a/tests/js/sole-trader-chip-visibility.test.js
+++ b/tests/js/sole-trader-chip-visibility.test.js
@@ -1,0 +1,262 @@
+/**
+ * TWO-40 follow-up, Doug live-test finding (2026-08-19): with the billing
+ * country set to United Kingdom - a country the registry DOES support sole
+ * traders for - the "Sole trader" mode chip did not render in the
+ * company-search dropdown at all.
+ *
+ * Unlike company-search-sole-trader-entry.test.js, which stubs
+ * `TwoSoleTrader_Instance` to test TwoCompanySearch's own wiring, these run the
+ * REAL TwoSoleTrader beside the real search control: the defects below are in
+ * the seam between the two - who resolves the availability answer, when, and
+ * who is told once it lands - and a stub on either side hides all three.
+ *
+ *  1. `{success: false}` (this endpoint's answer for a stale ajax token) was
+ *     flattened into `available: false` and cached as a real answer: in memory
+ *     for the page, and in localStorage for 24h on EVERY later load, with
+ *     nothing that re-asks inside the TTL. One expired token removed the chip
+ *     for a day.
+ *  2. A negative answer was persisted, so a country becoming eligible - or a
+ *     merchant environment being fixed - stayed invisible for up to 24h. It is
+ *     now REMOVED from the cache instead, which also stops an earlier "yes"
+ *     outliving the country's eligibility.
+ *  3. Availability resolves asynchronously and nothing pushed the answer to the
+ *     search control, which only reads it when IT re-evaluates - so a panel
+ *     opened before the round trip landed had no chip in it and nothing to add
+ *     one while it stayed open. TwoSoleTrader.apply() now re-syncs the chip,
+ *     the same direction WooCommerce already pushes it.
+ */
+
+'use strict';
+
+const {
+    loadCompanySearch,
+    loadSoleTrader,
+    buildAddressForm,
+    buildPaymentTileWithSoleTraderAnswer,
+    installStylesheet,
+    stubAjax,
+    releaseWidgets,
+    flushPromises,
+    panelParts,
+    openPanel,
+    shown
+} = require('./ps-harness');
+
+const CHECKOUT_HOST = 'https://checkout.staging.two.inc';
+
+let TwoCompanySearch;
+let TwoSoleTrader;
+let $;
+let ajax;
+let fetchCalls;
+let respond;
+
+/** The localStorage key TwoSoleTrader caches an availability answer under. */
+function storageKey(country) {
+    return 'two_sole_trader_availability::' + CHECKOUT_HOST + '::' + country;
+}
+
+/**
+ * Both modules, wired to each other exactly as twopayment.js wires them: the
+ * search instance is reachable only through the manager (which is what
+ * TwoSoleTrader resolves lazily, since the manager rebuilds it on every
+ * `updatedAddressForm`), and TwoSoleTrader is reachable through its own global.
+ *
+ * Search FIRST: TwoSoleTrader resolves availability from its own constructor,
+ * so the manager has to be in place before it can push the answer anywhere.
+ */
+function mount() {
+    const search = new TwoCompanySearch({ checkoutHost: CHECKOUT_HOST });
+    global.window.TwoCheckoutManager_Instance = { companySearch: search };
+    const soleTrader = new TwoSoleTrader({
+        checkoutHost: CHECKOUT_HOST,
+        orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+        ajaxToken: 'test-token',
+        shopCountry: 'ZZ',
+        billingCountry: 'GB'
+    });
+    global.window.TwoSoleTrader_Instance = soleTrader;
+    return { search: search, soleTrader: soleTrader };
+}
+
+/** Let the debounced observer callback and any promise chain run. */
+async function drain() {
+    jest.advanceTimersByTime(150);
+    await flushPromises();
+    jest.advanceTimersByTime(150);
+    await flushPromises();
+}
+
+/** A DOM mutation, i.e. what re-triggers a refresh on a real checkout. */
+function mutateBody() {
+    global.document.body.appendChild(global.document.createElement('span'));
+}
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    const loaded = loadCompanySearch();
+    TwoCompanySearch = loaded.TwoCompanySearch;
+    $ = loaded.$;
+    // Defaults to GB, `data-iso-code` and all - the country under test.
+    buildAddressForm();
+    installStylesheet('views/css/two.css');
+    ajax = stubAjax($);
+    window.twopayment = { checkout_host: CHECKOUT_HOST, countries: { 17: 'gb' } };
+
+    delete global.window.TwoSoleTrader;
+    TwoSoleTrader = loadSoleTrader();
+
+    fetchCalls = [];
+    respond = () => Promise.resolve({ success: true, available: true });
+    global.window.fetch = (url) => {
+        fetchCalls.push(url);
+        return Promise.resolve({ json: () => respond() });
+    };
+    global.fetch = global.window.fetch;
+});
+
+afterEach(() => {
+    if (global.window.TwoSoleTrader_Instance) {
+        global.window.TwoSoleTrader_Instance.destroy();
+        delete global.window.TwoSoleTrader_Instance;
+    }
+    delete global.window.TwoCheckoutManager_Instance;
+    releaseWidgets($);
+    ajax.restore();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+    delete window.twopayment;
+    delete global.window.fetch;
+    delete global.fetch;
+    global.window.localStorage.clear();
+});
+
+describe('the "Sole trader" chip renders for a supported billing country (GB)', () => {
+    test('shown once the availability answer has landed', async () => {
+        // Given a GB address step and a registry answer of "supported"
+        mount();
+        await drain();
+
+        // When the buyer opens the company-search panel
+        openPanel();
+
+        // Then the chip is there
+        expect(fetchCalls).toHaveLength(1);
+        expect(fetchCalls[0]).toContain('country=GB');
+        expect(shown(panelParts().soleTrader)).toBe(true);
+        expect(panelParts().soleTrader.text()).toBe('Sole trader');
+    });
+
+    test('appears without a reopen when the answer lands while the panel is already open', async () => {
+        // Given a round trip still in flight (the whole address step, on a
+        // first visit: no server-rendered answer to adopt, nothing cached)
+        let settle;
+        respond = () => new Promise((resolve) => { settle = resolve; });
+        mount();
+        jest.advanceTimersByTime(150);
+        await flushPromises();
+
+        // When the buyer opens the panel BEFORE it lands...
+        openPanel();
+        expect(shown(panelParts().soleTrader)).toBe(false);
+
+        // ...and it then lands, with the panel still open
+        settle({ success: true, available: true });
+        await drain();
+
+        // Then the chip appears in the open panel - no close/reopen needed
+        expect(shown(panelParts().soleTrader)).toBe(true);
+    });
+
+    test('a country that genuinely does not support sole traders still shows no chip', async () => {
+        respond = () => Promise.resolve({ success: true, available: false });
+        mount();
+        await drain();
+
+        openPanel();
+
+        expect(shown(panelParts().soleTrader)).toBe(false);
+    });
+});
+
+describe('an error response is not an availability answer', () => {
+    // Every shape this endpoint answers with when it declines to answer at
+    // all - all of them HTTP 200 with a JSON body, so none reaches the
+    // transport-failure catch().
+    const declined = [
+        [{ success: false, error: 'Invalid token' }, 'stale/absent ajax token'],
+        [{ success: false, error: 'Unknown action requested.' }, 'unknown action'],
+        [{}, 'no success field at all'],
+        [null, 'empty body']
+    ];
+
+    test.each(declined)('%j is never cached, in memory or in localStorage (%s)', async (body) => {
+        respond = () => Promise.resolve(body);
+        const { soleTrader } = mount();
+
+        await drain();
+
+        expect(fetchCalls).toHaveLength(1);
+        // Fail-soft on screen, as a transport failure already was...
+        expect(soleTrader.isAvailableForCurrentCountry()).toBe(false);
+        // ...but nothing recorded as an answer about GB, either cache.
+        expect(soleTrader.availabilityByCountry.GB).toBeUndefined();
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
+    });
+
+    test('a later trigger re-asks, and the chip appears once a real answer arrives', async () => {
+        // Given the first request was declined
+        respond = () => Promise.resolve({ success: false, error: 'Invalid token' });
+        mount();
+        await drain();
+        openPanel();
+        expect(shown(panelParts().soleTrader)).toBe(false);
+
+        // When anything triggers another refresh (a fragment re-render, a
+        // country change) and the endpoint answers properly this time
+        respond = () => Promise.resolve({ success: true, available: true });
+        mutateBody();
+        await drain();
+
+        // Then the chip is back - the decline did not poison the country
+        expect(fetchCalls).toHaveLength(2);
+        expect(shown(panelParts().soleTrader)).toBe(true);
+    });
+});
+
+describe('the persisted cache never holds a negative answer', () => {
+    test('a real "not available" answer writes nothing', async () => {
+        respond = () => Promise.resolve({ success: true, available: false });
+        mount();
+
+        await drain();
+
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
+    });
+
+    test('a server-rendered "not available" REMOVES a stale cached "available"', () => {
+        // The shape that made this sticky both ways: yesterday's cached "yes"
+        // for GB, and a payment step that has just rendered "no". Skipping the
+        // write would leave the "yes" standing for the rest of its 24h.
+        window.localStorage.setItem(
+            storageKey('GB'),
+            JSON.stringify({ available: true, ts: Date.now() })
+        );
+        buildPaymentTileWithSoleTraderAnswer('0', 'GB');
+
+        const { soleTrader } = mount();
+
+        expect(soleTrader.isAvailableForCurrentCountry()).toBe(false);
+        expect(window.localStorage.getItem(storageKey('GB'))).toBeNull();
+    });
+
+    test('a positive answer is still persisted, so a later load paints with no round trip', async () => {
+        mount();
+        await drain();
+
+        const cached = JSON.parse(window.localStorage.getItem(storageKey('GB')));
+        expect(cached.available).toBe(true);
+    });
+});

--- a/translations/es.php
+++ b/translations/es.php
@@ -412,7 +412,6 @@ $_MODULE['<{twopayment}prestashop>twopayment_128ce19a81ca82c86adfed35ed88578a'] 
 $_MODULE['<{twopayment}prestashop>twopayment_822f646e52655f26a80e2b6d0c79f41c'] = 'No se permite un límite de 0. Si no quieres cobrar nada en un plazo, establece el porcentaje y la cuota fija de ese plazo en 0.';
 $_MODULE['<{twopayment}prestashop>twopayment_d132286ce060a9349df55de2808b4d5f'] = 'No se han encontrado coincidencias';
 $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] = 'Autónomo';
-$_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Introducir manualmente';
-$_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Empresa registrada';
-$_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Autónomo';
+$_MODULE['<{twopayment}prestashop>twopayment_90a5f22cdff46c106eb927b92562347f'] = 'Introducir manualmente';
+$_MODULE['<{twopayment}prestashop>twopayment_22294ef90aa68e15429879889a0cdaf5'] = 'Empresa registrada';
 $_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Seleccionar otro autónomo';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -443,9 +443,8 @@ $_MODULE['<{twopayment}prestashop>twopayment_77e2ed15a93333cc525d628f5ea7f4ef'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9855bc833e3323f52fb6194bacc73588'] = 'Deze bestelling van %%s wordt waarschijnlijk geaccepteerd door %s';
 $_MODULE['<{twopayment}prestashop>twopayment_6b27878520893a281ad753cd30a03075'] = '%s is niet beschikbaar voor deze bestelling van %%s';
 $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] = 'Eenmanszaak';
-$_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Handmatig invoeren';
-$_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Geregistreerd bedrijf';
-$_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Eenmanszaak';
+$_MODULE['<{twopayment}prestashop>twopayment_90a5f22cdff46c106eb927b92562347f'] = 'Handmatig invoeren';
+$_MODULE['<{twopayment}prestashop>twopayment_22294ef90aa68e15429879889a0cdaf5'] = 'Geregistreerd bedrijf';
 $_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Selecteer een andere eenmanszaak';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Aangepaste betaaltermijn (dagen)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Optioneel. Bied een extra betaaltermijn (in dagen) aan die niet in de bovenstaande voorinstellingen is opgenomen. Laat leeg om alleen de hierboven geselecteerde termijnen aan te bieden. %s moet deze termijnlengte nog steeds toestaan voor je account - een niet-ondersteunde waarde wordt stilzwijgend genegeerd.';

--- a/translations/no.php
+++ b/translations/no.php
@@ -443,9 +443,8 @@ $_MODULE['<{twopayment}prestashop>twopayment_77e2ed15a93333cc525d628f5ea7f4ef'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9855bc833e3323f52fb6194bacc73588'] = 'Denne bestillingen fra %%s vil sannsynligvis bli godkjent av %s';
 $_MODULE['<{twopayment}prestashop>twopayment_6b27878520893a281ad753cd30a03075'] = '%s er ikke tilgjengelig for denne bestillingen fra %%s';
 $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] = 'Enkeltpersonforetak';
-$_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Angi manuelt';
-$_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrert virksomhet';
-$_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enkeltpersonforetak';
+$_MODULE['<{twopayment}prestashop>twopayment_90a5f22cdff46c106eb927b92562347f'] = 'Angi manuelt';
+$_MODULE['<{twopayment}prestashop>twopayment_22294ef90aa68e15429879889a0cdaf5'] = 'Registrert virksomhet';
 $_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Velg et annet enkeltpersonforetak';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Egendefinert betalingsfrist (dager)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Valgfritt. Tilby en ekstra betalingsfrist (i dager) som ikke er dekket av forhåndsinnstillingene ovenfor. La stå tomt for å kun tilby betingelsene valgt ovenfor. %s må fortsatt tillate denne fristlengden for kontoen din - en ustøttet verdi ignoreres stille.';

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -443,9 +443,8 @@ $_MODULE['<{twopayment}prestashop>twopayment_77e2ed15a93333cc525d628f5ea7f4ef'] 
 $_MODULE['<{twopayment}prestashop>twopayment_9855bc833e3323f52fb6194bacc73588'] = 'Den här beställningen från %%s kommer sannolikt att godkännas av %s';
 $_MODULE['<{twopayment}prestashop>twopayment_6b27878520893a281ad753cd30a03075'] = '%s är inte tillgängligt för den här beställningen från %%s';
 $_MODULE['<{twopayment}prestashop>twopayment_8fba17b1e1abfeb9ccc08c9248824add'] = 'Enskild firma';
-$_MODULE['<{twopayment}prestashop>twopayment_156b5d6812dcb5dcf1867a145cf5f1bf'] = 'Ange manuellt';
-$_MODULE['<{twopayment}prestashop>twopayment_040583ad2de8733ea4280fdf16dfef61'] = 'Registrerat företag';
-$_MODULE['<{twopayment}prestashop>twopayment_bd2b7238dd5be2875d527d62a880d043'] = 'Enskild firma';
+$_MODULE['<{twopayment}prestashop>twopayment_90a5f22cdff46c106eb927b92562347f'] = 'Ange manuellt';
+$_MODULE['<{twopayment}prestashop>twopayment_22294ef90aa68e15429879889a0cdaf5'] = 'Registrerat företag';
 $_MODULE['<{twopayment}prestashop>twopayment_f2b8ff605311079f7ab03db9fd5da02c'] = 'Välj en annan enskild firma';
 $_MODULE['<{twopayment}prestashop>twopayment_0f193cdd9a8a87ce1d829b1c1fecb7f9'] = 'Anpassat betalningsvillkor (dagar)';
 $_MODULE['<{twopayment}prestashop>twopayment_00106f12870853d59e2c9b3ade06c709'] = 'Valfritt. Erbjud ytterligare ett betalningsvillkor (i dagar) som inte täcks av förinställningarna ovan. Lämna tomt för att endast erbjuda de villkor som valts ovan. %s måste fortfarande tillåta denna villkorslängd för ditt konto - ett ej understött värde ignoreras tyst.';

--- a/twopayment.php
+++ b/twopayment.php
@@ -4425,7 +4425,7 @@ class Twopayment extends PaymentModule
             // deliberately DIVERGES from the other three plugins' current
             // wording for this affordance, pending their own rollout of the
             // same three-chip pattern.
-            'company_search_manual_entry' => $this->l('Enter Manually'),
+            'company_search_manual_entry' => $this->l('Enter manually'),
             'company_search_back_to_search' => $this->l('Search for company'),
             // Zero-result wording (TWO-25326 §1). EXACT across all four
             // plugins - "No results found" is a different string and the
@@ -4438,14 +4438,14 @@ class Twopayment extends PaymentModule
             // The three-chip mode selector (TWO-40 design revision). Shown
             // immediately on interacting with the search control, no
             // upfront choice OUTSIDE the control any more, no waiting for
-            // characters to be typed. "Registered Company" is the default;
-            // "Enter Manually" (above) is always visible alongside it;
-            // "Sole Trader" is added to the set only when the registry says
+            // characters to be typed. "Registered company" is the default;
+            // "Enter manually" (above) is always visible alongside it;
+            // "Sole trader" is added to the set only when the registry says
             // the currently-selected billing country supports sole traders
             // (TwoSoleTrader::isAvailable), and removed again live if the
             // buyer changes the country selector to one that does not.
-            'company_search_registered_entry' => $this->l('Registered Company'),
-            'company_search_sole_trader_entry' => $this->l('Sole Trader'),
+            'company_search_registered_entry' => $this->l('Registered company'),
+            'company_search_sole_trader_entry' => $this->l('Sole trader'),
             // Fallback status label shown once enrolment succeeds but the
             // registration carries no displayable company name or number
             // (TwoCompanyNumber.forDisplay() answers '' for both a blank name

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -712,6 +712,13 @@
     position: relative;
 }
 
+/* Hidden while the Sole trader chip is the selected one - same reason the
+   panel's own `[hidden]` rule exists above: the attribute has to out-rank a
+   theme that resets `[hidden]`. */
+.two-company-dropdown__search[hidden] {
+    display: none;
+}
+
 .two-company-dropdown__query {
     box-sizing: border-box;
     width: 100%;

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -909,6 +909,18 @@ class TwoCompanySearch {
                 // lost by closing - but doing it before keeps this handler's
                 // ordering symmetric with the other two.
                 this.renderChipSelection();
+                // Re-clicking this chip while a sole trader is already
+                // adopted (TWO-40 follow-up, Doug's explicit ruling: an
+                // earlier round made this a no-op, treating the standalone
+                // "select a different sole trader" link/button as the only
+                // entry point - that was wrong). Route through the exact
+                // same call the link uses rather than starting a fresh
+                // enrolment, which would re-mint tokens for an identity
+                // that's already adopted.
+                if (this.isSoleTraderAdopted()) {
+                    this.triggerSelectDifferentSoleTrader();
+                    return;
+                }
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {
                     // Keep the panel OPEN and show the query field's own
@@ -1289,11 +1301,17 @@ class TwoCompanySearch {
         this._dropdown.removeAttr('hidden').show();
         this.setDropdownExpandedState();
         // Every FRESH open starts at the default chip (TWO-40: "Default
-        // selected chip: Registered Company"). Not reachable from manual
-        // entry (early-returns above), so the only mode this could be
-        // carrying over from is 'sole_trader' - and cancelEnrollment() just
-        // above already reversed that.
-        this._chipMode = 'registered';
+        // selected chip: Registered Company") - UNLESS a sole trader is
+        // currently adopted (TWO-40 follow-up, Doug live-test finding). The
+        // earlier version of this comment reasoned that cancelEnrollment()
+        // above already reverses the only other source of 'sole_trader',
+        // which is true for an in-flight ENROLMENT but not for an already-
+        // ADOPTED identity: cancelEnrollment() only cancels a signup in
+        // progress, it does not un-adopt a completed one. A sole trader IS
+        // what's currently selected in that state, so the reopened panel
+        // must show that chip selected, not silently fall back to
+        // "Registered Company".
+        this._chipMode = this.isSoleTraderAdopted() ? 'sole_trader' : 'registered';
         this.renderChipSelection();
         this.syncNotListedVisibility();
         this.syncSoleTraderEntryVisibility();
@@ -1470,6 +1488,40 @@ class TwoCompanySearch {
                 button.toggleClass('two-company-mode-chip--selected', this._chipMode === mode);
             }
         });
+        this.syncQueryFieldSuppression();
+    }
+
+    /**
+     * Suppress the free-text query input while the Sole Trader chip is the
+     * selected one (TWO-40 follow-up, Doug live-test finding). There is
+     * deliberately only one way to pick a different company while a sole
+     * trader is selected - the chip/link re-launching the signup flow (see
+     * triggerSelectDifferentSoleTrader()) - typing a fresh live-search query
+     * is not it. `readonly`, not `disabled`: the field must stay focusable
+     * and part of the dropdown's own tab order, it just must not accept
+     * typed input. Called from renderChipSelection() so every place the chip
+     * selection changes - a fresh open, either chip's click handler - stays
+     * in sync with no separate call site to remember.
+     */
+    syncQueryFieldSuppression() {
+        if (!this._queryField || !this._queryField.length) {
+            return;
+        }
+        this._queryField.prop('readonly', this._chipMode === 'sole_trader');
+    }
+
+    /**
+     * Whether a sole-trader identity is currently adopted into the form
+     * (TWO-40 follow-up). The "Select a different sole trader" link/button
+     * only ever exists for exactly this state (see
+     * renderSelectDifferentSoleTraderLink()/removeSelectDifferentSoleTraderLink()),
+     * so its presence is the single source of truth rather than a second,
+     * independently-maintained flag that could drift from it.
+     *
+     * @returns {boolean}
+     */
+    isSoleTraderAdopted() {
+        return !!(this._selectDifferentSoleTraderLink && this._selectDifferentSoleTraderLink.length);
     }
 
     /**
@@ -1658,8 +1710,15 @@ class TwoCompanySearch {
             this.openDropdown();
             // The character that opened the panel belongs in the query field,
             // not lost. Only for a real printable character - `key` is a
-            // single code point exactly when the keypress produced text.
-            if (key && key.length === 1 && this._queryField && this._queryField.length) {
+            // single code point exactly when the keypress produced text. Not
+            // forwarded while the Sole Trader chip is selected (TWO-40
+            // follow-up): openDropdown() just set that chip mode when a
+            // sole trader is adopted, and the query field is `readonly` in
+            // that state (syncQueryFieldSuppression()) - `.val()` would
+            // still write through a readonly attribute, so this has to check
+            // explicitly rather than relying on the attribute alone.
+            if (key && key.length === 1 && this._chipMode !== 'sole_trader'
+                && this._queryField && this._queryField.length) {
                 this._queryField.val(key);
                 this._queryField.trigger('input');
             }
@@ -3520,6 +3579,16 @@ class TwoCompanySearch {
                         response([]);
                         return;
                     }
+                    // Sole Trader selected (TWO-40 follow-up): the query field
+                    // is `readonly` in this state (syncQueryFieldSuppression())
+                    // so no real keystroke reaches here, but this is the same
+                    // "defence in depth" posture as the manual-entry check
+                    // above - a programmatic `input`/`search` trigger must not
+                    // run a live search while a sole trader is what's selected.
+                    if (this._chipMode === 'sole_trader') {
+                        response([]);
+                        return;
+                    }
                     // Too short to search on - INCLUDING the empty query the
                     // panel opens with. No search is made and no row is
                     // rendered for this any more (TWO-40 follow-up): the
@@ -3865,7 +3934,7 @@ class TwoCompanySearch {
      */
     getManualEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_manual_entry)
-            || 'Enter Manually';
+            || 'Enter manually';
     }
 
     /**
@@ -3875,7 +3944,7 @@ class TwoCompanySearch {
      */
     getRegisteredEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_registered_entry)
-            || 'Registered Company';
+            || 'Registered company';
     }
 
     /**
@@ -3883,7 +3952,7 @@ class TwoCompanySearch {
      */
     getSoleTraderEntryText() {
         return (window.twopayment && window.twopayment.i18n && window.twopayment.i18n.company_search_sole_trader_entry)
-            || 'Sole Trader';
+            || 'Sole trader';
     }
 
     /**
@@ -4141,6 +4210,55 @@ class TwoCompanySearch {
     }
 
     /**
+     * Relaunch the sole-trader signup/re-selection flow (TWO-40 follow-up).
+     * The single shared call for BOTH entry points that mean "pick a
+     * different sole trader" - the standalone link/button below the company
+     * field, and re-clicking the "Sole Trader" mode chip while a sole
+     * trader is already adopted (Doug's ruling: the two must behave
+     * identically, not one being a no-op).
+     *
+     * Re-entrancy guard (adversarial review finding, TWO-40 follow-up -
+     * Han/Vader independently caught this): `TwoSoleTrader.startReplacement()`
+     * opens the popup SYNCHRONOUSLY with no guard of its own (unlike
+     * getCurrentBuyer()'s `isFetchingBuyer`) - without this, a double-click
+     * reliably opened two signup popups from one gesture.
+     */
+    triggerSelectDifferentSoleTrader() {
+        if (this._selectDifferentSoleTraderLoading) {
+            return;
+        }
+        this._selectDifferentSoleTraderLoading = true;
+        // Released on TwoSoleTrader.js's own settle event - fired from
+        // EVERY terminal branch of startReplacement()'s call graph (popup
+        // opened, popup blocked, mint failed, or abandoned via a
+        // cancelEnrollment() elsewhere) - same event beginSoleTraderLoading()
+        // already relies on for the "Sole Trader" chip's fresh-enrolment
+        // path, own namespace so the two guards never interfere.
+        $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
+            .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
+                this._selectDifferentSoleTraderLoading = false;
+            });
+        try {
+            if (window.TwoSoleTrader_Instance
+                && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
+                window.TwoSoleTrader_Instance.startReplacement();
+            } else {
+                // Nothing is going to fire the settle event for this click,
+                // so release the guard here rather than leaving it stuck and
+                // log visibly rather than a completely silent no-op
+                // (adversarial review finding).
+                // eslint-disable-next-line no-console
+                console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
+                this._selectDifferentSoleTraderLoading = false;
+                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+            }
+        } catch (e) {
+            this._selectDifferentSoleTraderLoading = false;
+            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+        }
+    }
+
+    /**
      * Render the "Select a different sole trader" link below the company
      * field (TWO-40 follow-up) - same slot, same styling/gating shape as
      * renderBackToSearchLink() above, but for a COMPLETED sole-trader
@@ -4168,50 +4286,7 @@ class TwoCompanySearch {
             // sibling inside the address step's markup, not something the
             // theme's delegated collapse handler is meant to hear from.
             event.stopPropagation();
-            // Re-entrancy guard (adversarial review finding, TWO-40 follow-
-            // up - Han/Vader independently caught this): THIS button only
-            // ever renders once tokens already exist from an earlier
-            // enrolment, which is exactly the branch of
-            // TwoSoleTrader.startReplacement() that opens the popup
-            // SYNCHRONOUSLY with no guard of its own (unlike
-            // getCurrentBuyer()'s `isFetchingBuyer`) - without this, a
-            // double-click reliably opened two signup popups from one
-            // gesture, the exact defect class `isFetchingBuyer`/
-            // `_soleTraderLoading` already exist elsewhere in this flow to
-            // close.
-            if (this._selectDifferentSoleTraderLoading) {
-                return;
-            }
-            this._selectDifferentSoleTraderLoading = true;
-            // Released on TwoSoleTrader.js's own settle event - fired from
-            // EVERY terminal branch of startReplacement()'s call graph
-            // (popup opened, popup blocked, mint failed, or abandoned via a
-            // cancelEnrollment() elsewhere) - same event
-            // beginSoleTraderLoading() already relies on for the "Sole
-            // Trader" chip, own namespace so the two guards never interfere.
-            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
-                .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
-                    this._selectDifferentSoleTraderLoading = false;
-                });
-            try {
-                if (window.TwoSoleTrader_Instance
-                    && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
-                    window.TwoSoleTrader_Instance.startReplacement();
-                } else {
-                    // Same shape as the "Sole Trader" chip's own missing-
-                    // instance branch: nothing is going to fire the settle
-                    // event for this click, so release the guard here rather
-                    // than leaving it stuck and log visibly rather than a
-                    // completely silent no-op (adversarial review finding).
-                    // eslint-disable-next-line no-console
-                    console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
-                    this._selectDifferentSoleTraderLoading = false;
-                    $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
-                }
-            } catch (e) {
-                this._selectDifferentSoleTraderLoading = false;
-                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
-            }
+            this.triggerSelectDifferentSoleTrader();
         });
 
         // Same placement as renderBackToSearchLink(): appended to the field
@@ -4663,6 +4738,12 @@ class TwoCompanySearch {
             const term = inputEl.value || '';
             clearTimeout(debounce.id);
             if (this._manualEntry) {
+                debounce.id = null;
+                return;
+            }
+            // Sole Trader selected (TWO-40 follow-up) - same defence-in-depth
+            // reasoning as the jQuery UI `source` callback's own check.
+            if (this._chipMode === 'sole_trader') {
                 debounce.id = null;
                 return;
             }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1480,11 +1480,14 @@ class TwoCompanySearch {
      * availability cache rather than duplicated here. `TwoSoleTrader_Instance`
      * may not exist yet (script load order) or may not have resolved an
      * answer for the current country yet; both read as "not available",
-     * matching this control's fail-soft posture everywhere else. Reactivity
-     * to a live country-selector change is inherited rather than built here:
-     * setupCountryChangeListener() already closes the panel on every country
-     * change, so the next open always re-evaluates this against the current
-     * country - the chip cannot go stale while sitting open across a change.
+     * matching this control's fail-soft posture everywhere else - which is
+     * why TwoSoleTrader.apply() calls back into this method (via
+     * resyncSoleTraderChip()) once an answer lands: a panel opened before that
+     * round trip returned would otherwise sit there with no chip in it and
+     * nothing to add one. That push is additive in practice - an answer already
+     * resolved for a country is memoised for the page's life, and a
+     * country-selector change closes the panel first (setupCountryChangeListener())
+     * - so a chip on screen does not vanish from under the buyer mid-panel.
      */
     syncSoleTraderEntryVisibility() {
         if (!this._soleTraderButton || !this._soleTraderButton.length) {
@@ -1564,6 +1567,15 @@ class TwoCompanySearch {
         if (suppressed && !this._soleTraderLoading) {
             this._queryField.val('');
             searchRow.hide().attr('hidden', 'hidden');
+            // Re-render the panel body for the term that was just dropped
+            // (final-review finding). Blanking the field with `.val()` fires no
+            // event, so nothing else re-evaluates: the result rows the OLD term
+            // produced stayed painted and clickable, offering registered
+            // companies next to a search row that is no longer rendered. Both
+            // engines' entry points answer an empty term in sole-trader mode
+            // with an empty list, so this is the same one call openDropdown()
+            // already makes rather than a second way to clear the menu.
+            this.openSearchForCurrentTerm();
         } else {
             searchRow.removeAttr('hidden').show();
         }
@@ -3655,6 +3667,17 @@ class TwoCompanySearch {
                     // above - a programmatic `input`/`search` trigger must not
                     // run a live search while a sole trader is what's selected.
                     if (this._chipMode === 'sole_trader') {
+                        // Cleared explicitly, exactly as the too-short branch
+                        // below does and for the same jQuery UI reason:
+                        // `response([])` runs `_close()`, which HIDES the menu
+                        // without emptying it. Unlike manual entry above -
+                        // which closes the whole panel (enterManualEntryMode())
+                        // so a stale list cannot be seen - this mode
+                        // deliberately keeps the panel OPEN, so those rows stay
+                        // on screen and clickable: registered companies offered
+                        // for a term the field no longer even holds, since
+                        // syncQueryFieldSuppression() blanks it on the way in.
+                        this.clearAutocompleteMenu();
                         response([]);
                         return;
                     }
@@ -4814,6 +4837,15 @@ class TwoCompanySearch {
             // reasoning as the jQuery UI `source` callback's own check.
             if (this._chipMode === 'sole_trader') {
                 debounce.id = null;
+                // Same clear as the widget path's own sole-trader branch, for
+                // the same reason: this mode keeps the panel open, so rows left
+                // from the previous term stay on screen above a blanked field.
+                // Rows only - deliberately NOT setLoadingState(false) the way
+                // the too-short branch below does: that branch abandons a real
+                // pending search, this one never issued a request, and the class
+                // it would clear is the one beginSoleTraderLoading() uses to
+                // spin for a sole-trader flight.
+                renderRows([]);
                 return;
             }
             // Handled SYNCHRONOUSLY, outside the debounce: there is no

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1316,13 +1316,43 @@ class TwoCompanySearch {
         this.syncNotListedVisibility();
         this.syncSoleTraderEntryVisibility();
         this.syncRegisteredEntryVisibility();
-        this._queryField.trigger('focus');
+        this.focusPanelEntry();
         // Render the current state immediately - for an empty query that is
         // the "type N more characters" hint (§1), not an empty or absent
         // panel. Matches the requirement that the hint is visible as soon as
         // the control opens, which is the Hyvä failure recorded on this
         // ticket.
         this.openSearchForCurrentTerm();
+    }
+
+    /**
+     * Where focus goes when the panel opens.
+     *
+     * The query field, normally. But in sole-trader mode that field is not
+     * rendered at all (syncQueryFieldSuppression()), and `.focus()` on a
+     * `display:none` element does nothing - which would leave focus on the
+     * company-name field, OUTSIDE the panel, where neither the
+     * Escape-to-close nor the close-on-focus-leave handler can see a
+     * keystroke: a keyboard buyer would have no way to close the panel they
+     * just opened. So focus the selected chip instead - inside the panel, and
+     * the only control this state offers. The Registered company chip is the
+     * fallback for the one state where the Sole trader chip is itself hidden
+     * (adopted, then the registry stops offering that country).
+     */
+    focusPanelEntry() {
+        if (this._chipMode === 'sole_trader') {
+            const chips = [this._soleTraderButton, this._registeredButton];
+            for (let i = 0; i < chips.length; i++) {
+                const chip = chips[i];
+                if (chip && chip.length && chip.css('display') !== 'none') {
+                    chip.trigger('focus');
+                    return;
+                }
+            }
+        }
+        if (this._queryField && this._queryField.length) {
+            this._queryField.trigger('focus');
+        }
     }
 
     /**
@@ -1497,17 +1527,46 @@ class TwoCompanySearch {
      * deliberately only one way to pick a different company while a sole
      * trader is selected - the chip/link re-launching the signup flow (see
      * triggerSelectDifferentSoleTrader()) - typing a fresh live-search query
-     * is not it. `readonly`, not `disabled`: the field must stay focusable
-     * and part of the dropdown's own tab order, it just must not accept
-     * typed input. Called from renderChipSelection() so every place the chip
+     * is not it. Called from renderChipSelection() so every place the chip
      * selection changes - a fresh open, either chip's click handler - stays
      * in sync with no separate call site to remember.
+     *
+     * HIDDEN, not merely `readonly` (Doug live-test finding, TWO-40 follow-up
+     * round 2): an earlier round made the field readonly and left it on
+     * screen, which reads as a search box that has stopped working. A field
+     * offering nothing must not be painted. `display:none` (plus the `hidden`
+     * attribute, same belt-and-braces as the panel itself) rather than
+     * `visibility`/`opacity`, so it leaves the tab order with it - a
+     * keyboard-only buyer must not land on an input they cannot see.
+     *
+     * The whole SEARCH ROW is hidden, not just the input: the spinner is an
+     * absolutely-positioned sibling inside that row, so hiding the input
+     * alone collapses the row to zero height and strands the spinner at its
+     * top edge. Which is also why the hide stands down while a sole-trader
+     * flight is in progress - that spinner, in this field, IS the in-flight
+     * state (see beginSoleTraderLoading()).
+     *
+     * The term is dropped on the way out. The row comes back on the
+     * "Registered company" chip, and a query the buyer typed before adopting
+     * describes a company they then did not pick; restoring it would put a
+     * stale term above results that no longer match it.
      */
     syncQueryFieldSuppression() {
         if (!this._queryField || !this._queryField.length) {
             return;
         }
-        this._queryField.prop('readonly', this._chipMode === 'sole_trader');
+        const suppressed = this._chipMode === 'sole_trader';
+        this._queryField.prop('readonly', suppressed);
+        const searchRow = this._queryField.closest('.two-company-dropdown__search');
+        if (!searchRow.length) {
+            return;
+        }
+        if (suppressed && !this._soleTraderLoading) {
+            this._queryField.val('');
+            searchRow.hide().attr('hidden', 'hidden');
+        } else {
+            searchRow.removeAttr('hidden').show();
+        }
     }
 
     /**
@@ -1551,6 +1610,11 @@ class TwoCompanySearch {
         if (this._queryField && this._queryField.length) {
             this._queryField.addClass('two-company-search-loading');
         }
+        // The chip is already `sole_trader` by the time this runs, so the
+        // search row has just been hidden by syncQueryFieldSuppression() -
+        // re-show it for the flight, or the spinner this method exists to
+        // paint has nowhere to appear.
+        this.syncQueryFieldSuppression();
         $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs)
             .on('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs, () => {
                 // closeDropdown() itself calls endSoleTraderLoading() as its
@@ -1580,6 +1644,10 @@ class TwoCompanySearch {
         if (this._queryField && this._queryField.length) {
             this._queryField.removeClass('two-company-search-loading');
         }
+        // Mirror of the call in beginSoleTraderLoading(): the keep-open
+        // window is over, so a still-selected Sole Trader chip goes back to
+        // hiding the row. A no-op for every other mode.
+        this.syncQueryFieldSuppression();
     }
 
     /**
@@ -1713,10 +1781,10 @@ class TwoCompanySearch {
             // single code point exactly when the keypress produced text. Not
             // forwarded while the Sole Trader chip is selected (TWO-40
             // follow-up): openDropdown() just set that chip mode when a
-            // sole trader is adopted, and the query field is `readonly` in
-            // that state (syncQueryFieldSuppression()) - `.val()` would
-            // still write through a readonly attribute, so this has to check
-            // explicitly rather than relying on the attribute alone.
+            // sole trader is adopted, and the query field is hidden and
+            // `readonly` in that state (syncQueryFieldSuppression()) -
+            // `.val()` writes through both of those, so this has to check
+            // the mode explicitly rather than relying on the field's state.
             if (key && key.length === 1 && this._chipMode !== 'sole_trader'
                 && this._queryField && this._queryField.length) {
                 this._queryField.val(key);
@@ -3580,8 +3648,9 @@ class TwoCompanySearch {
                         return;
                     }
                     // Sole Trader selected (TWO-40 follow-up): the query field
-                    // is `readonly` in this state (syncQueryFieldSuppression())
-                    // so no real keystroke reaches here, but this is the same
+                    // is not even rendered in this state
+                    // (syncQueryFieldSuppression()) so no real keystroke
+                    // reaches here, but this is the same
                     // "defence in depth" posture as the manual-entry check
                     // above - a programmatic `input`/`search` trigger must not
                     // run a live search while a sole trader is what's selected.

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -279,7 +279,16 @@ class TwoSoleTrader {
         // readPersistedAvailability() already re-validates freshness, so a
         // stale-but-matching entry still gets its `ts` refreshed rather than
         // being (wrongly) treated as "no write needed".
-        if (this.readPersistedAvailability(country) !== available) {
+        //
+        // Asymmetric, because the two answers are stored asymmetrically: a
+        // negative is REMOVED rather than written (writePersistedAvailability()),
+        // so a stored negative does not exist and `persisted` can never read
+        // back `false`. Comparing it to `available` directly made this guard a
+        // no-op for every negative answer - a redundant synchronous removeItem
+        // on each of the replacements it exists to absorb. A negative has work
+        // to do only when there is an entry to remove.
+        const persisted = this.readPersistedAvailability(country);
+        if (available ? persisted !== true : persisted !== null) {
             this.writePersistedAvailability(country, available);
         }
     }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -663,7 +663,27 @@ class TwoSoleTrader {
                 if (superseded()) {
                     return;
                 }
-                const available = !!(json && json.success && json.available);
+                // `success: false` is NOT an answer about this country
+                // (TWO-40 follow-up, Doug live-test finding: the sole-trader
+                // chip stopped rendering for GB). This endpoint answers
+                // `{success: false, error: ...}` for a stale/absent ajax token
+                // and for an unknown action - a 200 with a JSON body, so the
+                // catch() below never sees it - and flattening that into
+                // `available: false` cached it as a definite "this country does
+                // not do sole traders": for the page's life in memory, and for a
+                // FULL DAY in localStorage, on every later page load, with
+                // nothing that would ever re-ask. One expired token was enough
+                // to remove the chip for 24h. Same posture as the transport
+                // failure below instead: nothing cached, pending marker already
+                // released, so the next mutation batch or country change asks
+                // again.
+                if (!json || !json.success) {
+                    if (self.billingCountry() === country) {
+                        self.apply(country, false);
+                    }
+                    return;
+                }
+                const available = !!json.available;
                 self.availabilityByCountry[country] = available;
                 // A resolved server response - true or false - is a real
                 // answer about this country, unlike the transport-failure
@@ -817,6 +837,19 @@ class TwoSoleTrader {
      * Best-effort and silent: a write failure (quota, disabled storage) must
      * not affect checkout, only the latency this cache is there to cut.
      *
+     * A NEGATIVE answer REMOVES any stored entry rather than storing itself
+     * (TWO-40 follow-up, Doug live-test finding). This cache exists to paint an
+     * available chip on first evaluation instead of waiting out a round trip -
+     * there is nothing to paint faster for a country that has no chip, so
+     * storing "no" buys nothing, while a stored "no" costs a full day of the
+     * chip staying gone after the answer behind it changes (a registry country
+     * being enrolled, a merchant's environment being fixed) with nothing that
+     * re-asks inside the TTL. Removing rather than merely skipping the write
+     * matters: skipping would leave an earlier stored "yes" standing for up to
+     * 24h after the country stopped being eligible, which is the same bug
+     * pointing the other way. Either way the answer is still cached IN MEMORY
+     * for the page's life by the callers, so no extra request is made per page.
+     *
      * @param {string} country ISO-2, already uppercased by the caller
      * @param {boolean} available
      * @returns {void}
@@ -827,7 +860,11 @@ class TwoSoleTrader {
             if (!key) {
                 return;
             }
-            window.localStorage.setItem(key, JSON.stringify({ available: !!available, ts: Date.now() }));
+            if (!available) {
+                window.localStorage.removeItem(key);
+                return;
+            }
+            window.localStorage.setItem(key, JSON.stringify({ available: true, ts: Date.now() }));
         } catch (e) {
             // no-op: presentation-only cache, never a gate.
         }
@@ -842,6 +879,47 @@ class TwoSoleTrader {
         // behaviour, without a "business" mode to fall back to.
         if (!available && this.enrolling) {
             this.cancelEnrollment();
+        }
+        this.resyncSoleTraderChip();
+    }
+
+    /**
+     * Tell the company-search control to re-evaluate its "Sole trader" chip
+     * now that an availability answer has landed (TWO-40 follow-up, Doug
+     * live-test finding: the chip did not render at all on a GB address step).
+     *
+     * The chip is a child of the search dropdown and TwoCompanySearch decides
+     * its visibility by READING this instance's cache
+     * (isAvailableForCurrentCountry()) at the moments it already re-evaluates
+     * its own rows - the panel opening, an address-form re-render, an adoption.
+     * Availability resolves ASYNCHRONOUSLY, off a round trip this module owns,
+     * and nothing pushed the answer the other way: a buyer who reached the
+     * company field before that request landed - which is every first
+     * evaluation on a page with no server-rendered answer to adopt and no
+     * persisted one to read, i.e. the whole address step - got a panel with no
+     * Sole trader chip in it and nothing to add one while it stayed open.
+     *
+     * Resolved lazily through the manager, exactly as adoptEnrolledIdentity()
+     * does and for the same reason: the manager destroys and rebuilds its
+     * search instance on every `updatedAddressForm`. Fails soft - a missing
+     * instance costs this repaint, not the answer, which is already cached
+     * above by the time this runs.
+     *
+     * WooCommerce already pushes this way round (`twoincSoleTrader.apply()`
+     * calls the equivalent chip re-sync); this is the same shape, not a new
+     * mechanism.
+     *
+     * @returns {void}
+     */
+    resyncSoleTraderChip() {
+        try {
+            const manager = window.TwoCheckoutManager_Instance;
+            const search = manager && manager.companySearch;
+            if (search && typeof search.syncSoleTraderEntryVisibility === 'function') {
+                search.syncSoleTraderEntryVisibility();
+            }
+        } catch (e) {
+            // Presentation-only repaint; never let it cost the answer.
         }
     }
 


### PR DESCRIPTION
The "Sole trader" mode chip did not render at all for a billing country the registry does support sole traders for (GB, Doug's live test). Three defects in the seam between the module that resolves the availability answer and the one that draws the chip.

- **Nothing pushed a resolved answer to the search control.** It only reads availability when it re-evaluates, and the address step has no server-rendered answer to adopt — so on a first visit, every panel opened inside the availability round trip painted with no chip and nothing added one while it stayed open. `apply()` now re-syncs the chip, the direction WooCommerce already pushes it.
- **`success: false` was cached as a real answer.** That is what the endpoint replies for a stale/absent ajax token — HTTP 200 with a JSON body, so the transport-failure branch never sees it. Cached in memory for the page and in localStorage for 24h on every later load, with nothing re-asking inside the TTL: one expired token removed the chip for a day.
- **Negative answers were persisted.** A country becoming eligible stayed invisible for up to 24h. A negative now removes the stored entry instead, which also stops an earlier "yes" outliving the country's eligibility.

Also commits `.ai/sole-trader-porting-guide.md` (previously untracked) with this session's three UX rules, and pins the "Registered company" chip keeping the panel open with focus in the query field from an adopted state.

Stacked on `doug/two40-chip-state-parity`.

822/822 JS tests green. Not live-verified against the staging shop — read-only browser verification needed a per-session confirmation this session could not obtain, and that shop is in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
