### PR TITLE
PDEV-4669: pass invoice country to the sole-trader signup popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sole trader checkout** (TWO-24755, WooCommerce/Magento parity)
   - The payment step shows a Business / Sole trader toggle for buyers in countries where Two's registry supports sole traders (`GET /registry/v1/supported-company-types/<ISO>`, currently the UK and US), gated by a new "Enable sole trader checkout" admin toggle (default off)
   - Choosing Sole Trader mints delegation + autofill tokens server-side with the merchant API key and opens Two's hosted signup popup; on completion the buyer's company data autofills from `GET /autofill/v1/buyer/current` (case-insensitive email match) and persists through the existing company-save path, so order-intent and payment run unchanged
+  - The signup popup URL carries the cart's server-resolved invoice country as `&country=<ISO>`; without it Two's hosted signup defaults its whole form to GB, so a US buyer would have registered as a GB sole trader and skipped the US Onfido biometric-consent screen (PDEV-4669)
   - Module version bumped to `2.5.1`
 - **Buyer surcharge shown as a real PrestaShop cart line** (TWO-24739 parity)
   - Selecting Two at checkout now adds the payment-terms fee as a hidden virtual product line, so the fee appears in PrestaShop's own order summary, cart, order and invoice totals - previously it existed only on the Two-side invoice

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -409,13 +409,6 @@ class TwoSoleTrader {
             last_name: (lastName && lastName.value) || customer.lastname || '',
             phone_number: phone ? phone.value : ''
         };
-        // The signup page defaults its whole form to GB when no country is
-        // given (PDEV-4669), so a US buyer would register a GB sole trader.
-        // Same rule as applyBuyer(): the country MUST be the token
-        // response's server-resolved invoice country, never a DOM guess -
-        // it is also what decides whether the hosted flow shows the US
-        // Onfido biometric-consent screen before verification. Omitted when
-        // the server sent nothing, leaving the page on its own GB default.
         const country = (this.tokens.country || '').toUpperCase();
         const url =
             this.tokens.signup_url +

--- a/views/js/modules/TwoSoleTrader.js
+++ b/views/js/modules/TwoSoleTrader.js
@@ -409,11 +409,20 @@ class TwoSoleTrader {
             last_name: (lastName && lastName.value) || customer.lastname || '',
             phone_number: phone ? phone.value : ''
         };
+        // The signup page defaults its whole form to GB when no country is
+        // given (PDEV-4669), so a US buyer would register a GB sole trader.
+        // Same rule as applyBuyer(): the country MUST be the token
+        // response's server-resolved invoice country, never a DOM guess -
+        // it is also what decides whether the hosted flow shows the US
+        // Onfido biometric-consent screen before verification. Omitted when
+        // the server sent nothing, leaving the page on its own GB default.
+        const country = (this.tokens.country || '').toUpperCase();
         const url =
             this.tokens.signup_url +
             '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
             '&autofillToken=' + encodeURIComponent(this.tokens.autofill_token) +
-            '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill));
+            '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill)) +
+            (country ? '&country=' + encodeURIComponent(country) : '');
         const popup = window.open(
             url,
             '_blank',


### PR DESCRIPTION
[PDEV-4669](https://linear.app/two-inc/issue/PDEV-4669/add-consent-screen-for-business-registration-flow-api-for-us-buyers) · backend: two-inc/checkout-api#12861 · frontend: two-inc/checkout-page#2537 (both merged)

## Problem

Two's hosted sole-trader signup page now reads its country from a `country` query param and, when the param is absent, defaults **every** field to GB — business address, proprietor address, address history, and the phone prefix.

`openPopup()` in `views/js/modules/TwoSoleTrader.js` sent no country at all. `autofillData` carried only `email`, `first_name`, `last_name` and `phone_number`:

```js
const url =
    this.tokens.signup_url +
    '?businessToken=' + encodeURIComponent(this.tokens.delegation_token) +
    '&autofillToken=' + encodeURIComponent(this.tokens.autofill_token) +
    '&autofillData=' + encodeURIComponent(this.encodeAutofillData(prefill));
```

So a US buyer choosing **Sole trader** on a PrestaShop store registered as a **GB sole trader**. The toggle itself was already reachable for them — `isAvailable()` gates on `GET /registry/v1/supported-company-types/<ISO>`, which returns `SOLE_TRADER` for US.

That also silently defeated the compliance fix this ticket is about. The proposal's `country_code` is what makes checkout-api append `?country=` to `_sole_trader_verification_link()`, and that param is what renders the US Onfido biometric-consent block. A US proposal created as GB never shows it, and Document Verification proceeds on a consent the buyer was never asked for — exactly the BIPA gap PDEV-4669 closes.

## Change

One line, plus the comment explaining it: append `&country=<ISO>` to the popup URL.

The value is `this.tokens.country` — the invoice-address country the server resolved in `ajaxProcessSoleTraderTokens` — not a DOM read. This matters more here than in `applyBuyer()`, which already follows the same rule: on the consent page a tampered country only adds a checkbox, but on signup it decides what gets **written** to the proposal, so a DOM guess would let anyone self-select US. Uppercased because the page's `isoCountry()` validates against `/^[A-Z]{2}$/`.

Omitted entirely when the server sent nothing, leaving the page on its own GB default rather than sending an empty param.

## Testing

`node --check` clean; the PHP suite passes (14/14 `TwoSoleTraderSpec`, all specs green). Neither covers `openPopup()` — there is no JS test harness in this repo, and adding one is out of scope for a one-line fix. Verified by reading the merged checkout-page diff: `countryParam` is read via `$page.url.searchParams.get("country")` and takes precedence over `autofillData.country_code`.

Manual verification needs a **US billing address** on the cart — the toggle gates on the cart's invoice country, so a GB address exercises none of this. Then: Company → Sole trader → popup URL ends in `&country=US`, form shows United States with a `+1` prefix, and the Onfido step shows the second `onfido.usAgreement` checkbox with Continue gated on both.

## Notes for the reviewer

- **Both dependencies are already merged**, so this takes effect as soon as it ships — unlike the FE/BE pair, there is no dormant period.
- Passing `country_code` inside `autofillData` would also work now that checkout-page#2537 fixed the business-address bug, but the explicit param is what that PR documents as authoritative and it wins over `autofillData` regardless.
- **Not fixed here** (both flagged on the checkout-page PR as needing product sign-off, neither plugin-side): US field labels are still UK-flavoured — VAT rather than EIN, Postal code rather than ZIP — and the param is not authoritative on the hosted page, so any holder of a signup link can self-select US. Restricting that is a token-scope question for @gkerr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)