### PR TITLE
fix(js): rehome the sole-trader spinner and hold it for the whole flow

### DIFF
--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -383,6 +383,24 @@ is not persisted here", never to a dropped payment record.
     on the success path, so every failure and abandon would spin forever.
     A cancel/abandon must be able to FORCE the dispatch past that gate, since the
     generation bump it performs has already disowned whatever is still in the air.
+  - **Focus returning to the checkout page must take the POPUP down with the
+    spinner and the panel** (Doug, live, PrestaShop
+    `doug/two40-soletrader-spinner-rehome`). All three are one abandon, and it is
+    easy to implement a subset of it: PrestaShop stopped the spinner and closed the
+    dropdown on that path but left the hosted popup on screen. The trigger already exists if the
+    panel has a deferred close-on-focus-leaving handler (§1) — hang the popup close
+    off THAT decision point, not off the generic "panel closed" path, which also
+    covers a completed selection and a platform re-render and would slam a live
+    popup shut. It must sit AFTER that handler's own guards: a focus-out caused by
+    clicking one of the panel's own chips puts focus back inside the panel and
+    that chip's handler owns the flow. Closing is the opener's privilege however
+    cross-origin the popup is, and is a no-op on a window that has already gone —
+    so a buyer who hand-closed it, and a hosted flow that closed itself the moment
+    it posted its completion message, both need no special case. Leave the
+    `.closed` poll to clear the handle and dispatch the settle, so that stays a
+    one-owner job. Do NOT fold this into the resumable cancel/abandon call (§14's
+    "still glancing around" case) — that one runs on every reopen of the search
+    control and must leave the popup alone.
 - **Tokens must already exist when the chip is clicked.** A chip click has exactly two
   allowed outcomes — populate a company, or open the signup popup — and a fallback
   note/link is neither (WooCommerce `df1aaa1`). Minting inside the click handler puts

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -975,8 +975,15 @@ anything local to either symptom.
   now takes a flag that disowns the WRITE only (`cancelEnrollment(keepPopupTracked)`) and
   leaves the poll and the handle alone; the settle event's popup-open guard needs no change
   and instead becomes the mechanism, holding the spinner until the buyer's own popup closes.
-  The write staying disowned is deliberate and is the residue: an OTP completed after an
-  incidental re-render is still dropped on the generation check, as it was before.
+- **A surviving popup has to be RE-ADOPTABLE, not just re-findable** (round 2 adversarial
+  review of the fix above). Disowning the write bumps the generation the popup's own
+  completion message is checked against, so keeping the handle alive is only half an
+  answer: the buyer finishes signing up, the message is dropped on that check, and they get
+  an empty company field, no error, and — once the raise arms a spinner — something on
+  screen actively claiming progress. Raising a tracked popup is therefore the same explicit
+  resume as starting one, and re-stamps the token generation. Miss this and the two entry
+  points silently disagree, because the replacement-flow link re-stamps on its own path and
+  the chip does not.
 - **The raise branch is load-bearing on all of this, and is a trap when changing it.** That
   branch sits before the re-entrancy guard. It used to be reachable only with a flight of
   the current panel-open session still running — and the fix above deliberately widened

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -344,19 +344,45 @@ is not persisted here", never to a dropped payment record.
 
 - **In-flight spinner:** while the sole-trader autofill/token-fetch/signup-check
   round trip is running, keep the company-search control OPEN (don't close it) and
-  show a spinner inside the query/search input field itself — not a separate overlay.
-  Wire it to the real async duration (resolve on an actual "flight settled" event
-  fired from every terminal branch of the async call graph — success, failure,
-  retry-exhausted, abandoned), never a fixed timeout. Adversarial review on this
-  exact feature found real races on every iteration (stuck-forever spinners on two
-  different abandon/retry paths, a missing re-entrancy guard causing double signup
-  popups, a guard released too early) — budget for multiple review rounds, don't
-  expect to get this right in one pass.
+  show a spinner over the company-NAME field — not a separate overlay, and not in
+  the dropdown's query field. Wire it to the real async duration (resolve on an
+  actual "flight settled" event fired from every terminal branch of the async call
+  graph — success, failure, retry-exhausted, abandoned), never a fixed timeout.
+  Adversarial review on this exact feature found real races on every iteration
+  (stuck-forever spinners on two different abandon/retry paths, a missing
+  re-entrancy guard causing double signup popups, a guard released too early) —
+  budget for multiple review rounds, don't expect to get this right in one pass.
+  - **The NAME field, not the query field, and this was arrived at the long way
+    round.** Earlier rounds put it in the query input, which §1 does settle as
+    where an in-field spinner on ordinary company search belongs. It cannot be
+    where the sole-trader one belongs, for two independent reasons: selecting the
+    Sole trader chip hides that whole row immediately (§11 rule 2), so the spinner
+    has nowhere to paint and an earlier round had to un-hide the row for the flight
+    — which reintroduced the very bug rule 2 exists to fix; and the "select a
+    different sole trader" flow opens no dropdown at all, so it had no query field
+    to use and showed no spinner whatsoever. The name field is on screen in both
+    flows and is where the value being fetched is going to land. PrestaShop
+    `doug/two40-soletrader-spinner-rehome`.
   - **"Settled" means the popup CLOSED, not that `window.open()` returned**
     (PrestaShop `5651374`, live-reported). The spinner was clearing the instant the
     window was handed to the browser, leaving the buyer's whole signup happening
     behind an idle-looking checkout. Poll the popup handle's `.closed`, and make every
     exit path (popup close, cancel, teardown) stop that poll so no interval leaks.
+  - **…and popup-closed is still not the END of it — the WRITE is** (Doug, live,
+    PrestaShop `doug/two40-soletrader-spinner-rehome`). "Complete" is: the popup is
+    gone, AND the post-popup buyer lookup has fired and resolved, AND the company
+    name/number have been written to every field and variable that holds them.
+    Those are separate moments, and the popup one usually comes FIRST: the hosted
+    flow closes its own window as soon as it has posted its completion message, so
+    a 500ms `.closed` poll routinely wins the race against the lookup → save →
+    write chain that message starts, and the spinner dropped with the field still
+    empty. Extend the existing settle gate rather than adding a second signal
+    beside it — hold the dispatch while a lookup or a write-back is outstanding,
+    and let whichever finishes last do the dispatching. Do NOT reach for the
+    "adoption succeeded" event as the spinner's clear signal instead: it fires only
+    on the success path, so every failure and abandon would spin forever.
+    A cancel/abandon must be able to FORCE the dispatch past that gate, since the
+    generation bump it performs has already disowned whatever is still in the air.
 - **Tokens must already exist when the chip is clicked.** A chip click has exactly two
   allowed outcomes — populate a company, or open the signup popup — and a fallback
   note/link is neither (WooCommerce `df1aaa1`). Minting inside the click handler puts
@@ -590,12 +616,21 @@ than a wrong implementation of it — read both corrections before implementing 
    Three consequences that are easy to miss, all found by review rather than by
    testing the happy path:
 
-   - **Hide the query field's whole ROW, not the input.** The in-field spinner is an
-     absolutely-positioned sibling *inside* that row, so hiding the input alone
-     collapses the row to zero height and strands the spinner at its top edge. And
-     the hide has to stand down for the duration of a sole-trader flight, because
-     that same spinner in that same field IS the in-progress state the keep-open
-     window exists to show (rule 3's ordering trap lives next door to this).
+   - **Hide the query field's whole ROW, not the input.** The ordinary live-search
+     spinner is an absolutely-positioned sibling *inside* that row, so hiding the
+     input alone collapses the row to zero height and strands that spinner at its
+     top edge.
+   - **Gate the hide on the selected chip and NOTHING ELSE** (Doug, live). It has to
+     take effect on the click that selects the chip, synchronously, with no reopen
+     required — so drive it from wherever chip selection is rendered, not from the
+     panel's open handler, or it will look correct in every test that closes and
+     reopens and be wrong for the buyer who never closes anything. An earlier round
+     added a second condition — stand the hide down while a sole-trader flight is in
+     progress, because the in-flight spinner then lived in this very field — and
+     that condition WAS the bug: the chip click hid the row and un-hid it in the
+     same gesture, so a row the buyer had been told would go stayed up for the whole
+     round trip. The spinner belongs on the company-name field instead (§7); with it
+     gone, no second condition is needed and none should be added back.
    - **Something else in the panel has to take focus on open.** The open path focuses
      the query field; `.focus()` on a `display:none` element silently does nothing,
      leaving focus on the company-name field — *outside* the panel, and the panel is
@@ -628,6 +663,23 @@ than a wrong implementation of it — read both corrections before implementing 
    opposite of what "select a different" means. Shared entry points need a shared
    re-entrancy guard: the relaunch opens the popup SYNCHRONOUSLY with no guard of its
    own, so without one a double-click reliably opens two signup popups (§14).
+
+   **"The same call" means the same in-flight state too, not just the same
+   function** (Doug, live). Both entry points show the same spinner, in the same
+   place, for the same §7 duration. The first implementation shared the relaunch
+   function but gave each entry point its own loading flag and its own settle
+   listener under its own namespace — with the result that the standalone button
+   showed no spinner at all, and a chip click could open a second hosted popup over
+   a replacement flow already in flight, which is exactly what §14 forbids. One
+   flag, one listener, one spinner, for both. The single genuine difference is the
+   dropdown's open/closed state — the chip click leaves it open throughout, the
+   button never had one — and the resolution is to close the dropdown at
+   flow-complete **only if it is open**, a no-op otherwise. Not two flows; one flow
+   and one conditional. (Consequence worth stating: whatever renders/re-renders the
+   "select a different" element must NOT release that shared flag as a
+   belt-and-braces measure, because the successful adoption re-renders it
+   *mid-flight* — that release would drop the spinner just before the write it is
+   waiting for.)
 3. **Clicking back to "Registered company" keeps the dropdown OPEN with focus in the
    query field.** Unlike the other two chips, this one is not a hand-off to another
    flow — it means "stay here, search normally" — so it must not close the panel, and

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -982,6 +982,37 @@ local to either symptom.
   and it must then decide what it owes the spinner/settle bookkeeping. A raise with no
   spinner and no settle listener is not an answer.
 
+**Cross-platform: WooCommerce had one of these two gaps and its architecture rules out the
+other (WooCommerce PR #487 `7a11acb`).**
+
+- **The re-render trigger cannot reach the flow.** WooCommerce's equivalent reopen path is
+  `refresh()` → `hide()`, bound to `updated_checkout` — a coupon apply, a shipping-method
+  change, a quantity edit, not only a country change. Its mode revert is gated on nothing
+  being outstanding, and that predicate is true for as long as any popup RECORD exists, so
+  an incidental re-render cannot null popup state under a live popup. The widget-rebuild
+  paths are DOM-only and never touch popup or flight state, because the records live in a
+  module-level array rather than being torn down with the widget. The porting lesson:
+  records kept OFF the widget, plus every *derived* mode revert gated on "is anything still
+  outstanding", is what makes the platform's own re-render harmless — a single handle
+  nulled by a UI-restore function is what makes it fatal.
+- **The gesture trigger did reach it.** Every exit from sole-trader mode funnelled through
+  one function that dropped the popup records without CLOSING the windows and left the
+  autofill lookup running. So a deliberate exit — click-to-reopen on a captured field, the
+  Registered company chip, an ordinary registry pick — orphaned a still-open popup (the
+  next chip click then opened a second over it) AND let the lookup re-enter sole-trader
+  mode and re-adopt behind the buyer, credit check included. Fixed as one operation at that
+  single choke point: close the windows, THEN drop the records, then invalidate the lookup
+  through the same supersession counter the newer-flight case already used. Having exactly
+  one choke point is why this was a small fix and not a redesign — the records-not-a-handle
+  argument applies to the EXITS, not only the launches.
+- **One divergence by design, not a gap.** PrestaShop counts "the write-back has no
+  manual-entry guard" as a bug (fixed above). WooCommerce counts it as supported and pins
+  it (#486): a buyer who says "my company isn't in the registry", starts typing, then
+  corrects their email to one Two knows IS adopted, with the picker re-attached to render
+  the adopted name. The two platforms disagree here by design, not by oversight — settle it
+  the same way on both, or record why not, before porting a third platform from either one
+  alone.
+
 ## 15. Delegated-auth tokens expire while checkout sits open
 
 The tokens minted for autofill and the signup popup are short-lived. A buyer who parks

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -82,6 +82,11 @@ claim below as DOM-verified, cited by the actual structure captured live:
   already-ADOPTED identity — cancelling a signup in progress does not un-adopt a
   completed one. Derive the reopened selection from whether an identity is adopted,
   not from a mode variable the reopen path is free to clobber. Full rules in §11.
+- **Being inside the panel means every chip click is a `focusout`/`focusin` pair the
+  panel's own close machinery reacts to**, so any behaviour the panel hangs off "focus
+  left me" is a behaviour the chips silently opt out of. That is not a detail of the
+  close handler; it is a consequence of this section's nesting, and it cost three chips
+  the popup-lifetime decision — see §14's gesture rules.
 - **Chip labels are sentence case on both platforms** — "Registered company", "Sole
   trader", "Enter manually" (`1c1b3d7` aligned PrestaShop onto WooCommerce's existing
   wording; WooCommerce `f8ca174` then fixed its own last title-cased straggler,
@@ -844,6 +849,98 @@ Rules that generalise:
   adopted flag while that popup was undecided.
 - If you are writing round N+1 of a predicate over a list of popup records, stop and
   change the design. That is what this section is.
+
+**Once there is exactly one popup, decide which GESTURE closes it — in each gesture's
+own handler, never in the shared focus machinery.** Doug's rule: focus returning to the
+checkout page closes the popup, and the ONE exception is clicking the Sole trader chip,
+which means "give me that popup back" and must raise it to the front instead. Whichever
+other chip took the focus closes the popup *and* still does its own job unchanged.
+
+The trap is §0's fact — the chips are DOM children of the search panel — meeting the
+panel's own deferred close-on-focus-leaving. That close is what owns the popup
+(PrestaShop `928a84a`), and it cancels itself on any `focusin` back into the panel,
+which is exactly what a chip click produces. So all three chips escaped the popup
+decision, and which of them nevertheless closed it was decided by where its own action
+happened to leave focus afterwards (PrestaShop #176 `8c7447f`):
+
+- **"Enter manually" got the right outcome by accident** — it ends by focusing the
+  company-name field *outside* the panel, which re-scheduled a close nobody asked for.
+  Correct on screen, untested, and one refactor of that focus destination from breaking.
+- **"Registered company" left the popup up** — it focuses the query field, *inside* the
+  panel, so the close it needed was the one it cancelled.
+- **The Sole trader chip resolved to NOTHING AT ALL** — neither closing nor raising. Its
+  re-entrancy guard reads the in-flight spinner flag, and that flag stays true for the
+  popup's whole lifetime, so a re-click was swallowed before anything could raise the
+  window the buyer was asking for. The focus-the-existing-popup branch this guide already
+  credits above (`06655fb`) was live and correct, and unreachable.
+
+Rules that generalise:
+
+- Each gesture states its own answer explicitly. Three cases that differ must be
+  *structurally* distinct and readable as such, not separated by which one happens to
+  move focus where. A correct outcome you cannot point at a line for is a timing
+  accident with a good week.
+- **Gate the popup close on the PAGE having focus (`document.hasFocus()`), not on where
+  `activeElement` landed.** The rule is "focus came back to the *page*", so a focus-out
+  to another window — the popup you just raised, or another application — must leave the
+  popup alone. The first round of this fix cancelled only the close already pending when
+  the chip was clicked, and the close that the *raise itself* provokes arrives after that
+  handler has returned; what actually saved it was Chrome leaving `activeElement` on a
+  clicked `<button>` across the window deactivation. Incidental browser behaviour holding
+  up a spec rule. **Scope the guard to the popup decision only** — widening it to the
+  panel's own close changes when the panel survives an app switch, which is a separate
+  question and broke a pinned test when tried.
+- **Mutation-test this class of fix; the tests lie otherwise.** Three of the first
+  round's tests passed with the line they existed to pin deleted: two because letting
+  the deferred close run lets "Enter manually" satisfy the assertion through the old
+  accidental route, one because leaving focus on a control inside the panel means the
+  earlier `activeElement` guard returns before the code under test. Assert the handler's
+  own call *before* advancing timers, and put focus genuinely outside the panel.
+- **Report the raise as a boolean** ("was there a popup to raise?"), so the same handler
+  can fall through to an ordinary first-time launch when there was not. A void raise
+  forces the caller to keep its own second opinion about whether a popup is open, which
+  is the drift §0 warns about in a different register.
+- **Close BEFORE the cancel.** The cancel path deliberately nulls the popup handle so a
+  genuine completion survives a mere "still glancing around" reopen — so a close
+  attempted after it has no handle left and the window sits there orphaned.
+- **Wrap the `focus()`.** The hosted flow closes its own window the instant it has
+  posted `ACCEPTED`, so `closed` flipping between the check and the call is a real
+  interleaving, not a theoretical one. Nothing to raise then and nothing to report; the
+  close poll still solely owns clearing the handle and dispatching the settle.
+- **Closing the popup is not the same as cancelling the enrolment**, and a handler may
+  legitimately claim only the first. On PrestaShop "Registered company" does both;
+  "Enter manually" closes the popup and deliberately does not cancel. Whichever you
+  choose, know which one you chose — see the second known gap below for what the
+  narrower choice leaves open.
+
+**Known gaps here, documented rather than fixed (PrestaShop, as of `8c7447f`).** Both are
+pre-existing and both want the records-not-a-handle design this section argues for, rather
+than a patch; a port building fresh should start from records and never acquire either.
+
+- **A live popup goes untracked whenever the panel reopens.** Reopening calls the cancel
+  path unconditionally, which nulls the popup handle — so the window is left on screen
+  with nothing holding it, and the next Sole trader click opens a second one. Escape
+  reaches this by hand (it goes straight to the panel close and never touches the popup),
+  but the *common* trigger is not a buyer gesture at all: the platform's own address-form
+  re-render restores the panel through the same reopen path, and per §17 that event can
+  land tens of milliseconds after the click that opened the panel. The billing-country
+  change listener reaches it too. The nulling is deliberate — it is what lets a genuine
+  completion survive a mere "still glancing around" reopen — so this is a design change,
+  not a line fix.
+- **"Enter manually" closes the popup without cancelling the enrolment**, so a buyer
+  lookup already in flight can still resolve afterwards, and its write-back has no
+  manual-entry guard: it overwrites the company name the buyer is now typing by hand and
+  renders the adopted-sole-trader affordance inside manual-entry mode. The credit check
+  then runs on the identity they just walked away from — §5's write-back state machine,
+  reached through a gesture rather than a race. Escape has the same hole for the same
+  reason (the panel close never cancels either).
+- **These gaps are load-bearing for the Sole trader chip's raise branch, which is a trap
+  when fixing them.** That branch sits before the re-entrancy guard, and it is only
+  reachable today with a flight of the current panel-open session still running —
+  precisely *because* reopening nulls the handle. Close the first gap and the branch
+  becomes reachable with no flight running and an identity already adopted, at which
+  point it must decide what it owes the spinner/settle bookkeeping. A raise with no
+  spinner and no settle listener is not an answer.
 
 ## 15. Delegated-auth tokens expire while checkout sits open
 

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -930,10 +930,10 @@ Rules that generalise:
   distinguishing *who is asking* (see the re-render rule below); it is wrong for
   splitting an operation that should not be splittable.
 
-**Both gaps this section used to log as "documented rather than fixed" are now FIXED
-(PrestaShop #176 `4156ad3`).** Kept here because the *shape* of both is what a port needs
-to avoid, and because the fix is the atomic-operation rule above rather than anything
-local to either symptom.
+**Every gap this section used to log as "documented rather than fixed" is now FIXED
+(PrestaShop #176 `4156ad3`, `ffe4b53`).** Kept here because the *shape* of each is what a
+port needs to avoid, and because the fix is the atomic-operation rule above rather than
+anything local to either symptom.
 
 - **FIXED — a live popup went untracked whenever the panel reopened.** Reopening called
   the cancel path unconditionally, which nulls the popup handle — so the window was left
@@ -965,22 +965,27 @@ local to either symptom.
   the reopen deadline being armed: the buyer's own click arms that too, so a re-render
   landing in the same tick as a genuine click would be indistinguishable. An argument at
   the call site cannot be ambiguous however the timing falls.
-- **REMAINING GAP — instance teardown still discards the handle.** The platform destroys
-  and rebuilds the search instance on every address-form re-render (§17), and `destroy()`
-  cancels the enrolment to disown flights that would otherwise resolve against a replaced
-  instance. That cancel still nulls the popup handle, so the full re-render path can still
-  leave a live popup owned by nobody. Closing it there would be wrong — the enrolment
-  object is a singleton that outlives the search instance, and the buyer may be filling the
-  popup in because their shipping total recalculated behind it. The real fix is for the
-  cancel to stop discarding a handle it is not closing, which needs the settle event's
-  popup-open guard reworked with it; that is the records-not-a-handle design below.
+- **FIXED — instance teardown discarded the handle** (PrestaShop #176 `ffe4b53`). The
+  platform destroys and rebuilds the search instance on every address-form re-render (§17),
+  and `destroy()` cancels the enrolment to disown flights that would otherwise resolve
+  against a replaced instance — but that cancel also nulled the popup handle, so the full
+  re-render path left a live popup owned by nobody. Closing it there would be wrong: the
+  enrolment object is a singleton that outlives the search instance, and the buyer may be
+  filling the popup in because their shipping total recalculated behind it. So the cancel
+  now takes a flag that disowns the WRITE only (`cancelEnrollment(keepPopupTracked)`) and
+  leaves the poll and the handle alone; the settle event's popup-open guard needs no change
+  and instead becomes the mechanism, holding the spinner until the buyer's own popup closes.
+  The write staying disowned is deliberate and is the residue: an OTP completed after an
+  incidental re-render is still dropped on the generation check, as it was before.
 - **The raise branch is load-bearing on all of this, and is a trap when changing it.** That
-  branch sits before the re-entrancy guard, and is reachable only with a flight of the
-  current panel-open session still running. Anything that later leaves a popup up across a
-  panel session with no flight running — a completed, already-adopted identity, which is
-  exactly the remaining gap's shape — makes it reachable in a state it was not written for,
-  and it must then decide what it owes the spinner/settle bookkeeping. A raise with no
-  spinner and no settle listener is not an answer.
+  branch sits before the re-entrancy guard. It used to be reachable only with a flight of
+  the current panel-open session still running — and the fix above deliberately widened
+  that: a popup now outlives the instance that launched it, so a *replacement* instance
+  meets one it never started, with no flight of its own. Anything in that shape must decide
+  what it owes the spinner/settle bookkeeping, because a raise with no spinner and no settle
+  listener is not an answer — it leaves the restored panel with nothing to close it when the
+  popup finally goes. The branch therefore arms the spinner itself, which is a no-op on its
+  own re-entrancy guard in the ordinary same-session case.
 
 **Cross-platform: WooCommerce had one of these two gaps and its architecture rules out the
 other (WooCommerce PR #487 `7a11acb`).**

--- a/.ai/sole-trader-porting-guide.md
+++ b/.ai/sole-trader-porting-guide.md
@@ -900,46 +900,86 @@ Rules that generalise:
   can fall through to an ordinary first-time launch when there was not. A void raise
   forces the caller to keep its own second opinion about whether a popup is open, which
   is the drift §0 warns about in a different register.
-- **Close BEFORE the cancel.** The cancel path deliberately nulls the popup handle so a
-  genuine completion survives a mere "still glancing around" reopen — so a close
-  attempted after it has no handle left and the window sits there orphaned.
+- **Close BEFORE the cancel — and make that ordering unreachable.** The cancel path
+  deliberately nulls the popup handle, so a close attempted after it has no handle left
+  and the window sits there orphaned. Do not leave the sequence to callers; see the
+  atomic-operation rule below.
 - **Wrap the `focus()`.** The hosted flow closes its own window the instant it has
   posted `ACCEPTED`, so `closed` flipping between the check and the call is a real
   interleaving, not a theoretical one. Nothing to raise then and nothing to report; the
   close poll still solely owns clearing the handle and dispatching the settle.
-- **Closing the popup is not the same as cancelling the enrolment**, and a handler may
-  legitimately claim only the first. On PrestaShop "Registered company" does both;
-  "Enter manually" closes the popup and deliberately does not cancel. Whichever you
-  choose, know which one you chose — see the second known gap below for what the
-  narrower choice leaves open.
+- **Closure and cancellation are ONE operation, not two functions callers pair up.**
+  Doug's architectural call (PrestaShop #176 `4156ad3`), after both ways of getting the
+  pair wrong had shipped: *"the fix also requires that we make closure and enrolment
+  cancelation a single atomic operation, not two separate functions as now. It's just
+  begging to fail in some way."* It was. "Enter manually" closed without cancelling;
+  every dropdown open cancelled without closing. Neither is a bug you find by reading the
+  handler that has it — each one reads as a deliberate narrow choice, and the earlier
+  version of this very bullet blessed it as one.
 
-**Known gaps here, documented rather than fixed (PrestaShop, as of `8c7447f`).** Both are
-pre-existing and both want the records-not-a-handle design this section argues for, rather
-than a patch; a port building fresh should start from records and never acquire either.
+  So expose `abandonEnrollment()` — close, then cancel — and let every "the buyer is
+  leaving this flow" gesture call that. Keep the halves callable only for a caller that
+  genuinely wants one, and make it say why in a comment: on PrestaShop exactly two do
+  (see the remaining gap below, and the panel's focus-out close, which takes the popup
+  down without deciding anything about the enrolment because looking away is not a
+  decision). The win is not tidiness, it is that a THIRD caller cannot be added with the
+  ordering wrong or a half forgotten.
+- **Prefer one atomic operation over a skip-this-half parameter.** The first draft of the
+  re-render fix was a flag telling the reopen path not to cancel — which leaves the pair
+  separable and the next caller free to get it wrong again. A parameter is still right for
+  distinguishing *who is asking* (see the re-render rule below); it is wrong for
+  splitting an operation that should not be splittable.
 
-- **A live popup goes untracked whenever the panel reopens.** Reopening calls the cancel
-  path unconditionally, which nulls the popup handle — so the window is left on screen
-  with nothing holding it, and the next Sole trader click opens a second one. Escape
-  reaches this by hand (it goes straight to the panel close and never touches the popup),
-  but the *common* trigger is not a buyer gesture at all: the platform's own address-form
-  re-render restores the panel through the same reopen path, and per §17 that event can
-  land tens of milliseconds after the click that opened the panel. The billing-country
-  change listener reaches it too. The nulling is deliberate — it is what lets a genuine
-  completion survive a mere "still glancing around" reopen — so this is a design change,
-  not a line fix.
-- **"Enter manually" closes the popup without cancelling the enrolment**, so a buyer
-  lookup already in flight can still resolve afterwards, and its write-back has no
-  manual-entry guard: it overwrites the company name the buyer is now typing by hand and
-  renders the adopted-sole-trader affordance inside manual-entry mode. The credit check
-  then runs on the identity they just walked away from — §5's write-back state machine,
+**Both gaps this section used to log as "documented rather than fixed" are now FIXED
+(PrestaShop #176 `4156ad3`).** Kept here because the *shape* of both is what a port needs
+to avoid, and because the fix is the atomic-operation rule above rather than anything
+local to either symptom.
+
+- **FIXED — a live popup went untracked whenever the panel reopened.** Reopening called
+  the cancel path unconditionally, which nulls the popup handle — so the window was left
+  on screen with nothing holding it, and the next Sole trader click opened a second one.
+  Escape reaches this by hand (it goes straight to the panel close and never touches the
+  popup), but the *common* trigger was not a buyer gesture at all: the platform's own
+  address-form re-render restores the panel through the same reopen path, and per §17 that
+  event can land tens of milliseconds after the click that opened the panel — its XHR
+  callback is not blocked by the buyer being away in the popup window, so this fired at
+  buyers who were *looking at* the thing it cancelled. Now a buyer-initiated reopen closes
+  the popup as well as cancelling (so nothing is orphaned), and the re-render restore does
+  neither. The billing-country change listener reached this too, and now closes as well —
+  its tokens were minted against the country the buyer just left, so there is nothing to
+  finish in that window.
+- **FIXED — "Enter manually" closed the popup without cancelling the enrolment**, so a
+  buyer lookup already in flight still resolved afterwards, and its write-back has no
+  manual-entry guard: it overwrote the company name the buyer was now typing by hand and
+  rendered the adopted-sole-trader affordance inside manual-entry mode. The credit check
+  then ran on the identity they had just walked away from — §5's write-back state machine,
   reached through a gesture rather than a race. Escape has the same hole for the same
-  reason (the panel close never cancels either).
-- **These gaps are load-bearing for the Sole trader chip's raise branch, which is a trap
-  when fixing them.** That branch sits before the re-entrancy guard, and it is only
-  reachable today with a flight of the current panel-open session still running —
-  precisely *because* reopening nulls the handle. Close the first gap and the branch
-  becomes reachable with no flight running and an identity already adopted, at which
-  point it must decide what it owes the spinner/settle bookkeeping. A raise with no
+  reason (the panel close never cancels either). The chip now abandons; note the earlier
+  round's reasoning that the reopen's own cancel covered it was wrong, because that cancel
+  happens *before* the buyer can start a new flight from the reopened panel.
+- **A silent auto-restore must not inherit a buyer gesture's side effects.**
+  `restorePanelAfterRerender()` reopens a panel the platform tore down, and its doc already
+  said it "restores only what the buyer already had" — but it reached that by calling the
+  same `openDropdown()` a buyer click does, so it silently inherited the abandon. Pass the
+  distinction explicitly (`openDropdown(buyerInitiated)`), and do NOT try to infer it from
+  the reopen deadline being armed: the buyer's own click arms that too, so a re-render
+  landing in the same tick as a genuine click would be indistinguishable. An argument at
+  the call site cannot be ambiguous however the timing falls.
+- **REMAINING GAP — instance teardown still discards the handle.** The platform destroys
+  and rebuilds the search instance on every address-form re-render (§17), and `destroy()`
+  cancels the enrolment to disown flights that would otherwise resolve against a replaced
+  instance. That cancel still nulls the popup handle, so the full re-render path can still
+  leave a live popup owned by nobody. Closing it there would be wrong — the enrolment
+  object is a singleton that outlives the search instance, and the buyer may be filling the
+  popup in because their shipping total recalculated behind it. The real fix is for the
+  cancel to stop discarding a handle it is not closing, which needs the settle event's
+  popup-open guard reworked with it; that is the records-not-a-handle design below.
+- **The raise branch is load-bearing on all of this, and is a trap when changing it.** That
+  branch sits before the re-entrancy guard, and is reachable only with a flight of the
+  current panel-open session still running. Anything that later leaves a popup up across a
+  panel session with no flight running — a completed, already-adopted identity, which is
+  exactly the remaining gap's shape — makes it reachable in a state it was not written for,
+  and it must then decide what it owes the spinner/settle bookkeeping. A raise with no
   spinner and no settle listener is not an answer.
 
 ## 15. Delegated-auth tokens expire while checkout sits open

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -367,6 +367,27 @@ them. Covers the answer landing while the panel is already open, every declined-
 body shape (`success: false` and friends, all HTTP 200, so none reaches the transport
 catch), and that a negative answer is never persisted across page loads.
 
+### The sole-trader in-flight spinner: three suites, and which one is load-bearing
+
+The spinner sits over the company-NAME field, and "in flight" runs until the popup has
+closed AND the buyer lookup has resolved AND the name/number have been written. Those
+last two are what make the coverage awkward to place, so it is split deliberately:
+
+- `sole-trader-flight-settled.test.js` owns the DURATION, on the `TwoSoleTrader` side,
+  and is the load-bearing one. Note especially the test that closes the popup while the
+  write-back is still held open by hand: it asserts the settle event has NOT fired at
+  that point, which is the only assertion in the suite that fails against a
+  popup-close-only signal. Every other test here passes either way, so removing that
+  one silently removes the coverage for this rule.
+- `sole-trader-select-different.test.js` owns the shared flow: the spinner appearing for
+  the standalone-button entry point (it previously showed none), the shared re-entrancy
+  guard now refusing a chip click during a button-launched flight, and the
+  close-the-dropdown-only-if-open split between the two.
+- `sole-trader-chip-adopted-state.test.js` owns the LOCATION's consequence — the query
+  row hiding immediately on the chip click and staying hidden for the flight, driven
+  with no close/reopen in between, since a suite that reopens the panel cannot tell an
+  open-handler-only implementation from a correct one.
+
 ## Known gaps
 
 Deliberately out of scope for this suite, which covers company-search resilience and

--- a/tests/js/company-search-mode-chips.test.js
+++ b/tests/js/company-search-mode-chips.test.js
@@ -142,7 +142,7 @@ describe('clicking "Registered Company"', () => {
         const soleTraderInstance = {
             isAvailableForCurrentCountry: () => true,
             startEnrollment: jest.fn(),
-            cancelEnrollment: jest.fn()
+            abandonEnrollment: jest.fn()
         };
         global.window.TwoSoleTrader_Instance = soleTraderInstance;
 
@@ -150,67 +150,68 @@ describe('clicking "Registered Company"', () => {
         openPanel();
         panelParts().soleTrader.trigger('click');
         expect(soleTraderInstance.startEnrollment).toHaveBeenCalledTimes(1);
-        const cancelCallsBefore = soleTraderInstance.cancelEnrollment.mock.calls.length;
+        const callsBefore = soleTraderInstance.abandonEnrollment.mock.calls.length;
 
-        // Reopening ALSO calls cancelEnrollment() once, unconditionally, via
-        // openDropdown() - isolate the chip's OWN call by asserting the exact
-        // delta (+2: one from the reopen, one from the chip click), not just
-        // "more than before". A weaker assertion here would still pass even
-        // if the chip's own handler stopped calling cancelEnrollment() at
-        // all, since the reopen's call alone already satisfies
-        // `toBeGreaterThan`.
+        // Reopening ALSO abandons once, unconditionally, via openDropdown() -
+        // isolate the chip's OWN call by asserting the exact delta (one from
+        // the reopen, one from the chip click), not just "more than before". A
+        // weaker assertion here would still pass even if the chip's own
+        // handler stopped abandoning at all, since the reopen's call alone
+        // already satisfies `toBeGreaterThan`.
         $("input[name='company']").trigger('mousedown');
-        const cancelCallsAfterReopen = soleTraderInstance.cancelEnrollment.mock.calls.length;
-        expect(cancelCallsAfterReopen).toBe(cancelCallsBefore + 1);
+        const callsAfterReopen = soleTraderInstance.abandonEnrollment.mock.calls.length;
+        expect(callsAfterReopen).toBe(callsBefore + 1);
 
         panelParts().registered.trigger('click');
 
-        expect(soleTraderInstance.cancelEnrollment.mock.calls.length).toBe(cancelCallsAfterReopen + 1);
+        expect(soleTraderInstance.abandonEnrollment.mock.calls.length).toBe(callsAfterReopen + 1);
     });
 });
 
 describe('clicking "Enter Manually" while a sole-trader enrolment is active', () => {
     /**
-     * Round 2 adversarial review OBSERVATION: "Enter Manually" has no
-     * click-handler call to cancelEnrollment() of its own - only
-     * "Registered Company" and openDropdown() call it. That is safe ONLY
-     * because "Enter Manually" is unreachable except through an open panel,
-     * and every route into an open panel goes through openDropdown(), which
-     * calls cancelEnrollment() unconditionally before the chip is even
-     * visible. This test pins THAT invariant directly, so a future change
-     * that makes the panel reachable some other way (a deep link, a
-     * programmatic re-open) trips a failure here instead of silently
-     * reintroducing the cross-flow selection clobber
-     * sole-trader-generation-guard.test.js covers.
+     * This test used to pin the OPPOSITE, and was wrong to (Doug, TWO-40
+     * follow-up). A round-2 review observed that "Enter Manually" had no
+     * cancel of its own and reasoned it was safe because the chip is
+     * unreachable except through an open panel, and openDropdown() cancels
+     * before the chip is even visible. The reopen's cancel does happen - but
+     * it happens BEFORE the buyer clicks this chip, so it cannot disown a
+     * lookup the buyer sets going afterwards by clicking Sole trader from the
+     * reopened panel. That flight resolved into adoptSoleTraderBuyer(), which
+     * has no manual-entry guard, over a name the buyer had typed by hand.
+     *
+     * So the chip now abandons on its own account, and what is pinned is that
+     * it does so on the CLICK - the timing the earlier invariant could not
+     * give.
      */
-    test('cancelEnrollment has already been called by the time the chip is clickable', () => {
+    test('abandons the flow on the click itself, not only via the earlier reopen', () => {
         const soleTraderInstance = {
             isAvailableForCurrentCountry: () => true,
             startEnrollment: jest.fn(),
-            cancelEnrollment: jest.fn()
+            abandonEnrollment: jest.fn()
         };
         global.window.TwoSoleTrader_Instance = soleTraderInstance;
 
         makeInstance();
-        // The FIRST open already calls cancelEnrollment() once too
-        // (openDropdown() calls it unconditionally, even with nothing to
-        // cancel yet) - baseline against that rather than assuming zero.
+        // The FIRST open already abandons once too (openDropdown() does it
+        // unconditionally, even with nothing to cancel yet) - baseline against
+        // that rather than assuming zero.
         openPanel();
-        const callsAfterFirstOpen = soleTraderInstance.cancelEnrollment.mock.calls.length;
+        const callsAfterFirstOpen = soleTraderInstance.abandonEnrollment.mock.calls.length;
         panelParts().soleTrader.trigger('click');
-        expect(soleTraderInstance.cancelEnrollment.mock.calls.length).toBe(callsAfterFirstOpen);
+        expect(soleTraderInstance.abandonEnrollment.mock.calls.length).toBe(callsAfterFirstOpen);
 
-        // The only way back to a clickable "Enter Manually" is reopening the
-        // panel - which must have already cancelled the enrolment BEFORE
-        // this click fires.
+        // Reopen, then start a SECOND enrolment from the reopened panel - the
+        // flight the reopen's own abandon cannot possibly have covered.
         $("input[name='company']").trigger('mousedown');
-        const callsAfterReopen = soleTraderInstance.cancelEnrollment.mock.calls.length;
-        expect(callsAfterReopen).toBe(callsAfterFirstOpen + 1);
+        panelParts().soleTrader.trigger('click');
+        expect(soleTraderInstance.startEnrollment).toHaveBeenCalledTimes(2);
+        const callsBeforeChip = soleTraderInstance.abandonEnrollment.mock.calls.length;
 
+        $("input[name='company']").trigger('mousedown');
         panelParts().notListed.trigger('click');
 
-        // The click itself adds nothing further - proving the safety came
-        // from the reopen, not from "Enter Manually" doing its own cancel.
-        expect(soleTraderInstance.cancelEnrollment.mock.calls.length).toBe(callsAfterReopen);
+        // Two: the reopen's, and the chip's own.
+        expect(soleTraderInstance.abandonEnrollment.mock.calls.length).toBe(callsBeforeChip + 2);
     });
 });

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -42,6 +42,13 @@ function stubSoleTrader(available) {
         startEnrollment: jest.fn(),
         cancelEnrollment: jest.fn(),
         closeSignupPopup: jest.fn(),
+        // The atomic "buyer is leaving this flow" pair (TWO-40 follow-up,
+        // Doug). Stubbed as ONE fn, not as a composition of the two above:
+        // what belongs to TwoCompanySearch is which operation each gesture
+        // picks. That it really does close before cancelling is
+        // TwoSoleTrader's own contract, pinned against the real module in
+        // sole-trader-abandon-enrollment.test.js.
+        abandonEnrollment: jest.fn(),
         // "Was there a popup to raise?" - false is the no-popup-open default,
         // and the tests that need one still up flip it (see soleTraderPopupOpen()).
         focusSignupPopup: jest.fn(() => false)
@@ -360,13 +367,14 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         popupOpen(soleTrader);
         soleTrader.closeSignupPopup.mockClear();
         soleTrader.focusSignupPopup.mockClear();
+        soleTrader.abandonEnrollment.mockClear();
     }
 
     test.each([
-        ['soleTrader', false, true, 'the one exception - raises the popup, never closes it'],
-        ['registered', true, false, 'closes the popup, keeps the panel'],
-        ['notListed', true, false, 'closes the popup, hands off to manual entry']
-    ])('%s: closed=%s raised=%s - %s', (chip, closed, raised) => {
+        ['soleTrader', false, true, 'the one exception - raises the popup, never abandons'],
+        ['registered', true, false, 'abandons the flow, keeps the panel'],
+        ['notListed', true, false, 'abandons the flow, hands off to manual entry']
+    ])('%s: abandoned=%s raised=%s - %s', (chip, abandoned, raised) => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         launchThenPopupOpen(soleTrader);
@@ -376,11 +384,14 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         // adversarial review finding, mutation-proved): letting it run lets
         // "Enter manually" satisfy this through the OLD accidental route -
         // enterManualEntryMode() focuses the company-name field, re-schedules
-        // a close, and that close calls closeSignupPopup(). The assertion then
-        // passes with the chip's own call deleted, which is precisely the line
-        // this table exists to pin. Asserted synchronously, only the handler's
-        // own call can have happened.
-        expect(soleTrader.closeSignupPopup.mock.calls.length > 0).toBe(closed);
+        // a close, and that close closes the popup. Asserted synchronously,
+        // only the handler's own call can have happened.
+        //
+        // On abandonEnrollment() rather than closeSignupPopup(), which also
+        // shuts that accidental route out by construction: the deferred close
+        // only ever takes the popup down, never the enrolment with it, so it
+        // cannot satisfy this column however the timers are advanced.
+        expect(soleTrader.abandonEnrollment.mock.calls.length > 0).toBe(abandoned);
         expect(soleTrader.focusSignupPopup.mock.calls.length > 0).toBe(raised);
     });
 
@@ -491,7 +502,7 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
      * #5.2. Closing the popup must not cost the chip its own job - "stay here,
      * search normally" still means the query row is back and focused.
      */
-    test('Registered company: closes the popup AND still shows and focuses the query field', () => {
+    test('Registered company: abandons the flow AND still shows and focuses the query field', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         launchThenPopupOpen(soleTrader);
@@ -499,29 +510,35 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         panelParts().registered.trigger('click');
         jest.advanceTimersByTime(10);
 
-        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.abandonEnrollment).toHaveBeenCalledTimes(1);
         expect(shown(panelParts().searchRow)).toBe(true);
         expect(document.activeElement).toBe(panelParts().query.get(0));
         expect(shown(panelParts().panel)).toBe(true);
     });
 
     /**
-     * The ordering that makes #5.2 work at all: cancelEnrollment() nulls
-     * TwoSoleTrader's popup handle - deliberately, so a genuine completion
-     * survives a mere reopen - so a close attempted after it has no handle left
-     * and the window would sit there orphaned.
+     * The ordering that makes #5.2 work at all - close BEFORE cancel, because
+     * the cancel nulls the popup handle - is no longer any caller's to get
+     * right: it lives inside abandonEnrollment() (Doug, TWO-40 follow-up,
+     * "closure and enrolment cancelation [must be] a single atomic operation,
+     * not two separate functions as now"). Pinned against the real
+     * implementation in sole-trader-abandon-enrollment.test.js.
+     *
+     * What is pinned HERE is that this handler no longer takes the two halves
+     * itself, in any order. A future edit reaching for the pair directly is
+     * the failure mode the merge exists to stop, so it fails here.
      */
-    test('Registered company: closes the popup BEFORE cancelling, while a handle still exists', () => {
+    test('Registered company: goes through the atomic pair, never the halves', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         launchThenPopupOpen(soleTrader);
 
-        const order = [];
-        soleTrader.closeSignupPopup.mockImplementation(() => order.push('close'));
-        soleTrader.cancelEnrollment.mockImplementation(() => order.push('cancel'));
+        soleTrader.cancelEnrollment.mockClear();
         panelParts().registered.trigger('click');
 
-        expect(order).toEqual(['close', 'cancel']);
+        expect(soleTrader.abandonEnrollment).toHaveBeenCalledTimes(1);
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(soleTrader.cancelEnrollment).not.toHaveBeenCalled();
     });
 
     /**
@@ -529,8 +546,15 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
      * via enterManualEntryMode() focusing the company-name field OUTSIDE the
      * panel and re-scheduling a close nobody asked for. Pinned here on the
      * chip's own call, together with the effects that must survive it.
+     *
+     * The ENROLMENT half is the bug Doug found (TWO-40 follow-up): this chip
+     * used to close the popup and leave the enrolment running, so a lookup
+     * already in flight still resolved into adoptSoleTraderBuyer() and
+     * overwrote the name the buyer had just typed by hand. That the abandon
+     * really does stop such a resolution is pinned on the real modules in
+     * sole-trader-abandon-enrollment.test.js.
      */
-    test('Enter manually: closes the popup AND still switches to manual entry', () => {
+    test('Enter manually: abandons the flow AND still switches to manual entry', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         launchThenPopupOpen(soleTrader);
@@ -539,7 +563,7 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         // Same reason as the table above: the chip's OWN call is the claim, and
         // it is only distinguishable from the deferred close's before the
         // timers run.
-        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.abandonEnrollment).toHaveBeenCalledTimes(1);
 
         jest.advanceTimersByTime(10);
         expect(shown(panelParts().panel)).toBe(false);
@@ -583,11 +607,11 @@ describe('reopening search cancels a pending enrolment (TWO-40)', () => {
     test('opening the dropdown again cancels an in-progress sole-trader enrolment', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
-        // openDropdown() unconditionally calls cancelEnrollment() on every
+        // openDropdown() abandons unconditionally on every buyer-initiated
         // open - cheap and idempotent when nothing was pending - so this
         // baselines against the FIRST open rather than asserting zero calls.
         openPanel();
-        const callsBeforeEnrolling = soleTrader.cancelEnrollment.mock.calls.length;
+        const callsBeforeEnrolling = soleTrader.abandonEnrollment.mock.calls.length;
         panelParts().soleTrader.trigger('click');
         expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
 
@@ -595,6 +619,68 @@ describe('reopening search cancels a pending enrolment (TWO-40)', () => {
         // company field again - rather than completing the sole-trader flow.
         openPanel();
 
-        expect(soleTrader.cancelEnrollment.mock.calls.length).toBe(callsBeforeEnrolling + 1);
+        expect(soleTrader.abandonEnrollment.mock.calls.length).toBe(callsBeforeEnrolling + 1);
+    });
+
+    /**
+     * The other side of that rule, and the bug Doug found (TWO-40 follow-up):
+     * an address-form re-render restores a panel the buyer already had, which
+     * says nothing about their intent - so it must NOT abandon. It used to,
+     * and because the cancel nulls TwoSoleTrader's popup handle without
+     * closing the window, that left a live popup tracked by nothing, from
+     * where the Sole trader chip would open a SECOND one (guide §14).
+     *
+     * Not a focus event and not blocked by one: PrestaShop fires
+     * `updatedAddressForm` for shipping recalculations whose XHR callback runs
+     * with the buyer looking at the popup in another window.
+     */
+    test('a re-render restore leaves an in-flight enrolment and its popup alone', () => {
+        const soleTrader = stubSoleTrader(true);
+        const instance = makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        soleTrader.focusSignupPopup.mockReturnValue(true);
+        soleTrader.abandonEnrollment.mockClear();
+        soleTrader.closeSignupPopup.mockClear();
+        soleTrader.cancelEnrollment.mockClear();
+
+        // Arm the window the re-render restore runs inside, exactly as the
+        // `updatedAddressForm` handler does for a panel that was open.
+        TwoCompanySearch._reopenPanelUntil = Date.now() + 1000;
+        instance.restorePanelAfterRerender();
+
+        // Neither the pair nor either half - the popup is still the buyer's,
+        // and still TwoSoleTrader's to track.
+        expect(soleTrader.abandonEnrollment).not.toHaveBeenCalled();
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(soleTrader.cancelEnrollment).not.toHaveBeenCalled();
+        // Still tracked, so the Sole trader chip raises that popup rather than
+        // opening a second one beside it.
+        expect(shown(panelParts().panel)).toBe(true);
+        soleTrader.focusSignupPopup.mockClear();
+        panelParts().soleTrader.trigger('click');
+        expect(soleTrader.focusSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * The restore path is told what it is, rather than inferring it from
+     * `_reopenPanelUntil` being armed - which the buyer's OWN click arms too
+     * (setupAddressFormListener()). So a re-render landing in the same tick as
+     * a genuine click cannot make one look like the other: this is the genuine
+     * click, inside an armed window, and it still abandons.
+     */
+    test('a buyer-initiated open inside the re-render window still abandons', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        soleTrader.focusSignupPopup.mockReturnValue(true);
+        soleTrader.abandonEnrollment.mockClear();
+
+        TwoCompanySearch._reopenPanelUntil = Date.now() + 1000;
+        openPanel();
+
+        expect(soleTrader.abandonEnrollment).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -664,6 +664,51 @@ describe('reopening search cancels a pending enrolment (TWO-40)', () => {
     });
 
     /**
+     * The FULL re-render path, which is the one that used to still orphan the
+     * window (guide §14): the checkout manager destroys this instance and
+     * builds a replacement, and destroy()'s cancel is what disowns a flight
+     * that would otherwise resolve against an instance owning no fields. It
+     * must disown the WRITE only - `cancelEnrollment(true)` - because the buyer
+     * may be filling that popup in right now.
+     *
+     * The consequence is the second half: the replacement instance meets a live
+     * popup it never launched, so its Sole trader chip has to raise that window
+     * AND pick up the spinner/settle bookkeeping the destroyed instance took
+     * with it. Without the spinner there is no listener left to close the
+     * restored panel when the popup finally goes.
+     */
+    test('destroy() keeps the popup for the replacement instance, which raises it rather than opening a second', () => {
+        const soleTrader = stubSoleTrader(true);
+        const instance = makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        soleTrader.focusSignupPopup.mockReturnValue(true);
+        // Baselined rather than asserted at zero: the buyer-initiated open
+        // above abandons unconditionally, as every one of them does.
+        soleTrader.cancelEnrollment.mockClear();
+        soleTrader.abandonEnrollment.mockClear();
+        soleTrader.closeSignupPopup.mockClear();
+
+        instance.destroy();
+
+        // The cancel half only, and told to keep the handle.
+        expect(soleTrader.cancelEnrollment.mock.calls).toEqual([[true]]);
+        expect(soleTrader.abandonEnrollment).not.toHaveBeenCalled();
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+
+        const replacement = makeInstance();
+        TwoCompanySearch._reopenPanelUntil = Date.now() + 1000;
+        replacement.restorePanelAfterRerender();
+        soleTrader.focusSignupPopup.mockClear();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.focusSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(true);
+    });
+
+    /**
      * The restore path is told what it is, rather than inferring it from
      * `_reopenPanelUntil` being armed - which the buyer's OWN click arms too
      * (setupAddressFormListener()). So a re-render landing in the same tick as

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -41,7 +41,10 @@ function stubSoleTrader(available) {
         isAvailableForCurrentCountry: jest.fn(() => available),
         startEnrollment: jest.fn(),
         cancelEnrollment: jest.fn(),
-        closeSignupPopup: jest.fn()
+        closeSignupPopup: jest.fn(),
+        // "Was there a popup to raise?" - false is the no-popup-open default,
+        // and the tests that need one still up flip it (see soleTraderPopupOpen()).
+        focusSignupPopup: jest.fn(() => false)
     };
     global.window.TwoSoleTrader_Instance = instance;
     return instance;
@@ -312,36 +315,6 @@ describe('focus returning to the checkout page abandons the flow (TWO-40 follow-
     });
 
     /**
-     * The same focus-out, caused by the buyer clicking a DIFFERENT chip on the
-     * panel. The pending close is cancelled by the `focusin` that chip's own
-     * handler produces when it puts focus back in the query field, so the
-     * popup-close must not run either - "Registered Company" means "stay here,
-     * search normally", and it owns what happens to the flow (endSoleTraderLoading()
-     * then cancelEnrollment()).
-     *
-     * Whether it should ALSO take an abandoned popup down is a separate
-     * question, deliberately not answered here: its route is
-     * cancelEnrollment(), which openDropdown() calls on every open and which
-     * TwoSoleTrader.js documents as "still glancing around" rather than
-     * "abandoned".
-     */
-    test('a focus-out from clicking a different chip leaves the popup to that chip handler', () => {
-        const soleTrader = stubSoleTrader(true);
-        makeInstance();
-        openPanel();
-        panelParts().soleTrader.trigger('click');
-
-        const { panel, registered } = panelParts();
-        panel.trigger('focusout');
-        registered.trigger('click');
-        jest.advanceTimersByTime(10);
-
-        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
-        expect(soleTrader.cancelEnrollment).toHaveBeenCalled();
-        expect(shown(panelParts().panel)).toBe(true);
-    });
-
-    /**
      * The second layer of the same guard, and the one that makes the popup
      * close's PLACEMENT matter: a focus-out whose deferred close does run, but
      * finds focus settled on a control inside the panel. Nothing has been
@@ -361,6 +334,178 @@ describe('focus returning to the checkout page abandons the flow (TWO-40 follow-
         expect(document.activeElement).toBe(registered.get(0));
         expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
         expect(shown(panelParts().panel)).toBe(true);
+    });
+});
+
+describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug spec)', () => {
+    /**
+     * The rule: focus returning to the checkout closes the popup, and the ONLY
+     * exception is the Sole trader chip, which raises it to the front instead.
+     *
+     * Every chip now says so in its own handler. Before this, none of the three
+     * reached the popup by intent: the deferred close is cancelled by the
+     * `focusin` a chip click produces, so whether a chip closed the popup was
+     * decided by whether its own action happened to push focus out of the panel
+     * again - which "Enter manually" does (the company-name field) and
+     * "Registered company" does not (the query field, inside the panel).
+     */
+    function popupOpen(soleTrader) {
+        soleTrader.focusSignupPopup.mockReturnValue(true);
+    }
+
+    /** Launch the flow so a popup is notionally up, then clear the bookkeeping. */
+    function launchThenPopupOpen(soleTrader) {
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        popupOpen(soleTrader);
+        soleTrader.closeSignupPopup.mockClear();
+        soleTrader.focusSignupPopup.mockClear();
+    }
+
+    test.each([
+        ['soleTrader', false, true, 'the one exception - raises the popup, never closes it'],
+        ['registered', true, false, 'closes the popup, keeps the panel'],
+        ['notListed', true, false, 'closes the popup, hands off to manual entry']
+    ])('%s: closed=%s raised=%s - %s', (chip, closed, raised) => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        panelParts()[chip].trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup.mock.calls.length > 0).toBe(closed);
+        expect(soleTrader.focusSignupPopup.mock.calls.length > 0).toBe(raised);
+    });
+
+    /**
+     * #5.1. The gap was not "closed the popup when it should not have" - it was
+     * that the click resolved to NOTHING: `_soleTraderLoading` stays true for
+     * the popup's whole lifetime, so the re-entrancy guard swallowed the click
+     * before anything could raise the window the buyer was asking for.
+     */
+    test('Sole trader: raises the popup, keeps the panel open, and stays the selected chip', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        const { soleTrader: chip } = panelParts();
+        chip.trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.focusSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(panelParts().soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
+        // No second enrolment either - the popup on screen IS the flight.
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * A pending deferred close must not survive the raise: the popup taking
+     * focus is itself "focus settled outside the panel", which is exactly the
+     * condition scheduleDropdownClose() closes the popup on.
+     */
+    test('Sole trader: a close already scheduled by this click\'s own focus-out does not fire', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        const { panel, soleTrader: chip } = panelParts();
+        panel.trigger('focusout');
+        chip.trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(shown(panelParts().panel)).toBe(true);
+    });
+
+    /**
+     * #5.2. Closing the popup must not cost the chip its own job - "stay here,
+     * search normally" still means the query row is back and focused.
+     */
+    test('Registered company: closes the popup AND still shows and focuses the query field', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        panelParts().registered.trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
+        expect(shown(panelParts().searchRow)).toBe(true);
+        expect(document.activeElement).toBe(panelParts().query.get(0));
+        expect(shown(panelParts().panel)).toBe(true);
+    });
+
+    /**
+     * The ordering that makes #5.2 work at all: cancelEnrollment() nulls
+     * TwoSoleTrader's popup handle - deliberately, so a genuine completion
+     * survives a mere reopen - so a close attempted after it has no handle left
+     * and the window would sit there orphaned.
+     */
+    test('Registered company: closes the popup BEFORE cancelling, while a handle still exists', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        const order = [];
+        soleTrader.closeSignupPopup.mockImplementation(() => order.push('close'));
+        soleTrader.cancelEnrollment.mockImplementation(() => order.push('cancel'));
+        panelParts().registered.trigger('click');
+
+        expect(order).toEqual(['close', 'cancel']);
+    });
+
+    /**
+     * "Enter manually" reached the same outcome before this change, but only
+     * via enterManualEntryMode() focusing the company-name field OUTSIDE the
+     * panel and re-scheduling a close nobody asked for. Pinned here on the
+     * chip's own call, together with the effects that must survive it.
+     */
+    test('Enter manually: closes the popup AND still switches to manual entry', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        panelParts().notListed.trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup.mock.calls.length).toBeGreaterThanOrEqual(1);
+        expect(shown(panelParts().panel)).toBe(false);
+        expect(panelParts().nameField.attr('readonly')).toBeUndefined();
+        expect(document.activeElement).toBe(panelParts().nameField.get(0));
+    });
+
+    /**
+     * The no-popup-open case for the one chip that behaves differently: with
+     * nothing to raise, the Sole trader chip must still be an ordinary chip.
+     */
+    test('Sole trader with no popup open starts an enrolment as before', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.focusSignupPopup).toHaveBeenCalledTimes(1);
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Fail-soft against an older TwoSoleTrader.js that has no focusSignupPopup()
+     * - twopayment.js loads the two modules independently, and the panel must
+     * not lose its chip behaviour to a missing method.
+     */
+    test('a TwoSoleTrader without focusSignupPopup() still gets an ordinary chip click', () => {
+        const soleTrader = stubSoleTrader(true);
+        delete soleTrader.focusSignupPopup;
+        makeInstance();
+        openPanel();
+
+        panelParts().soleTrader.trigger('click');
+
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -127,14 +127,19 @@ describe('activation', () => {
     });
 
     /**
-     * TWO-40 round 4, Doug's explicit request: "keep the company search
-     * control open, show spinner in query field" for the duration of the
-     * Sole Trader autofill round trip. Driven by the REAL settle event
+     * TWO-40 round 4, Doug's explicit request: keep the company search
+     * control open, with a spinner, for the duration of the Sole Trader
+     * autofill round trip. Driven by the REAL settle event
      * TwoSoleTrader.js's notifyEnrollmentSettled() fires (see
      * TwoSoleTrader.js), not a fixed timeout - the panel must stay open for
      * however long the actual call takes, and no longer.
+     *
+     * The spinner is on the company-NAME field, not the query field (TWO-40
+     * follow-up, Doug). The query field's whole row is hidden the instant
+     * this chip is selected, so a spinner in it would have nowhere to paint;
+     * and the name field is where the value being fetched is going to land.
      */
-    test('clicking it starts sole-trader enrolment, keeps the panel open with the query-field spinner, and only closes when the flight settles', () => {
+    test('clicking it starts sole-trader enrolment, keeps the panel open with the name-field spinner, and only closes when the flight settles', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         openPanel();
@@ -144,18 +149,22 @@ describe('activation', () => {
 
         expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
         expect(shown(panelParts().panel)).toBe(true);
-        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(true);
+        expect(shown(panelParts().nameSpinner)).toBe(true);
+        // And NOT in the query field it used to live in - that row is gone.
+        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(false);
 
         // No fixed timeout closes it - it would still be open five seconds
         // later if the real call were still out.
         jest.advanceTimersByTime(5000);
         expect(shown(panelParts().panel)).toBe(true);
-        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+        expect(shown(panelParts().nameSpinner)).toBe(true);
 
         document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
 
         expect(shown(panelParts().panel)).toBe(false);
-        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(false);
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(false);
+        expect(shown(panelParts().nameSpinner)).toBe(false);
     });
 
     test('does nothing destructive if TwoSoleTrader_Instance is missing, and still closes (after a paint) rather than dead-ending open', () => {

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -40,7 +40,8 @@ function stubSoleTrader(available) {
     const instance = {
         isAvailableForCurrentCountry: jest.fn(() => available),
         startEnrollment: jest.fn(),
-        cancelEnrollment: jest.fn()
+        cancelEnrollment: jest.fn(),
+        closeSignupPopup: jest.fn()
     };
     global.window.TwoSoleTrader_Instance = instance;
     return instance;
@@ -276,6 +277,90 @@ describe('activation', () => {
         expect(soleTrader.hasClass('two-company-mode-chip--selected')).toBe(true);
         expect(registered.hasClass('two-company-mode-chip--selected')).toBe(false);
         expect(notListed.hasClass('two-company-mode-chip--selected')).toBe(false);
+    });
+});
+
+describe('focus returning to the checkout page abandons the flow (TWO-40 follow-up, Doug live test)', () => {
+    /**
+     * Doug's live finding: the spinner stopped and the panel closed when the
+     * buyer clicked back onto the checkout page with the hosted signup popup
+     * still open, but the popup itself stayed on screen. All three go together.
+     *
+     * Driven with a real focusable element outside the panel rather than
+     * `<body>`, for the same reason company-search-dropdown.test.js's own
+     * focus-out tests are: jsdom will not make `<body>` the activeElement, so
+     * the guard this has to get PAST would hold vacuously.
+     */
+    test('closes the hosted signup popup, and not only the panel and the spinner', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        expect(soleTrader.startEnrollment).toHaveBeenCalledTimes(1);
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+
+        const outside = $("input[name='dni']").get(0);
+        outside.focus();
+        panelParts().panel.trigger('focusout');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
+        // The two that already worked before this fix - asserted separately so
+        // a regression in either is not mistaken for the popup one.
+        expect(shown(panelParts().panel)).toBe(false);
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(false);
+    });
+
+    /**
+     * The same focus-out, caused by the buyer clicking a DIFFERENT chip on the
+     * panel. The pending close is cancelled by the `focusin` that chip's own
+     * handler produces when it puts focus back in the query field, so the
+     * popup-close must not run either - "Registered Company" means "stay here,
+     * search normally", and it owns what happens to the flow (endSoleTraderLoading()
+     * then cancelEnrollment()).
+     *
+     * Whether it should ALSO take an abandoned popup down is a separate
+     * question, deliberately not answered here: its route is
+     * cancelEnrollment(), which openDropdown() calls on every open and which
+     * TwoSoleTrader.js documents as "still glancing around" rather than
+     * "abandoned".
+     */
+    test('a focus-out from clicking a different chip leaves the popup to that chip handler', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+
+        const { panel, registered } = panelParts();
+        panel.trigger('focusout');
+        registered.trigger('click');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(soleTrader.cancelEnrollment).toHaveBeenCalled();
+        expect(shown(panelParts().panel)).toBe(true);
+    });
+
+    /**
+     * The second layer of the same guard, and the one that makes the popup
+     * close's PLACEMENT matter: a focus-out whose deferred close does run, but
+     * finds focus settled on a control inside the panel. Nothing has been
+     * abandoned, so neither the panel nor the popup may go.
+     */
+    test('a deferred close that finds focus still inside the panel closes neither the panel nor the popup', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+
+        const { panel, registered } = panelParts();
+        registered.get(0).focus();
+        panel.triggerHandler('focusout');
+        jest.advanceTimersByTime(10);
+
+        expect(document.activeElement).toBe(registered.get(0));
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        expect(shown(panelParts().panel)).toBe(true);
     });
 });
 

--- a/tests/js/company-search-sole-trader-entry.test.js
+++ b/tests/js/company-search-sole-trader-entry.test.js
@@ -372,8 +372,14 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         launchThenPopupOpen(soleTrader);
 
         panelParts()[chip].trigger('click');
-        jest.advanceTimersByTime(10);
-
+        // NOT advanced past the deferred close, deliberately (round 2
+        // adversarial review finding, mutation-proved): letting it run lets
+        // "Enter manually" satisfy this through the OLD accidental route -
+        // enterManualEntryMode() focuses the company-name field, re-schedules
+        // a close, and that close calls closeSignupPopup(). The assertion then
+        // passes with the chip's own call deleted, which is precisely the line
+        // this table exists to pin. Asserted synchronously, only the handler's
+        // own call can have happened.
         expect(soleTrader.closeSignupPopup.mock.calls.length > 0).toBe(closed);
         expect(soleTrader.focusSignupPopup.mock.calls.length > 0).toBe(raised);
     });
@@ -402,22 +408,83 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
     });
 
     /**
-     * A pending deferred close must not survive the raise: the popup taking
-     * focus is itself "focus settled outside the panel", which is exactly the
-     * condition scheduleDropdownClose() closes the popup on.
+     * A close ALREADY PENDING when the chip is clicked must not survive the
+     * raise - it would close the popup the click just asked for.
+     *
+     * Driven with focus genuinely OUTSIDE the panel (round 2 adversarial review
+     * finding, mutation-proved): with focus left on a control inside the panel,
+     * scheduleDropdownClose()'s own activeElement guard returns first and the
+     * test passes with the `clearTimeout` deleted, pinning nothing.
      */
-    test('Sole trader: a close already scheduled by this click\'s own focus-out does not fire', () => {
+    test('Sole trader: a close already pending when the chip is clicked does not fire', () => {
         const soleTrader = stubSoleTrader(true);
         makeInstance();
         launchThenPopupOpen(soleTrader);
 
-        const { panel, soleTrader: chip } = panelParts();
-        panel.trigger('focusout');
-        chip.trigger('click');
+        $("input[name='dni']").get(0).focus();
+        panelParts().panel.trigger('focusout');
+        panelParts().soleTrader.trigger('click');
         jest.advanceTimersByTime(10);
 
         expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
         expect(shown(panelParts().panel)).toBe(true);
+    });
+
+    /**
+     * The close the RAISE itself provokes, which the `clearTimeout` above
+     * cannot reach: the popup taking focus fires its focus-out after the chip
+     * handler has already returned, so that close is scheduled with nothing
+     * left to cancel it.
+     *
+     * What stops it is the checkout page no longer having focus at all - the
+     * direct form of Doug's rule ("if I move focus back to the page the popup
+     * should be closed"), rather than the browser incidentally leaving
+     * `activeElement` on the clicked chip, which is what the first round
+     * actually relied on.
+     */
+    test('Sole trader: the close provoked by the raise itself does not fire either', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        panelParts().soleTrader.trigger('click');
+        // The popup now holds focus, and the page's own activeElement is
+        // OUTSIDE the panel - which is the whole point of this test. With it
+        // left on the clicked chip, scheduleDropdownClose()'s activeElement
+        // guard returns first and this passes with the hasFocus() guard
+        // deleted (caught by re-running the mutation: Chrome retaining focus
+        // on a clicked `<button>` is exactly the incidental behaviour round 1
+        // leaned on, so a test that reproduces it pins nothing).
+        $("input[name='dni']").get(0).focus();
+        jest.spyOn(document, 'hasFocus').mockReturnValue(false);
+        panelParts().panel.trigger('focusout');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).not.toHaveBeenCalled();
+        // The PANEL is not asserted here. Its close keeps its existing meaning
+        // - focus left it, so it goes - and narrowing the new guard to the
+        // popup decision alone is deliberate: widening it to the panel too
+        // changes when the panel survives an app switch, which is neither
+        // asked for nor covered by the spec.
+    });
+
+    /**
+     * The other half of that guard, and the case Doug listed as case 4: focus
+     * coming back to the checkout page itself still closes the popup, with no
+     * chip involved.
+     */
+    test('focus returning to the page with the page focused still closes the popup', () => {
+        const soleTrader = stubSoleTrader(true);
+        makeInstance();
+        launchThenPopupOpen(soleTrader);
+
+        jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+        $("input[name='dni']").get(0).focus();
+        panelParts().panel.trigger('focusout');
+        jest.advanceTimersByTime(10);
+
+        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
+        expect(shown(panelParts().panel)).toBe(false);
     });
 
     /**
@@ -469,9 +536,12 @@ describe('a chip clicked while the signup popup is open (TWO-40 follow-up, Doug 
         launchThenPopupOpen(soleTrader);
 
         panelParts().notListed.trigger('click');
-        jest.advanceTimersByTime(10);
+        // Same reason as the table above: the chip's OWN call is the claim, and
+        // it is only distinguishable from the deferred close's before the
+        // timers run.
+        expect(soleTrader.closeSignupPopup).toHaveBeenCalledTimes(1);
 
-        expect(soleTrader.closeSignupPopup.mock.calls.length).toBeGreaterThanOrEqual(1);
+        jest.advanceTimersByTime(10);
         expect(shown(panelParts().panel)).toBe(false);
         expect(panelParts().nameField.attr('readonly')).toBeUndefined();
         expect(document.activeElement).toBe(panelParts().nameField.get(0));

--- a/tests/js/ps-harness.js
+++ b/tests/js/ps-harness.js
@@ -888,6 +888,12 @@ function panelParts() {
         // trader chip is selected, since the spinner is a sibling inside it.
         searchRow: $('.two-company-dropdown__search'),
         results: $('.two-company-dropdown__results'),
+        // The company-NAME field and the sole-trader in-flight spinner that
+        // now sits over it (TWO-40 follow-up). Outside the panel, unlike
+        // everything else here, and deliberately so: the spinner has to serve
+        // the "Select a different sole trader" flow, which opens no panel.
+        nameField: $("input[name='company']"),
+        nameSpinner: $('.two-company-name-spinner'),
         // The three-chip mode selector (TWO-40 design revision).
         modeChips: $('.two-company-mode-chips'),
         notListed: $('.two-company-not-listed'),

--- a/tests/js/sole-trader-abandon-enrollment.test.js
+++ b/tests/js/sole-trader-abandon-enrollment.test.js
@@ -1,0 +1,280 @@
+/**
+ * TWO-40 follow-up: closing the hosted signup popup and cancelling the
+ * enrolment behind it are ONE operation, abandonEnrollment().
+ *
+ * Doug's architectural call, after finding both ways of getting the pair wrong
+ * already shipped: "the fix also requires that we make closure and enrolment
+ * cancelation a single atomic operation, not two separate functions as now.
+ * It's just begging to fail in some way." The "Enter manually" chip closed and
+ * never cancelled, so a lookup still in flight resolved into a company name the
+ * buyer had since typed by hand; openDropdown() cancelled and never closed,
+ * leaving a live popup on screen tracked by nothing.
+ *
+ * These tests are on the REAL TwoSoleTrader, not a stub: the whole point of the
+ * merge is that the ordering and the effects are the module's own contract
+ * rather than something each caller re-derives. Which gesture picks which
+ * operation is TwoCompanySearch's, and lives in
+ * company-search-sole-trader-entry.test.js.
+ */
+
+'use strict';
+
+const {
+    loadSoleTrader,
+    buildPaymentTile,
+    buildAddressForm,
+    flushPromises
+} = require('./ps-harness');
+
+let TwoSoleTrader;
+
+function build(overrides) {
+    return new TwoSoleTrader(Object.assign({
+        checkoutHost: 'https://api.example.test',
+        orderIntentUrl: 'https://shop.example.test/module/twopayment/orderintent',
+        ajaxToken: 'test-token',
+        billingCountry: 'GB'
+    }, overrides || {}));
+}
+
+/** A manager stub recording every publish, the way TwoCompanySearch's real one does. */
+function stubManager() {
+    const publishes = [];
+    global.window.TwoCheckoutManager_Instance = {
+        setConfirmedCompanySelection(selection) {
+            publishes.push(selection);
+        }
+    };
+    return publishes;
+}
+
+/**
+ * A popup window that behaves like the real one in the one way that matters
+ * here: `close()` flips `closed`, so a second close is observably a no-op and
+ * an attempt to close a handle that was already discarded never reaches it.
+ */
+function fakePopup() {
+    const popup = {
+        closed: false,
+        closeCalls: 0,
+        close() {
+            this.closeCalls += 1;
+            this.closed = true;
+        },
+        focus: jest.fn()
+    };
+    return popup;
+}
+
+/**
+ * Answer the availability request "available", so the constructor's own
+ * refreshAvailability() does not read as "country ineligible" and abandon the
+ * very enrolment under test. Same reasoning as
+ * sole-trader-generation-guard.test.js's identical stub.
+ */
+function stubFetch(handlers) {
+    global.window.fetch = (url) => {
+        const target = String(url);
+        if (target.includes('soleTraderAvailability')) {
+            return Promise.resolve({ json: () => Promise.resolve({ success: true, available: true }) });
+        }
+        const matched = Object.keys(handlers).find((key) => target.includes(key));
+        if (matched) {
+            return handlers[matched](target);
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ success: true }) });
+    };
+    global.fetch = global.window.fetch;
+}
+
+const TOKENS = {
+    success: true,
+    autofill_token: 'af-token',
+    delegation_token: 'del-token',
+    signup_url: 'https://signup.example.test/',
+    country: 'GB'
+};
+
+/**
+ * Stand the flow up with a popup actually open.
+ *
+ * On the ADDRESS-FORM page, deliberately: with no `.two-sole-trader` container
+ * a no-match lookup opens the popup straight away, where the payment tile would
+ * stop at a prompt the buyer has to click first
+ * (sole-trader-containerless-popup.test.js). Fewer moving parts between the
+ * enrolment starting and a real handle existing to abandon.
+ */
+async function enrolWithPopupOpen() {
+    document.body.innerHTML = '';
+    buildAddressForm();
+    const popup = fakePopup();
+    global.window.open = jest.fn(() => popup);
+    stubFetch({
+        soleTraderTokens: () => Promise.resolve({ json: () => Promise.resolve(TOKENS) }),
+        '/autofill/v1/buyer/current': () => Promise.resolve({ ok: false, status: 404 })
+    });
+
+    const instance = build();
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(global.window.open).toHaveBeenCalledTimes(1);
+    expect(instance._popup).toBe(popup);
+    return { instance: instance, popup: popup };
+}
+
+beforeEach(() => {
+    buildPaymentTile();
+    TwoSoleTrader = loadSoleTrader();
+});
+
+afterEach(() => {
+    delete global.window.TwoCheckoutManager_Instance;
+    delete global.window.open;
+    delete global.fetch;
+    delete global.window.fetch;
+    delete global.window.TwoCompanyNumber;
+    document.body.innerHTML = '';
+    global.window.localStorage.clear();
+});
+
+/**
+ * The ordering, pinned on the EFFECT rather than on call order: cancelEnrollment()
+ * discards the popup handle, so a close attempted after it cannot reach the
+ * window at all. `closeCalls` is therefore 1 only if the close really did run
+ * while a handle still existed - which is the whole reason the pair cannot be
+ * left to callers to sequence.
+ */
+test('abandonEnrollment() closes the popup while a handle still exists, then cancels', async () => {
+    const { instance, popup } = await enrolWithPopupOpen();
+    const generationBefore = instance._enrollGeneration;
+
+    instance.abandonEnrollment();
+
+    // The close reached the real window...
+    expect(popup.closeCalls).toBe(1);
+    expect(popup.closed).toBe(true);
+    // ...and the cancel really ran after it, not instead of it.
+    expect(instance._popup).toBeNull();
+    expect(instance._enrollGeneration).toBe(generationBefore + 1);
+    expect(instance.enrolling).toBe(false);
+
+    instance.destroy();
+});
+
+/**
+ * The re-render half of the same bug (Doug, TWO-40 follow-up), from this side:
+ * an address-form re-render restores a panel without abandoning, so the popup
+ * must still be THIS instance's to close and raise afterwards. Pinned on the
+ * handle rather than on who called what - a nulled handle is exactly what left
+ * a live window owned by nobody.
+ */
+test('an enrolment nobody abandoned keeps its popup handle, closable and raisable', async () => {
+    const { instance, popup } = await enrolWithPopupOpen();
+
+    expect(instance._popup).toBe(popup);
+    expect(instance.focusSignupPopup()).toBe(true);
+    expect(popup.focus).toHaveBeenCalledTimes(1);
+    expect(popup.closeCalls).toBe(0);
+
+    // And it is still the handle a later abandon closes.
+    instance.abandonEnrollment();
+    expect(popup.closeCalls).toBe(1);
+
+    instance.destroy();
+});
+
+/**
+ * The mutation this file exists to catch: swap the two lines inside
+ * abandonEnrollment() and the window is never closed, because the handle is
+ * gone by the time the close is attempted. Asserted as the difference between
+ * the pair and the halves-in-the-wrong-order, on the same instance shape.
+ */
+test('cancelling first would leave the window open - which is why the pair is one call', async () => {
+    const { instance, popup } = await enrolWithPopupOpen();
+
+    instance.cancelEnrollment();
+    instance.closeSignupPopup();
+
+    // Nothing closed it, and nothing is tracking it any more: a live window on
+    // screen owned by nobody, from where the Sole trader chip would open a
+    // SECOND one (guide §14).
+    expect(popup.closeCalls).toBe(0);
+    expect(popup.closed).toBe(false);
+    expect(instance._popup).toBeNull();
+
+    instance.destroy();
+});
+
+/**
+ * The buyer-facing half of bug 2 (Doug, TWO-40 follow-up), end to end on the
+ * real module: "Enter manually" used to close the popup and leave the enrolment
+ * running, so a buyer lookup already in flight still resolved and published the
+ * sole-trader identity - over the company name the buyer had typed by hand, with
+ * the order-intent credit check then running against the identity they walked
+ * away from.
+ *
+ * Asserted on the publish, not on the generation counter: the counter is the
+ * mechanism, the silent overwrite is the bug.
+ */
+test('a lookup in flight when the buyer abandons publishes nothing afterwards', async () => {
+    const publishes = stubManager();
+    global.window.TwoCompanyNumber = { forDisplay: (v) => v };
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='buyer@example.test' />");
+
+    let resolveBuyerLookup;
+    stubFetch({
+        soleTraderTokens: () => Promise.resolve({ json: () => Promise.resolve(TOKENS) }),
+        '/autofill/v1/buyer/current': () => new Promise((resolve) => { resolveBuyerLookup = resolve; })
+    });
+
+    const instance = build();
+    // The lookup this starts never resolves until this test says so - it is
+    // what is still in the air when the buyer gives up on the flow.
+    instance.startEnrollment();
+    await flushPromises();
+    await flushPromises();
+    expect(typeof resolveBuyerLookup).toBe('function');
+
+    // The buyer clicks "Enter manually" and types their own company name.
+    instance.abandonEnrollment();
+    publishes.length = 0;
+
+    resolveBuyerLookup({
+        ok: true,
+        json: () => Promise.resolve({
+            email: 'buyer@example.test',
+            company_name: 'Sole Trader AS',
+            organization_number: '923456789'
+        })
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(publishes).toEqual([]);
+
+    instance.destroy();
+});
+
+/**
+ * The pair is idempotent and safe with nothing open - every caller fires it
+ * unconditionally rather than testing for a popup first (openDropdown() on
+ * every buyer-initiated open, both chips on every click).
+ */
+test('abandonEnrollment() with no popup and no enrolment is a no-op that still disowns', () => {
+    stubFetch({});
+    const instance = build();
+    const generationBefore = instance._enrollGeneration;
+
+    instance.abandonEnrollment();
+    instance.abandonEnrollment();
+
+    // The generation bump is unconditional by design (cancelEnrollment()'s own
+    // comment): a lookup can be in flight with `enrolling` already false.
+    expect(instance._enrollGeneration).toBe(generationBefore + 2);
+    expect(instance._popup).toBeNull();
+
+    instance.destroy();
+});

--- a/tests/js/sole-trader-abandon-enrollment.test.js
+++ b/tests/js/sole-trader-abandon-enrollment.test.js
@@ -209,6 +209,56 @@ test('cancelling first would leave the window open - which is why the pair is on
 });
 
 /**
+ * The other half of the same rule (guide §14): a caller that is NOT a buyer
+ * gesture and does NOT close the window - TwoCompanySearch.destroy(), which the
+ * platform fires on every address-form re-render - disowns the write and keeps
+ * the popup. The buyer may be filling that popup in right now because their
+ * shipping total recalculated behind it.
+ *
+ * The mutation this catches is dropping the argument: every assertion below
+ * fails against a cancel that nulls the handle, and the pair of them is what
+ * "owned by nobody" actually meant - nothing polling it, and nothing able to
+ * close or raise it afterwards.
+ */
+test('cancelEnrollment(true) disowns the write but keeps the popup tracked', async () => {
+    jest.useFakeTimers();
+    const settles = [];
+    const onSettled = () => settles.push(true);
+    document.addEventListener('two:sole-trader-flight-settled', onSettled);
+    try {
+        const { instance, popup } = await enrolWithPopupOpen();
+        const generationBefore = instance._enrollGeneration;
+
+        instance.cancelEnrollment(true);
+
+        // The write is disowned...
+        expect(instance._enrollGeneration).toBe(generationBefore + 1);
+        expect(instance.enrolling).toBe(false);
+        // ...and the window is not.
+        expect(instance._popup).toBe(popup);
+        expect(instance._popupPollInterval).not.toBeNull();
+        expect(popup.closeCalls).toBe(0);
+        // The live-popup guard still sees it, so the next Sole trader click
+        // raises this window instead of opening a SECOND one over it.
+        expect(instance.openPopup()).toBe(popup);
+        expect(global.window.open).toHaveBeenCalledTimes(1);
+        // Held back by notifyEnrollmentSettled()'s popup-open guard, which is
+        // the point: nothing has been taken away from the buyer, so their own
+        // close is what settles the flight.
+        expect(settles.length).toBe(0);
+
+        popup.closed = true;
+        jest.advanceTimersByTime(500);
+        expect(settles.length).toBe(1);
+
+        instance.destroy();
+    } finally {
+        document.removeEventListener('two:sole-trader-flight-settled', onSettled);
+        jest.useRealTimers();
+    }
+});
+
+/**
  * The buyer-facing half of bug 2 (Doug, TWO-40 follow-up), end to end on the
  * real module: "Enter manually" used to close the popup and leave the enrolment
  * running, so a buyer lookup already in flight still resolved and published the

--- a/tests/js/sole-trader-abandon-enrollment.test.js
+++ b/tests/js/sole-trader-abandon-enrollment.test.js
@@ -259,6 +259,58 @@ test('cancelEnrollment(true) disowns the write but keeps the popup tracked', asy
 });
 
 /**
+ * The consequence of that survival, and the round-2 adversarial review finding
+ * it produced: the cancel bumps `_enrollGeneration`, so the popup it leaves
+ * behind is one the message listener would drop on its generation check. The
+ * buyer raising it is an explicit resume - the same statement
+ * startEnrollment()/startReplacement() re-stamp for - so the raise re-stamps
+ * too, or a buyer who completes signup after a shipping recalculation gets
+ * nothing written and no error, with a spinner over it saying otherwise.
+ *
+ * Asserted on the publish rather than on the counters: the stamp is the
+ * mechanism, the silently dropped completion is the bug.
+ */
+test('a popup kept across a teardown still completes once the buyer raises it', async () => {
+    const publishes = stubManager();
+    global.window.TwoCompanyNumber = { forDisplay: (v) => v };
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='buyer@example.test' />");
+    const { instance, popup } = await enrolWithPopupOpen();
+
+    // The address form re-renders under the buyer - a shipping recalculation,
+    // not a gesture - so the search instance is torn down and rebuilt.
+    instance.cancelEnrollment(true);
+
+    // The buyer clicks Sole trader again: "give me that popup back".
+    expect(instance.focusSignupPopup()).toBe(true);
+    expect(instance._tokensGeneration).toBe(instance._enrollGeneration);
+
+    // ...and finishes signing up in it.
+    stubFetch({
+        '/autofill/v1/buyer/current': () => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+                email: 'buyer@example.test',
+                company_name: 'Sole Trader AS',
+                organization_number: '923456789'
+            })
+        })
+    });
+    window.dispatchEvent(new window.MessageEvent('message', {
+        data: 'ACCEPTED',
+        origin: 'https://signup.example.test'
+    }));
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(publishes.length).toBe(1);
+    expect(publishes[0].company).toBe('Sole Trader AS');
+    expect(popup.closeCalls).toBe(0);
+
+    instance.destroy();
+});
+
+/**
  * The buyer-facing half of bug 2 (Doug, TWO-40 follow-up), end to end on the
  * real module: "Enter manually" used to close the popup and leave the enrolment
  * running, so a buyer lookup already in flight still resolved and published the

--- a/tests/js/sole-trader-chip-adopted-state.test.js
+++ b/tests/js/sole-trader-chip-adopted-state.test.js
@@ -266,17 +266,58 @@ describe('query input suppressed while Sole Trader is selected (item 2)', () => 
         instance.destroy();
     });
 
-    test('the field stays visible for the flight of a FIRST sole-trader click, spinner and all', () => {
+    /**
+     * The direct reversal of what this test asserted for one round (Doug,
+     * TWO-40 follow-up): the row used to be un-hidden again for the duration
+     * of the flight, because the in-flight spinner lived inside it. The
+     * spinner has moved to the company-name field, and the rule is now that
+     * the hide is a pure function of the selected chip - "gate on mode alone,
+     * nothing else". A regression here means someone reintroduced a second
+     * condition in syncQueryFieldSuppression().
+     */
+    test('the row is hidden IMMEDIATELY by the chip click, and stays hidden for the flight', () => {
+        const instance = makeInstance();
+        stubSoleTrader();
+        openPanel();
+        expect(shown(panelParts().searchRow)).toBe(true);
+
+        panelParts().soleTrader.trigger('click');
+
+        // Synchronous with the click - no reopen needed, and the flight this
+        // same click just started does not buy the row a reprieve.
+        expect(shown(panelParts().searchRow)).toBe(false);
+        expect(shown(panelParts().query)).toBe(false);
+        // The panel is still open around it, and the spinner is on the name
+        // field where it can actually be seen.
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(shown(panelParts().nameSpinner)).toBe(true);
+
+        instance.destroy();
+    });
+
+    /**
+     * The reopen-independence half of the same rule. `openPanel()` is what
+     * ran syncQueryFieldSuppression() in the version of this code where the
+     * sync was only reachable from the open path, so a test that closes and
+     * reopens cannot tell the two implementations apart - this one never
+     * closes the panel at all, and drives the mode purely from clicks.
+     */
+    test('the row hides and returns on chip clicks alone, with no close or reopen in between', () => {
         const instance = makeInstance();
         stubSoleTrader();
         openPanel();
 
         panelParts().soleTrader.trigger('click');
+        expect(shown(panelParts().searchRow)).toBe(false);
+        expect(shown(panelParts().panel)).toBe(true);
 
-        // Round 4's keep-open window: the spinner lives IN this field, so
-        // hiding the row for the duration would leave nothing to spin.
-        expect(shown(panelParts().query)).toBe(true);
-        expect(panelParts().query.hasClass('two-company-search-loading')).toBe(true);
+        panelParts().registered.trigger('click');
+        expect(shown(panelParts().searchRow)).toBe(true);
+        expect(shown(panelParts().panel)).toBe(true);
+
+        panelParts().soleTrader.trigger('click');
+        expect(shown(panelParts().searchRow)).toBe(false);
+        expect(shown(panelParts().panel)).toBe(true);
 
         instance.destroy();
     });

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -194,6 +194,121 @@ test('a genuine OTP completion settles the buyer lookup but withholds the spinne
     document.removeEventListener('two:sole-trader-flight-settled', handler);
 });
 
+/**
+ * The OPPOSITE ordering to the test above, and the common one in a real
+ * browser: the hosted flow closes its own window as soon as it has posted
+ * 'ACCEPTED', so the 500ms popup poll routinely observes `closed` while the
+ * getCurrentBuyer() -> saveCompany -> adoptEnrolledIdentity() chain that
+ * message started is still in the air.
+ *
+ * Doug's definition of complete (TWO-40 follow-up) is popup closed AND the
+ * lookup resolved AND the company name/number written - all three, not the
+ * first one. The buyer watches a spinner over the company-name field for
+ * exactly this duration, and settling at popup-close dropped it while the
+ * field was still empty.
+ *
+ * This test is written to FAIL against a popup-close-only settle: the
+ * assertion right after `popup.closed = true` is the whole point of it, and
+ * the ordering assertion at the end is what stops the two events being
+ * "eventually both true" in an order nobody checked.
+ */
+test('the popup closing does NOT settle the flight while the write-back is still out - the write does', async () => {
+    buildPaymentTile();
+    global.window.TwoCompanyNumber = { forDisplay: (v) => v };
+
+    const order = [];
+    global.window.TwoCheckoutManager_Instance = {
+        setConfirmedCompanySelection: () => {},
+        companySearch: {
+            adoptSoleTraderBuyer: () => {
+                order.push('write');
+                return true;
+            }
+        }
+    };
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='order-contact@example.test' />");
+
+    const popup = { closed: false };
+    global.window.open = jest.fn(() => popup);
+
+    // Held open so the popup can close first, then released by hand.
+    let releaseSave;
+    const savePending = new Promise((resolve) => { releaseSave = resolve; });
+
+    let buyerLookupCalls = 0;
+    stubFetch({
+        buyer: () => {
+            buyerLookupCalls += 1;
+            if (buyerLookupCalls === 1) {
+                return Promise.resolve({ ok: false, status: 404 });
+            }
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({
+                    email: 'sole-trader-real-account@example.test',
+                    company_name: 'Sole Trader AS',
+                    organization_number: '923456789'
+                })
+            });
+        },
+        save: () => savePending.then(() => ({ json: () => Promise.resolve({ success: true }) }))
+    });
+
+    const calls = [];
+    const handler = () => { calls.push(true); order.push('settle'); };
+    document.addEventListener('two:sole-trader-flight-settled', handler);
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+            expect(calls.length).toBe(1);
+
+            document.querySelector('.two-sole-trader__prompt')
+                .dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+            expect(instance._popup).toBe(popup);
+
+            window.dispatchEvent(new window.MessageEvent('message', {
+                data: 'ACCEPTED',
+                origin: 'https://signup.example.test'
+            }));
+            await flushPromises();
+            await flushPromises();
+
+            // The lookup came back and applyBuyer() is now waiting on
+            // saveCompany - nothing has been written yet.
+            expect(order).not.toContain('write');
+
+            // The hosted flow closes its window here, BEFORE the write lands.
+            popup.closed = true;
+            jest.advanceTimersByTime(500);
+            await flushPromises();
+
+            // The assertion this test exists for. Popup gone, poll fired,
+            // and the flight is still NOT settled.
+            expect(calls.length).toBe(1);
+
+            releaseSave();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(calls.length).toBe(2);
+            // And in this order, not merely both eventually true.
+            expect(order).toEqual(['settle', 'write', 'settle']);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
 test('a failed token mint fires the settle event', async () => {
     buildPaymentTile();
     stubFetch({ tokens: () => Promise.resolve({ json: () => Promise.resolve({ success: false }) }) });

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -195,6 +195,88 @@ test('a genuine OTP completion settles the buyer lookup but withholds the spinne
 });
 
 /**
+ * TWO-40 follow-up, Doug live test: focus coming back to the checkout page has
+ * to take the hosted signup popup down with the panel and the spinner.
+ * TwoCompanySearch.js only ASKS for that (scheduleDropdownClose()); the close
+ * is this module's, since it holds the handle window.open() returned.
+ *
+ * The settle must still come from watchPopupUntilClosed()'s poll - the one
+ * owner it already had - not from a second dispatch on the close itself, or
+ * an abandon would settle a flight whose write-back may still be in the air.
+ */
+test('closeSignupPopup() closes a still-open popup, and leaves the settle to the poll that owns it', async () => {
+    buildPaymentTile();
+    document.body.insertAdjacentHTML('beforeend', "<input name='email' value='order-contact@example.test' />");
+
+    const popup = {
+        closed: false,
+        close: jest.fn(() => { popup.closed = true; })
+    };
+    global.window.open = jest.fn(() => popup);
+    stubFetch({ buyer: () => Promise.resolve({ ok: false, status: 404 }) });
+    const { calls, handler } = recordSettled();
+
+    jest.useFakeTimers();
+    try {
+        const instance = build();
+        try {
+            instance.startEnrollment();
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            document.querySelector('.two-sole-trader__prompt')
+                .dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+            expect(instance._popup).toBe(popup);
+            const settlesBefore = calls.length;
+
+            instance.closeSignupPopup();
+
+            expect(popup.close).toHaveBeenCalledTimes(1);
+            // Nothing settled yet: the poll has not run, and this method
+            // deliberately does not dispatch on its own.
+            expect(calls.length).toBe(settlesBefore);
+
+            jest.advanceTimersByTime(500);
+
+            expect(calls.length).toBe(settlesBefore + 1);
+            expect(instance._popup).toBe(null);
+        } finally {
+            instance.destroy();
+        }
+    } finally {
+        jest.useRealTimers();
+    }
+    document.removeEventListener('two:sole-trader-flight-settled', handler);
+});
+
+/**
+ * The abandon can land on a window that is already gone - the buyer closed it
+ * by hand, or the hosted flow closed it itself the moment it posted
+ * 'ACCEPTED', which is the ordinary ordering (see the test below). Both must
+ * be no-ops rather than a throw that takes the panel close down with it.
+ */
+test('closeSignupPopup() is a safe no-op with no popup, or one that has already gone', async () => {
+    buildPaymentTile();
+    stubFetch({});
+
+    const instance = build();
+    try {
+        expect(instance._popup).toBe(null);
+        expect(() => instance.closeSignupPopup()).not.toThrow();
+
+        const alreadyClosed = { closed: true, close: jest.fn() };
+        instance._popup = alreadyClosed;
+        instance.closeSignupPopup();
+
+        expect(alreadyClosed.close).not.toHaveBeenCalled();
+    } finally {
+        instance.destroy();
+    }
+    await flushPromises();
+});
+
+/**
  * The OPPOSITE ordering to the test above, and the common one in a real
  * browser: the hosted flow closes its own window as soon as it has posted
  * 'ACCEPTED', so the 500ms popup poll routinely observes `closed` while the

--- a/tests/js/sole-trader-flight-settled.test.js
+++ b/tests/js/sole-trader-flight-settled.test.js
@@ -251,6 +251,74 @@ test('closeSignupPopup() closes a still-open popup, and leaves the settle to the
 });
 
 /**
+ * focusSignupPopup() is closeSignupPopup()'s opposite number, for the ONE
+ * gesture that means "give me that popup back" - re-clicking the Sole trader
+ * chip. It reports whether there WAS a popup to raise, so TwoCompanySearch can
+ * tell that from "nothing open" and fall through to an ordinary launch.
+ *
+ * The throw case is not defensive padding: the hosted flow closes its own
+ * window the instant it has posted 'ACCEPTED', so `closed` flipping between
+ * the check and the call is a real interleaving. It must report false rather
+ * than propagate - a raise nobody can perform is not a failure worth taking
+ * the chip handler down with.
+ */
+test.each([
+    [() => null, false, false, 'no popup was ever opened'],
+    [() => ({ closed: true, focus: jest.fn() }), false, false, 'the popup has already gone'],
+    [() => ({ closed: false, focus: jest.fn() }), true, true, 'a live popup is raised'],
+    [() => ({ closed: false, focus: jest.fn(() => { throw new Error('gone'); }) }), false, true,
+        'the window went away between the check and the raise'],
+])('focusSignupPopup(): raised=%s called=%s when %s', (makePopup, raised, called) => {
+    buildPaymentTile();
+    stubFetch({});
+
+    const instance = build();
+    try {
+        const popup = makePopup();
+        instance._popup = popup;
+
+        expect(instance.focusSignupPopup()).toBe(raised);
+        if (popup) {
+            expect(popup.focus.mock.calls.length > 0).toBe(called);
+            // Never clears the handle - watchPopupUntilClosed()'s poll is the
+            // one owner of that, and of the settle it dispatches.
+            expect(instance._popup).toBe(popup);
+        }
+    } finally {
+        instance.destroy();
+    }
+});
+
+/**
+ * openPopup()'s never-open-over-a-live-window guard is gated on the window
+ * being live, NOT on the raise succeeding (round 2 adversarial review finding).
+ * A focus() that throws must still return the existing handle: falling through
+ * would window.open() a second popup and retarget `this._popup` onto it,
+ * orphaning the first untracked - the exact failure that guard exists for
+ * (guide §14).
+ */
+test('openPopup() returns the live popup even when raising it throws, rather than opening a second', () => {
+    buildPaymentTile();
+    stubFetch({});
+
+    const instance = build();
+    try {
+        const popup = {
+            closed: false,
+            focus: jest.fn(() => { throw new Error('gone'); })
+        };
+        instance._popup = popup;
+        instance.tokens = { signup_url: 'https://signup.example.test/', delegation_token: 'd', autofill_token: 'a' };
+        global.window.open = jest.fn();
+
+        expect(instance.openPopup()).toBe(popup);
+        expect(global.window.open).not.toHaveBeenCalled();
+    } finally {
+        instance.destroy();
+    }
+});
+
+/**
  * The abandon can land on a window that is already gone - the buyer closed it
  * by hand, or the hosted flow closed it itself the moment it posted
  * 'ACCEPTED', which is the ordinary ordering (see the test below). Both must

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -336,28 +336,37 @@ describe('popup URL (c)', () => {
 });
 
 describe('country change abandons an in-flight replacement flow (e, round-2 review finding)', () => {
-    test('changing the billing country calls TwoSoleTrader_Instance.cancelEnrollment()', () => {
+    test('changing the billing country calls TwoSoleTrader_Instance.abandonEnrollment()', () => {
         const instance = makeSearchInstance();
         instance.adoptSoleTraderBuyer(NAMED_BUYER);
 
+        // The POPUP goes with the enrolment here (TWO-40 follow-up): its
+        // tokens were minted against the country the buyer just left, so
+        // cancelling without closing left a window up that nothing could
+        // complete and nothing was tracking.
+        const abandonEnrollment = jest.fn();
         const cancelEnrollment = jest.fn();
         global.window.TwoSoleTrader_Instance = {
             startReplacement: jest.fn(),
-            cancelEnrollment: cancelEnrollment
+            cancelEnrollment: cancelEnrollment,
+            abandonEnrollment: abandonEnrollment
         };
 
         // Simulate the buyer having clicked "Select a different sole
         // trader" (a mint/lookup is now conceptually in flight for the OLD
         // country) - this test targets the country-change listener itself,
         // not startReplacement(), so the click is not required to exercise
-        // the fix; the point is that cancelEnrollment() fires REGARDLESS of
+        // the fix; the point is that the abandon fires REGARDLESS of
         // whether a flow is actually in flight, exactly like the
         // "Registered Company" chip handler and openDropdown() already do.
         const countryField = document.querySelector("select[name='id_country']");
         expect(countryField).not.toBeNull();
         countryField.dispatchEvent(new window.Event('change', { bubbles: true }));
 
-        expect(cancelEnrollment).toHaveBeenCalledTimes(1);
+        expect(abandonEnrollment).toHaveBeenCalledTimes(1);
+        // Through the atomic pair, not the halves - see
+        // sole-trader-abandon-enrollment.test.js.
+        expect(cancelEnrollment).not.toHaveBeenCalled();
 
         instance.destroy();
     });

--- a/tests/js/sole-trader-select-different.test.js
+++ b/tests/js/sole-trader-select-different.test.js
@@ -19,7 +19,11 @@ const {
     loadCompanySearch,
     loadSoleTrader,
     buildAddressForm,
-    flushPromises
+    flushPromises,
+    installStylesheet,
+    panelParts,
+    shown,
+    openPanel
 } = require('./ps-harness');
 
 const CHECKOUT_HOST = 'https://api.example.test';
@@ -377,5 +381,137 @@ describe('destroy() abandons an in-flight replacement flow too (f, round-3 revie
         instance.destroy();
 
         expect(cancelEnrollment).toHaveBeenCalledTimes(1);
+    });
+});
+
+/**
+ * TWO-40 follow-up, Doug: the replacement flow gets the SAME in-flight
+ * spinner, in the SAME place, for the SAME duration as the Sole trader chip's
+ * first-time enrolment - it previously showed none at all, so a buyer who
+ * clicked "Select a different sole trader" got an idle-looking checkout while
+ * tokens were minted and a popup was opened.
+ *
+ * Both entry points now run through beginSoleTraderLoading(). The only
+ * difference between them is whether a dropdown happens to be open, and that
+ * is resolved by closing it only if it is - never by a second code path.
+ */
+describe('the shared in-flight spinner (TWO-40 follow-up)', () => {
+    let sheet;
+
+    beforeEach(() => {
+        sheet = installStylesheet('views/css/two.css');
+    });
+
+    afterEach(() => {
+        if (sheet && sheet.parentNode) {
+            sheet.parentNode.removeChild(sheet);
+        }
+    });
+
+    test('clicking the link paints the spinner over the company-NAME field, and holds it until the flight completes', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        global.window.TwoSoleTrader_Instance = { startReplacement: jest.fn() };
+
+        expect(shown(panelParts().nameSpinner)).toBe(false);
+
+        document.querySelector('.two-company-select-different-sole-trader')
+            .dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(true);
+        expect(shown(panelParts().nameSpinner)).toBe(true);
+        // Over the name field, not somewhere else in the form: a sibling
+        // inside the same wrapper, positioned against the input's own row.
+        expect(panelParts().nameSpinner.parent().hasClass('two-company-field-wrap')).toBe(true);
+
+        // Held for the WHOLE round trip - which for this flow spans a token
+        // mint, a popup, and the write-back after it. Only the settle event
+        // ends it, and TwoSoleTrader.js withholds that until the company name
+        // and number have actually been written (see
+        // sole-trader-flight-settled.test.js).
+        document.dispatchEvent(new window.CustomEvent('two:sole-trader-flight-settled'));
+
+        expect(panelParts().nameField.hasClass('two-company-name-loading')).toBe(false);
+        expect(shown(panelParts().nameSpinner)).toBe(false);
+
+        instance.destroy();
+    });
+
+    /**
+     * Doug's own resolution of the one real difference between the two entry
+     * points: hide the dropdown at flow-complete ONLY IF it is open, a no-op
+     * otherwise. The link click never had one open, so the settle must not run
+     * closeDropdown()'s side effects - of which yanking focus back to the
+     * company field is the one a buyer would actually feel, since by then they
+     * may well have tabbed on.
+     */
+    test('completing a link-launched flight does not run a close on a dropdown that was never open', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        global.window.TwoSoleTrader_Instance = { startReplacement: jest.fn() };
+
+        document.querySelector('.two-company-select-different-sole-trader')
+            .dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        const elsewhere = document.querySelector("input[name='vat_number']")
+            || document.querySelector("input[name='dni']");
+        expect(elsewhere).not.toBeNull();
+        elsewhere.focus();
+
+        document.dispatchEvent(new window.CustomEvent('two:sole-trader-flight-settled'));
+
+        // Spinner gone - the flight really did settle, so this is not just
+        // "nothing happened at all".
+        expect(shown(panelParts().nameSpinner)).toBe(false);
+        // But focus stayed where the buyer put it.
+        expect(document.activeElement).toBe(elsewhere);
+
+        instance.destroy();
+    });
+
+    test('completing a chip-launched flight DOES close the dropdown the chip left open', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        global.window.TwoSoleTrader_Instance = { startReplacement: jest.fn() };
+
+        openPanel();
+        expect(shown(panelParts().panel)).toBe(true);
+
+        // Re-clicking the chip while adopted routes into the SAME call the
+        // link uses (see the adopted-state suite) - the dropdown being open
+        // is the only thing that differs.
+        panelParts().soleTrader.trigger('click');
+        expect(shown(panelParts().panel)).toBe(true);
+        expect(shown(panelParts().nameSpinner)).toBe(true);
+
+        document.dispatchEvent(new window.CustomEvent('two:sole-trader-flight-settled'));
+
+        expect(shown(panelParts().panel)).toBe(false);
+        expect(shown(panelParts().nameSpinner)).toBe(false);
+
+        instance.destroy();
+    });
+
+    /**
+     * The guard is now shared between the two entry points, which is a real
+     * behaviour change and the one guide §14 asks for: one hosted popup at a
+     * time, whichever control asked for it.
+     */
+    test('a link click is refused while a chip-launched flight is still in progress, and vice versa', () => {
+        const instance = makeSearchInstance();
+        instance.adoptSoleTraderBuyer(NAMED_BUYER);
+        const startReplacement = jest.fn();
+        global.window.TwoSoleTrader_Instance = { startReplacement: startReplacement };
+
+        openPanel();
+        panelParts().soleTrader.trigger('click');
+        expect(startReplacement).toHaveBeenCalledTimes(1);
+
+        document.querySelector('.two-company-select-different-sole-trader')
+            .dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(startReplacement).toHaveBeenCalledTimes(1);
+
+        instance.destroy();
     });
 });

--- a/views/css/two.css
+++ b/views/css/two.css
@@ -612,6 +612,47 @@
 }
 
 /*
+ * The sole-trader in-flight spinner (TWO-40 follow-up, Doug): shown over the
+ * company-NAME field for the whole round trip, from the click that starts it
+ * until the name and number have actually been written.
+ *
+ * It used to be the dropdown row's own spinner, which cannot work now that
+ * selecting the Sole trader chip hides that row immediately, and which the
+ * "Select a different sole trader" flow could not use at all - it opens no
+ * panel. Same 16px loader as `.two-company-dropdown__spinner`, same
+ * right-hand lane, one field further out.
+ *
+ * Height comes from `--two-company-input-height`, not from the wrapper: the
+ * wrapper also carries the org-number hint and the "select a different sole
+ * trader" button below the input, so `100%` here would centre the spinner
+ * somewhere under the field. Same variable, and the same reason, as the
+ * dropdown panel's own `top` below - ensureFieldWrapper() keeps it current.
+ */
+.two-company-name-spinner {
+    display: none;
+    position: absolute;
+    top: 0;
+    right: 8px;
+    width: 16px;
+    height: var(--two-company-input-height, 100%);
+    background: url('../img/loader.gif') no-repeat center center;
+    background-size: 16px 16px;
+    pointer-events: none;
+}
+
+/* Deliberately NOT also qualified on `.two-company-search-input`, the way
+   `.two-company-dropdown__query`'s spinner rule is on its own field. That
+   marker class is applied only once the dropdown is known to have built
+   (setupAutocomplete()), and it is skipped entirely on the fallback where the
+   panel failed to build - a state the "Select a different sole trader" flow
+   still reaches, since that button is rendered from the adoption and needs no
+   panel. `two-company-name-loading` is only ever set on the company field, so
+   the extra qualifier bought nothing but a way to silently not paint. */
+.two-company-name-loading ~ .two-company-name-spinner {
+    display: block;
+}
+
+/*
  * Selected company's organisation number, shown as a plain label BELOW the
  * company-name field once a search result is chosen (TWO-25326 §5).
  *

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -931,14 +931,17 @@ class TwoCompanySearch {
                 // a panel whose flight was already running, so it reaches this
                 // branch in the same state a buyer's own click would.
                 //
-                // Anything that later leaves a popup up across a panel session
-                // with no flight running - a completed, already-adopted
-                // identity - makes this branch reachable in a state it was not
-                // written for, and must decide what it owes
-                // beginSoleTraderLoading() first: a raise with no spinner and
-                // no settle listener is not it. destroy()'s known gap (§14) is
-                // exactly that shape.
+                // It is ALSO reachable with no flight running on this instance,
+                // now that destroy() keeps a live popup tracked across the
+                // rebuild (§14): the popup outlives the instance that launched
+                // it, so a replacement instance can meet one it never started.
+                // Hence beginSoleTraderLoading() below - a raise with no
+                // spinner and no settle listener leaves the restored panel with
+                // nothing to close it when the popup finally goes. It is a
+                // no-op on its own re-entrancy guard in the ordinary
+                // same-session case, where the flight is already loading.
                 if (this.focusSoleTraderSignupPopup()) {
+                    this.beginSoleTraderLoading();
                     this._chipMode = 'sole_trader';
                     this.renderChipSelection();
                     // Cancels the close ALREADY PENDING from this click's own
@@ -6143,15 +6146,15 @@ class TwoCompanySearch {
         // buyer may be actively filling in because their shipping total
         // recalculated behind it.
         //
-        // KNOWN GAP, guide §14: cancelEnrollment() still nulls the popup
-        // handle, so this path leaves a live popup tracked by nothing exactly
-        // as openDropdown() used to. Closing it here is the wrong fix (above);
-        // the fix is for the cancel to stop discarding the handle, which needs
-        // its own change to notifyEnrollmentSettled()'s popup-open guard.
+        // `keepPopupTracked` for exactly that reason (guide §14): a cancel that
+        // also nulled the handle would leave that same live popup owned by
+        // nobody - nothing polling it for closure, closeSignupPopup() unable to
+        // find it, and the next Sole trader click opening a SECOND window over
+        // it. Disowning the write does not require disowning the window.
         try {
             if (window.TwoSoleTrader_Instance
                 && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
-                window.TwoSoleTrader_Instance.cancelEnrollment();
+                window.TwoSoleTrader_Instance.cancelEnrollment(true);
             }
         } catch (e) {
             // no-op

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -225,15 +225,14 @@ class TwoCompanySearch {
         // freezeResultsHeight().
         this._resultsHeightFrozen = false;
         this._resultsFreezeReleaseId = null;
-        // True between beginSoleTraderLoading() and endSoleTraderLoading() -
-        // the panel is being kept open with the query-field spinner showing
-        // for a Sole Trader click's autofill round trip (TWO-40 round 4).
+        // True between beginSoleTraderLoading() and endSoleTraderLoading():
+        // a sole-trader round trip is in flight, the company-name field is
+        // showing its spinner, and any open panel is being kept open for the
+        // duration. Shared by BOTH entry points - the Sole trader chip and
+        // the "Select a different sole trader" button - and therefore also
+        // the re-entrancy guard that keeps them to one hosted popup between
+        // them (TWO-40 follow-up).
         this._soleTraderLoading = false;
-        // Re-entrancy guard for the "Select a different sole trader" link's
-        // click handler (TWO-40 follow-up) - same shape as
-        // `_soleTraderLoading` above, released on the same settle event, but
-        // its own flag/namespace since the two buttons/flows are independent.
-        this._selectDifferentSoleTraderLoading = false;
         // Per-instance event namespace suffix. The `mouseup` guard has to be
         // bound on `document` (a drag can end anywhere, including outside the
         // panel), and `document` is a page-wide singleton - so unbinding by
@@ -386,6 +385,15 @@ class TwoCompanySearch {
         if (!wrapper.length || !wrapper.hasClass('two-company-field-wrap')) {
             this.companyField.wrap('<span class="two-company-field-wrap"></span>');
             wrapper = this.companyField.parent();
+        }
+        // The sole-trader in-flight spinner (beginSoleTraderLoading()). Lives
+        // here rather than in buildDropdown() because it has to exist for the
+        // "Select a different sole trader" flow too, which never opens a
+        // panel. Absolutely positioned over the input's own row, so DOM order
+        // only has to keep it somewhere AFTER the input for the sibling
+        // selector in two.css to reach it.
+        if (!wrapper.children('.two-company-name-spinner').length) {
+            wrapper.append('<span class="two-company-name-spinner" aria-hidden="true"></span>');
         }
         // TWO-25326 bug 10: RELEASE any width this method pinned on a previous
         // call before measuring, or the pin latches and the control never
@@ -865,7 +873,7 @@ class TwoCompanySearch {
                 this._chipMode = 'manual';
                 // Abandons any Sole Trader wait in progress (TWO-40 round 4)
                 // - this handler does not go through closeDropdown(), so
-                // without this the query-field spinner would keep spinning
+                // without this the name-field spinner would keep spinning
                 // and the settle listener would stay bound past the flow the
                 // buyer just walked away from.
                 this.endSoleTraderLoading();
@@ -923,7 +931,7 @@ class TwoCompanySearch {
                 }
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.startEnrollment === 'function') {
-                    // Keep the panel OPEN and show the query field's own
+                    // Keep the panel OPEN and show the company-name field's
                     // spinner for the actual duration of this click's
                     // autofill round trip (Doug, TWO-40 round 4), instead of
                     // closing immediately. This also subsumes the round-3
@@ -1542,12 +1550,23 @@ class TwoCompanySearch {
      * `visibility`/`opacity`, so it leaves the tab order with it - a
      * keyboard-only buyer must not land on an input they cannot see.
      *
-     * The whole SEARCH ROW is hidden, not just the input: the spinner is an
-     * absolutely-positioned sibling inside that row, so hiding the input
-     * alone collapses the row to zero height and strands the spinner at its
-     * top edge. Which is also why the hide stands down while a sole-trader
-     * flight is in progress - that spinner, in this field, IS the in-flight
-     * state (see beginSoleTraderLoading()).
+     * The whole SEARCH ROW is hidden, not just the input: the ordinary
+     * live-search spinner is an absolutely-positioned sibling inside that
+     * row, so hiding the input alone collapses the row to zero height and
+     * strands that spinner at its top edge.
+     *
+     * A PURE FUNCTION OF `_chipMode`, with no second condition of any kind
+     * (Doug, TWO-40 follow-up: the hide must be immediate on the click that
+     * selects the chip, whatever else that click starts). An earlier round
+     * stood the hide down for the duration of a sole-trader flight, because
+     * the in-flight spinner lived in this very field and hiding the row would
+     * have left nothing to spin. That spinner has since moved onto the
+     * company-name field (beginSoleTraderLoading()), which removes the reason
+     * for the exception - and the exception WAS the bug: the chip click hid
+     * the row and then immediately un-hid it for the flight, so a row the
+     * buyer had been told would go stayed on screen for the whole round trip.
+     * Do not reintroduce a condition here; anything that must survive in
+     * sole-trader mode belongs outside this row.
      *
      * The term is dropped on the way out. The row comes back on the
      * "Registered company" chip, and a query the buyer typed before adopting
@@ -1564,7 +1583,7 @@ class TwoCompanySearch {
         if (!searchRow.length) {
             return;
         }
-        if (suppressed && !this._soleTraderLoading) {
+        if (suppressed) {
             this._queryField.val('');
             searchRow.hide().attr('hidden', 'hidden');
             // Re-render the panel body for the term that was just dropped
@@ -1596,45 +1615,77 @@ class TwoCompanySearch {
     }
 
     /**
-     * Keep the panel open and show the query field's own spinner for the
-     * duration of a Sole Trader click's real autofill round trip (TWO-40
-     * round 4, Doug's explicit request: "keep the company search control
-     * open, show spinner in query field"). Reuses the SAME spinner the
-     * ordinary search path already shows - `.two-company-dropdown__spinner`,
-     * toggled by the `two-company-search-loading` class on the query field
-     * (see two.css) - rather than inventing a second one; §1 already settled
-     * where an in-field spinner on this control lives.
+     * Show the in-flight spinner for a sole-trader round trip, and arrange
+     * for it - and the dropdown, if one is open - to be cleared when that
+     * round trip is COMPLETE.
      *
-     * Bound to a single, namespaced `document` listener for
-     * `two:sole-trader-flight-settled` - the event TwoSoleTrader.js's
-     * notifyEnrollmentSettled() fires from every terminal branch of
-     * startEnrollment()'s call graph (success, failure, or a hand-off to the
-     * on-page prompt/popup). One-shot in effect: endSoleTraderLoading()
-     * unbinds it as its first act, so a second, unrelated settle (there
-     * should not be one for a single click, but nothing here depends on
-     * that) is a no-op rather than a second close.
+     * THE ONE ENTRY POINT for both sole-trader flows (Doug, TWO-40
+     * follow-up): the Sole trader chip's first-time enrolment, and
+     * triggerSelectDifferentSoleTrader()'s replacement flow, which the chip
+     * also routes into once an identity is adopted. The only genuine
+     * difference between them is whether a dropdown happens to be open - the
+     * chip click leaves it open throughout, the standalone button never had
+     * one - and that difference is resolved by the settle handler closing the
+     * panel only if it is open, rather than by two parallel flows.
+     *
+     * ON THE COMPANY-NAME FIELD, not the query field (Doug, TWO-40
+     * follow-up). The round-4 spinner lived in the dropdown's query input,
+     * which cannot work now that selecting the Sole trader chip hides that
+     * whole row immediately (syncQueryFieldSuppression()), and never worked
+     * for the replacement flow at all, which shows no spinner today and has
+     * no dropdown to put one in. The company-name field is the surface the
+     * buyer is actually watching for the name to land in, it exists in both
+     * flows, and it is where the value being fetched is going to appear.
+     *
+     * A distinct class from the ordinary live-search spinner
+     * (`two-company-name-loading` vs `two-company-search-loading`): that one
+     * still belongs to the query field and its own dropdown-row spinner, and
+     * the two can be in flight for different reasons.
+     *
+     * "Complete" is `two:sole-trader-flight-settled`, which TwoSoleTrader.js
+     * holds back until the popup has closed AND the buyer lookup has resolved
+     * AND the company name/number write-back has landed - see
+     * notifyEnrollmentSettled()/isWriteRoundTripOutstanding() there. Popup
+     * close alone used to fire it, which is why this spinner used to
+     * disappear while the name was still on its way.
+     *
+     * One-shot in effect: endSoleTraderLoading() unbinds the listener as its
+     * first act, so a second, unrelated settle is a no-op rather than a
+     * second close.
+     *
+     * @returns {boolean} false if a sole-trader flight was ALREADY in
+     *   progress, which makes this the shared re-entrancy guard for both
+     *   entry points - one hosted popup at a time, whichever control asked
+     *   for it (guide §14).
      */
     beginSoleTraderLoading() {
         if (this._soleTraderLoading) {
-            return;
+            return false;
         }
         this._soleTraderLoading = true;
-        if (this._queryField && this._queryField.length) {
-            this._queryField.addClass('two-company-search-loading');
+        if (this.companyField && this.companyField.length) {
+            this.companyField.addClass('two-company-name-loading');
         }
-        // The chip is already `sole_trader` by the time this runs, so the
-        // search row has just been hidden by syncQueryFieldSuppression() -
-        // re-show it for the flight, or the spinner this method exists to
-        // paint has nowhere to appear.
-        this.syncQueryFieldSuppression();
         $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs)
             .on('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs, () => {
-                // closeDropdown() itself calls endSoleTraderLoading() as its
-                // own first line (TWO-40 round 5 cleanup, Yoda finding) - no
-                // need to call it again here too, and this keeps every close
-                // path funnelled through the one centralized call.
-                this.closeDropdown(true);
+                if (this._dropdownOpen) {
+                    // closeDropdown() itself calls endSoleTraderLoading() as
+                    // its own first line (TWO-40 round 5 cleanup, Yoda
+                    // finding) - no need to call it again here too, and this
+                    // keeps every close path funnelled through the one
+                    // centralized call.
+                    this.closeDropdown(true);
+                    return;
+                }
+                // No panel to close - the replacement flow launched from the
+                // standalone button. Drop the spinner directly rather than
+                // closing a dropdown that is already closed: closeDropdown()
+                // also blanks the query term, resets the reopen deadline and
+                // pulls focus back to the company field, none of which this
+                // flow asked for.
+                this.endSoleTraderLoading();
             });
+        return true;
     }
 
     /**
@@ -1653,13 +1704,9 @@ class TwoCompanySearch {
         }
         this._soleTraderLoading = false;
         $(document).off('two:sole-trader-flight-settled.twoSoleTraderFlight' + this._instanceNs);
-        if (this._queryField && this._queryField.length) {
-            this._queryField.removeClass('two-company-search-loading');
+        if (this.companyField && this.companyField.length) {
+            this.companyField.removeClass('two-company-name-loading');
         }
-        // Mirror of the call in beginSoleTraderLoading(): the keep-open
-        // window is over, so a still-selected Sole Trader chip goes back to
-        // hiding the row. A no-op for every other mode.
-        this.syncQueryFieldSuppression();
     }
 
     /**
@@ -3527,7 +3574,7 @@ class TwoCompanySearch {
                 // `_queryField`, so it is unaffected by the nulling here.
                 this.removeDropdown();
                 previousField.removeClass(
-                    'two-company-search-input two-company-search-loading ui-autocomplete-loading'
+                    'two-company-search-input two-company-search-loading two-company-name-loading ui-autocomplete-loading'
                 );
                 // Bound directly via jQuery, not through the widget -
                 // `autocomplete('destroy')` above only unwinds bindings the
@@ -4314,22 +4361,21 @@ class TwoCompanySearch {
      * opens the popup SYNCHRONOUSLY with no guard of its own (unlike
      * getCurrentBuyer()'s `isFetchingBuyer`) - without this, a double-click
      * reliably opened two signup popups from one gesture.
+     *
+     * That guard, the spinner and the settle listener are now
+     * beginSoleTraderLoading()'s, shared with the chip's own first-time
+     * enrolment path rather than duplicated here under a second namespace
+     * (Doug, TWO-40 follow-up). It buys three things beyond the tidying: this
+     * flow shows the same in-flight spinner in the same place as the chip's,
+     * which it previously showed nowhere at all; the guard is now shared, so
+     * a chip click cannot open a second popup over a replacement already in
+     * flight (guide §14) or vice versa; and there is one settle contract to
+     * reason about instead of two.
      */
     triggerSelectDifferentSoleTrader() {
-        if (this._selectDifferentSoleTraderLoading) {
+        if (!this.beginSoleTraderLoading()) {
             return;
         }
-        this._selectDifferentSoleTraderLoading = true;
-        // Released on TwoSoleTrader.js's own settle event - fired from
-        // EVERY terminal branch of startReplacement()'s call graph (popup
-        // opened, popup blocked, mint failed, or abandoned via a
-        // cancelEnrollment() elsewhere) - same event beginSoleTraderLoading()
-        // already relies on for the "Sole Trader" chip's fresh-enrolment
-        // path, own namespace so the two guards never interfere.
-        $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs)
-            .on('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs, () => {
-                this._selectDifferentSoleTraderLoading = false;
-            });
         try {
             if (window.TwoSoleTrader_Instance
                 && typeof window.TwoSoleTrader_Instance.startReplacement === 'function') {
@@ -4341,12 +4387,10 @@ class TwoCompanySearch {
                 // (adversarial review finding).
                 // eslint-disable-next-line no-console
                 console.error('Two: TwoSoleTrader_Instance is missing or malformed; cannot reopen the signup popup.');
-                this._selectDifferentSoleTraderLoading = false;
-                $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+                this.endSoleTraderLoading();
             }
         } catch (e) {
-            this._selectDifferentSoleTraderLoading = false;
-            $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+            this.endSoleTraderLoading();
         }
     }
 
@@ -4404,15 +4448,13 @@ class TwoCompanySearch {
             this._selectDifferentSoleTraderLink = null;
         }
         $('.two-company-select-different-sole-trader').off('.twoSoleTraderReplace').remove();
-        // Belt-and-braces: release the re-entrancy guard and its settle
-        // listener too, in case this runs while a flight it started is still
-        // outstanding (e.g. clearSelectedCompany() firing mid-flight) - a
-        // stuck-true guard would otherwise silently no-op every future click
-        // on a FUTURE re-rendered link, exactly the failure shape
-        // fetchTokens()'s own try/catch elsewhere in this flow exists to
-        // avoid.
-        this._selectDifferentSoleTraderLoading = false;
-        $(document).off('two:sole-trader-flight-settled.twoSoleTraderReplace' + this._instanceNs);
+        // Deliberately does NOT release the in-flight guard/spinner. This
+        // method runs mid-flight on the success path - adoptSoleTraderBuyer()
+        // renders the link, and renderSelectDifferentSoleTraderLink() removes
+        // the old one first - and the spinner has to outlive that (Doug: the
+        // flow is not complete until the name and number are written). The
+        // guard's own release points are endSoleTraderLoading()'s callers,
+        // led by the settle event itself.
     }
 
     /**
@@ -5848,7 +5890,7 @@ class TwoCompanySearch {
             // and a fresh instance may reuse this very node.
             if (this.companyField && this.companyField.length) {
                 this.companyField.removeClass(
-                    'two-company-search-input two-company-search-loading ui-autocomplete-loading'
+                    'two-company-search-input two-company-search-loading two-company-name-loading ui-autocomplete-loading'
                 );
                 this.companyField.off('.twoCompanyOpen');
                 this.companyField.removeAttr('readonly aria-haspopup aria-expanded');

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -877,14 +877,20 @@ class TwoCompanySearch {
                 // and the settle listener would stay bound past the flow the
                 // buyer just walked away from.
                 this.endSoleTraderLoading();
-                // Same rule as "Registered Company" (Doug, TWO-40 follow-up):
-                // this chip is a focus return to the checkout, so the popup
-                // goes with the spinner. Stated here rather than left to the
-                // deferred close, which DID reach it - but only because
+                // The popup goes: this chip is a focus return to the checkout
+                // (Doug, TWO-40 follow-up). Stated here rather than left to
+                // the deferred close, which DID reach it - but only because
                 // enterManualEntryMode() ends by focusing the company-name
                 // field outside the panel, re-scheduling a close this chip
                 // never asked for. Correct outcome, reached by accident of
-                // where focus landed, and invisible to any test.
+                // where focus landed.
+                //
+                // Closing the popup is NOT the same as cancelling the
+                // enrolment, and this handler deliberately claims only the
+                // first - "Registered Company" does both. See §14 of
+                // .ai/sole-trader-porting-guide.md for the gap that leaves
+                // open: a lookup already in flight can still land after this,
+                // and its write-back has no manual-entry guard.
                 this.closeSoleTraderSignupPopup();
                 this.enterManualEntryMode();
             });
@@ -913,15 +919,28 @@ class TwoCompanySearch {
                 //
                 // BEFORE that guard, deliberately: after it, this branch would
                 // be unreachable in exactly the state it exists for.
+                //
+                // Reachable ONLY with a flight of this panel-open session still
+                // in progress today, because openDropdown() nulls the popup
+                // handle on every open - which is itself the orphan gap logged
+                // in §14 of .ai/sole-trader-porting-guide.md. Whoever closes
+                // that gap makes this branch reachable with no flight running
+                // and an identity already adopted, and must then decide what
+                // it owes beginSoleTraderLoading() - a raise with no spinner
+                // and no settle listener is not it.
                 if (this.focusSoleTraderSignupPopup()) {
                     this._chipMode = 'sole_trader';
                     this.renderChipSelection();
-                    // The deferred close this click's own focus-out scheduled
-                    // would call closeSoleTraderSignupPopup() if focus were to
-                    // settle outside the panel - the popup taking focus is
-                    // precisely that. Cancel it here rather than relying on
-                    // the `focusin` a chip click happens to produce, which is
-                    // the timing accident this whole rework replaces.
+                    // Cancels the close ALREADY PENDING from this click's own
+                    // focus-out, and only that one - explicitly, rather than
+                    // relying on the `focusin` a chip click happens to
+                    // produce, which is the timing accident this rework
+                    // replaces. It cannot cover the close that the raise
+                    // itself provokes when the popup takes focus: that
+                    // focus-out arrives after this handler has returned
+                    // (round 2 adversarial review finding - an earlier comment
+                    // here claimed otherwise). scheduleDropdownClose()'s
+                    // document.hasFocus() guard is what covers that one.
                     clearTimeout(this._closeTimerId);
                     this._closeTimerId = null;
                     return;
@@ -1312,7 +1331,21 @@ class TwoCompanySearch {
             // inside the panel, so it never reaches here - each chip's handler
             // states its own answer to the popup question directly instead
             // (see closeSoleTraderSignupPopup()'s callers).
-            this.closeSoleTraderSignupPopup();
+            //
+            // Gated on the CHECKOUT PAGE having focus, which the panel's own
+            // close deliberately is not (round 2 adversarial review finding).
+            // Doug's rule is specifically "if I move focus back to the page the
+            // popup should be closed" - so a focus-out to another window,
+            // including the popup the Sole trader chip just raised, must leave
+            // it alone. Without this, the raise survived only because Chrome
+            // leaves `activeElement` on a clicked `<button>` across the window
+            // deactivation, so the guard above happened to catch it: incidental
+            // browser behaviour holding up a spec rule. The panel's own close
+            // keeps its existing meaning either way, deliberately - narrowing
+            // this to the popup decision is the whole point.
+            if (typeof document.hasFocus !== 'function' || document.hasFocus()) {
+                this.closeSoleTraderSignupPopup();
+            }
             this.closeDropdown(false);
         }, 0);
     }

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1235,7 +1235,8 @@ class TwoCompanySearch {
     }
 
     /**
-     * Close once focus has genuinely settled somewhere outside the panel.
+     * Close once focus has genuinely settled somewhere outside the panel -
+     * and with it any hosted sole-trader signup popup still on screen.
      *
      * Deliberately does NOT move focus. This fires on the way OUT - a Tab off
      * the "not on the list" button, or a click elsewhere on the form - and the
@@ -1256,6 +1257,20 @@ class TwoCompanySearch {
             const active = document.activeElement;
             if (active && this._dropdown.get(0).contains(active)) {
                 return;
+            }
+            // Focus is back on the checkout page and has settled OUTSIDE the
+            // panel, so the buyer is looking at checkout rather than at the
+            // hosted signup popup - take the popup down with the panel and the
+            // spinner (Doug live test: those two already went on this path,
+            // the popup was the one thing left up).
+            //
+            // AFTER this handler's own guards, deliberately. A focus-out caused by
+            // clicking one of the panel's own chips puts focus straight back
+            // inside the panel, so it never reaches here - that chip's handler
+            // owns what happens to the flow instead.
+            if (window.TwoSoleTrader_Instance
+                && typeof window.TwoSoleTrader_Instance.closeSignupPopup === 'function') {
+                window.TwoSoleTrader_Instance.closeSignupPopup();
             }
             this.closeDropdown(false);
         }, 0);

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -877,6 +877,15 @@ class TwoCompanySearch {
                 // and the settle listener would stay bound past the flow the
                 // buyer just walked away from.
                 this.endSoleTraderLoading();
+                // Same rule as "Registered Company" (Doug, TWO-40 follow-up):
+                // this chip is a focus return to the checkout, so the popup
+                // goes with the spinner. Stated here rather than left to the
+                // deferred close, which DID reach it - but only because
+                // enterManualEntryMode() ends by focusing the company-name
+                // field outside the panel, re-scheduling a close this chip
+                // never asked for. Correct outcome, reached by accident of
+                // where focus landed, and invisible to any test.
+                this.closeSoleTraderSignupPopup();
                 this.enterManualEntryMode();
             });
         }
@@ -891,6 +900,32 @@ class TwoCompanySearch {
             this._soleTraderButton.on('click.twoDropdown', (event) => {
                 event.preventDefault();
                 event.stopPropagation();
+                // THE ONE CHIP that does not take an open signup popup down
+                // (Doug, TWO-40 follow-up): clicking it while a popup from an
+                // earlier launch is still up means "give me that popup back",
+                // so raise it to the front instead. Everything else this
+                // handler would otherwise do is already done - the popup IS
+                // the flight in progress - which is why this returns rather
+                // than falling through to the guard below, whose bail-out was
+                // the whole gap: `_soleTraderLoading` stays true for the
+                // popup's entire lifetime, so the click resolved to nothing at
+                // all, neither closing nor raising.
+                //
+                // BEFORE that guard, deliberately: after it, this branch would
+                // be unreachable in exactly the state it exists for.
+                if (this.focusSoleTraderSignupPopup()) {
+                    this._chipMode = 'sole_trader';
+                    this.renderChipSelection();
+                    // The deferred close this click's own focus-out scheduled
+                    // would call closeSoleTraderSignupPopup() if focus were to
+                    // settle outside the panel - the popup taking focus is
+                    // precisely that. Cancel it here rather than relying on
+                    // the `focusin` a chip click happens to produce, which is
+                    // the timing accident this whole rework replaces.
+                    clearTimeout(this._closeTimerId);
+                    this._closeTimerId = null;
+                    return;
+                }
                 // Re-entrancy guard (TWO-40 round 5, adversarial review
                 // finding - Han/Vader both independently caught this): round
                 // 4 keeps this button clickable for the WHOLE round trip
@@ -997,6 +1032,14 @@ class TwoCompanySearch {
                 // click would immediately close the very panel it is trying
                 // to keep open.
                 this.endSoleTraderLoading();
+                // Focus is coming back to the panel's query field, so the
+                // popup goes (Doug, TWO-40 follow-up - the question 928a84a
+                // left open, now answered: only the Sole trader chip keeps
+                // it). BEFORE cancelEnrollment(), which nulls TwoSoleTrader's
+                // popup handle to let a genuine completion survive a mere
+                // "still glancing around" reopen - after it there is no handle
+                // left to close with, and the window would sit there orphaned.
+                this.closeSoleTraderSignupPopup();
                 if (window.TwoSoleTrader_Instance
                     && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
                     window.TwoSoleTrader_Instance.cancelEnrollment();
@@ -1266,14 +1309,51 @@ class TwoCompanySearch {
             //
             // AFTER this handler's own guards, deliberately. A focus-out caused by
             // clicking one of the panel's own chips puts focus straight back
-            // inside the panel, so it never reaches here - that chip's handler
-            // owns what happens to the flow instead.
-            if (window.TwoSoleTrader_Instance
-                && typeof window.TwoSoleTrader_Instance.closeSignupPopup === 'function') {
-                window.TwoSoleTrader_Instance.closeSignupPopup();
-            }
+            // inside the panel, so it never reaches here - each chip's handler
+            // states its own answer to the popup question directly instead
+            // (see closeSoleTraderSignupPopup()'s callers).
+            this.closeSoleTraderSignupPopup();
             this.closeDropdown(false);
         }, 0);
+    }
+
+    /**
+     * Take down the hosted sole-trader signup popup, if one is up.
+     *
+     * The rule the whole panel obeys (Doug, TWO-40 follow-up): focus coming
+     * back to the checkout page means the buyer is looking at checkout rather
+     * than at the popup, so the popup goes - whether focus came back by
+     * alt-tab, by a click on the form, or by clicking one of the panel's own
+     * chips. THE ONE EXCEPTION is the Sole trader chip, which is a statement
+     * that the popup is what the buyer wants; that handler calls
+     * focusSoleTraderSignupPopup() instead.
+     *
+     * Each of the three chip handlers calls one or the other EXPLICITLY rather
+     * than leaving it to scheduleDropdownClose()'s deferred path, which by its
+     * own design cancels itself on any `focusin` back into the panel - so a
+     * chip click reached it only when the chip's own action happened to move
+     * focus out of the panel again ("Enter manually", via the company-name
+     * field). Which of the three closed the popup was therefore a property of
+     * where each one happened to leave focus, not of what any of them meant.
+     */
+    closeSoleTraderSignupPopup() {
+        if (window.TwoSoleTrader_Instance
+            && typeof window.TwoSoleTrader_Instance.closeSignupPopup === 'function') {
+            window.TwoSoleTrader_Instance.closeSignupPopup();
+        }
+    }
+
+    /**
+     * Raise an already-open signup popup back to the front.
+     *
+     * @returns {boolean} whether there was a popup to raise - false means this
+     *   click is an ordinary Sole trader chip click with nothing on screen to
+     *   go back to.
+     */
+    focusSoleTraderSignupPopup() {
+        return !!(window.TwoSoleTrader_Instance
+            && typeof window.TwoSoleTrader_Instance.focusSignupPopup === 'function'
+            && window.TwoSoleTrader_Instance.focusSignupPopup());
     }
 
     /**

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -885,13 +885,16 @@ class TwoCompanySearch {
                 // never asked for. Correct outcome, reached by accident of
                 // where focus landed.
                 //
-                // Closing the popup is NOT the same as cancelling the
-                // enrolment, and this handler deliberately claims only the
-                // first - "Registered Company" does both. See §14 of
-                // .ai/sole-trader-porting-guide.md for the gap that leaves
-                // open: a lookup already in flight can still land after this,
-                // and its write-back has no manual-entry guard.
-                this.closeSoleTraderSignupPopup();
+                // The enrolment goes WITH it (Doug, TWO-40 follow-up). An
+                // earlier version of this handler closed the popup and left
+                // the enrolment running, on the reasoning that the two are
+                // different questions - they are not, for a buyer who has just
+                // said "I'll type it myself": a lookup or mint already in
+                // flight would still resolve into adoptSoleTraderBuyer(), which
+                // has no manual-entry guard, overwriting the name the buyer
+                // typed by hand and running the credit check against the
+                // identity they walked away from.
+                this.abandonSoleTraderFlow();
                 this.enterManualEntryMode();
             });
         }
@@ -921,13 +924,20 @@ class TwoCompanySearch {
                 // be unreachable in exactly the state it exists for.
                 //
                 // Reachable ONLY with a flight of this panel-open session still
-                // in progress today, because openDropdown() nulls the popup
-                // handle on every open - which is itself the orphan gap logged
-                // in §14 of .ai/sole-trader-porting-guide.md. Whoever closes
-                // that gap makes this branch reachable with no flight running
-                // and an identity already adopted, and must then decide what
-                // it owes beginSoleTraderLoading() - a raise with no spinner
-                // and no settle listener is not it.
+                // in progress: a buyer-initiated open takes any earlier popup
+                // down with it (openDropdown() -> abandonSoleTraderFlow()), so
+                // there is nothing left from a previous panel session to raise.
+                // A re-render restore does NOT, deliberately - but it restores
+                // a panel whose flight was already running, so it reaches this
+                // branch in the same state a buyer's own click would.
+                //
+                // Anything that later leaves a popup up across a panel session
+                // with no flight running - a completed, already-adopted
+                // identity - makes this branch reachable in a state it was not
+                // written for, and must decide what it owes
+                // beginSoleTraderLoading() first: a raise with no spinner and
+                // no settle listener is not it. destroy()'s known gap (§14) is
+                // exactly that shape.
                 if (this.focusSoleTraderSignupPopup()) {
                     this._chipMode = 'sole_trader';
                     this.renderChipSelection();
@@ -1054,15 +1064,10 @@ class TwoCompanySearch {
                 // Focus is coming back to the panel's query field, so the
                 // popup goes (Doug, TWO-40 follow-up - the question 928a84a
                 // left open, now answered: only the Sole trader chip keeps
-                // it). BEFORE cancelEnrollment(), which nulls TwoSoleTrader's
-                // popup handle to let a genuine completion survive a mere
-                // "still glancing around" reopen - after it there is no handle
-                // left to close with, and the window would sit there orphaned.
-                this.closeSoleTraderSignupPopup();
-                if (window.TwoSoleTrader_Instance
-                    && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
-                    window.TwoSoleTrader_Instance.cancelEnrollment();
-                }
+                // it), and the enrolment with it. The close-before-cancel
+                // ordering this used to spell out itself now lives inside
+                // abandonSoleTraderFlow().
+                this.abandonSoleTraderFlow();
                 this.renderChipSelection();
                 if (this._queryField && this._queryField.length) {
                     this._queryField.trigger('focus');
@@ -1343,6 +1348,15 @@ class TwoCompanySearch {
             // browser behaviour holding up a spec rule. The panel's own close
             // keeps its existing meaning either way, deliberately - narrowing
             // this to the popup decision is the whole point.
+            //
+            // The CLOSE HALF ONLY, not abandonSoleTraderFlow(): looking away
+            // from the popup is not a decision about the enrolment. The
+            // enrolment stays live and resumable, its tokens unspent, and a
+            // completion that was already on its way still publishes - which
+            // is the whole reason bindPopupMessageListener() is not gated on
+            // `enrolling`. The gestures that DO cancel are the ones that say
+            // what the buyer wants instead: the two chips, and reopening
+            // ordinary search.
             if (typeof document.hasFocus !== 'function' || document.hasFocus()) {
                 this.closeSoleTraderSignupPopup();
             }
@@ -1377,6 +1391,31 @@ class TwoCompanySearch {
     }
 
     /**
+     * The buyer is leaving the sole-trader flow: popup down AND enrolment
+     * cancelled, as one call.
+     *
+     * Every gesture that means "I am done with sole trader" routes here rather
+     * than making the two calls itself (Doug, TWO-40 follow-up - closure and
+     * cancellation are "a single atomic operation, not two separate functions
+     * as now"). Both ways of getting the pair wrong had already shipped: one
+     * chip closed without cancelling, openDropdown() cancelled without
+     * closing. The ordering that makes the pair work lives in
+     * TwoSoleTrader.abandonEnrollment(), once, where no future caller can get
+     * it wrong.
+     *
+     * Callers must still unbind their own settle listener FIRST where they mean
+     * to keep the panel open - see endSoleTraderLoading()'s callers - because
+     * the cancel dispatches a settle event. That is a separate contract from
+     * this pair, not part of it.
+     */
+    abandonSoleTraderFlow() {
+        if (window.TwoSoleTrader_Instance
+            && typeof window.TwoSoleTrader_Instance.abandonEnrollment === 'function') {
+            window.TwoSoleTrader_Instance.abandonEnrollment();
+        }
+    }
+
+    /**
      * Raise an already-open signup popup back to the front.
      *
      * @returns {boolean} whether there was a popup to raise - false means this
@@ -1400,8 +1439,13 @@ class TwoCompanySearch {
      * field. Seeding it would re-run a search for a company the buyer has
      * already confirmed, and the first thing they would see on reopening is a
      * list containing only the company they are trying to move away from.
+     *
+     * @param {boolean} [buyerInitiated] Whether a buyer gesture asked for this
+     *   open. True for every ordinary caller, hence the default. Only
+     *   restorePanelAfterRerender() passes false - see the abandon below for
+     *   what turns on it.
      */
-    openDropdown() {
+    openDropdown(buyerInitiated = true) {
         if (this._destroyed || this._manualEntry) {
             return;
         }
@@ -1409,21 +1453,32 @@ class TwoCompanySearch {
             || !this._queryField || !this._queryField.length) {
             return;
         }
-        // BEFORE cancelEnrollment() (TWO-40 round 5, adversarial review
-        // finding - same reasoning as the "Registered Company" handler):
-        // cancelEnrollment() now fires the settle event too, and this
-        // method's own listener reacting to it would call closeDropdown(true)
-        // from INSIDE openDropdown() itself, re-closing the very panel this
-        // call is in the middle of opening. Unbind first.
+        // BEFORE abandonSoleTraderFlow() (TWO-40 round 5, adversarial review
+        // finding - same reasoning as the "Registered Company" handler): the
+        // cancel inside it fires the settle event too, and this method's own
+        // listener reacting to it would call closeDropdown(true) from INSIDE
+        // openDropdown() itself, re-closing the very panel this call is in the
+        // middle of opening. Unbind first.
         this.endSoleTraderLoading();
         // Reopening the search control is the buyer choosing ordinary company
         // search over an "I'm a sole trader" row they may have clicked
-        // moments earlier (TWO-40). Cancel any not-yet-completed enrolment -
-        // TwoSoleTrader.js keeps its minted tokens either way, so a buyer who
-        // comes back to this row resumes rather than re-mints.
-        if (window.TwoSoleTrader_Instance
-            && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
-            window.TwoSoleTrader_Instance.cancelEnrollment();
+        // moments earlier (TWO-40), so the popup goes and the enrolment with
+        // it. TwoSoleTrader.js keeps its minted tokens either way, so a buyer
+        // who comes back to this row resumes rather than re-mints.
+        //
+        // ONLY for an open a buyer actually asked for. An address-form
+        // re-render restores a panel the buyer already had
+        // (restorePanelAfterRerender()) without anything about their intent
+        // having changed - and PrestaShop fires `updatedAddressForm` for
+        // ordinary things like a shipping recalculation, whose XHR callback is
+        // not blocked by the buyer being in another window. So this used to
+        // reach a buyer sitting looking AT their signup popup and cancel the
+        // enrolment out from under them; worse, the cancel nulls
+        // TwoSoleTrader's popup handle without closing the window, leaving it
+        // on screen tracked by nothing, from where the Sole trader chip would
+        // open a SECOND one (guide §14, "Han/Vader's finding").
+        if (buyerInitiated) {
+            this.abandonSoleTraderFlow();
         }
         clearTimeout(this._closeTimerId);
         this._closeTimerId = null;
@@ -4142,7 +4197,12 @@ class TwoCompanySearch {
         // leave the real one closed. The deadline expires on its own, and any
         // close clears it.
         const deadline = TwoCompanySearch._reopenPanelUntil;
-        this.openDropdown();
+        // NOT buyer-initiated, which is what keeps this path's hands off an
+        // open signup popup and the enrolment behind it (see openDropdown()).
+        // Stated as an argument rather than inferred from `_reopenPanelUntil`
+        // being armed: that deadline is armed by the buyer's OWN click too, so
+        // it says a re-render is plausible, never that this open is one.
+        this.openDropdown(false);
         TwoCompanySearch._reopenPanelUntil = deadline;
     }
 
@@ -5896,10 +5956,12 @@ class TwoCompanySearch {
                 // reads as still-current, and can pop a signup popup - or
                 // worse, silently publish a completed enrolment - for a
                 // country the buyer has already moved off.
-                if (window.TwoSoleTrader_Instance
-                    && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {
-                    window.TwoSoleTrader_Instance.cancelEnrollment();
-                }
+                //
+                // The popup goes too, for the same reason: its tokens were
+                // minted against the country the buyer just left, so nothing
+                // the buyer does in that window can complete. Cancelling
+                // without closing left it up and tracked by nothing.
+                this.abandonSoleTraderFlow();
 
                 if (this.companyField && this.companyField.length > 0) {
                     this.companyField.val('');
@@ -6071,6 +6133,21 @@ class TwoCompanySearch {
         // reference - silently adopting the identity into an address context
         // the buyer has since moved on from, ungated because no generation
         // bump ever ran for this trigger.
+        //
+        // The CANCEL HALF ONLY - the one caller that deliberately does not use
+        // abandonSoleTraderFlow(). Tearing down a search instance is not the
+        // buyer saying anything about their popup: `TwoSoleTrader_Instance` is
+        // a singleton that outlives this object, and on the
+        // `updatedAddressForm` path a replacement instance is built
+        // immediately, so closing the window here would take down a popup the
+        // buyer may be actively filling in because their shipping total
+        // recalculated behind it.
+        //
+        // KNOWN GAP, guide §14: cancelEnrollment() still nulls the popup
+        // handle, so this path leaves a live popup tracked by nothing exactly
+        // as openDropdown() used to. Closing it here is the wrong fix (above);
+        // the fix is for the cancel to stop discarding the handle, which needs
+        // its own change to notifyEnrollmentSettled()'s popup-open guard.
         try {
             if (window.TwoSoleTrader_Instance
                 && typeof window.TwoSoleTrader_Instance.cancelEnrollment === 'function') {

--- a/views/js/modules/TwoCompanySearch.js
+++ b/views/js/modules/TwoCompanySearch.js
@@ -1050,16 +1050,16 @@ class TwoCompanySearch {
                 if (this._manualEntry) {
                     this.exitManualEntryMode();
                 }
-                // BEFORE cancelEnrollment() (TWO-40 round 5, adversarial
+                // BEFORE abandonSoleTraderFlow() (TWO-40 round 5, adversarial
                 // review finding), not after - see the reasoning at
-                // notifyEnrollmentSettled() in TwoSoleTrader.js:
-                // cancelEnrollment() now fires the SAME settle event that
+                // notifyEnrollmentSettled() in TwoSoleTrader.js: the cancel
+                // inside it fires the SAME settle event that
                 // beginSoleTraderLoading()'s own listener reacts to by
                 // calling closeDropdown(true). This handler wants to STAY
                 // OPEN, not close - so its own listener must already be
-                // unbound before cancelEnrollment() can dispatch, or this
-                // click would immediately close the very panel it is trying
-                // to keep open.
+                // unbound before that cancel can dispatch, or this click
+                // would immediately close the very panel it is trying to
+                // keep open.
                 this.endSoleTraderLoading();
                 // Focus is coming back to the panel's query field, so the
                 // popup goes (Doug, TWO-40 follow-up - the question 928a84a

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2036,15 +2036,14 @@ class TwoSoleTrader {
         if (!this.tokens) {
             return null;
         }
-        if (this._popup && !this._popup.closed) {
-            // Round trip already handed off to a popup that is still open
-            // (adversarial review finding, Han + Vader independently) -
-            // opening a SECOND window here would orphan the first one,
-            // untracked: `this._popup` would move to the new popup and the
-            // poll would never learn the first window even existed, so a
-            // buyer who closes THAT one instead of the new one would leave
-            // the spinner stuck forever. Focus the existing popup instead.
-            this._popup.focus();
+        // Round trip already handed off to a popup that is still open
+        // (adversarial review finding, Han + Vader independently) - opening a
+        // SECOND window here would orphan the first one, untracked:
+        // `this._popup` would move to the new popup and the poll would never
+        // learn the first window even existed, so a buyer who closes THAT one
+        // instead of the new one would leave the spinner stuck forever. Focus
+        // the existing popup instead.
+        if (this.focusSignupPopup()) {
             return this._popup;
         }
         const ps = window.prestashop;
@@ -2176,6 +2175,38 @@ class TwoSoleTrader {
         if (this._popup && !this._popup.closed) {
             this._popup.close();
         }
+    }
+
+    /**
+     * Raise the hosted signup popup back to the front, if one is still up.
+     *
+     * The counterpart to closeSignupPopup() for the ONE gesture that means
+     * "I want that popup, not this page" (Doug, TWO-40 follow-up): re-clicking
+     * the Sole trader chip while a popup from an earlier launch is still open.
+     * Every other way focus comes back to the checkout takes the popup down.
+     *
+     * `focus()` is wrapped because `closed` can flip between the check and the
+     * call - the hosted flow closes its own window the moment it has posted
+     * 'ACCEPTED', so a buyer completing signup in the same instant as this
+     * runs is a real interleaving, not a theoretical one. There is nothing to
+     * raise in that case and nothing to report either: the popup is going
+     * away for the right reason, and watchPopupUntilClosed()'s poll still owns
+     * clearing the handle and dispatching the settle.
+     *
+     * @returns {boolean} whether a popup was actually there to raise, so a
+     *   caller can tell "brought it to the front" from "no popup open" and
+     *   pick a different behaviour for the latter.
+     */
+    focusSignupPopup() {
+        if (!this._popup || this._popup.closed) {
+            return false;
+        }
+        try {
+            this._popup.focus();
+        } catch (e) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2043,7 +2043,16 @@ class TwoSoleTrader {
         // learn the first window even existed, so a buyer who closes THAT one
         // instead of the new one would leave the spinner stuck forever. Focus
         // the existing popup instead.
-        if (this.focusSignupPopup()) {
+        //
+        // Gated on LIVENESS, not on whether the raise succeeded (round 2
+        // adversarial review finding). focusSignupPopup() answers "did I raise
+        // it?", which is what the Sole trader chip needs and NOT what this
+        // branch needs: it reports false for a focus() that threw, and
+        // returning false here would fall through and open the second window
+        // this guard exists to prevent. A window we hold and that is not
+        // `closed` must never be opened over, whether or not it can be raised.
+        if (this._popup && !this._popup.closed) {
+            this.focusSignupPopup();
             return this._popup;
         }
         const ps = window.prestashop;

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2152,6 +2152,33 @@ class TwoSoleTrader {
     }
 
     /**
+     * Close the hosted signup popup, if one is still up.
+     *
+     * Deliberately NOT folded into cancelEnrollment() (TWO-40 follow-up, Doug
+     * live test: PrestaShop stopped the spinner and closed the panel when focus
+     * came back to the checkout page, but left the popup on screen).
+     * cancelEnrollment() runs on EVERY openDropdown(), which per
+     * bindPopupMessageListener()'s own doc is "still glancing around" rather
+     * than "abandoned" - a genuine completion arriving from a popup the buyer
+     * left open has to survive it. This is the narrower route: the buyer's
+     * focus is on the checkout page instead of the popup, so the popup goes.
+     *
+     * `close()` is ours to call however cross-origin the popup's document is -
+     * we are the opener - and it is a no-op on a window that has already gone,
+     * which covers a buyer who closed it by hand and the hosted flow closing
+     * itself the moment it posted 'ACCEPTED'. `this._popup` is deliberately
+     * left for watchPopupUntilClosed()'s poll to clear, so the settle event
+     * still has exactly one owner.
+     *
+     * @returns {void}
+     */
+    closeSignupPopup() {
+        if (this._popup && !this._popup.closed) {
+            this._popup.close();
+        }
+    }
+
+    /**
      * The hosted signup posts 'ACCEPTED' back to the opener when the
      * buyer completes registration; re-fetch the buyer to autofill.
      * Origin must be the signup page's own. Any other message from that

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2243,6 +2243,18 @@ class TwoSoleTrader {
      * away for the right reason, and watchPopupUntilClosed()'s poll still owns
      * clearing the handle and dispatching the settle.
      *
+     * Raising a popup RE-ADOPTS it, which is why the tokens are re-stamped as
+     * current here (adversarial review round 2). "I want that popup" is exactly
+     * the explicit resume that startEnrollment()/startReplacement() re-stamp
+     * for, and without it a raise is the one way back into a popup that leaves
+     * `_tokensGeneration` behind - so the buyer's completion arrives and
+     * bindPopupMessageListener() drops it on the generation check, silently.
+     * That became reachable when destroy() started keeping a live popup across
+     * an instance rebuild: the cancel bumps the generation, the raise is the
+     * only thing the buyer does next, and nothing else would ever re-stamp it.
+     * A no-op on every other path here, which reaches this with the two
+     * generations already in agreement.
+     *
      * @returns {boolean} whether a popup was actually there to raise, so a
      *   caller can tell "brought it to the front" from "no popup open" and
      *   pick a different behaviour for the latter.
@@ -2256,6 +2268,7 @@ class TwoSoleTrader {
         } catch (e) {
             return false;
         }
+        this._tokensGeneration = this._enrollGeneration;
         return true;
     }
 

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -197,6 +197,14 @@ class TwoSoleTrader {
         // already true for a different call (TWO-40 round 8, adversarial
         // review finding, Han) - see getCurrentBuyer()'s own .finally().
         this._pendingTrustedResume = false;
+        // How many applyBuyer() write-backs are still out. A COUNT, not a
+        // boolean: a generation bump can leave two overlapping saveCompany
+        // round trips in the air, and the first one's `.finally()` must not
+        // report the second one finished. See isWriteRoundTripOutstanding().
+        this._pendingAdoptionWrites = 0;
+        // A notifyEnrollmentSettled() call that isWriteRoundTripOutstanding()
+        // held back, to be re-fired once it isn't. See flushDeferredSettle().
+        this._settleDeferred = false;
         // The setInterval handle for the 30-minute background token refresh
         // (TWO-40 follow-up) - held so destroy() can clear it. Started once,
         // by fetchTokens()'s own success branch, on the first real mint; see
@@ -415,6 +423,13 @@ class TwoSoleTrader {
             this._messageHandler = null;
         }
         this.messageListenerBound = false;
+        // A deferred settle belongs to the flight that deferred it, and this
+        // instance is not going to finish that flight - drop it rather than
+        // let a late `.finally()` dispatch it over whatever the buyer is
+        // doing by then. `_pendingAdoptionWrites` is deliberately NOT reset:
+        // an outstanding applyBuyer() still owns its own decrement, and
+        // zeroing the count here would just drive it negative.
+        this._settleDeferred = false;
     }
 
     container() {
@@ -1086,7 +1101,13 @@ class TwoSoleTrader {
         // cancelEnrollment(), all of which now unbind their listener BEFORE
         // calling this, so this dispatch reaching an already-unbound
         // listener there is the expected, harmless case.
-        this.notifyEnrollmentSettled();
+        //
+        // Forced past notifyEnrollmentSettled()'s write-round-trip guard: the
+        // generation bump above has already disowned whatever lookup or write
+        // is still in the air, so there is nothing left worth waiting for -
+        // and waiting would hold a spinner up over a flow the buyer has
+        // already left for a different search interaction.
+        this.notifyEnrollmentSettled(true);
     }
 
     /**
@@ -1610,6 +1631,11 @@ class TwoSoleTrader {
                     return true;
                 }
             }
+            // AFTER the resume above, not before it: a resume re-holds the
+            // guard for a lookup that has not answered yet, and releasing a
+            // deferred settle in between would end the spinner in the middle
+            // of the very round trip it is waiting on.
+            self.flushDeferredSettle();
             return false;
         };
         // Same reasoning as fetchTokens()'s own try/catch around its
@@ -1822,6 +1848,12 @@ class TwoSoleTrader {
      */
     applyBuyer(buyer, generation) {
         const self = this;
+        // Held for this whole chain so the flight cannot settle - and the
+        // buyer's spinner cannot stop - before the company name and number
+        // are actually in the form. Released in `.finally()` below, which
+        // covers the superseded early return and showError() as well as the
+        // success branch. See notifyEnrollmentSettled().
+        this._pendingAdoptionWrites += 1;
         const companyLabel = buyer.company_name || buyer.organization_number || '';
         const body = new URLSearchParams({
             company: companyLabel,
@@ -1906,6 +1938,10 @@ class TwoSoleTrader {
             })
             .catch(function () {
                 self.showError();
+            })
+            .finally(function () {
+                self._pendingAdoptionWrites -= 1;
+                self.flushDeferredSettle();
             });
     }
 
@@ -2279,12 +2315,60 @@ class TwoSoleTrader {
      * whenever a popup is the thing still open. cancelEnrollment() clears
      * `this._popup` itself first, since that path means the buyer moved on
      * to a different search interaction, not the popup closing.
+     *
+     * Gated on the post-popup WRITE too (Doug, TWO-40 follow-up: "the flow is
+     * complete when the popup is gone AND the lookup has come back AND the
+     * name and number are saved"). The popup poll fires within 500ms of the
+     * window closing, and the hosted flow closes it as soon as it has posted
+     * 'ACCEPTED' - so the poll routinely won this race against the
+     * getCurrentBuyer() -> saveCompany -> adoptEnrolledIdentity() chain that
+     * message starts, and settled the flight with the company field still
+     * empty. isWriteRoundTripOutstanding() covers that chain; whichever of
+     * the two finishes last is the one that dispatches.
+     *
+     * @param {boolean} [force] Dispatch even with a write round trip out.
+     *   For cancelEnrollment() only: the generation bump it just made means
+     *   that write can no longer publish anything, so waiting for it would
+     *   only leave the spinner up for a flow the buyer has already left.
      */
-    notifyEnrollmentSettled() {
+    notifyEnrollmentSettled(force = false) {
         if (this._popup && !this._popup.closed) {
             return;
         }
+        if (!force && this.isWriteRoundTripOutstanding()) {
+            this._settleDeferred = true;
+            return;
+        }
+        this._settleDeferred = false;
         document.dispatchEvent(new CustomEvent('two:sole-trader-flight-settled'));
+    }
+
+    /**
+     * @returns {boolean} whether a round trip that could still write the
+     *   company name/number into the form is outstanding - the buyer lookup
+     *   itself (`isFetchingBuyer`, which is deliberately held across the
+     *   read-after-write retry wait too, see getCurrentBuyer()) or an
+     *   applyBuyer() write-back it led to.
+     */
+    isWriteRoundTripOutstanding() {
+        return this.isFetchingBuyer || this._pendingAdoptionWrites > 0;
+    }
+
+    /**
+     * Re-fire a settle that isWriteRoundTripOutstanding() held back.
+     *
+     * Re-checks the predicate itself rather than trusting its callers, which
+     * is what lets it be called from every point one of those flags drops
+     * without each caller reasoning about the others - notably
+     * getCurrentBuyer()'s `settle()`, which may immediately re-issue a
+     * lookup for a pending trusted resume and so must NOT release the settle
+     * it is about to make outstanding again.
+     */
+    flushDeferredSettle() {
+        if (!this._settleDeferred || this.isWriteRoundTripOutstanding()) {
+            return;
+        }
+        this.notifyEnrollmentSettled();
     }
 }
 

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -1077,19 +1077,29 @@ class TwoSoleTrader {
      * buyer explicitly moved on to search and select, with the order-intent
      * credit check then running against the WRONG entity and nothing on
      * screen to show it happened. See getCurrentBuyer()/applyBuyer().
+     *
+     * @param {boolean} [keepPopupTracked] Disown the WRITE without giving up
+     *   the popup handle. For a caller that is NOT a buyer gesture and does
+     *   not close the window it is walking away from -
+     *   TwoCompanySearch.destroy(), see there. Default false, because every
+     *   other caller IS such a gesture: the buyer has visibly moved on, so
+     *   tracking a window they are no longer looking at only holds the settle
+     *   back behind notifyEnrollmentSettled()'s popup-open guard.
      */
-    cancelEnrollment() {
+    cancelEnrollment(keepPopupTracked = false) {
         this._enrollGeneration += 1;
         // Belt-and-braces alongside afterTokensReady()'s own reset: an
         // abandoned startReplacement() must not leave this set for whatever
         // ORDINARY flow resumes next.
         this._skipAutofillCheck = false;
-        // The buyer moved on to a different search interaction, not the
-        // popup itself closing - stop tracking it (no leaked poll interval)
-        // and clear the reference so the notify below isn't held back by
-        // notifyEnrollmentSettled()'s popup-open guard.
-        this.stopPopupWatch();
-        this._popup = null;
+        if (!keepPopupTracked) {
+            // The buyer moved on to a different search interaction, not the
+            // popup itself closing - stop tracking it (no leaked poll interval)
+            // and clear the reference so the notify below isn't held back by
+            // notifyEnrollmentSettled()'s popup-open guard.
+            this.stopPopupWatch();
+            this._popup = null;
+        }
         if (!this.enrolling) {
             return;
         }
@@ -1111,7 +1121,10 @@ class TwoSoleTrader {
         // generation bump above has already disowned whatever lookup or write
         // is still in the air, so there is nothing left worth waiting for -
         // and waiting would hold a spinner up over a flow the buyer has
-        // already left for a different search interaction.
+        // already left for a different search interaction. Under
+        // `keepPopupTracked` the popup-open guard still holds it back, which is
+        // the point: nothing was taken away from the buyer, so the popup's own
+        // close is what settles.
         this.notifyEnrollmentSettled(true);
     }
 
@@ -2409,7 +2422,9 @@ class TwoSoleTrader {
      * defer to watchPopupUntilClosed()'s poll instead of firing early
      * whenever a popup is the thing still open. cancelEnrollment() clears
      * `this._popup` itself first, since that path means the buyer moved on
-     * to a different search interaction, not the popup closing.
+     * to a different search interaction, not the popup closing - except
+     * under its `keepPopupTracked` caller, which relies on this guard
+     * holding the settle back until the popup it left open closes.
      *
      * Gated on the post-popup WRITE too (Doug, TWO-40 follow-up: "the flow is
      * complete when the popup is gone AND the lookup has come back AND the

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -2320,11 +2320,11 @@ class TwoSoleTrader {
             // arrives, which reads as a brand-new legitimate attempt however
             // stale the tokens actually are - silently overwriting the real
             // selection the buyer made in between. `_tokensGeneration` is
-            // only re-stamped as current by an EXPLICIT resume
-            // (fetchTokens()'s success handler, or startEnrollment() calling
-            // back into an existing token set) - never by this listener
-            // itself - so a stale popup finishing on its own has no way to
-            // pass this check.
+            // only re-stamped as current by an EXPLICIT resume - fetchTokens()'s
+            // success handler, startEnrollment()/startReplacement() calling back
+            // into an existing token set, or focusSignupPopup() raising a popup
+            // the buyer asked for by name - never by this listener itself, so a
+            // stale popup finishing on its own has no way to pass this check.
             if (self._enrollGeneration !== self._tokensGeneration) {
                 return;
             }

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -901,8 +901,13 @@ class TwoSoleTrader {
         // eligible (buyer changed country mid-flow) must not keep showing a
         // prompt/status for it - mirrors the old chip's hide()-forces-business
         // behaviour, without a "business" mode to fall back to.
+        //
+        // The full abandon, popup included: the tokens this popup is signing
+        // against were minted for the country that just stopped being
+        // eligible (mintTokensRequest()), so there is nothing for the buyer to
+        // usefully finish in it.
         if (!available && this.enrolling) {
-            this.cancelEnrollment();
+            this.abandonEnrollment();
         }
         this.resyncSoleTraderChip();
     }
@@ -1108,6 +1113,31 @@ class TwoSoleTrader {
         // and waiting would hold a spinner up over a flow the buyer has
         // already left for a different search interaction.
         this.notifyEnrollmentSettled(true);
+    }
+
+    /**
+     * The buyer is leaving the sole-trader flow: take the popup down AND
+     * disown what it started, as ONE operation.
+     *
+     * ONE method rather than two calls every caller has to remember (Doug,
+     * TWO-40 follow-up: "closure and enrolment cancelation [must be] a single
+     * atomic operation, not two separate functions as now. It's just begging
+     * to fail in some way."). It had already failed twice: "Enter manually"
+     * closed the popup and never cancelled, so a lookup still in flight landed
+     * on a company name the buyer had since typed by hand and ran the credit
+     * check against the identity they walked away from; openDropdown()
+     * cancelled and never closed, orphaning a window still on screen.
+     *
+     * closeSignupPopup() FIRST, and that ordering is the reason this pair
+     * cannot be left to callers: cancelEnrollment() nulls `this._popup`, so
+     * after it there is no handle left to close with.
+     *
+     * The one caller that wants only ONE half calls that half directly, and
+     * says why - see TwoCompanySearch.destroy().
+     */
+    abandonEnrollment() {
+        this.closeSignupPopup();
+        this.cancelEnrollment();
     }
 
     /**
@@ -2162,14 +2192,12 @@ class TwoSoleTrader {
     /**
      * Close the hosted signup popup, if one is still up.
      *
-     * Deliberately NOT folded into cancelEnrollment() (TWO-40 follow-up, Doug
-     * live test: PrestaShop stopped the spinner and closed the panel when focus
-     * came back to the checkout page, but left the popup on screen).
-     * cancelEnrollment() runs on EVERY openDropdown(), which per
-     * bindPopupMessageListener()'s own doc is "still glancing around" rather
-     * than "abandoned" - a genuine completion arriving from a popup the buyer
-     * left open has to survive it. This is the narrower route: the buyer's
-     * focus is on the checkout page instead of the popup, so the popup goes.
+     * Still a separate method from cancelEnrollment() rather than folded INTO
+     * it, because cancelEnrollment() has one caller that must NOT close a
+     * popup (TwoCompanySearch.destroy(), see there). What no longer exists is a
+     * caller that wants BOTH and has to remember to say so twice:
+     * abandonEnrollment() is that pair, and is what "the buyer is leaving this
+     * flow" calls.
      *
      * `close()` is ours to call however cross-origin the popup's document is -
      * we are the opener - and it is a no-op on a window that has already gone,


### PR DESCRIPTION
Three of Doug's live findings on the sole-trader adoption flow. They collapse into one change, because the first two share a cause.

## 1. Query row hides on mode alone

Already almost right: the hide ran from `renderChipSelection()`, so it was synchronous with the chip click and needed no reopen. The bug was the second condition — the hide stood down for the duration of the flight, because the spinner lived in that row. So the click hid the row and un-hid it in the same gesture. Removing the condition is the fix, and change 2 is what makes it possible.

## 2. Spinner moves to the company-name field

`beginSoleTraderLoading()` now toggles `two-company-name-loading` on the company field, with a new `.two-company-name-spinner` element in the field wrapper positioned against the input's own row via the existing `--two-company-input-height`. PrestaShop makes this smaller than the WooCommerce equivalent: the picker *is* the name field, so there is no native-field/search-widget duality to follow.

## 3. Both "select a different" entry points share one flow

They already shared `triggerSelectDifferentSoleTrader()`, but kept a flag and a settle listener each — so the standalone button showed no spinner at all. Now one flag, one listener, one spinner, with the dropdown closed at flow-complete only if it is open. The shared flag also closes a real gap: a chip click could previously open a second hosted popup over a replacement flow already in flight.

## "Flow complete"

Was popup-closed, which is the wrong moment — the hosted flow closes its own window as soon as it posts completion, so the 500ms `.closed` poll routinely beat the lookup/save/write chain that message starts. `notifyEnrollmentSettled()`'s existing popup gate is extended rather than joined by a second signal: it also withholds while a buyer lookup or a write-back is outstanding, and whichever finishes last dispatches. Cancellation forces past it.

## Verification

837 JS tests green. The load-bearing new test closes the popup with the write-back held open by hand and asserts the settle has **not** fired — confirmed failing against the old semantics (`Expected: 1, Received: 2`) before the fix.

**Needs live verification before merge** — this is visual, timing-dependent state on a control with a documented history of oscillating bugs.
